### PR TITLE
fix: client-side funding TX verification before tree signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to SuperScalar are documented here.
 
+## Unreleased
+
+Client-side verification hardening across all factory lifecycle boundaries. Fixes the economic model default and adds defense-in-depth conservation checks.
+
+### Client verification (PR #63)
+
+- **Funding TX on-chain verification** (`client.c`, `client.h`): new `client_verify_funding_fn` callback verifies the on-chain funding TX amount matches the LSP's claim before signing the factory tree. Without this, an adversarial LSP could claim phantom funding. Implemented via RPC (`getrawtransaction`) when `--rpcuser` is provided; logs explicit WARNING when chain verification is unavailable.
+- **Distribution TX amount verification** (`client.c`): during factory rotation, the client compares the LSP's offered `dist_amounts[my_index]` to its channel balance and refuses to sign if the distribution is less than owed.
+- **Rotation balance carry verification** (`client.c`): saves old channel balance before `client_init_channel` overwrites it during rotation, then verifies the new balance >= old balance. Prevents LSP from silently dropping accumulated sats.
+- **Participant index verification** (`client.c`): after HELLO_ACK, verifies `all_pubkeys[my_index]` matches the client's own pubkey. Prevents signing a tree where the client's slot is controlled by a different key.
+- **Cooperative close verification** (`client.c`, `client.h`): `client_do_close_ceremony` now takes an optional `channel_t*` and verifies at least one close output >= the client's channel balance before signing. Previously the client signed LSP-proposed close amounts blindly.
+- **Economic terms logging + enforcement** (`client.c`, `client.h`): logs economic_mode and profit_share_bps before signing. New `--min-profit-bps N` CLI flag and `client_set_min_profit_bps()` API reject factories offering less than the client's minimum profit share.
+- **Client-side conservation invariant** (`client.c`): `client_check_conservation()` runs after every `channel_add_htlc` and `channel_fulfill_htlc`, verifying `local + remote + htlc_sum + fees == funding`. Defense-in-depth — the MuSig2 commitment signature already prevents exploitation, but this catches balance arithmetic bugs.
+
+### Economic model fix
+
+- **Default `--lsp-balance-pct` changed from 50 to 100** (`superscalar_lsp.c`): LSP now retains all initial channel capacity by default. The old default gave away 50% of the LSP's capital to clients for free, contradicting the SuperScalar design where clients earn balance by receiving payments or purchasing liquidity. `--demo` mode auto-overrides to 50 for test convenience.
+
+### Testing
+
+- **`--test-bad-terms` mode** (`superscalar_lsp.c`): LSP offers 0 bps profit share with `economic_mode=profit-shared`. Clients with `--min-profit-bps > 0` should refuse. Test PASSES on client rejection, FAILS if any client accepts. Verified end-to-end on regtest.
+
+### Bug fixes (direct to main)
+
+- **RPC error logging** (`chain_backend_rpc.c`): `rpc_call()` now logs the method name, error code, and error message for every bitcoind RPC failure. Previously errors were silently discarded.
+- **Test stack overflow** (`test_wire.c`): `test_wire_distributed_signing` heap-allocated ~2.1 MB of structs that were overflowing the stack. Full test suite now runs: 1363/1363 pass (was 866 before crash).
+- **Rotation conservation violation** (`lsp_rotation.c`): `ch->funding_amount` updated to match carried balances after rotation. Previously, HTLC settlement fees consumed during the old factory caused a permanent -152 sat/channel delta.
+- **Schema v18** (`persist.c`, `persist.h`): `to_self_delay`, `fee_rate_sat_per_kvb`, `use_revocation_leaf` columns added to `channels` table. The standalone watchtower hydrator now reads these from DB instead of hardcoding defaults.
+
 ## 0.1.12 — 2026-04-16
 
 Standalone watchtower penalty signing, secp256k1-zkp pin sync with CLN/wally, test infrastructure fix, and rotation conservation fix. 30/30 signet exhibition tests passed. 1363 unit tests.

--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -52,6 +52,11 @@ int client_init_channel(channel_t *ch, secp256k1_context *ctx,
                          const unsigned char *local_htlc_sec32,
                          fee_estimator_t *fee_est);
 
