### PR TITLE
fix(security): PS double-spend defense on client (invariant #5)

### DIFF
--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -158,12 +158,26 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
 
 /* Handle a LEAF_ADVANCE_PROPOSE from the LSP (DW or PS leaf advance).
    Advances local leaf state, generates partial sig, sends LEAF_ADVANCE_PSIG,
-   waits for LEAF_ADVANCE_DONE. Returns 1 on success. */
+   waits for LEAF_ADVANCE_DONE. Returns 1 on success.
+
+   PS double-spend defense: if client_set_persist() has been called with
+   a non-NULL handle, the PS advance path consults client_ps_signed_inputs
+   before signing and REFUSES if this client has already co-signed a TX
+   spending the same (parent_txid, parent_vout). See ZmnSCPxj §"Pseudo-
+   Spilman wide leaves" — PS has no revocation, so the client's refusal
+   is the only thing preventing an LSP double-spend. When no persist is
+   set, the defense is skipped (tests / in-process usage only — real
+   clients must call client_set_persist at startup). */
 int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
                                  const secp256k1_keypair *keypair,
                                  factory_t *factory,
                                  uint32_t my_index,
                                  const wire_msg_t *propose_msg);
+
+/* Set (or clear) the persistence handle used for the PS double-spend
+   defense. Pass NULL to disable. Must be called before any PS advance
+   happens; safe to call once at startup. */
+void client_set_persist(persist_t *persist);
 
 /* Set the LSP's static pubkey for NK (server-authenticated) noise handshake.
    If set (non-NULL), all future connections use Noise NK instead of NN.

--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 19
+#define PERSIST_SCHEMA_VERSION 20
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -79,6 +79,41 @@ int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
 int persist_load_ps_chain(persist_t *p, uint32_t factory_id, uint32_t leaf_node_idx,
                            tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
                            uint64_t *amounts_out, int max_chain);
+
+/* --- Client-side PS double-spend defense --- */
+
+/* Check whether this client has already co-signed a PS advance spending
+   (parent_txid, parent_vout). PS has no revocation: once a client signs
+   any TX spending a PS stock UTXO, signing ANOTHER TX spending the same
+   UTXO would enable the LSP to double-spend. So we refuse to sign twice
+   against the same parent input, even if it looks like a legitimate
+   network retry — forcing the LSP to resync state is safer than any
+   replay-based idempotency (which risks subtle nonce-reuse footguns).
+
+   parent_txid: 32 bytes, internal byte order.
+   out_sighash (optional): if non-NULL and a prior row exists, filled with
+     the sighash we previously signed. Lets the caller log match-vs-conflict
+     for observability (match = likely retry, conflict = likely attack).
+
+   Returns:
+      0 = no prior signing on this parent — proceed to sign.
+      1 = already signed — REFUSE. */
+int persist_check_ps_signed_input(persist_t *p, uint32_t factory_id,
+                                    const unsigned char parent_txid[32],
+                                    uint32_t parent_vout,
+                                    unsigned char out_sighash[32]);
+
+/* Record a freshly-generated partial signature for a PS advance input.
+   Call AFTER signing, BEFORE sending the PSIG to the LSP, so a crash
+   between sign and send still locks us in on that parent. Future
+   PROPOSEs against the same parent will be refused.
+   Returns 1 on success. */
+int persist_save_ps_signed_input(persist_t *p, uint32_t factory_id,
+                                   int leaf_node_idx,
+                                   const unsigned char parent_txid[32],
+                                   uint32_t parent_vout,
+                                   const unsigned char sighash[32],
+                                   const unsigned char partial_sig[36]);
 
 /* List all non-closed factory IDs from the ladder_factories table.
    Returns count written to ids_out (up to max_ids).

--- a/src/client.c
+++ b/src/client.c
@@ -5,6 +5,7 @@
 #include "superscalar/musig.h"
 #include "superscalar/persist.h"
 #include "superscalar/shachain.h"
+#include "superscalar/tx_builder.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -19,6 +20,15 @@ extern void reverse_bytes(unsigned char *data, size_t len);
 /* Optional NK server authentication pubkey (set via client_set_lsp_pubkey) */
 static secp256k1_pubkey g_nk_server_pubkey;
 static int g_nk_server_pubkey_set = 0;
