### PR TITLE
release: v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to SuperScalar are documented here.
 
 ## Unreleased
 
-Factory participant cap raised from 64 to 128. Per-channel fee tracking and HTLC-based profit settlement. Client-side verification at every factory lifecycle boundary. Memory-safety CI hardening (LSan leak gate, TSan job, OSS-Fuzz integration) — 1050 pre-existing leaks found and fixed. End-to-end spendability + economic-correctness verification across all three factory arities (Chart A 22/28, Chart B 28/29 regtest + 3/3 bridge econ). On-chain stranded-funds recovery tool. 1377 unit tests, all passing under ASan+UBSan+LSan and TSan.
+## 0.1.13 — 2026-04-24
+
+Factory participant cap raised from 64 to 128. Per-channel fee tracking and HTLC-based profit settlement. Client-side verification at every factory lifecycle boundary. Memory-safety CI hardening (LSan leak gate, TSan job, OSS-Fuzz integration) — 1050 pre-existing leaks found and fixed. End-to-end spendability + economic-correctness verification across all three factory arities (**Chart A 28/28**, Chart B 28/29 regtest + 3/3 bridge external_in; 3 external_out cells remain 🟡 pending signet infrastructure — see `tools/test_bridge_econ_signet.sh`). Production-blocking cooperative-close-after-payments bug fixed (`factory_recovery_scan` no longer force-publishes the tree at startup). On-chain stranded-funds recovery tool. 1377 unit tests, all passing under ASan+UBSan+LSan and TSan.
 
 ### Spendability + economic-correctness verification (PRs #68–#72)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # rejects.  This silences the error without patching the vendored dep.
 # Ignored on CMake < 3.31 (variable simply doesn't exist yet).
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-project(superscalar VERSION 0.1.11 LANGUAGES C)
+project(superscalar VERSION 0.1.13 LANGUAGES C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
## Summary
- Bumps `CMakeLists.txt` project version `0.1.11 → 0.1.13` (stale since 0.1.12 skipped the bump)
- Converts `## Unreleased` CHANGELOG section → `## 0.1.13 — 2026-04-24`
- Updates the summary blurb to reflect the final post-merge state (Chart A 28/28, coop-close-after-payments bug fixed, 1377 unit tests)

## What ships in 0.1.13
- Factory cap 64→128 + per-channel fee tracking + HTLC-based profit settlement + client-side lifecycle verification (forward-carried from earlier PR #63 work)
- Spendability gauntlet + economic-correctness harness (#68–#71)
- Cooperative-close-after-payments fix (#74) — production-blocking, verified end-to-end via hybrid CLN bridge regtest
- Chart A 28/28 (#76)
- Signet bridge-econ port (#73)
- On-chain stranded-funds recovery tool
- Memory-safety CI hardening (LSan gate, TSan job, 1050 leaks fixed)

## Known limitation shipping with this release
- Chart B external_out × 3 arities remain 🟡 on regtest due to CLN's private-channel routing behavior. The signet port (`tools/test_bridge_econ_signet.sh`) flips them to ✓ once the operator wires `cln-signet` with the SuperScalar plugin and opens a balanced channel — tracked as a 0.1.14 item.

## Test plan
- [x] `./test_superscalar --unit` 1377/1377 on VPS
- [x] `./test_superscalar --regtest` 62/62 on VPS
- [x] Hybrid CLN bridge econ regtest `=== PASS ===` end-to-end
- [ ] CI green
- [ ] After merge: tag `v0.1.13`, create GitHub release, release workflow builds platform tarballs