+/* Set the minimum acceptable profit share in basis points.  If > 0 and
+   the LSP's FACTORY_PROPOSE offers less, the client refuses to sign.
+   0 = accept any terms (default). */
+void client_set_min_profit_bps(uint16_t bps);
+
 /* Optional callback to verify the funding TX on-chain before signing the
    factory tree.  If provided to client_run_with_channels, called after
    FACTORY_PROPOSE is parsed and before any tree signing.  Return 1 if the

--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -84,6 +84,8 @@ int client_run_with_channels(secp256k1_context *ctx,
 /* Perform the cooperative close ceremony on an already-received CLOSE_PROPOSE.
    If initial_msg is non-NULL, it is the already-received CLOSE_PROPOSE message;
    otherwise we recv it from the wire.
+   If ch is non-NULL, the client verifies its close output >= ch->local_amount
+   before signing.  Pass NULL to skip balance verification (legacy callers).
    Returns 1 on success. */
 int client_do_close_ceremony(int fd, secp256k1_context *ctx,
                                const secp256k1_keypair *keypair,
@@ -91,7 +93,8 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
                                factory_t *factory,
                                size_t n_participants,
                                const wire_msg_t *initial_msg,
-                               uint32_t current_height);
+                               uint32_t current_height,
+                               const channel_t *ch);
 
 /* Reconnect to LSP using persisted state from SQLite.
    Loads factory + channel from DB, sends MSG_RECONNECT, receives

--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -52,15 +52,29 @@ int client_init_channel(channel_t *ch, secp256k1_context *ctx,
                          const unsigned char *local_htlc_sec32,
                          fee_estimator_t *fee_est);
 
+/* Optional callback to verify the funding TX on-chain before signing the
+   factory tree.  If provided to client_run_with_channels, called after
+   FACTORY_PROPOSE is parsed and before any tree signing.  Return 1 if the
+   funding TX at txid:vout has at least expected_sats, 0 to abort.
+   ctx is the opaque pointer passed alongside the callback. */
+typedef int (*client_verify_funding_fn)(const unsigned char *txid32,
+                                         uint32_t vout,
+                                         uint64_t expected_sats,
+                                         void *ctx);
+
 /* Run the full ceremony with optional channel operations.
    If channel_cb is NULL, behaves identically to client_run_ceremony
    (creates factory then immediately closes).
-   If channel_cb is non-NULL, calls it after CHANNEL_READY and before close. */
+   If channel_cb is non-NULL, calls it after CHANNEL_READY and before close.
+   If verify_funding is non-NULL, called to verify the on-chain funding TX
+   before signing the factory tree.  Pass verify_ctx for the callback. */
 int client_run_with_channels(secp256k1_context *ctx,
                               const secp256k1_keypair *keypair,
                               const char *host, int port,
                               client_channel_cb_t channel_cb,
-                              void *user_data);
+                              void *user_data,
+                              client_verify_funding_fn verify_funding,
+                              void *verify_ctx);
 
 /* Perform the cooperative close ceremony on an already-received CLOSE_PROPOSE.
    If initial_msg is non-NULL, it is the already-received CLOSE_PROPOSE message;

--- a/src/client.c
+++ b/src/client.c
@@ -1149,6 +1149,31 @@ int client_run_with_channels(secp256k1_context *ctx,
     }
     cJSON_Delete(msg.json);
 
+    /* Verify our pubkey is at the assigned participant index.  If the LSP
+       put a different key at our index, we'd sign a tree where our slot
+       is controlled by someone else. */
+    if (my_index >= n_participants) {
+        fprintf(stderr, "Client: participant_index %u out of range (%zu)\n",
+                my_index, n_participants);
+        wire_close(fd);
+        return 0;
+    }
+    {
+        unsigned char my_ser[33], their_ser[33];
+        size_t my_len = 33, their_len = 33;
+        secp256k1_ec_pubkey_serialize(ctx, my_ser, &my_len, &my_pubkey,
+                                       SECP256K1_EC_COMPRESSED);
+        secp256k1_ec_pubkey_serialize(ctx, their_ser, &their_len,
+                                       &all_pubkeys[my_index],
+                                       SECP256K1_EC_COMPRESSED);
+        if (memcmp(my_ser, their_ser, 33) != 0) {
+            fprintf(stderr, "Client: REFUSING — pubkey at index %u does not "
+                    "match our key (identity mismatch)\n", my_index);
+            wire_close(fd);
+            return 0;
+        }
+    }
+
     /* Receive FACTORY_PROPOSE — disable timeout since LSP may be waiting for
        on-chain funding confirmation (up to ~10 min on signet/testnet) */
     if (!wire_recv_handle_ping(fd, &msg, 0) || check_msg_error(&msg) || msg.msg_type != MSG_FACTORY_PROPOSE) {

--- a/src/client.c
+++ b/src/client.c
@@ -20,6 +20,14 @@ extern void reverse_bytes(unsigned char *data, size_t len);
 static secp256k1_pubkey g_nk_server_pubkey;
 static int g_nk_server_pubkey_set = 0;
 
+/* Minimum acceptable profit share in basis points (set via client_set_min_profit_bps).
+   If > 0 and the LSP offers less, the client refuses to sign the factory tree. */
+static uint16_t g_min_profit_bps = 0;
+
+void client_set_min_profit_bps(uint16_t bps) {
+    g_min_profit_bps = bps;
+}
+
 void client_set_lsp_pubkey(const secp256k1_pubkey *pubkey) {
     if (pubkey) {
         g_nk_server_pubkey = *pubkey;
@@ -1341,14 +1349,24 @@ int client_run_with_channels(secp256k1_context *ctx,
                                ? econ_names[economic_mode] : "unknown";
         printf("Client %u: factory terms — economic_mode=%s",
                my_index, econ_str);
-        if (economic_mode == 1 && my_index >= 1) {
-            uint32_t pidx = my_index;
-            uint16_t bps = (pidx < FACTORY_MAX_SIGNERS)
-                           ? profiles[pidx].profit_share_bps : 0;
-            printf(", my profit_share=%u bps (%.2f%%)", bps, bps / 100.0);
-        }
+        uint16_t my_bps = 0;
+        if (my_index >= 1 && my_index < FACTORY_MAX_SIGNERS)
+            my_bps = profiles[my_index].profit_share_bps;
+        if (economic_mode == 1)
+            printf(", my profit_share=%u bps (%.2f%%)", my_bps, my_bps / 100.0);
         printf(", funding=%llu sats, %zu participants\n",
                (unsigned long long)funding_amount, n_participants);
+
+        /* Enforce minimum profit share if the client set --min-profit-bps */
+        if (g_min_profit_bps > 0 && my_bps < g_min_profit_bps) {
+            fprintf(stderr, "Client %u: REFUSING — profit_share %u bps < "
+                    "minimum %u bps (use --min-profit-bps to adjust)\n",
+                    my_index, my_bps, g_min_profit_bps);
+            free(factory);
+            client_send_error(fd, "profit_share_too_low");
+            wire_close(fd);
+            return 0;
+        }
     }
 
     if (n_level_arity > 0)

--- a/src/client.c
+++ b/src/client.c
@@ -307,7 +307,8 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
                                factory_t *factory,
                                size_t n_participants,
                                const wire_msg_t *initial_msg,
-                               uint32_t current_height) {
+                               uint32_t current_height,
+                               const channel_t *ch) {
     wire_msg_t msg;
     int got_propose = 0;
 
@@ -377,6 +378,28 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
             item, "spk", close_outputs[i].script_pubkey, 34);
     }
     if (!initial_msg) cJSON_Delete(msg.json);
+
+    /* Verify cooperative close outputs before signing.
+       The client must receive at least its channel balance.  If the LSP
+       short-changes the close outputs, the client refuses to sign and
+       can force-close instead (using the pre-signed commitment TX). */
+    if (ch && ch->local_amount > 0) {
+        uint64_t my_balance = ch->local_amount;
+        int found = 0;
+        for (size_t i = 0; i < n_outputs; i++) {
+            if (close_outputs[i].amount_sats >= my_balance) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            fprintf(stderr, "Client: REFUSING cooperative close — no output "
+                    ">= channel balance %llu sats (force-close instead)\n",
+                    (unsigned long long)my_balance);
+            free(close_outputs);
+            return 0;
+        }
+    }
 
     tx_buf_t close_unsigned;
     tx_buf_init(&close_unsigned, 256);
@@ -1865,7 +1888,8 @@ int client_run_with_channels(secp256k1_context *ctx,
 
     /* === Cooperative Close Ceremony === */
     if (!client_do_close_ceremony(fd, ctx, keypair, &my_pubkey,
-                                    factory, n_participants, NULL, 0)) {
+                                    factory, n_participants, NULL, 0,
+                                    NULL)) {
         goto fail;
     }
 
@@ -2249,7 +2273,7 @@ int client_run_reconnect(secp256k1_context *ctx,
         /* Run close ceremony */
         int close_ok = client_do_close_ceremony(fd, ctx, keypair, &my_pubkey,
                                                   factory, n_participants,
-                                                  NULL, 0);
+                                                  NULL, 0, &channel);
         factory_free(factory); free(factory);
         wire_close(fd);
         return close_ok;

--- a/src/client.c
+++ b/src/client.c
@@ -729,6 +729,23 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
         nonce_count++;
     }
 
