### PR TITLE
fix: cooperative close — LSP output uses its own P2TR, not N-of-N funding SPK

### DIFF
--- a/include/superscalar/lsp_channels.h
+++ b/include/superscalar/lsp_channels.h
@@ -200,6 +200,14 @@ typedef struct {
         int valid;
     } pending_reconnects[8];
     size_t n_pending_reconnects;
+
+    /* P2TR scriptPubKey for the LSP's cooperative-close output.
+       Symmetric with per-entry close_spk (each client's own P2TR). Derived
+       from factory->pubkeys[0] at init so that the LSP alone can spend its
+       recovered share (L-stock + sum(local_amounts) + accumulated_fees)
+       with its own seckey, instead of the N-of-N factory funding SPK. */
+    unsigned char lsp_close_spk[34];
+    size_t lsp_close_spk_len;       /* 34 when populated, 0 if unset */
 } lsp_channel_mgr_t;
 
 /* Initialize channels from factory leaf outputs.

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -160,6 +160,20 @@ int lsp_channels_init(lsp_channel_mgr_t *mgr,
     mgr->leaf_arity = factory->leaf_arity;
     htlc_inbound_init(&mgr->htlc_inbound);
 
+    /* Derive LSP cooperative-close SPK: P2TR of the LSP's own factory pubkey.
+       Symmetric with per-client close_spk below. This lets the LSP alone
+       spend its recovered share (L-stock + sum(local_amounts) + accumulated
+       fees) with just its own seckey, instead of locking those sats in the
+       N-of-N factory funding SPK. */
+    if (factory->n_participants > 0) {
+        secp256k1_xonly_pubkey lsp_xonly_for_close;
+        if (secp256k1_xonly_pubkey_from_pubkey(ctx, &lsp_xonly_for_close, NULL,
+                                                &factory->pubkeys[0])) {
+            build_p2tr_script_pubkey(mgr->lsp_close_spk, &lsp_xonly_for_close);
+            mgr->lsp_close_spk_len = 34;
+        }
+    }
+
     for (size_t c = 0; c < n_clients; c++) {
         lsp_channel_entry_t *entry = &mgr->entries[c];
         entry->channel_id = (uint32_t)c;
@@ -304,6 +318,16 @@ int lsp_channels_init_from_db(lsp_channel_mgr_t *mgr,
     mgr->next_request_id = 1;
     mgr->leaf_arity = factory->leaf_arity;
     htlc_inbound_init(&mgr->htlc_inbound);
+
+    /* Derive LSP cooperative-close SPK (see init() for rationale). */
+    if (factory->n_participants > 0) {
+        secp256k1_xonly_pubkey lsp_xonly_for_close;
+        if (secp256k1_xonly_pubkey_from_pubkey(ctx, &lsp_xonly_for_close, NULL,
+                                                &factory->pubkeys[0])) {
+            build_p2tr_script_pubkey(mgr->lsp_close_spk, &lsp_xonly_for_close);
+            mgr->lsp_close_spk_len = 34;
+        }
+    }
 
     /* Restore accumulated fees from DB (crash recovery) */
     persist_load_fee_settlement(pdb, 0,
@@ -2981,9 +3005,30 @@ size_t lsp_channels_build_close_outputs(const lsp_channel_mgr_t *mgr,
                                          size_t close_spk_len) {
     if (!mgr || !factory || !outputs) return 0;
 
-    /* Use override SPK if provided, otherwise fall back to factory funding SPK */
+    /* Clients: rotation override SPK wins; otherwise per-client close_spk;
+       otherwise fall back to factory funding SPK (legacy path). */
     const unsigned char *spk = close_spk ? close_spk : factory->funding_spk;
     size_t spk_len = close_spk ? close_spk_len : factory->funding_spk_len;
+
+    /* LSP (output 0): rotation override wins (recycles funds into the new
+       factory's SPK); otherwise use mgr->lsp_close_spk (P2TR of the LSP's own
+       factory pubkey — LSP-alone spendable); otherwise fall back to factory
+       funding SPK (legacy path kept for tests that don't populate
+       lsp_close_spk). This keeps the LSP's recovered share unilaterally
+       spendable by the LSP with its own seckey, instead of locking it back
+       in the N-of-N funding MuSig. */
+    const unsigned char *lsp_spk;
+    size_t lsp_spk_len;
+    if (close_spk) {
+        lsp_spk = close_spk;
+        lsp_spk_len = close_spk_len;
+    } else if (mgr->lsp_close_spk_len > 0) {
+        lsp_spk = mgr->lsp_close_spk;
+        lsp_spk_len = mgr->lsp_close_spk_len;
+    } else {
+        lsp_spk = factory->funding_spk;
+        lsp_spk_len = factory->funding_spk_len;
+    }
 
     /* Output 0: LSP gets factory_funding - sum(client_remotes) - close_fee.
        In a cooperative close that bypasses the tree, the LSP recovers the
@@ -2996,8 +3041,8 @@ size_t lsp_channels_build_close_outputs(const lsp_channel_mgr_t *mgr,
     uint64_t lsp_total = factory->funding_amount_sats - client_total - close_fee;
 
     outputs[0].amount_sats = lsp_total;
-    memcpy(outputs[0].script_pubkey, spk, spk_len);
-    outputs[0].script_pubkey_len = spk_len;
+    memcpy(outputs[0].script_pubkey, lsp_spk, lsp_spk_len);
+    outputs[0].script_pubkey_len = lsp_spk_len;
 
     /* Outputs 1..N: each client gets their remote_amount.
        When close_spk override is active, all outputs use it (rotation/recycling).

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -3622,7 +3622,111 @@ int test_close_outputs_wallet_spk(void) {
     TEST_ASSERT(memcmp(outputs[2].script_pubkey, wallet_spk, 34) == 0,
                 "override+per-client: client 1 uses override (rotation mode)");
 
+    /* Test 5: Production path — mgr->lsp_close_spk populated (P2TR of LSP
+       pubkey) plus per-client close_spks. LSP output must use its own SPK,
+       NOT the N-of-N factory funding SPK. Clients keep their own SPKs. */
+    unsigned char lsp_spk[34];
+    memset(lsp_spk, 0xD0, 34);
+    memcpy(mgr.lsp_close_spk, lsp_spk, 34);
+    mgr.lsp_close_spk_len = 34;
+
+    n = lsp_channels_build_close_outputs(&mgr, f, outputs, close_fee,
+                                           NULL, 0);
+    TEST_ASSERT_EQ(n, 3, "lsp_close_spk: 3 outputs");
+    TEST_ASSERT(memcmp(outputs[0].script_pubkey, lsp_spk, 34) == 0,
+                "lsp_close_spk: LSP uses its own SPK (not factory SPK)");
+    TEST_ASSERT(memcmp(outputs[0].script_pubkey, expected_factory_spk, 34) != 0,
+                "lsp_close_spk: LSP SPK differs from factory funding SPK");
+    TEST_ASSERT(memcmp(outputs[1].script_pubkey, client0_spk, 34) == 0,
+                "lsp_close_spk: client 0 still uses its own close address");
+    TEST_ASSERT(memcmp(outputs[2].script_pubkey, client1_spk, 34) == 0,
+                "lsp_close_spk: client 1 still uses its own close address");
+
+    /* Test 6: Rotation override still wins over lsp_close_spk (recycling) */
+    n = lsp_channels_build_close_outputs(&mgr, f, outputs, close_fee,
+                                           wallet_spk, 34);
+    TEST_ASSERT_EQ(n, 3, "override beats lsp_close_spk: 3 outputs");
+    TEST_ASSERT(memcmp(outputs[0].script_pubkey, wallet_spk, 34) == 0,
+                "override beats lsp_close_spk: LSP uses override");
+    TEST_ASSERT(memcmp(outputs[1].script_pubkey, wallet_spk, 34) == 0,
+                "override beats lsp_close_spk: client 0 uses override");
+
     free(mgr.entries);
+    free(f);
+    return 1;
+}
+
+/* ---- Test: mgr->lsp_close_spk derived symmetric with client close_spk ---- */
+
+int test_lsp_close_spk_derived(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[5];
+    for (int i = 0; i < 5; i++)
+        if (!secp256k1_keypair_create(ctx, &kps[i], seckeys[i])) return 0;
+
+    secp256k1_pubkey pks[5];
+    for (int i = 0; i < 5; i++)
+        if (!secp256k1_keypair_pub(ctx, &pks[i], &kps[i])) return 0;
+
+    /* Build the N-of-N funding SPK the factory uses. */
+    musig_keyagg_t ka;
+    musig_aggregate_keys(ctx, &ka, pks, 5);
+    unsigned char internal_ser[32];
+    if (!secp256k1_xonly_pubkey_serialize(ctx, internal_ser, &ka.agg_pubkey)) return 0;
+    unsigned char tweak[32];
+    sha256_tagged("TapTweak", internal_ser, 32, tweak);
+    musig_keyagg_t ka_copy = ka;
+    secp256k1_pubkey tweaked_pk;
+    if (!secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tweaked_pk, &ka_copy.cache, tweak)) return 0;
+    secp256k1_xonly_pubkey tweaked_xonly;
+    if (!secp256k1_xonly_pubkey_from_pubkey(ctx, &tweaked_xonly, NULL, &tweaked_pk)) return 0;
+    unsigned char fund_spk[34];
+    build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    if (!f) return 0;
+    factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
+    unsigned char fake_txid[32] = {0};
+    fake_txid[0] = 0xEE;
+    factory_set_funding(f, fake_txid, 0, 1000000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+
+    /* Expected LSP close SPK = P2TR(xonly(pubkeys[0])) — LSP-alone spendable. */
+    secp256k1_xonly_pubkey lsp_xonly_expected;
+    TEST_ASSERT(secp256k1_xonly_pubkey_from_pubkey(ctx, &lsp_xonly_expected, NULL, &pks[0]),
+                "derive LSP xonly");
+    unsigned char expected_lsp_spk[34];
+    build_p2tr_script_pubkey(expected_lsp_spk, &lsp_xonly_expected);
+
+    /* Init mgr — this is what should populate lsp_close_spk. */
+    lsp_channel_mgr_t mgr;
+    memset(&mgr, 0, sizeof(mgr));
+    TEST_ASSERT(lsp_channels_init(&mgr, ctx, f, seckeys[0], 4),
+                "lsp_channels_init");
+
+    TEST_ASSERT_EQ(mgr.lsp_close_spk_len, 34, "lsp_close_spk populated");
+    TEST_ASSERT(memcmp(mgr.lsp_close_spk, expected_lsp_spk, 34) == 0,
+                "mgr.lsp_close_spk == P2TR(xonly(factory.pubkeys[0]))");
+    TEST_ASSERT(memcmp(mgr.lsp_close_spk, fund_spk, 34) != 0,
+                "mgr.lsp_close_spk differs from factory funding SPK (N-of-N MuSig)");
+
+    /* build_close_outputs with NULL override must put outputs[0] at lsp_close_spk. */
+    tx_output_t outputs[6];
+    memset(outputs, 0, sizeof(outputs));
+    /* Give clients a little remote_amount so outputs[1..] are non-dust. */
+    for (size_t c = 0; c < 4; c++)
+        mgr.entries[c].channel.remote_amount = 2000;
+    /* Make funding_amount big enough to cover sum(remotes) + close_fee + LSP residual. */
+    f->funding_amount_sats = 100000;
+
+    size_t n = lsp_channels_build_close_outputs(&mgr, f, outputs, 500, NULL, 0);
+    TEST_ASSERT_EQ(n, 5, "build_close_outputs: 1 LSP + 4 clients");
+    TEST_ASSERT(memcmp(outputs[0].script_pubkey, mgr.lsp_close_spk, 34) == 0,
+                "cooperative close: LSP output uses mgr.lsp_close_spk");
+    TEST_ASSERT(memcmp(outputs[0].script_pubkey, fund_spk, 34) != 0,
+                "cooperative close: LSP output is NOT factory funding SPK");
+
+    lsp_channels_cleanup(&mgr);
     free(f);
     return 1;
 }

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -3727,7 +3727,9 @@ int test_lsp_close_spk_derived(void) {
                 "cooperative close: LSP output is NOT factory funding SPK");
 
     lsp_channels_cleanup(&mgr);
+    factory_free(f);
     free(f);
+    secp256k1_context_destroy(ctx);
     return 1;
 }
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1510,6 +1510,7 @@ extern int test_profit_settlement_calculation(void);
 extern int test_settlement_trigger_at_interval(void);
 extern int test_on_close_includes_unsettled(void);
 extern int test_close_outputs_wallet_spk(void);
+extern int test_lsp_close_spk_derived(void);
 extern int test_fee_accumulation_and_settlement(void);
 extern int test_fee_levels_and_profit_split(void);
 extern int test_client_rejects_bad_profit_terms(void);
@@ -3238,6 +3239,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_settlement_trigger_at_interval);
     RUN_TEST(test_on_close_includes_unsettled);
     RUN_TEST(test_close_outputs_wallet_spk);
+    RUN_TEST(test_lsp_close_spk_derived);
     RUN_TEST(test_fee_accumulation_and_settlement);
     RUN_TEST(test_fee_levels_and_profit_split);
     RUN_TEST(test_client_rejects_bad_profit_terms);


### PR DESCRIPTION
## Problem

`lsp_channels_build_close_outputs` was routing the LSP's recovered share (L-stock + `sum(channel.local_amount)` + accumulated routing fees) to `factory->funding_spk` — the N-of-N MuSig aggregate with no script path. Consequence: the cooperative close TX is itself signed by all N and confirms fine, but the LSP's *output* from that TX requires another N-of-N ceremony to spend. Once clients receive their own payouts they have no reason to re-sign, so the LSP's capital is effectively stranded.

### Live-net evidence

Three real signet runs confirmed and stranded ~434,560 sats at N-of-N outputs:
- Arity-1: `dd8df3e5ddfc14e9…:0` — 150,508 sats at `5120 9e9bcdb802951f9ac9f6f8546adfd55eb5509d16b8779fa4062afa02996cbf55` (== factory funding SPK)
- Arity-2: `202066ddc6e519bc…:0` — 133,544 sats at `5120 7f734347bda718b106c0aba8efbd242f8bb4351697935b9543e03f3a138d94bf` (== factory funding SPK)
- Arity-3 PS: `dd80e5e16d6d7b90…:0` — 150,508 sats at `5120 172a214ad7216930e296637babc107288d1ec5224712b2444e3823e7f27e1983` (== factory funding SPK)

`getaddressinfo` on each: `"ismine": false, "solvable": false`. `listreceivedbyaddress` for the wallet addresses the LSP log *claimed* to be sending to (`tb1p3g4ck…`, `tb1pmtx450…`, `tb1ptwm3tu…`): 0 sats received. The LSP generated those wallet addresses via `regtest_get_new_address` into `final_wallet_spk`, then passed `NULL, 0` for `close_spk` to the build function, which fell back to `factory->funding_spk`.

## Fix

Symmetric with how each client's output is already handled:

- Add `mgr->lsp_close_spk[34]` / `lsp_close_spk_len`, derived at `lsp_channels_init` (both variants) as `P2TR(xonly(factory->pubkeys[0]))` — the LSP's own factory pubkey. This mirrors `entry->close_spk = P2TR(xonly(client_pubkey))` at the same site.
- `lsp_channels_build_close_outputs` LSP-slot precedence is now: rotation override `close_spk` → `mgr->lsp_close_spk` → `factory->funding_spk` (legacy fallback retained so tests without `init` keep compiling).
- Client outputs: unchanged.
- Rotation: unchanged — the override still wins and recycled funds land in the new factory's SPK.

## Tracking model

| Party | Share | Output | Spendable with |
|-------|-------|--------|----------------|
| Client `i` | `channel[i].remote_amount` | `P2TR(xonly(pubkeys[i+1]))` | client's own seckey + BIP341 taptweak |
| LSP | `funding − Σ remote − fee` (i.e. L-stock + Σ local + routing fees) | `P2TR(xonly(pubkeys[0]))` — **new** | LSP's own seckey + BIP341 taptweak |

Each participant can scan the confirmed close TX for an output whose SPK matches their own derived P2TR and sweep it unilaterally.

## Tests

- `test_close_outputs_wallet_spk` extended: Tests 1–4 (legacy fallback paths) unchanged; **new Tests 5 & 6** assert LSP uses `mgr->lsp_close_spk` when populated, and that the rotation override still wins over it.
- **New** `test_lsp_close_spk_derived`: builds a 5-participant factory, calls `lsp_channels_init`, asserts `mgr->lsp_close_spk == P2TR(xonly(factory->pubkeys[0]))` and `!= factory->funding_spk`, then runs `build_close_outputs(NULL, 0)` and asserts `outputs[0].script_pubkey == mgr->lsp_close_spk`.

## Regtest verification

Ran `tools/multi_arity_scenario.py --arity 1 --clients 4 --payments 3 --pay-amount 1000 --demo` on VPS regtest with the new binary. Decoded the close TX from `broadcast_log`:

```
close tx vout[0]  150508 sats  spk=5120a92c9b7cac68758de5783ed8e5123598e4ad137091e42987d3bad8a08e35bf3d
                               addr=bcrt1p4ykfkl9vdp6cmetc8mvw2y34nrj26ymsj8jznp7nhtv2pr34hu7s5xjc2v
```

LSP's factory pubkey in that run: `03a92c9b7cac68758de5783ed8e5123598e4ad137091e42987d3bad8a08e35bf3d`. The 32-byte xonly portion matches exactly — LSP-alone spendable.

## Test plan

- [x] 1377/1377 unit tests pass on VPS
- [x] Regtest scenario arity-1 confirms close tx vout[0] uses LSP pubkey P2TR
- [ ] Follow-up PR: spendability gauntlet — for each closing method, actually sign and broadcast a sweep of each party's output on regtest
- [ ] Follow-up: bitcoind `importdescriptors tr(LSP_pubkey)` at LSP startup so `listunspent` sees LSP close outputs as wallet-owned

## Note on already-stranded signet sats

The ~434,560 sats in the three pre-fix N-of-N outputs remain stuck. Recovering them would require an out-of-band multi-party sweep ceremony; they are signet test sats and can be written off. This PR prevents the bug going forward.