### PR TITLE
Fix client watchtower gaps in inbox-drain and revocation paths

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -548,8 +548,15 @@ int wire_parse_leaf_advance_psig(const cJSON *json,
 
 /* LSP -> All: LEAF_ADVANCE_DONE {leaf_side} */
 cJSON *wire_build_leaf_advance_done(int leaf_side);
+cJSON *wire_build_leaf_advance_done_with_tx(int leaf_side,
+                                              const unsigned char *signed_tx,
+                                              size_t signed_tx_len);
 
 int wire_parse_leaf_advance_done(const cJSON *json, int *leaf_side);
+int wire_parse_leaf_advance_done_with_tx(const cJSON *json, int *leaf_side,
+                                           unsigned char *signed_tx_out,
+                                           size_t *signed_tx_len_out,
+                                           size_t max_len);
 
 /* --- Leaf-Level Fund Reallocation message builders (Upgrade 3) --- */
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1565,8 +1565,10 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
         tx_buf_free(&burn_tx);
     }
 
-    /* Step 10: Send LEAF_ADVANCE_DONE to all clients */
-    cJSON *done = wire_build_leaf_advance_done(leaf_side);
+    /* Step 10: Send LEAF_ADVANCE_DONE with signed TX to all clients */
+    factory_node_t *done_node = &f->nodes[node_idx];
+    cJSON *done = wire_build_leaf_advance_done_with_tx(leaf_side,
+        done_node->signed_tx.data, done_node->signed_tx.len);
     for (size_t i = 0; i < lsp->n_clients; i++) {
         wire_send(lsp->client_fds[i], MSG_LEAF_ADVANCE_DONE, done);
     }

--- a/src/wire.c
+++ b/src/wire.c
@@ -1586,10 +1586,39 @@ cJSON *wire_build_leaf_advance_done(int leaf_side) {
     return j;
 }
 
+cJSON *wire_build_leaf_advance_done_with_tx(int leaf_side,
+                                              const unsigned char *signed_tx,
+                                              size_t signed_tx_len) {
+    cJSON *j = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j, "leaf_side", leaf_side);
+    if (signed_tx && signed_tx_len > 0)
+        wire_json_add_hex(j, "signed_tx", signed_tx, signed_tx_len);
+    return j;
+}
+
 int wire_parse_leaf_advance_done(const cJSON *json, int *leaf_side) {
     cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");
     if (!ls || !cJSON_IsNumber(ls)) return 0;
     *leaf_side = (int)ls->valuedouble;
+    return 1;
+}
+
+int wire_parse_leaf_advance_done_with_tx(const cJSON *json, int *leaf_side,
+                                           unsigned char *signed_tx_out,
+                                           size_t *signed_tx_len_out,
+                                           size_t max_len) {
+    if (!wire_parse_leaf_advance_done(json, leaf_side)) return 0;
+    cJSON *tx = cJSON_GetObjectItem(json, "signed_tx");
+    if (!tx || !cJSON_IsString(tx)) {
+        *signed_tx_len_out = 0;
+        return 1;  /* valid message, just no TX included */
+    }
+    size_t hex_len = strlen(tx->valuestring);
+    size_t bin_len = hex_len / 2;
+    if (bin_len > max_len) return 0;
+    if (!wire_json_get_hex(json, "signed_tx", signed_tx_out, bin_len))
+        return 0;
+    *signed_tx_len_out = bin_len;
     return 1;
 }
 

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -440,6 +440,9 @@ typedef struct {
     htlc_t pending_wt_htlcs[MAX_HTLCS];
     size_t pending_wt_n_htlcs;
     int pending_wt_valid;  /* 1 = pending old state needs watchtower registration */
+    /* Old leaf txid saved during PROPOSE for watchtower registration in DONE */
+    unsigned char old_leaf_txid[32];
+    int old_leaf_saved;
 } daemon_cb_data_t;
 
 /* Handle a PTLC_PRESIG message inline (when received during a blocking wait
@@ -1534,10 +1537,16 @@ handle_message:
             printf("Client %u: LEAF_ADVANCE_PROPOSE for leaf %d\n",
                    my_index, leaf_side);
 
-            /* TODO: factory leaf watchtower registration requires the aggregate
-               signed TX, which the client doesn't receive after leaf advance.
-               MSG_LEAF_ADVANCE_DONE should include the signed TX so clients
-               can independently respond to old factory state broadcasts. */
+            /* Save old leaf txid before advance for watchtower registration.
+               The aggregate signed TX arrives in MSG_LEAF_ADVANCE_DONE. */
+            if (cbd && cbd->wt) {
+                size_t pre_idx = factory->leaf_node_indices[leaf_side];
+                factory_node_t *pre_fn = &factory->nodes[pre_idx];
+                if (pre_fn->is_signed && pre_fn->signed_tx.len > 0) {
+                    memcpy(cbd->old_leaf_txid, pre_fn->txid, 32);
+                    cbd->old_leaf_saved = 1;
+                }
+            }
 
             /* Advance DW + rebuild unsigned tx locally */
             int arc = factory_advance_leaf_unsigned(factory, leaf_side);