+    /* Verify distribution amounts: if the LSP provided per-client dist_amounts,
+       check that this client's allocation is at least its old channel balance.
+       Prevents the LSP from silently reducing the client's distribution output
+       during rotation (balance theft). */
+    if (rot_n_dist_amounts > 0 && my_index >= 1) {
+        size_t ci = my_index - 1;  /* client index in dist_amounts array */
+        uint64_t offered = (ci < rot_n_dist_amounts) ? rot_dist_amounts[ci] : 0;
+        uint64_t expected = channel_out->local_amount;  /* client's balance */
+        if (offered < expected) {
+            fprintf(stderr, "Client %u: REFUSING rotation — distribution amount "
+                    "%llu < channel balance %llu (balance theft attempt)\n",
+                    my_index, (unsigned long long)offered,
+                    (unsigned long long)expected);
+            return 0;
+        }
+    }
+
     /* Distribution TX: build unsigned TX and generate nonce (same as initial) */
     int rot_has_dist = 0;
     uint32_t rot_dist_node_idx = (uint32_t)factory_out->n_nodes;
@@ -1533,6 +1550,19 @@ int client_run_with_channels(secp256k1_context *ctx,
     }
     client_apply_factory_ready(factory, msg.json);
     cJSON_Delete(msg.json);
+
+    /* Log expected distribution amount.  The distribution TX is a fallback
+       (used only if the factory expires without cooperative rotation), so
+       this is informational.  The hard enforcement is in
+       client_do_factory_rotation where the client REFUSES to sign if
+       dist_amounts[my_index-1] < channel balance. */
+    if (factory->dist_tx_ready && n_participants > 1 && my_index >= 1) {
+        uint64_t expected_dist_sats = funding_amount / n_participants;
+        printf("Client %u: distribution TX received — expected share "
+               "~%llu sats (equal split of %llu / %zu participants)\n",
+               my_index, (unsigned long long)expected_dist_sats,
+               (unsigned long long)funding_amount, n_participants);
+    }
 
     printf("Client %u: factory creation complete!\n", my_index);
 