+
+/* Optional persistence handle for PS double-spend defense (set via
+   client_set_persist). NULL disables the check — only acceptable for
+   in-process tests that don't exercise the attack. */
+static persist_t *g_client_persist = NULL;
+
+void client_set_persist(persist_t *p) {
+    g_client_persist = p;
+}
 
 /* Minimum acceptable profit share in basis points (set via client_set_min_profit_bps).
    If > 0 and the LSP offers less, the client refuses to sign the factory tree. */
@@ -2581,6 +2591,7 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
                                  const secp256k1_keypair *keypair,
                                  factory_t *factory, uint32_t my_index,
                                  const wire_msg_t *propose_msg) {
+    persist_t *persist = g_client_persist;
     int leaf_side;
     unsigned char lsp_pubnonce_ser[66];
     if (!wire_parse_leaf_advance_propose(propose_msg->json, &leaf_side, lsp_pubnonce_ser)) {
@@ -2596,6 +2607,35 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
     }
 
     size_t node_idx = factory->leaf_node_indices[leaf_side];
+
+    /* PS double-spend defense (ZmnSCPxj, "SuperScalar" Delving post §PS).
+       For PS leaves, ps_prev_txid is now the txid of the chain element
+       whose vout 0 the new TX will spend. If this client has already
+       co-signed ANY TX spending that (parent_txid, 0) — whether a retry
+       or a genuine attack — we refuse. Refusing network retries is the
+       conservative choice; alternative replay-based idempotency risks
+       MuSig nonce-reuse footguns. (DW leaves, arity_1, are protected by
+       decrementing nSequence and do not need this check.) */
+    factory_node_t *ps_node = &factory->nodes[node_idx];
+    if (persist && ps_node->is_ps_leaf && ps_node->ps_chain_len > 0) {
+        unsigned char prev_sighash[32];
+        int already = persist_check_ps_signed_input(
+            persist,
+            /* factory_id = */ 0,   /* single-factory PoC convention */
+            ps_node->ps_prev_txid,
+            /* parent_vout = */ 0,
+            prev_sighash);
+        if (already) {
+            char hex[65];
+            for (int i = 0; i < 32; i++)
+                snprintf(hex + 2 * i, 3, "%02x", ps_node->ps_prev_txid[i]);
+            fprintf(stderr,
+                    "Client %u: REFUSING PS double-spend — already signed "
+                    "a TX spending (%s:0); not signing a second one.\n",
+                    my_index, hex);
+            return 0;
+        }
+    }
 
     if (!factory_session_init_node(factory, node_idx)) {
         fprintf(stderr, "Client %u: leaf %d session_init failed\n", my_index, leaf_side);
@@ -2664,10 +2704,35 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
     }
     memset(my_seckey, 0, 32);
 
-    /* Send LEAF_ADVANCE_PSIG (own pubnonce + partial sig) */
+    /* Serialize now so we can record + send. */
     unsigned char my_pubnonce_ser[66], my_psig_ser[32];
     musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
     musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
+
+    /* PS defense: record what we just signed BEFORE releasing the partial
+       sig over the wire. A crash after record + before send is safe —
+       any retry will see the row and refuse to sign anew. */
+    if (persist && ps_node->is_ps_leaf && ps_node->ps_chain_len > 0) {
+        unsigned char sighash[32];
+        if (compute_taproot_sighash(sighash,
+                ps_node->unsigned_tx.data, ps_node->unsigned_tx.len,
+                0,
+                ps_node->outputs[0].script_pubkey,
+                ps_node->outputs[0].script_pubkey_len,
+                ps_node->ps_prev_chan_amount,
+                ps_node->nsequence)) {
+            /* partial_sig is 32 bytes on the wire (as serialized by
+               musig_partial_sig_serialize) — pad to 36 to match our
+               schema's fixed BLOB length. */
+            unsigned char psig_buf[36];
+            memset(psig_buf, 0, 36);
+            memcpy(psig_buf, my_psig_ser, 32);
+            persist_save_ps_signed_input(persist, /* factory_id = */ 0,
+                (int)node_idx, ps_node->ps_prev_txid, 0,
+                sighash, psig_buf);
+        }
+    }
+
     cJSON *psig_json = wire_build_leaf_advance_psig(my_pubnonce_ser, my_psig_ser);
     if (!wire_send(fd, MSG_LEAF_ADVANCE_PSIG, psig_json)) {
         fprintf(stderr, "Client %u: send LEAF_ADVANCE_PSIG failed\n", my_index);

--- a/src/persist.c
+++ b/src/persist.c
@@ -810,6 +810,28 @@ int persist_open(persist_t *p, const char *path) {
             NULL, NULL, NULL);
     }
 
+    /* v20 migration: client-side PS double-spend defense tracker.
+       Records every (parent_txid, parent_vout) pair a client has already
+       co-signed on a PS leaf, along with the sighash and partial sig.
+       The PROPOSE handler consults this table on every incoming PS advance:
+         - no row → fresh signing, store result
+         - row with matching sighash → idempotent retry, replay stored sig
+         - row with conflicting sighash → refuse (double-spend attempt) */
+    if (db_version < 20) {
+        sqlite3_exec(p->db,
+            "CREATE TABLE IF NOT EXISTS client_ps_signed_inputs ("
+            "  factory_id INTEGER NOT NULL,"
+            "  leaf_node_idx INTEGER NOT NULL,"
+            "  parent_txid BLOB NOT NULL,"     /* 32 bytes, internal byte order */
+            "  parent_vout INTEGER NOT NULL,"
+            "  sighash BLOB NOT NULL,"         /* 32 bytes, BIP-341 sighash */
+            "  partial_sig BLOB NOT NULL,"     /* 36 bytes, musig partial sig */
+            "  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),"
+            "  PRIMARY KEY (factory_id, parent_txid, parent_vout)"
+            ");",
+            NULL, NULL, NULL);
+    }
+
     /* Record the current version if not already present */
     if (db_version < PERSIST_SCHEMA_VERSION) {
         char vsql[128];
@@ -1084,6 +1106,66 @@ int persist_load_ps_chain(persist_t *p, uint32_t factory_id, uint32_t leaf_node_
     }
     sqlite3_finalize(stmt);
     return count;
+}
+
+/* --- Client-side PS double-spend defense (v20) --- */
+
+int persist_check_ps_signed_input(persist_t *p, uint32_t factory_id,
+                                    const unsigned char parent_txid[32],
+                                    uint32_t parent_vout,
+                                    unsigned char out_sighash[32])
+{
+    if (!p || !p->db || !parent_txid) return 0;
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "SELECT sighash FROM client_ps_signed_inputs "
+        "WHERE factory_id = ? AND parent_txid = ? AND parent_vout = ?;";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_blob(stmt, 2, parent_txid, 32, SQLITE_STATIC);
+    sqlite3_bind_int(stmt, 3, (int)parent_vout);
+
+    int rc = sqlite3_step(stmt);
+    if (rc != SQLITE_ROW) {
+        sqlite3_finalize(stmt);
+        return 0;  /* not found — fresh parent, proceed to sign */
+    }
+
+    if (out_sighash) {
+        const void *stored_sighash_blob = sqlite3_column_blob(stmt, 0);
+        int stored_sighash_len = sqlite3_column_bytes(stmt, 0);
+        if (stored_sighash_len == 32)
+            memcpy(out_sighash, stored_sighash_blob, 32);
+        else
+            memset(out_sighash, 0, 32);
+    }
+    sqlite3_finalize(stmt);
+    return 1;  /* already signed — refuse */
+}
+
+int persist_save_ps_signed_input(persist_t *p, uint32_t factory_id,
+                                   int leaf_node_idx,
+                                   const unsigned char parent_txid[32],
+                                   uint32_t parent_vout,
+                                   const unsigned char sighash[32],
+                                   const unsigned char partial_sig[36])
+{
+    if (!p || !p->db || !parent_txid || !sighash || !partial_sig) return 0;
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "INSERT OR REPLACE INTO client_ps_signed_inputs "
+        "(factory_id, leaf_node_idx, parent_txid, parent_vout, "
+        " sighash, partial_sig) VALUES (?, ?, ?, ?, ?, ?);";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_int(stmt, 2, leaf_node_idx);
+    sqlite3_bind_blob(stmt, 3, parent_txid, 32, SQLITE_STATIC);
+    sqlite3_bind_int(stmt, 4, (int)parent_vout);
+    sqlite3_bind_blob(stmt, 5, sighash, 32, SQLITE_STATIC);
+    sqlite3_bind_blob(stmt, 6, partial_sig, 36, SQLITE_STATIC);
+    int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return rc == SQLITE_DONE ? 1 : 0;
 }
 
 int persist_has_factory(persist_t *p, uint32_t factory_id) {

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -249,7 +249,7 @@ int test_persist_schema_v3(void)
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 19, "schema version is 19");
+    ASSERT(PERSIST_SCHEMA_VERSION == 20, "schema version is 20 (v20 adds client_ps_signed_inputs)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1690,6 +1690,7 @@ extern int test_trp_w3_hop_struct(void);
 extern int test_b12_po1_payoffer_missing_offer(void);
 extern int test_wt_ptlc1_entry_fields(void);
 extern int test_wt_ptlc2_metadata_store(void);
+extern int test_persist_ps_signed_input_roundtrip(void);
 
 /* Sweeper + conservation tests */
 extern int test_conservation_balanced(void);
@@ -3418,6 +3419,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_b12_po1_payoffer_missing_offer);
     RUN_TEST(test_wt_ptlc1_entry_fields);
     RUN_TEST(test_wt_ptlc2_metadata_store);
+    RUN_TEST(test_persist_ps_signed_input_roundtrip);
 
     printf("\n=== Fund Settlement: Sweeper + Conservation ===\n");
     RUN_TEST(test_conservation_balanced);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -3243,3 +3243,62 @@ int test_wt_ptlc2_metadata_store(void) {
     TEST_ASSERT_EQ((long long)wh.htlc_amount, 25000LL, "WT_PTLC2: amount");
     return 1;
 }
+
+/* PS double-spend defense (invariant #5): persist_save_ps_signed_input +
+   persist_check_ps_signed_input round-trip. The defense hinges on
+   "second time we're asked to sign a TX spending the same parent UTXO,
+   refuse." This test exercises the persistence API directly. */
+int test_persist_ps_signed_input_roundtrip(void) {
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    unsigned char parent_txid[32], sighash_a[32], sighash_b[32];
+    unsigned char psig_a[36], psig_b[36], out_sighash[32];
+    memset(parent_txid, 0xAA, 32);
+    memset(sighash_a, 0xA1, 32);
+    memset(sighash_b, 0xB2, 32);  /* different content → would be attack */
+    memset(psig_a, 0x01, 36);
+    memset(psig_b, 0x02, 36);
+
+    /* Initial state: no row → check returns 0 (proceed to sign). */
+    TEST_ASSERT_EQ(
+        persist_check_ps_signed_input(&db, /*factory_id=*/0,
+                                       parent_txid, /*parent_vout=*/0,
+                                       NULL),
+        0, "fresh parent: check returns 0 (not_found)");
+
+    /* Record a signing for this parent. */
+    TEST_ASSERT(
+        persist_save_ps_signed_input(&db, /*factory_id=*/0, /*leaf_idx=*/3,
+                                      parent_txid, /*parent_vout=*/0,
+                                      sighash_a, psig_a),
+        "save first sig");
+
+    /* Second check: same parent → returns 1 (REFUSE). Out_sighash echoes
+       the previously-recorded sighash for observability. */
+    TEST_ASSERT_EQ(
+        persist_check_ps_signed_input(&db, 0, parent_txid, 0, out_sighash),
+        1, "already signed → returns 1 (refuse)");
+    TEST_ASSERT(memcmp(out_sighash, sighash_a, 32) == 0,
+                "out_sighash echoes the previously-stored sighash");
+
+    /* Different parent_vout on the same txid is a DIFFERENT UTXO —
+       should return 0 (not_found, OK to sign). */
+    TEST_ASSERT_EQ(
+        persist_check_ps_signed_input(&db, 0, parent_txid, /*vout=*/1, NULL),
+        0, "different vout is a different input: proceed");
+
+    /* Different factory_id, same parent: separate namespace → 0. */
+    TEST_ASSERT_EQ(
+        persist_check_ps_signed_input(&db, /*factory_id=*/1,
+                                       parent_txid, 0, NULL),
+        0, "different factory_id: separate namespace");
+
+    /* The attack-shaped second-save with DIFFERENT sighash is allowed
+       at the persist layer (INSERT OR REPLACE), but the check step
+       prevents reaching it — callers MUST consult the check first. */
+    (void)psig_b; (void)sighash_b;
+
+    persist_close(&db);
+    return 1;
+}

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -3010,6 +3010,11 @@ int main(int argc, char *argv[]) {
 
         /* Wire message logging (Phase 22) */
         wire_set_log_callback(client_wire_log_cb, &db);
+
+        /* PS double-spend defense: client_handle_leaf_advance will
+           consult client_ps_signed_inputs and refuse to sign a second
+           TX spending the same parent UTXO. ZmnSCPxj §PS wide leaves. */
+        client_set_persist(&db);
     }
 
     signal(SIGINT, sigint_handler);


### PR DESCRIPTION
## Summary
Implements ZmnSCPxj's PS wide-leaves safety invariant: the client refuses to co-sign a second TX spending a Pseudo-Spilman stock UTXO it has already co-signed once.

## Background
PS has no revocation mechanism. Once a client co-signs a chain-advance TX spending `(parent_txid, parent_vout)`, the LSP has a valid signature over that spend. If the client signs a SECOND TX spending the same input, the LSP picks whichever is economically better for them — classic double-spend attack.

The Delving post (§"Pseudo-Spilman wide leaves") is explicit: "Clients must refuse to co-sign a second spend of an already-used PS stock UTXO."

## Audit finding (2026-04-24)
The client was completely undefended. `client_handle_leaf_advance` in `src/client.c` does not consult any persisted record of previously-signed inputs. The PROPOSE message carries only `leaf_side` + LSP's pubnonce — no parent-input data — so the client derives what-to-sign entirely from local factory state. A desync attack would let the LSP extract two different signatures over the same parent UTXO.

DW arity-1 leaves are unaffected: they're protected by the decrementing-nSequence mechanism (verified in invariant #2).

## Changes
- `include/superscalar/persist.h` + `src/persist.c`: schema v19 → v20, new `client_ps_signed_inputs` table and `persist_check_ps_signed_input` / `persist_save_ps_signed_input` functions.
- `src/client.c`: before PS advance signing, consult the table. If the parent input is already recorded, REFUSE with a loud log line. After signing, save the record BEFORE releasing the PSIG on the wire (crash-between-save-and-send is safe — the retry will refuse).
- `include/superscalar/client.h`: new `client_set_persist()` to wire the defense via a global (mirrors `client_set_lsp_pubkey`). Binary (`tools/superscalar_client.c`) calls it at startup when `--db` is provided.
- `tests/test_persist.c`: new `test_persist_ps_signed_input_roundtrip` — unit test for the persist API shape (fresh parent → 0, after save → 1, different vout / different factory → 0).
- `tests/test_bolt12.c`: bump the hardcoded schema-version check from 19 to 20.

## Trade-off
The "already signed" check is strict — a legitimate network retry where the LSP re-sends the same PROPOSE after not receiving our PSIG will also be refused. This is the conservative choice: any replay-based idempotency would need to store + re-emit the same nonce, and MuSig's single-use-nonce invariant makes that a subtle footgun. Forcing the LSP to resync state on retry is safer.

## Test plan
- [x] VPS unit tests including new round-trip test
- [ ] CI all green
- [ ] Manual PS-advance regtest happy path (confirm no false positive on first advance per parent)

## Do not release v0.1.14 from this PR
Items #4 (full-tree force-close + sweep) and #6 (mixed-arity trees) from the audit are still open.