### PR TITLE
docs: CHANGELOG for post-Chart-B verification work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to SuperScalar are documented here.
 
 ## Unreleased
 
-Factory participant cap raised from 64 to 128. Per-channel fee tracking and HTLC-based profit settlement. Client-side verification at every factory lifecycle boundary. Memory-safety CI hardening (LSan leak gate, TSan job, OSS-Fuzz integration) — 1050 pre-existing leaks found and fixed. 1367 unit tests, all passing under ASan+UBSan+LSan and TSan.
+Factory participant cap raised from 64 to 128. Per-channel fee tracking and HTLC-based profit settlement. Client-side verification at every factory lifecycle boundary. Memory-safety CI hardening (LSan leak gate, TSan job, OSS-Fuzz integration) — 1050 pre-existing leaks found and fixed. End-to-end spendability + economic-correctness verification across all three factory arities (Chart A 22/28, Chart B 28/29 regtest + 3/3 bridge econ). On-chain stranded-funds recovery tool. 1377 unit tests, all passing under ASan+UBSan+LSan and TSan.
+
+### Spendability + economic-correctness verification (PRs #68–#72)
+
+- **Cooperative close: LSP output uses its own P2TR, not the N-of-N funding SPK** (PR #68, `lsp_channels.c`, `lsp_channels.h`). Before: `lsp_channels_build_close_outputs` sent the LSP's recovered share (L-stock + local_amount sums + accumulated fees) back to the factory's 5-of-5 MuSig funding SPK, leaving those sats spendable only with N-of-N cooperation. After: `mgr->lsp_close_spk = P2TR(xonly(factory->pubkeys[0]))`, derived in `lsp_channels_init` (and `init_from_db`). Existing rotation-override SPK still wins when present.
+- **Client-side conservation check off-by-154** (PR #70, `client.c`). `client_check_conservation` compared `local + remote + Σhtlc` against `funding_amount` but `lsp_channels_init` already deducts `base_commit_fee = ceil(fee_rate × 154 / 1000)` from the channel's usable balance. On arity-1 multi-payment this printed a false `CONSERVATION VIOLATION delta=-154` every HTLC add/fulfill. Log-noise fix; check never aborted.
+- **Spendability test gauntlet** (merged via PR #71, `tests/spend_helpers.{c,h}`, `tests/test_close_spendability_full.c`): reusable `spend_coop_close_gauntlet` harness (BIP-341 key-path sweep per party with only their own seckey) and 22 Chart A cells covering coop close × 5 parties × 3 arities, force-close to_remote / to_local (CSV script-path), breach penalty via revocation secret, rotation balance-carry, PS chain close (arity 3), and HTLC-in-flight acknowledgment.
+- **Economic-correctness harness (Chart B)** (PR #71, `tests/econ_helpers.{c,h}`, `tests/test_economic_correctness.c`): `econ_snap_pre/post`, `econ_assert_close_amounts`, `econ_assert_wallet_deltas` (asserts on-chain output amounts match the production formula AND wallet deltas match expectations, via `scantxoutset` RPC ground truth). 30+ cells covering baseline × 3 arities, rotation × 3, buy_liquidity (arity-2 only, by design), JIT cooperative close, `ps_advance`, and hybrid CLN bridge invoicing (external_in × 3 arities ✓, external_out × 3 still 🟡 on regtest due to CLN private-channel routing).
+- **Arity-1 + arity-PS close ceremony handles post-fulfill leaf-advance messages** (PR #71, `src/client.c`). `client_do_close_ceremony`'s `CLOSE_PROPOSE` and `CLOSE_ALL_NONCES` recv loops now transparently handle `MSG_LEAF_ADVANCE_PROPOSE/DONE` interleaved with close traffic. Fixed arity-1 and arity-PS multi-payment + close tests that were failing on "expected LEAF_ADVANCE_PSIG from client, got 0x58".
+- **CLI line buffer grows to 2048** (PR #71, `src/lsp_channels.c:4512`). BOLT11 invoices run 300–700 chars; the 256-char CLI input buffer was truncating `pay_external` commands.
+- **LSP-side conservation check off-by-154** (PR #71, `src/lsp_channels.c`). Same shape as PR #70's client-side fix; this one trips the "refusing new HTLCs" alert (not just log noise). Paired with a regression test (`test_conservation_with_real_htlc`) whose hardcoded balances now account for `base_commit_fee`.
+- **Stranded-funds recovery tool** (PR #71, `tools/recover_stranded_coop_output.c`): offline N-party MuSig2 sweep of N-of-N factory coop-close outputs stranded by the pre-PR-#68 behavior. Recovered 433,060 signet sats across 3 outputs during v0.1.12 validation.
+- **cppcheck `invalidPrintfArgType_uint` warnings** (PR #72, `tools/superscalar_lsp_pre_daemon_tests.inc`): 4 pre-existing `%u`/`int` mismatches in PS-advance diagnostics switched to `%d`, unblocking Static Analysis CI for the spendability/econ stack.
+
+### Planned follow-ups (in-flight PRs)
+
+- **Signet bridge-econ port** (PR #73, `tools/test_bridge_econ_signet.sh`): runs the hybrid-CLN flow against the persistent signet environment to flip the three external_out 🟡 cells to ✓ on a real network with announced channels. Manual; blocks are ~10 min so per-run latency is ~60 min.
+- **Factory recovery scan must not auto-broadcast** (PR #74, `src/factory_recovery.c`): `factory_recovery_scan` (startup/reorg) force-published the tree whenever funding confirmed, causing `bad-txns-inputs-missingorspent` on subsequent coop close. Fix gates tree broadcast on an explicit operator force-close.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Factory participant cap raised from 64 to 128. Per-channel fee tracking and HTLC
 ### Planned follow-ups (in-flight PRs)
 
 - **Signet bridge-econ port** (PR #73, `tools/test_bridge_econ_signet.sh`): runs the hybrid-CLN flow against the persistent signet environment to flip the three external_out 🟡 cells to ✓ on a real network with announced channels. Manual; blocks are ~10 min so per-run latency is ~60 min.
-- **Factory recovery scan must not auto-broadcast** (PR #74, `src/factory_recovery.c`): `factory_recovery_scan` (startup/reorg) force-published the tree whenever funding confirmed, causing `bad-txns-inputs-missingorspent` on subsequent coop close. Fix gates tree broadcast on an explicit operator force-close.
+- **Factory recovery scan must not auto-broadcast** (PR #74, `src/factory_recovery.c`): `factory_recovery_scan` (startup/reorg) force-published the tree whenever funding confirmed, causing `bad-txns-inputs-missingorspent` on subsequent coop close. Fix gates tree broadcast on an explicit operator force-close via a new `allow_root_broadcast` parameter to `do_factory_recovery`. Verified end-to-end: hybrid CLN bridge econ regtest now passes full flow (external_in + external_out + coop close after payments, 5-conf close TX decoded and client output matched to invoice amount).
 
 ### Added
 


### PR DESCRIPTION
## Summary
- Adds Unreleased-section entries for PRs #68 through #72 (merged) and #73/#74 (in flight) covering the cooperative-close SPK fix, conservation-check fixes, spendability gauntlet (22 Chart A cells), economic-correctness harness (30+ Chart B cells), arity-1/PS close-ceremony interleaving fix, CLI buffer fix, and the stranded-funds recovery tool.
- Bumps the unit-test headline to 1377 to match post-merge VPS runs.

## Test plan
- [x] Factual — no code changes
- [x] Preserves existing Unreleased structure and format