--- a/src/client.c
+++ b/src/client.c
@@ -1029,7 +1029,9 @@ int client_run_with_channels(secp256k1_context *ctx,
                               const secp256k1_keypair *keypair,
                               const char *host, int port,
                               client_channel_cb_t channel_cb,
-                              void *user_data) {
+                              void *user_data,
+                              client_verify_funding_fn verify_funding,
+                              void *verify_ctx) {
     secp256k1_pubkey my_pubkey;
     secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
 
@@ -1236,6 +1238,28 @@ int client_run_with_channels(secp256k1_context *ctx,
     }
 
     cJSON_Delete(msg.json);
+
+    /* Verify funding TX on-chain before signing anything.  If the caller
+       provided a verify_funding callback (e.g. backed by RPC or BIP 158),
+       query the chain for the actual output amount.  An adversarial LSP could
+       claim a larger funding_amount than actually exists on-chain; without
+       this check the client would sign a tree against phantom funds. */
+    if (verify_funding) {
+        if (!verify_funding(funding_txid, funding_vout, funding_amount,
+                            verify_ctx)) {
+            fprintf(stderr, "Client: funding TX verification FAILED — "
+                    "on-chain output does not match claimed %llu sats. "
+                    "Refusing to sign factory tree.\n",
+                    (unsigned long long)funding_amount);
+            client_send_error(fd, "funding_tx_verification_failed");
+            wire_close(fd);
+            return 0;
+        }
+    } else {
+        fprintf(stderr, "Client: WARNING — funding TX not verified on-chain "
+                "(no --rpcuser or --light-client). Trusting LSP claim of "
+                "%llu sats.\n", (unsigned long long)funding_amount);
+    }
 
     /* Build factory locally (heap — factory_t is ~3MB) */
     factory_t *factory = calloc(1, sizeof(factory_t));
@@ -2289,5 +2313,6 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
 int client_run_ceremony(secp256k1_context *ctx,
                         const secp256k1_keypair *keypair,
                         const char *host, int port) {
-    return client_run_with_channels(ctx, keypair, host, port, NULL, NULL);
+    return client_run_with_channels(ctx, keypair, host, port, NULL, NULL,
+                                     NULL, NULL);
 }

--- a/src/client.c
+++ b/src/client.c
@@ -37,6 +37,32 @@ void client_set_lsp_pubkey(const secp256k1_pubkey *pubkey) {
     }
 }
 
+/* Client-side conservation invariant check (defense-in-depth).
+   The commitment signature already prevents exploitation, but this catches
+   bugs in the balance arithmetic itself. */
+static void client_check_conservation(const channel_t *ch, const char *context) {
+    if (!ch || ch->funding_amount == 0) return;
+    uint64_t sum = ch->local_amount + ch->remote_amount;
+    for (size_t h = 0; h < ch->n_htlcs; h++) {
+        if (ch->htlcs[h].state == HTLC_STATE_ACTIVE) {
+            sum += ch->htlcs[h].amount_sats;
+            sum += ch->htlcs[h].fee_at_add;
+        }
+    }
+    if (sum != ch->funding_amount) {
+        fprintf(stderr, "CLIENT CONSERVATION VIOLATION (%s): "
+                "local=%llu remote=%llu htlc_sum=%llu total=%llu "
+                "funding=%llu (delta=%lld)\n",
+                context,
+                (unsigned long long)ch->local_amount,
+                (unsigned long long)ch->remote_amount,
+                (unsigned long long)(sum - ch->local_amount - ch->remote_amount),
+                (unsigned long long)sum,
+                (unsigned long long)ch->funding_amount,
+                (long long)(sum - ch->funding_amount));
+    }
+}
+
 /* Returns 1 if message is MSG_ERROR (and prints it), 0 otherwise */
 static int check_msg_error(const wire_msg_t *msg) {
     if (msg->msg_type == MSG_ERROR) {
@@ -282,6 +308,7 @@ int client_handle_add_htlc(channel_t *ch, const wire_msg_t *msg) {
        send FULFILL_HTLC back, we reference the LSP's ID for this HTLC. */
     ch->htlcs[ch->n_htlcs - 1].id = htlc_id;
 
+    client_check_conservation(ch, "after add_htlc");
     return 1;
 }
 
@@ -291,6 +318,8 @@ int client_fulfill_payment(int fd, channel_t *ch,
     /* Fulfill locally */
     if (!channel_fulfill_htlc(ch, htlc_id, preimage32))
         return 0;
+
+    client_check_conservation(ch, "after fulfill_htlc");
 
     /* Send FULFILL_HTLC to LSP */
     cJSON *msg = wire_build_update_fulfill_htlc(htlc_id, preimage32);

--- a/src/client.c
+++ b/src/client.c
@@ -973,6 +973,10 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
         cJSON_Delete(msg.json);
     }
 
+    /* Save old channel balance before client_init_channel overwrites it.
+       Used below to verify the LSP carried the balance correctly. */
+    uint64_t old_local_balance = channel_out->local_amount;
+
     /* Initialize client-side channel */
     if (!client_init_channel(channel_out, ctx, factory_out, keypair, my_index,
                               &rot_lsp_pay_bp, &rot_lsp_delay_bp,
@@ -987,6 +991,20 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
     if (rot_bal_local > 0 || rot_bal_remote > 0) {
         channel_out->local_amount  = rot_bal_remote / 1000;
         channel_out->remote_amount = rot_bal_local  / 1000;
+    }
+
+    /* Verify the LSP carried the client's balance into the new factory.
+       The client's local_amount in the new channel must be >= the old
+       channel's local_amount.  A decrease without a corresponding payment
+       means the LSP is stealing sats during rotation. */
+    if (old_local_balance > 0 &&
+        channel_out->local_amount < old_local_balance) {
+        fprintf(stderr, "Client %u: REFUSING rotation — new channel balance "
+                "%llu < old balance %llu (balance not carried)\n",
+                my_index,
+                (unsigned long long)channel_out->local_amount,
+                (unsigned long long)old_local_balance);
+        free(secnonces); free(nonce_entries); return 0;
     }
 
     /* Override local_pcs[0,1] with pre-generated secrets + store LSP PCPs */

--- a/src/client.c
+++ b/src/client.c
@@ -1331,6 +1331,26 @@ int client_run_with_channels(secp256k1_context *ctx,
     factory->placement_mode = (placement_mode_t)placement_mode;
     factory->economic_mode = (economic_mode_t)economic_mode;
     memcpy(factory->profiles, profiles, sizeof(profiles));
+
+    /* Log the economic terms the client is about to sign.  The client
+       should review these before proceeding — once the tree is signed,
+       the profit split is locked for this factory's lifetime. */
+    {
+        const char *econ_names[] = {"lsp-takes-all", "profit-shared"};
+        const char *econ_str = (economic_mode >= 0 && economic_mode <= 1)
+                               ? econ_names[economic_mode] : "unknown";
+        printf("Client %u: factory terms — economic_mode=%s",
+               my_index, econ_str);
+        if (economic_mode == 1 && my_index >= 1) {
+            uint32_t pidx = my_index;
+            uint16_t bps = (pidx < FACTORY_MAX_SIGNERS)
+                           ? profiles[pidx].profit_share_bps : 0;
+            printf(", my profit_share=%u bps (%.2f%%)", bps, bps / 100.0);
+        }
+        printf(", funding=%llu sats, %zu participants\n",
+               (unsigned long long)funding_amount, n_participants);
+    }
+
     if (n_level_arity > 0)
         factory_set_level_arity(factory, level_arities, n_level_arity);
     else if (leaf_arity == 1)

--- a/tests/test_bridge.c
+++ b/tests/test_bridge.c
@@ -1226,7 +1226,8 @@ int test_regtest_bridge_payment(void) {
 
             int ok = client_run_with_channels(child_ctx, &child_kp,
                                                "127.0.0.1", lsp_port,
-                                               bridge_payee_cb, cb_data);
+                                               bridge_payee_cb, cb_data,
+                                               NULL, NULL);
             secp256k1_context_destroy(child_ctx);
             _exit(ok ? 0 : 1);
         }
@@ -1659,7 +1660,8 @@ int test_regtest_bridge_invoice_flow(void) {
 
             int ok = client_run_with_channels(child_ctx, &child_kp,
                                                "127.0.0.1", lsp_port,
-                                               invoice_flow_cb, cb_data);
+                                               invoice_flow_cb, cb_data,
+                                               NULL, NULL);
             secp256k1_context_destroy(child_ctx);
             _exit(ok ? 0 : 1);
         }

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -735,7 +735,8 @@ int test_regtest_intra_factory_payment(void) {
 
             int ok = client_run_with_channels(child_ctx, &child_kp,
                                                "127.0.0.1", port,
-                                               payment_client_cb, cb_data);
+                                               payment_client_cb, cb_data,
+                                               NULL, NULL);
             secp256k1_context_destroy(child_ctx);
             _exit(ok ? 0 : 1);
         }
@@ -1118,7 +1119,8 @@ int test_regtest_multi_payment(void) {
             int ok = client_run_with_channels(child_ctx, &child_kp,
                                                "127.0.0.1", port,
                                                multi_payment_client_cb,
-                                               &mp_data[c]);
+                                               &mp_data[c],
+                                               NULL, NULL);
             secp256k1_context_destroy(child_ctx);
             _exit(ok ? 0 : 1);
         }
@@ -1893,7 +1895,8 @@ int test_regtest_lsp_restart_recovery(void) {
             else cb_data = &idle_data;
             int ok = client_run_with_channels(child_ctx, &child_kp,
                                                "127.0.0.1", port,
-                                               payment_client_cb, cb_data);
+                                               payment_client_cb, cb_data,
+                                               NULL, NULL);
             secp256k1_context_destroy(child_ctx);
             _exit(ok ? 0 : 1);
         }
