### PR TITLE
test: gap-closers — PS at N=64 + PS defense integration

### DIFF
--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -4022,3 +4022,138 @@ int test_conservation_with_real_htlc(void) {
     return 1;
 }
 
+/* ---- PS double-spend defense: integration test (Gap 2).
+ *
+ * PR #79 added client-side tracking of previously-signed PS parent inputs
+ * (client_ps_signed_inputs table + persist_check/save API + wiring into
+ * client_handle_leaf_advance). test_persist_ps_signed_input_roundtrip
+ * covers the persist API. THIS test covers the wire-up: given a persist
+ * pre-seeded with a signed_input row for a would-be-parent, does
+ * client_handle_leaf_advance actually call the check and refuse?
+ *
+ * Mechanism:
+ *   1. Build a 3-party PS factory; capture leaf[0]'s pre-advance txid T0.
+ *      After factory_advance_leaf_unsigned, ps_prev_txid becomes T0 — so
+ *      (T0, 0) is the parent UTXO the client is about to co-sign spending.
+ *   2. Seed persist with client_ps_signed_inputs row for (factory_id=0,
+ *      parent_txid=T0, parent_vout=0). This simulates "client has already
+ *      co-signed one TX spending T0:0."
+ *   3. client_set_persist(&db) wires the defense.
+ *   4. Build a wire_msg_t PROPOSE for leaf_side=0 with any valid LSP
+ *      pubnonce, invoke client_handle_leaf_advance on a writable fd that
+ *      nothing reads from.
+ *   5. Assert return value == 0 (refuse). The function bails before any
+ *      PSIG is written to fd, so the fd side is moot.
+ */
+int test_client_ps_double_spend_defense_refuses(void) {
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    /* 3-party PS factory: LSP (idx 0) + 2 clients (idx 1, 2). We play the
+       client at idx 1 below (leaf 0's client). */
+    const size_t N = 3;
+    secp256k1_keypair kps[3];
+    for (size_t i = 0; i < N; i++) {
+        unsigned char sk[32] = {0};
+        sk[31] = (unsigned char)(i + 1);
+        sk[0]  = 0x99;
+        TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], sk), "keypair");
+    }
+
+    /* Funding SPK: 3-of-3 MuSig taptweaked. */
+    unsigned char fund_spk[34];
+    {
+        secp256k1_pubkey pks[3];
+        for (size_t i = 0; i < N; i++)
+            secp256k1_keypair_pub(ctx, &pks[i], &kps[i]);
+        musig_keyagg_t ka;
+        musig_aggregate_keys(ctx, &ka, pks, N);
+        unsigned char ser[32];
+        secp256k1_xonly_pubkey_serialize(ctx, ser, &ka.agg_pubkey);
+        unsigned char tweak[32];
+        sha256_tagged("TapTweak", ser, 32, tweak);
+        secp256k1_pubkey tw_pk;
+        secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tw_pk, &ka.cache, tweak);
+        secp256k1_xonly_pubkey tw_xo;
+        secp256k1_xonly_pubkey_from_pubkey(ctx, &tw_xo, NULL, &tw_pk);
+        build_p2tr_script_pubkey(fund_spk, &tw_xo);
+    }
+    unsigned char fake_fund_txid[32];
+    memset(fake_fund_txid, 0x7A, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+    factory_init(f, ctx, kps, N, 6, 10);
+    factory_set_arity(f, FACTORY_ARITY_PS);
+    factory_set_funding(f, fake_fund_txid, 0, 500000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(f), "build PS tree");
+    TEST_ASSERT(factory_sign_all(f), "sign PS tree");
+
+    /* Capture leaf[0]'s txid BEFORE advance — this becomes ps_prev_txid
+       after factory_advance_leaf_unsigned runs inside the handler. */
+    size_t leaf_idx = f->leaf_node_indices[0];
+    unsigned char expected_parent_txid[32];
+    memcpy(expected_parent_txid, f->nodes[leaf_idx].txid, 32);
+
+    /* Open an in-memory persist and pre-seed a signed_input row for
+       (parent_txid=expected_parent_txid, parent_vout=0). Dummy sighash /
+       partial_sig — the check only uses the (parent_txid, parent_vout)
+       key, not the stored sighash. */
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory persist");
+    unsigned char dummy_sighash[32], dummy_psig[36];
+    memset(dummy_sighash, 0x55, 32);
+    memset(dummy_psig, 0x66, 36);
+    TEST_ASSERT(persist_save_ps_signed_input(&db, /*factory_id=*/0,
+                    /*leaf_idx=*/(int)leaf_idx,
+                    expected_parent_txid, /*parent_vout=*/0,
+                    dummy_sighash, dummy_psig),
+                "pre-seed signed_input row");
+
+    /* Wire the defense into client_handle_leaf_advance. */
+    client_set_persist(&db);
+
+    /* Build a valid LEAF_ADVANCE_PROPOSE from the LSP (index 0) so the
+       handler can parse it and proceed far enough to hit our check. */
+    unsigned char lsp_seckey[32];
+    TEST_ASSERT(secp256k1_keypair_sec(ctx, lsp_seckey, &kps[0]), "lsp seckey");
+    secp256k1_pubkey lsp_pub;
+    secp256k1_keypair_pub(ctx, &lsp_pub, &kps[0]);
+    secp256k1_musig_secnonce lsp_secnonce;
+    secp256k1_musig_pubnonce lsp_pubnonce;
+    TEST_ASSERT(musig_generate_nonce(ctx, &lsp_secnonce, &lsp_pubnonce,
+                                       lsp_seckey, &lsp_pub, NULL),
+                "lsp nonce");
+    memset(lsp_seckey, 0, 32);
+    unsigned char lsp_pubnonce_ser[66];
+    musig_pubnonce_serialize(ctx, lsp_pubnonce_ser, &lsp_pubnonce);
+    cJSON *propose_json = wire_build_leaf_advance_propose(0, lsp_pubnonce_ser);
+    TEST_ASSERT(propose_json != NULL, "build PROPOSE json");
+    wire_msg_t propose = {0};
+    propose.msg_type = 0x58;  /* MSG_LEAF_ADVANCE_PROPOSE — unused after
+                                  wire_parse consumes the json */
+    propose.json = propose_json;
+
+    /* Pipe as the output fd — nothing will be written on the refuse path,
+       but we pass a valid fd in case the function starts to. */
+    int pipefd[2];
+    TEST_ASSERT(pipe(pipefd) == 0, "pipe");
+
+    /* Invoke the handler. The check should trigger early and return 0. */
+    int rc = client_handle_leaf_advance(pipefd[1], ctx, &kps[1], f,
+                                          /*my_index=*/1, &propose);
+
+    TEST_ASSERT(rc == 0, "handler REFUSES when parent already signed");
+
+    /* Cleanup — reset the global persist hook. */
+    client_set_persist(NULL);
+    cJSON_Delete(propose_json);
+    close(pipefd[0]);
+    close(pipefd[1]);
+    persist_close(&db);
+    factory_free(f);
+    free(f);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -4989,6 +4989,112 @@ int test_factory_ps_leaf_build(void) {
     return 1;
 }
 
+/* Build, sign, verify, and advance a PS factory at N=64 (1 LSP + 63 clients).
+ * This is the scale test — the existing PS tests use N=3 (2 clients), which
+ * doesn't exercise the interior-tree layers or the 64-way MuSig ceremony.
+ * Proves the PS construction is structurally correct at half of our
+ * FACTORY_MAX_SIGNERS=128 cap and that advances still work.
+ *
+ * What this does:
+ *   - build_tree + sign_all with 64 keypairs (64-way MuSig at every node)
+ *   - verify_all confirms every signature validates
+ *   - advance one leaf and verify chain_len incremented + ps_prev_txid set
+ *
+ * What this does NOT do:
+ *   - broadcast on chain (unit test, no regtest)
+ *   - advance all 63 leaves (one is sufficient to prove the ceremony scales)
+ *   - measure performance (accept whatever runtime; correctness is the bar)
+ */
+int test_factory_ps_leaf_build_n64(void) {
+    secp256k1_context *ctx = test_ctx();
+    const size_t N = 64;
+    secp256k1_keypair kps[64];
+    for (size_t i = 0; i < N; i++) {
+        unsigned char sk[32] = {0};
+        sk[31] = (unsigned char)(i + 1);
+        sk[0]  = 0xDD;
+        TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], sk), "keypair");
+    }
+
+    /* Funding SPK: 64-of-64 MuSig aggregate, BIP-341 taptweaked. */
+    unsigned char fund_spk[34];
+    {
+        secp256k1_pubkey pks[64];
+        for (size_t i = 0; i < N; i++)
+            secp256k1_keypair_pub(ctx, &pks[i], &kps[i]);
+        musig_keyagg_t ka;
+        TEST_ASSERT(musig_aggregate_keys(ctx, &ka, pks, N),
+                    "64-way MuSig aggregate");
+        unsigned char ser[32];
+        secp256k1_xonly_pubkey_serialize(ctx, ser, &ka.agg_pubkey);
+        unsigned char tweak[32];
+        sha256_tagged("TapTweak", ser, 32, tweak);
+        secp256k1_pubkey tweaked_pk;
+        TEST_ASSERT(secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tweaked_pk,
+                                                             &ka.cache, tweak),
+                    "taptweak 64-way key");
+        secp256k1_xonly_pubkey fund_tw;
+        secp256k1_xonly_pubkey_from_pubkey(ctx, &fund_tw, NULL, &tweaked_pk);
+        build_p2tr_script_pubkey(fund_spk, &fund_tw);
+    }
+
+    unsigned char fake_txid[32];
+    memset(fake_txid, 0xEE, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+    /* step=4, states_per_layer=3 — modest values so tree depth with 63
+       clients stays within DW_MAX_LAYERS=8. */
+    factory_init(f, ctx, kps, N, 4, 3);
+    factory_set_arity(f, FACTORY_ARITY_PS);
+    factory_set_funding(f, fake_txid, 0, 10000000, fund_spk, 34); /* 10M sats */
+
+    TEST_ASSERT(factory_build_tree(f), "build PS tree at N=64");
+    printf("  N=64 PS factory built: %zu nodes, %d leaves\n",
+           f->n_nodes, f->n_leaf_nodes);
+
+    /* Each of 63 clients should have their own PS leaf. */
+    TEST_ASSERT_EQ(f->n_leaf_nodes, (int)(N - 1), "63 PS leaves (1 per client)");
+
+    /* Every leaf must be is_ps_leaf with chain_len=0 and nseq=0xFFFFFFFE. */
+    for (int i = 0; i < f->n_leaf_nodes; i++) {
+        size_t ni = f->leaf_node_indices[i];
+        TEST_ASSERT(f->nodes[ni].is_ps_leaf, "leaf is_ps_leaf");
+        TEST_ASSERT_EQ(f->nodes[ni].ps_chain_len, 0, "initial chain_len=0");
+        TEST_ASSERT(f->nodes[ni].nsequence == 0xFFFFFFFEu,
+                    "PS leaf nseq=0xFFFFFFFE");
+        TEST_ASSERT_EQ((int)f->nodes[ni].n_outputs, 2, "PS leaf has 2 outputs");
+    }
+
+    /* Sign + verify every node — this is the 64-way MuSig ceremony. */
+    TEST_ASSERT(factory_sign_all(f), "sign N=64 PS factory (64-way MuSig)");
+    TEST_ASSERT(factory_verify_all(f), "verify every signature");
+    printf("  64-way MuSig ceremony complete; every node signed + verified\n");
+
+    /* Advance one leaf via the production API; verify chain_len++ and
+       ps_prev_txid becomes the pre-advance leaf txid. */
+    int leaf_side = 0;
+    size_t leaf_idx = f->leaf_node_indices[leaf_side];
+    unsigned char pre_txid[32];
+    memcpy(pre_txid, f->nodes[leaf_idx].txid, 32);
+
+    int rc = factory_advance_leaf(f, leaf_side);
+    TEST_ASSERT(rc == 1, "advance leaf 0 succeeds at N=64");
+    TEST_ASSERT_EQ(f->nodes[leaf_idx].ps_chain_len, 1,
+                   "post-advance chain_len=1");
+    TEST_ASSERT(memcmp(f->nodes[leaf_idx].ps_prev_txid, pre_txid, 32) == 0,
+                "ps_prev_txid points at pre-advance leaf txid");
+    TEST_ASSERT_EQ((int)f->nodes[leaf_idx].n_outputs, 1,
+                   "post-advance leaf has 1 output (L-stock gone)");
+    TEST_ASSERT(f->nodes[leaf_idx].is_signed, "post-advance leaf re-signed");
+    printf("  advance OK: leaf 0 chain_len 0→1, L-stock collapsed into channel\n");
+
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* Advance a PS leaf multiple times; verify chain grows and txids change. */
 int test_factory_ps_leaf_advance(void) {
     secp256k1_context *ctx = test_ctx();

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1599,6 +1599,7 @@ extern int test_factory_config_default(void);
 
 /* Pseudo-Spilman Leaves */
 extern int test_factory_ps_leaf_build(void);
+extern int test_factory_ps_leaf_build_n64(void);
 extern int test_factory_ps_leaf_advance(void);
 extern int test_factory_ps_amount_invariant(void);
 extern int test_factory_ps_dust_limit(void);
@@ -3328,6 +3329,7 @@ static void run_unit_tests(void) {
 
     printf("\n=== Pseudo-Spilman Leaves ===\n");
     RUN_TEST(test_factory_ps_leaf_build);
+    RUN_TEST(test_factory_ps_leaf_build_n64);
     RUN_TEST(test_factory_ps_leaf_advance);
     RUN_TEST(test_factory_ps_amount_invariant);
     RUN_TEST(test_factory_ps_dust_limit);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1698,6 +1698,7 @@ extern int test_conservation_balanced(void);
 extern int test_conservation_violated(void);
 extern int test_conservation_with_ptlc(void);
 extern int test_conservation_with_real_htlc(void);
+extern int test_client_ps_double_spend_defense_refuses(void);
 extern int test_sweep_persist_roundtrip(void);
 
 /* Mainnet Audit: Shell Injection Fix */
@@ -3428,6 +3429,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_conservation_violated);
     RUN_TEST(test_conservation_with_ptlc);
     RUN_TEST(test_conservation_with_real_htlc);
+    RUN_TEST(test_client_ps_double_spend_defense_refuses);
     RUN_TEST(test_sweep_persist_roundtrip);
 
     printf("\n=== Mainnet Audit: Shell Injection Fix ===\n");


### PR DESCRIPTION
## Summary
Two gap-closing tests the post-v0.1.13 audit identified:

### Gap 1 — PS factory at N=64 scale (`test_factory_ps_leaf_build_n64`)
Existing PS unit tests use N=3 (2 clients). At N=64 (63 clients, half of FACTORY_MAX_SIGNERS=128):
- 250 tree nodes built
- 63 PS leaves
- 64-way MuSig ceremony runs on every tree node
- Every signature verified
- One leaf advanced; chain_len 0→1, ps_prev_txid points at pre-advance txid, L-stock collapsed

Proves PS is structurally correct at scale. Doesn't go to 128 to keep runtime modest — 64 is enough to catch wide-MuSig / deep-tree bugs.

### Gap 2 — PS double-spend defense integration (`test_client_ps_double_spend_defense_refuses`)
PR #79 added the persist primitive + wired it into `client_handle_leaf_advance`. This test exercises the handler end-to-end:
- Build 3-party PS factory; capture leaf[0]'s pre-advance txid T0
- Seed `client_ps_signed_inputs` with a row for (factory_id=0, parent_txid=T0, parent_vout=0)
- `client_set_persist(&db)`
- Build a PROPOSE message, call `client_handle_leaf_advance`
- Assert return==0 (refuse)

Verified output:
```
Client 1: REFUSING PS double-spend — already signed a TX spending
(2b8406d01d3c277768294b55d7db66cebcbd95f923293ff8a2e5491c9be15324:0);
not signing a second one.
```

Proves the defense is wired — before this, only the persist round-trip was tested.

## Test plan
- [x] VPS unit tests: **1380/1380 passed**
- [ ] CI green

## Do not cut v0.1.14 from this PR
PRs #78, #79, #80, #81 + this one cover all three audit safety invariants + the accounting property + the mixed-arity gap. Release is ready once CI is green on all.