### PR TITLE
fix(#6): allow mixed-arity CLI values + design doc

### DIFF
--- a/docs/factory-arity.md
+++ b/docs/factory-arity.md
@@ -1,0 +1,122 @@
+# Factory arity: picking the right tree shape
+
+SuperScalar factories are Decker–Wattenhofer trees. Each internal level's
+branching factor ("arity") is configurable independently of the others
+via the `--arity` CLI flag. Picking the wrong shape at large client
+counts stacks too much BIP-68 CSV delay along the exit path and pushes
+HTLC `final_cltv_expiry` past BOLT's 2016-block ceiling — clients
+routed through the factory then refuse to accept forwards because the
+worst-case exit time exceeds what they consider safe. This doc explains
+the tradeoff and recommends shapes.
+
+## The three arity types
+
+| Value | Meaning | Primary use |
+|-------|---------|-------------|
+| `1`   | Single-client leaves, 2-of-2 DW with per-leaf independent counter | Low-uptime clients; smallest exit blast radius per client |
+| `2`   | Two-client leaves, 3-of-3 DW with shared state | "Best arity for leaf nodes" per ZmnSCPxj — smallest online cohort (2 clients + LSP) for leaf updates |
+| `3` / `FACTORY_ARITY_PS` | Pseudo-Spilman chained leaves, 2-of-2 with TX chaining instead of DW nSequence | LSP-unidirectional liquidity sales; zero CLTV delta contribution |
+| `4`+  | Wide branching for mid-tree / near-root levels | Caps tree depth as client count scales |
+
+Arities `1`, `2`, and `3` describe distinct leaf/state mechanisms. Values
+`>= 4` are pure branching factors applied at interior tree levels —
+they don't change the leaf state machine, just how many children fan
+out at that level.
+
+## The ZmnSCPxj recommended shape
+
+From the Delving Bitcoin thread ([t/1242](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories-with-pseudo-spilman-leaves/1242)):
+
+> "The best arity for leaf nodes is 2 … The tree can have low arity near
+> the leaves, then increase the arity when building nodes a few levels
+> away from the leaves. Beyond a few layers away from the leaves, we
+> could entirely remove state transactions (i.e. those with decrementing
+> nSequences) … a root timeout-sig-tree that backs multiple
+> timeout-tree-structured Decker-Wattenhofer mechanisms."
+
+And:
+
+> "Kickoff nodes may also have an arity of 1 … this reduces the number of
+> affected clients if one client wants to unilaterally exit."
+
+Reason to prefer higher arity mid-tree and at the root: every additional
+DW state layer contributes `step_blocks * (states_per_layer - 1)` blocks
+of BIP-68 CSV to the exit path. Deep trees of uniform low arity stack
+this delay linearly in tree depth. Mid-tree wide branching collapses
+multiple levels into one, capping total depth.
+
+## The math at our target scale
+
+With `FACTORY_MAX_SIGNERS = 128` (1 LSP + up to 127 clients) and mainnet
+defaults (`step_blocks = 144`, `states_per_layer = 4`, giving
+`144 * (4-1) = 432` blocks of CSV per layer):
+
+| Shape | Tree depth | Worst-path CSV | vs BOLT 2016-block ceiling |
+|-------|-----------|----------------|-----------------------------|
+| Uniform arity-2, 127 clients | 7 layers | ~3024 blocks (~21 days) | **EXCEEDS** |
+| Mixed 2 / 4 / 8 (leaf / mid / root), 127 clients | 4 layers | ~1728 blocks (~12 days) | Under, but tight |
+| Uniform arity-2, 16 clients | 4 layers | ~1728 blocks | Under |
+| Uniform arity-2, 8 clients | 3 layers | ~1296 blocks | Under |
+
+**Uniform arity-2 is safe up to ~16 clients on mainnet.** Beyond that,
+mixed arity is required for the `final_cltv_expiry` budget to hold.
+On regtest with `step_blocks = 10`, uniform arity-2 is fine at any
+supported client count — but that's a test artifact, not a property of
+the design.
+
+## Setting the arity
+
+Single arity (applies uniformly):
+
+```
+superscalar_lsp --arity 2 --clients 8 ...
+```
+
+Mixed per-level (comma-separated, deepest → shallowest, the last entry
+applies to all deeper levels):
+
+```
+# 127 clients, mixed 2/4/8 — ZmnSCPxj's recommended shape:
+superscalar_lsp --arity 2,4,8 --clients 127 ...
+
+# 32 clients, mixed 2/4:
+superscalar_lsp --arity 2,4 --clients 32 ...
+```
+
+Supported values are 1–16 per level. Values `1`, `2`, and `3` (PS) are
+the leaf-mechanism choices; `4`+ are pure branching factors for
+interior levels.
+
+## Recommendation by deployment
+
+| Client count | Recommended `--arity` | Why |
+|-------------|----------------------|-----|
+| ≤ 8 | `2` (uniform) | Depth stays shallow; no need for mixed |
+| 9–16 | `2` (uniform) | Still under BOLT ceiling |
+| 17–32 | `2,4` | One extra level of fan-out at the root |
+| 33–64 | `2,4,8` | ZmnSCPxj's canonical mid-tree shape |
+| 65–127 | `2,4,8` or `2,2,4,8` | Add a leaf-kickoff layer for exit isolation |
+
+Regtest and testnet deployments at any client count may use uniform
+arity-2 — the `step_blocks` scaling makes the CSV budget nonbinding.
+
+## Implementation
+
+- `include/superscalar/factory.h:185-190` — `uint8_t level_arity[FACTORY_MAX_LEVELS=8]`.
+- `src/factory.c:606-622` — `factory_set_level_arity()` populates it and
+  re-initializes the DW counter from the resulting depth.
+- `src/factory.c:554-560` — `arity_at_depth()` lookup; last entry wraps.
+- `src/factory.c:849-895` — `build_subtree()` branches per depth.
+- `tools/superscalar_lsp.c:1261-1290` — `--arity` parsing (comma or single).
+
+## Caveats
+
+- The `factory_set_arity()` legacy API (single-value) remains for
+  backward compatibility. New code should use `--arity` on the CLI
+  (which maps to `factory_set_level_arity` when a comma-list is passed).
+- Arity changes between rotations are allowed, but clients must be
+  online during the rotation window to accept the new shape.
+- The CSV numbers above assume `step_blocks = 144` and
+  `states_per_layer = 4`. Changing either rescales the budget; the
+  mixed-arity guidance stays directionally correct but the specific
+  recommended shapes shift.

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -1260,7 +1260,14 @@ int main(int argc, char *argv[]) {
         }
         else if (strcmp(argv[i], "--arity") == 0 && i + 1 < argc) {
             const char *arity_str = argv[++i];
-            /* Comma-separated: --arity 1,1,2,2  or single: --arity 2 */
+            /* Comma-separated: --arity 2,4,8 for per-level mixed arity, or
+               single: --arity 2 for uniform. Per ZmnSCPxj's SuperScalar
+               design (Delving t/1242 §"Graduated arity"), mixed shapes with
+               low arity at leaves and higher arity toward the root are
+               safer at scale: uniform arity-2 with 127 clients and mainnet
+               step_blocks=144 stacks ~3024 blocks of BIP-68 CSV along the
+               exit path, exceeding BOLT's 2016-block final_cltv_expiry
+               ceiling. See docs/factory-arity.md for recommended shapes. */
             if (strchr(arity_str, ',')) {
                 char buf[128];
                 strncpy(buf, arity_str, sizeof(buf) - 1);
@@ -1268,7 +1275,14 @@ int main(int argc, char *argv[]) {
                 char *tok = strtok(buf, ",");
                 while (tok && n_level_arity < FACTORY_MAX_LEVELS) {
                     int v = atoi(tok);
-                    if (v != 1 && v != 2) { fprintf(stderr, "Error: each arity must be 1 or 2\n"); return 1; }
+                    /* 1 = single-client DW leaf, 2 = two-client DW leaf,
+                       3 = pseudo-Spilman chained leaf, >= 4 = wide fan-out
+                       for interior/root levels. Capped at 16 to keep MuSig
+                       cohorts manageable. */
+                    if (v < 1 || v > 16) {
+                        fprintf(stderr, "Error: each arity must be in [1, 16]\n");
+                        return 1;
+                    }
                     level_arities[n_level_arity++] = (uint8_t)v;
                     tok = strtok(NULL, ",");
                 }


### PR DESCRIPTION
## Summary
Per-level mixed arity was already implemented internally (`factory_set_level_arity` at `src/factory.c:606`, `--arity X,Y,Z` CLI parsing). The only blocker to ZmnSCPxj's recommended mid-tree shapes was a `v != 1 && v != 2` check in the CLI parser. Loosens it to `[1, 16]`.

## Why this matters
At 127 clients with mainnet `step_blocks=144`, uniform arity-2 stacks ~3024 blocks of BIP-68 CSV along the exit path. That exceeds BOLT's 2016-block `final_cltv_expiry` ceiling — HTLCs terminating at factory clients would force channel partners to accept unsafe CLTV deltas. ZmnSCPxj calls this out explicitly in the Delving post: the CSV stack drives the minimum final_cltv_expiry budget.

Mixed `2/4/8` (leaf/mid/root) for 127 clients: 4 layers, ~1728 blocks — under the BOLT ceiling.

## Changes
- `tools/superscalar_lsp.c:1261` — loosen arity range `{1,2}` → `[1,16]`; update comment with Delving-post reference and safety rationale.
- `docs/factory-arity.md` — new doc explaining the tradeoff, the target-scale math, and recommended shapes by client count. Shipped in-repo (not `.claude/`).

## Recommended shapes (from the doc)
| Client count | `--arity` | Why |
|--------------|-----------|-----|
| ≤ 16 | `2` | CSV stack under 2016 blocks |
| 17–32 | `2,4` | One level of mid-tree fan-out |
| 33–127 | `2,4,8` | ZmnSCPxj's canonical shape |

## Test plan
- [ ] Build on VPS
- [ ] Smoke test with `--arity 2,4` on regtest (existing tests exercise mixed arity; see `tests/test_factory.c:4537, 4596, 5215, 5234`)

## Do not release v0.1.14 yet
PRs #78/#79/#80 plus this one cover audit items #1, #2, #3, #5, #4 baseline, and #6. A full v0.1.14 release should wait for: (a) all four PRs merged, (b) CI green on main afterward, (c) a coordinated release note that calls out the CSV-budget/arity guidance explicitly so operators don't default-deploy uniform-2 at 100+ clients.