@@ -2437,7 +2440,8 @@ int test_regtest_crash_double_recovery(void) {
             else cb_data = &idle_data;
             int ok = client_run_with_channels(child_ctx, &child_kp,
                                                "127.0.0.1", port,
-                                               payment_client_cb, cb_data);
+                                               payment_client_cb, cb_data,
+                                               NULL, NULL);
             secp256k1_context_destroy(child_ctx);
             _exit(ok ? 0 : 1);
         }
@@ -2901,7 +2905,8 @@ int test_regtest_tcp_reconnect(void) {
             else cb_data = &idle_data;
             int ok = client_run_with_channels(child_ctx, &child_kp,
                                                "127.0.0.1", port,
-                                               payment_client_cb, cb_data);
+                                               payment_client_cb, cb_data,
+                                               NULL, NULL);
             secp256k1_context_destroy(child_ctx);
             _exit(ok ? 0 : 1);
         }

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -124,6 +124,78 @@ static int attach_hd_wallet_client(watchtower_t *wt, persist_t *db_ptr,
     return 1;
 }
 
+/* --- Funding TX on-chain verification callback ---
+ * Called by client_run_with_channels() between FACTORY_PROPOSE parsing and
+ * tree signing.  Uses the RPC chain backend to query the funding TX and
+ * confirm the output amount matches the LSP's claim.
+ * ctx is a regtest_t* (same RPC backend used for force-close and sweep). */
+static int verify_funding_rpc(const unsigned char *txid32, uint32_t vout,
+                                uint64_t expected_sats, void *ctx) {
+    regtest_t *rt = (regtest_t *)ctx;
+    if (!rt) return 0;
+
+    /* Convert internal-order txid to display hex */
+    unsigned char disp[32];
+    memcpy(disp, txid32, 32);
+    extern void reverse_bytes(unsigned char *, size_t);
+    reverse_bytes(disp, 32);
+    char txid_hex[65];
+    extern void hex_encode(const unsigned char *, size_t, char *);
+    hex_encode(disp, 32, txid_hex);
+
+    int confs = regtest_get_confirmations(rt, txid_hex);
+    if (confs < 0) {
+        fprintf(stderr, "verify_funding: TX %s not found on-chain\n", txid_hex);
+        return 0;
+    }
+    if (confs < 1) {
+        fprintf(stderr, "verify_funding: TX %s in mempool but not confirmed\n",
+                txid_hex);
+        /* Allow mempool TX — LSP may have just broadcast */
+    }
+
+    /* Query the actual output amount via getrawtransaction (verbose=true) */
+    char params[256];
+    snprintf(params, sizeof(params), "\"%s\", true", txid_hex);
+    char *resp = regtest_exec(rt, "getrawtransaction", params);
+    if (!resp) {
+        fprintf(stderr, "verify_funding: getrawtransaction failed for %s\n",
+                txid_hex);
+        return 0;
+    }
+    cJSON *jtx = cJSON_Parse(resp);
+    free(resp);
+    if (!jtx) {
+        fprintf(stderr, "verify_funding: failed to parse TX JSON\n");
+        return 0;
+    }
+    cJSON *vout_arr = cJSON_GetObjectItem(jtx, "vout");
+    cJSON *vout_obj = vout_arr ? cJSON_GetArrayItem(vout_arr, (int)vout) : NULL;
+    cJSON *val_item = vout_obj ? cJSON_GetObjectItem(vout_obj, "value") : NULL;
+    if (!val_item || !cJSON_IsNumber(val_item)) {
+        fprintf(stderr, "verify_funding: cannot read output %s:%u\n",
+                txid_hex, vout);
+        cJSON_Delete(jtx);
+        return 0;
+    }
+    /* value is in BTC (float); convert to sats */
+    uint64_t actual_sats = (uint64_t)(val_item->valuedouble * 100000000.0 + 0.5);
+    cJSON_Delete(jtx);
+    if (actual_sats < expected_sats) {
+        fprintf(stderr, "verify_funding: output %s:%u has %llu sats, "
+                "LSP claimed %llu sats\n",
+                txid_hex, vout,
+                (unsigned long long)actual_sats,
+                (unsigned long long)expected_sats);
+        return 0;
+    }
+    printf("Client: funding TX verified on-chain: %s:%u = %llu sats (>= %llu)\n",
+           txid_hex, vout,
+           (unsigned long long)actual_sats,
+           (unsigned long long)expected_sats);
+    return 1;
+}
+
 /*
  * Initialise the BIP 158 backend, connect to the peer, restore checkpoint,
  * then plug the backend into the watchtower as its chain backend.
@@ -2956,11 +3028,32 @@ int main(int argc, char *argv[]) {
         if (!first_run && cbd.wt)
             watchtower_check(cbd.wt);
 
+        /* Initialize RPC backend for funding TX verification (if credentials available) */
+        regtest_t verify_rt;
+        (void)verify_rt; /* used only when RPC credentials are available */
+        client_verify_funding_fn vfn = NULL;
+        void *vctx = NULL;
+        if (rpcuser && rpcpassword && strcmp(network, "regtest") != 0) {
+            if (regtest_init_full(&verify_rt, network, NULL,
+                                   rpcuser, rpcpassword, NULL, rpcport)) {
+                /* verify_rt initialized */
+                vfn = verify_funding_rpc;
+                vctx = &verify_rt;
+            }
+        } else if (strcmp(network, "regtest") == 0 && rpcuser && rpcpassword) {
+            if (regtest_init_full(&verify_rt, "regtest", NULL,
+                                   rpcuser, rpcpassword, NULL, rpcport)) {
+                /* verify_rt initialized */
+                vfn = verify_funding_rpc;
+                vctx = &verify_rt;
+            }
+        }
+
         while (!g_shutdown) {
             if (first_run || !use_db) {
                 ok = client_run_with_channels(ctx, &kp, host, port,
                                                 daemon_channel_cb, &cbd,
-                                                NULL, NULL);
+                                                vfn, vctx);
                 /* Only switch to reconnect mode once factory is persisted */
                 if (ok || cbd.saved_initial)
                     first_run = 0;
@@ -2984,8 +3077,19 @@ int main(int argc, char *argv[]) {
         }
     } else if (n_actions > 0 || expect_channels) {
         multi_payment_data_t data = { actions, n_actions, 0 };
+        /* Standalone mode also gets funding verification if RPC available */
+        regtest_t sa_verify_rt;
+        client_verify_funding_fn sa_vfn = NULL;
+        void *sa_vctx = NULL;
+        if (rpcuser && rpcpassword) {
+            if (regtest_init_full(&sa_verify_rt, network, NULL,
+                                   rpcuser, rpcpassword, NULL, rpcport)) {
+                sa_vfn = verify_funding_rpc;
+                sa_vctx = &sa_verify_rt;
+            }
+        }
         ok = client_run_with_channels(ctx, &kp, host, port, standalone_channel_cb, &data,
-                                      NULL, NULL);
+                                      sa_vfn, sa_vctx);
     } else {
         ok = client_run_ceremony(ctx, &kp, host, port);
     }

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -2959,7 +2959,8 @@ int main(int argc, char *argv[]) {
         while (!g_shutdown) {
             if (first_run || !use_db) {
                 ok = client_run_with_channels(ctx, &kp, host, port,
-                                                daemon_channel_cb, &cbd);
+                                                daemon_channel_cb, &cbd,
+                                                NULL, NULL);
                 /* Only switch to reconnect mode once factory is persisted */
                 if (ok || cbd.saved_initial)
                     first_run = 0;
@@ -2983,7 +2984,8 @@ int main(int argc, char *argv[]) {
         }
     } else if (n_actions > 0 || expect_channels) {
         multi_payment_data_t data = { actions, n_actions, 0 };
-        ok = client_run_with_channels(ctx, &kp, host, port, standalone_channel_cb, &data);
+        ok = client_run_with_channels(ctx, &kp, host, port, standalone_channel_cb, &data,
+                                      NULL, NULL);
     } else {
         ok = client_run_ceremony(ctx, &kp, host, port);
     }

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1932,6 +1932,7 @@ static void usage(const char *prog) {
         "                                    scanning. bitcoind not required when set.\n"
         "  --light-client-fallback HOST:PORT Add a fallback peer (up to 7 total).\n"
         "  --auto-accept-jit                 Auto-accept JIT channel offers (default: off)\n"
+        "  --min-profit-bps N                Refuse factory if profit share < N bps (default: 0 = accept any)\n"
         "  --lsp-pubkey HEX                  LSP static pubkey (33-byte hex) for NK authentication\n"
         "  --tor-proxy HOST:PORT             SOCKS5 proxy for Tor (default: 127.0.0.1:9050)\n"
         "  --generate-mnemonic               Generate 24-word BIP39 mnemonic, derive key, save to --keyfile, then exit\n"
@@ -2136,6 +2137,8 @@ int main(int argc, char *argv[]) {
 
         } else if (strcmp(argv[i], "--auto-accept-jit") == 0) {
             auto_accept_jit = 1;
+        } else if (strcmp(argv[i], "--min-profit-bps") == 0 && i + 1 < argc) {
+            client_set_min_profit_bps((uint16_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--test-lsps2") == 0) {
             test_lsps2 = 1;
         } else if (strcmp(argv[i], "--test-lsps2-buy") == 0) {

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1100,7 +1100,7 @@ handle_message:
         case MSG_CLOSE_PROPOSE:
             printf("Client %u: received CLOSE_PROPOSE in daemon mode\n", my_index);
             client_do_close_ceremony(fd, ctx, keypair, &my_pubkey,
-                                      factory, n_participants, &msg, 0);
+                                      factory, n_participants, &msg, 0, ch);
             cJSON_Delete(msg.json);
             return 2;  /* close already handled */
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -290,6 +290,7 @@ static void usage(const char *prog) {
         "  --test-htlc-force-close  After demo: add pending HTLC, force-close, broadcast HTLC timeout TX\n"
         "  --test-multi-htlc-force-close  After demo: add HTLCs on ALL channels, force-close, broadcast all timeout TXs\n"
         "  --test-full-settlement  After demo: force-close tree, broadcast ALL commitment TXs, verify cross-leaf balances\n"
+        "  --test-bad-terms    Offer 0 bps profit share; PASSES if client rejects (use with --min-profit-bps on client)\n"
         "  --test-dw-advance   After demo: advance DW counter, re-sign tree, force-close (shows nSequence decrease)\n"
         "  --test-leaf-advance After demo: advance left leaf only, force-close (proves per-leaf independence)\n"
         "  --test-partial-rotation After demo: 1 client goes offline, partial rotation with 3/4, dist TX on old factory\n"
@@ -1052,6 +1053,7 @@ int main(int argc, char *argv[]) {
     int accept_risk = 0;             /* --i-accept-the-risk for mainnet */
     int placement_mode_arg = 3;      /* 0=sequential, 1=inward, 2=outward, 3=timezone-cluster */
     int economic_mode_arg = 0;       /* 0=lsp-takes-all, 1=profit-shared */
+    int test_bad_terms = 0;          /* --test-bad-terms: offer 0 bps profit to verify client rejects */
     uint16_t default_profit_bps = 0; /* per-client profit share bps */
     uint32_t settlement_interval = 144; /* blocks between profit settlements */
     const char *rpc_file_arg = NULL;
@@ -1279,6 +1281,8 @@ int main(int argc, char *argv[]) {
             test_multi_htlc_force_close = 1;
         else if (strcmp(argv[i], "--test-full-settlement") == 0)
             test_full_settlement = 1;
+        else if (strcmp(argv[i], "--test-bad-terms") == 0)
+            test_bad_terms = 1;
         else if (strcmp(argv[i], "--test-dw-advance") == 0)
             test_dw_advance = 1;
         else if (strcmp(argv[i], "--test-leaf-advance") == 0)
@@ -2955,6 +2959,18 @@ accept_new_factory:
         lsp_p->factory.profiles[pi].timezone_bucket = 0;
     }
 
+    /* --test-bad-terms: force profit-shared mode with 0 bps for all clients.
+       Clients running with --min-profit-bps should refuse to sign.
+       The test PASSES if factory creation fails (client rejection). */
+    if (test_bad_terms) {
+        lsp_p->factory.economic_mode = ECON_PROFIT_SHARED;
+        for (size_t pi = 1; pi < (size_t)(1 + n_clients) && pi < FACTORY_MAX_SIGNERS; pi++)
+            lsp_p->factory.profiles[pi].profit_share_bps = 0;
+        lsp_p->factory.profiles[0].profit_share_bps = 10000; /* LSP takes 100% */
+        printf("LSP: --test-bad-terms: offering 0 bps profit to all clients\n");
+        printf("LSP: clients with --min-profit-bps > 0 should REFUSE\n");
+    }
+
     /* If --test-burn, enable L-stock revocation before tree construction.
        Uses flat secrets (per ZmnSCPxj: no multi-party shachain method exists,
        just store all revocation keys independently).
@@ -2990,7 +3006,21 @@ accept_new_factory:
             fprintf(stderr, "LSP: factory creation attempt %d failed\n", attempt + 1);
         }
         if (!creation_ok) {
+            if (test_bad_terms) {
+                printf("\n=== BAD TERMS TEST PASSED ===\n");
+                printf("Client correctly refused factory with 0 bps profit share.\n");
+                lsp_cleanup(lsp_p);
+                secp256k1_context_destroy(ctx);
+                return 0;  /* success — client rejection is the expected outcome */
+            }
             fprintf(stderr, "LSP: factory creation failed after 3 attempts\n");
+            lsp_cleanup(lsp_p);
+            secp256k1_context_destroy(ctx);
+            return 1;
+        }
+        if (test_bad_terms) {
+            fprintf(stderr, "\n=== BAD TERMS TEST FAILED ===\n");
+            fprintf(stderr, "Client accepted 0 bps profit share — should have refused!\n");
             lsp_cleanup(lsp_p);
             secp256k1_context_destroy(ctx);
             return 1;

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -318,7 +318,7 @@ static void usage(const char *prog) {
         "  --max-handshakes N  Max concurrent handshakes (default: 4)\n"
         "  --accept-timeout N  Max seconds to wait for each client connection (default: 0 = no timeout)\n"
         "  --routing-fee-ppm N Routing fee in parts-per-million (default: 0 = free)\n"
-        "  --lsp-balance-pct N LSP's share of channel capacity, 0-100 (default: 50 = fair split)\n"
+        "  --lsp-balance-pct N LSP's share of channel capacity, 0-100 (default: 100; --demo overrides to 50)\n"
         "  --placement-mode M  Client placement: sequential, inward, outward, timezone-cluster (default: timezone-cluster)\n"
         "  --economic-mode M   Fee model: lsp-takes-all, profit-shared (default: lsp-takes-all)\n"
         "  --default-profit-bps N  Default profit share basis points per client (default: 0)\n"
@@ -1047,7 +1047,8 @@ int main(int argc, char *argv[]) {
     int max_conn_rate_arg = 10;      /* max connections per IP per minute */
     int max_handshakes_arg = 4;      /* max concurrent handshakes */
     uint64_t routing_fee_ppm = 0;    /* 0 = zero-fee (no routing fee) */
-    uint16_t lsp_balance_pct = 50;   /* 50 = fair 50-50 split */
+    uint16_t lsp_balance_pct = 100;  /* 100 = LSP retains all capacity (production default) */
+    int lsp_balance_pct_explicit = 0; /* 1 if user passed --lsp-balance-pct */
     int accept_risk = 0;             /* --i-accept-the-risk for mainnet */
     int placement_mode_arg = 3;      /* 0=sequential, 1=inward, 2=outward, 3=timezone-cluster */
     int economic_mode_arg = 0;       /* 0=lsp-takes-all, 1=profit-shared */
@@ -1321,6 +1322,7 @@ int main(int argc, char *argv[]) {
             routing_fee_ppm = (uint64_t)strtoull(argv[++i], NULL, 10);
         else if (strcmp(argv[i], "--lsp-balance-pct") == 0 && i + 1 < argc) {
             lsp_balance_pct = (uint16_t)atoi(argv[++i]);
+            lsp_balance_pct_explicit = 1;
             if (lsp_balance_pct > 100) {
                 fprintf(stderr, "Error: --lsp-balance-pct must be 0-100\n");
                 return 1;
@@ -1645,6 +1647,14 @@ int main(int argc, char *argv[]) {
     }
 
     /* --- BIP39 Test placeholder (moved after key init) --- */
+
+    /* Demo mode: override lsp_balance_pct to 50 if the user didn't set it
+       explicitly.  Demo payments send FROM clients which requires them to
+       have a balance.  Production default is 100 (LSP retains all capacity;
+       clients earn sats by receiving payments or buying liquidity). */
+    if (demo_mode && !lsp_balance_pct_explicit) {
+        lsp_balance_pct = 50;
+    }
 
     /* Mainnet safety guard: refuse unless explicitly acknowledged */
     if (strcmp(network, "mainnet") == 0 && !accept_risk) {


### PR DESCRIPTION
## Problem

The client accepts the LSP's claimed `funding_amount` from FACTORY_PROPOSE without verifying the actual on-chain TX output. An adversarial LSP could claim 10 BTC funded while only 0.1 BTC exists on-chain. The client would sign a valid factory tree against phantom funds and only discover the discrepancy on force-close.

**Location**: `src/client.c:1157` — `funding_amount = (uint64_t)fa_item->valuedouble` accepted from wire with zero chain verification.

## Fix

### Commit 1: Callback infrastructure
- New `client_verify_funding_fn` callback type in `client.h`
- Added as optional parameter to `client_run_with_channels()` (NULL = skip, backward compatible)
- Verification fires between FACTORY_PROPOSE parsing and tree building
- If callback returns 0: refuses to sign, sends error to LSP, disconnects
- If callback is NULL: logs explicit WARNING about trust assumption

### Commit 2: RPC verification implementation
- `verify_funding_rpc()` in `superscalar_client.c` calls `getrawtransaction(txid, true)`, parses `vout[N].value`, compares to claimed amount
- Wired at both daemon-mode and standalone-mode call sites
- Only activates when `--rpcuser`/`--rpcpassword` are provided
- Without RPC credentials: callback is NULL, warning logged

## What this does NOT cover (separate items)

- Distribution TX output verification (Item 2)
- Rotation balance carry verification (Item 3)
- Participant index verification (Item 4)
- Per-client balance negotiation (Item 5)
- Default lsp-balance-pct change (Item 6)

## Test plan

- [x] 1363/1363 unit tests pass
- [x] All 9 callers of `client_run_with_channels` updated
- [ ] Integration: run S1 on signet with `--rpcuser` to verify the callback fires and logs "funding TX verified on-chain"