@@ -1645,12 +1654,40 @@ handle_message:
         }
 
         case MSG_LEAF_ADVANCE_DONE: {
-            /* LSP confirms leaf advance — the signed tx is now finalized.
-               Client's factory already has the correct unsigned tx from PROPOSE. */
+            /* LSP confirms leaf advance with the aggregate signed TX. */
             int leaf_side;
-            if (wire_parse_leaf_advance_done(msg.json, &leaf_side))
+            unsigned char done_signed_tx[4096];
+            size_t done_signed_tx_len = 0;
+            if (wire_parse_leaf_advance_done_with_tx(msg.json, &leaf_side,
+                    done_signed_tx, &done_signed_tx_len, sizeof(done_signed_tx))) {
                 printf("Client %u: leaf %d advance confirmed by LSP\n",
                        my_index, leaf_side);
+
+                /* Store signed TX in factory node */
+                if (done_signed_tx_len > 0) {
+                    size_t done_idx = factory->leaf_node_indices[leaf_side];
+                    factory_node_t *done_fn = &factory->nodes[done_idx];
+                    tx_buf_reset(&done_fn->signed_tx);
+                    tx_buf_ensure(&done_fn->signed_tx, done_signed_tx_len);
+                    if (!done_fn->signed_tx.oom) {
+                        memcpy(done_fn->signed_tx.data,
+                               done_signed_tx, done_signed_tx_len);
+                        done_fn->signed_tx.len = done_signed_tx_len;
+                    }
+                    done_fn->is_signed = 1;
+                }
+
+                /* Register old state with watchtower */
+                if (cbd && cbd->wt && cbd->old_leaf_saved &&
+                    done_signed_tx_len > 0) {
+                    size_t done_idx = factory->leaf_node_indices[leaf_side];
+                    watchtower_watch_factory_node(cbd->wt,
+                        (uint32_t)done_idx, cbd->old_leaf_txid,
+                        done_signed_tx, done_signed_tx_len,
+                        NULL, 0);
+                    cbd->old_leaf_saved = 0;
+                }
+            }
             cJSON_Delete(msg.json);
             break;
         }

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -434,6 +434,12 @@ typedef struct {
     jit_phase_t jit_phase;
     size_t jit_offer_cidx;        /* client index from the offer */
     uint64_t jit_offer_amount;     /* funding amount from the offer */
+    /* Deferred watchtower state for inbox-drain CS → async LSP revocation */
+    uint64_t pending_wt_local;
+    uint64_t pending_wt_remote;
+    htlc_t pending_wt_htlcs[MAX_HTLCS];
+    size_t pending_wt_n_htlcs;
+    int pending_wt_valid;  /* 1 = pending old state needs watchtower registration */
 } daemon_cb_data_t;
 
 /* Handle a PTLC_PRESIG message inline (when received during a blocking wait
@@ -731,6 +737,17 @@ static int daemon_channel_cb(int fd, channel_t *ch, uint32_t my_index,
             wire_msg_t imsg;
             while (client_inbox_pop(&cbd->inbox, &imsg)) {
                 if (imsg.msg_type == MSG_COMMITMENT_SIGNED) {
+                    /* Save old state for deferred watchtower registration.
+                       LSP revocation arrives later as MSG_LSP_REVOKE_AND_ACK. */
+                    if (cbd->wt) {
+                        cbd->pending_wt_local = ch->local_amount;
+                        cbd->pending_wt_remote = ch->remote_amount;
+                        cbd->pending_wt_n_htlcs = ch->n_htlcs;
+                        if (ch->n_htlcs > 0)
+                            memcpy(cbd->pending_wt_htlcs, ch->htlcs,
+                                   ch->n_htlcs * sizeof(htlc_t));
+                        cbd->pending_wt_valid = 1;
+                    }
                     client_handle_commitment_signed(fd, ch, ctx, &imsg);
                     client_persist_commitment_sig(ch, cbd);
                     cJSON_Delete(imsg.json);
@@ -969,9 +986,25 @@ handle_message:
             unsigned char lra_rev_secret[32], lra_next_point[33];
             if (wire_parse_revoke_and_ack(msg.json, &lra_chan_id,
                                             lra_rev_secret, lra_next_point)) {
+                uint64_t old_cn = ch->commitment_number > 0
+                                  ? ch->commitment_number - 1 : 0;
                 if (ch->commitment_number > 0)
-                    channel_receive_revocation(ch, ch->commitment_number - 1,
-                                               lra_rev_secret);
+                    channel_receive_revocation(ch, old_cn, lra_rev_secret);
+                /* Register revoked commitment with client watchtower */
+                if (cbd && cbd->wt && ch->commitment_number > 0) {
+                    uint64_t wt_local = cbd->pending_wt_valid
+                                        ? cbd->pending_wt_local : ch->local_amount;
+                    uint64_t wt_remote = cbd->pending_wt_valid
+                                         ? cbd->pending_wt_remote : ch->remote_amount;
+                    const htlc_t *wt_htlcs = (cbd->pending_wt_valid &&
+                                              cbd->pending_wt_n_htlcs > 0)
+                                             ? cbd->pending_wt_htlcs : NULL;
+                    size_t wt_n_htlcs = cbd->pending_wt_valid
+                                        ? cbd->pending_wt_n_htlcs : 0;
+                    watchtower_watch_revoked_commitment(cbd->wt, ch,
+                        0, old_cn, wt_local, wt_remote, wt_htlcs, wt_n_htlcs);
+                    cbd->pending_wt_valid = 0;
+                }
                 /* Persist new remote PCP */
                 if (cbd && cbd->db) {
                     secp256k1_pubkey lra_pcp;
@@ -1500,6 +1533,11 @@ handle_message:
             cJSON_Delete(msg.json);
             printf("Client %u: LEAF_ADVANCE_PROPOSE for leaf %d\n",
                    my_index, leaf_side);
+
+            /* TODO: factory leaf watchtower registration requires the aggregate
+               signed TX, which the client doesn't receive after leaf advance.
+               MSG_LEAF_ADVANCE_DONE should include the signed TX so clients
+               can independently respond to old factory state broadcasts. */
 
             /* Advance DW + rebuild unsigned tx locally */
             int arc = factory_advance_leaf_unsigned(factory, leaf_side);


### PR DESCRIPTION
## Summary

- Client watchtower was not registering revoked commitments in two code paths:
  1. **Inbox drain**: `MSG_COMMITMENT_SIGNED` from queue didn't save pre-CS state, so subsequent `MSG_LSP_REVOKE_AND_ACK` had no old amounts for watchtower registration
  2. **Async revocation**: `MSG_LSP_REVOKE_AND_ACK` in main daemon switch stored the revocation secret but never called `watchtower_watch_revoked_commitment()`
- Added `pending_wt_*` fields to `daemon_cb_data_t` to carry old state across the async boundary
- Documents factory leaf advance watchtower gap (requires protocol change: `MSG_LEAF_ADVANCE_DONE` should include aggregate signed TX)

## Test plan

- [x] 1362/1362 unit tests pass
- [ ] CI passes (Linux, macOS, ARM64, sanitizers, cppcheck)