### PR TITLE
test(#137): full force-close + sweep accounting for arity-2 and arity-PS

### DIFF
--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -2164,3 +2164,520 @@ int test_regtest_full_force_close_and_sweep_arity1(void) {
     secp256k1_context_destroy(ctx);
     return 1;
 }
+
+/*
+ * Arity-2 mirror of test_regtest_full_force_close_and_sweep_arity1.
+ *
+ * Topology: N = 5 (LSP + 4 clients) → 2 arity-2 leaves, each holding 2
+ * clients. Each leaf has 3 outputs:
+ *   outputs[0] = MuSig(client_a, LSP) channel       (2-of-2)
+ *   outputs[1] = MuSig(client_b, LSP) channel       (2-of-2)
+ *   outputs[2] = L-stock                            (LSP only)
+ *
+ * Per-leaf pairing is recovered from node->signer_indices, where index [0]
+ * is LSP and [1], [2] are the two clients on that leaf.
+ *
+ * Conservation: Σ(swept) + Σ(sweep_fees) == Σ(allocated across outputs[0..2]
+ * of every leaf). Per-party wallet deltas match expected.
+ */
+int test_regtest_full_force_close_and_sweep_arity2(void) {
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    regtest_t rt;
+    if (!regtest_init(&rt)) {
+        printf("  SKIP: bitcoind not available\n");
+        secp256k1_context_destroy(ctx);
+        return 1;
+    }
+    regtest_create_wallet(&rt, "full_fc_sweep_a2");
+    rt.scan_depth = 200;
+
+    char mine_addr[128];
+    if (!regtest_get_new_address(&rt, mine_addr, sizeof(mine_addr))) return 0;
+    if (!regtest_fund_from_faucet(&rt, 1.0))
+        regtest_mine_blocks(&rt, 101, mine_addr);
+
+    const size_t N = 5;  /* LSP + 4 clients → 2 arity-2 leaves */
+    secp256k1_keypair kps[5];
+    factory_t *f = calloc(1, sizeof(factory_t));
+    if (!f) { secp256k1_context_destroy(ctx); return 0; }
+
+    unsigned char fund_spk[34];
+    char fund_txid[65];
+    uint32_t fund_vout = 0;
+    uint64_t fund_amount = 0;
+    if (!fund_n_party_factory(&rt, ctx, N, FACTORY_ARITY_2, mine_addr, kps, f,
+                               fund_spk, fund_txid, &fund_vout, &fund_amount)) {
+        factory_free(f); free(f); secp256k1_context_destroy(ctx); return 0;
+    }
+    printf("  [arity=2] factory funded: %llu sats, %zu nodes, %d leaves\n",
+           (unsigned long long)fund_amount, f->n_nodes, f->n_leaf_nodes);
+
+    /* Broadcast every signed tree node in order with correct BIP-68 spacing. */
+    char txids[FACTORY_MAX_NODES][65];
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        factory_node_t *nd = &f->nodes[i];
+        TEST_ASSERT(nd->is_signed && nd->signed_tx.len > 0, "node signed");
+        char *tx_hex = malloc(nd->signed_tx.len * 2 + 1);
+        TEST_ASSERT(tx_hex != NULL, "tx_hex malloc");
+        hex_encode(nd->signed_tx.data, nd->signed_tx.len, tx_hex);
+        int ok = regtest_send_raw_tx(&rt, tx_hex, txids[i]);
+        free(tx_hex);
+        TEST_ASSERT(ok, "broadcast tree node");
+        int blocks_to_mine = 1;
+        if (i + 1 < f->n_nodes) {
+            uint32_t cns = f->nodes[i + 1].nsequence;
+            if (!(cns & 0x80000000u)) blocks_to_mine = (int)(cns & 0xFFFF) + 1;
+        }
+        regtest_mine_blocks(&rt, blocks_to_mine, mine_addr);
+    }
+    int n_leaves = f->n_leaf_nodes;
+    for (int li = 0; li < n_leaves; li++) {
+        int conf = regtest_get_confirmations(&rt,
+            txids[f->leaf_node_indices[li]]);
+        TEST_ASSERT(conf >= 1, "leaf on chain");
+    }
+    printf("  full tree broadcast OK — %zu nodes, %d leaves confirmed\n",
+           f->n_nodes, n_leaves);
+
+    /* Build per-party P2TR destinations for all 5 parties. */
+    unsigned char party_spk[5][34];
+    for (int p = 0; p < (int)N; p++) {
+        secp256k1_pubkey pk;
+        secp256k1_keypair_pub(ctx, &pk, &kps[p]);
+        secp256k1_xonly_pubkey xo;
+        secp256k1_xonly_pubkey_from_pubkey(ctx, &xo, NULL, &pk);
+        build_p2tr_script_pubkey(party_spk[p], &xo);
+    }
+
+    /* Wire econ harness: snapshot pre-sweep balance for all 5 parties. */
+    econ_ctx_t econ;
+    econ_ctx_init(&econ, &rt, ctx);
+    static const char *party_names[5] = {
+        "LSP", "client0", "client1", "client2", "client3"
+    };
+    for (size_t p = 0; p < N; p++) {
+        TEST_ASSERT(econ_register_party(&econ, p, party_names[p],
+                                         N_PARTY_SECKEYS[p]),
+                    "register party");
+    }
+    econ.factory_funding_amount = fund_amount;
+    TEST_ASSERT(econ_snap_pre(&econ), "econ_snap_pre");
+
+    const uint64_t LSTOCK_SWEEP_FEE = 300;
+    const uint64_t CHAN_SWEEP_FEE   = 400;  /* per channel sweep, 2 outputs */
+
+    /* Same payment-flow model as arity-1: client paid LSP during operation. */
+    const uint64_t SIMULATED_PAYMENT     = 20000;
+    const uint64_t SIMULATED_ROUTING_FEE = 100;
+    const uint64_t CLIENT_BALANCE_SHIFT  = SIMULATED_PAYMENT + SIMULATED_ROUTING_FEE;
+
+    uint64_t per_party_recv[5] = {0,0,0,0,0};
+
+    for (int li = 0; li < n_leaves; li++) {
+        size_t nidx = f->leaf_node_indices[li];
+        factory_node_t *leaf = &f->nodes[nidx];
+        const char *leaf_txid = txids[nidx];
+
+        /* Recover client_a / client_b from signer_indices: index 0 is LSP. */
+        TEST_ASSERT(leaf->n_signers == 3,
+                    "arity-2 leaf has 3 signers (LSP + 2 clients)");
+        TEST_ASSERT(leaf->signer_indices[0] == 0, "signer[0] is LSP");
+        uint32_t client_a_idx = leaf->signer_indices[1];
+        uint32_t client_b_idx = leaf->signer_indices[2];
+        TEST_ASSERT(client_a_idx >= 1 && client_a_idx < N,
+                    "client_a_idx in range");
+        TEST_ASSERT(client_b_idx >= 1 && client_b_idx < N,
+                    "client_b_idx in range");
+        TEST_ASSERT(leaf->n_outputs == 3, "arity-2 leaf has 3 outputs");
+
+        unsigned char leaf_txid_bytes[32];
+        TEST_ASSERT(hex_decode(leaf_txid, leaf_txid_bytes, 32),
+                    "decode leaf txid");
+        reverse_bytes(leaf_txid_bytes, 32);
+
+        /* (A) Sweep L-stock (vout 2) LSP-alone to LSP's P2TR(xonly(LSP)). */
+        uint64_t lstock_amt = leaf->outputs[2].amount_sats;
+        unsigned char lstock_spk[34];
+        memcpy(lstock_spk, leaf->outputs[2].script_pubkey, 34);
+
+        tx_buf_t lstock_sweep;
+        tx_buf_init(&lstock_sweep, 256);
+        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
+                        N_PARTY_SECKEYS[0],
+                        leaf_txid, 2, lstock_amt,
+                        lstock_spk, 34,
+                        party_spk[0], 34,
+                        LSTOCK_SWEEP_FEE, &lstock_sweep),
+                    "build L-stock sweep");
+        char *lh = malloc(lstock_sweep.len * 2 + 1);
+        TEST_ASSERT(lh != NULL, "lh malloc");
+        hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
+        lh[lstock_sweep.len * 2] = '\0';
+        char lstock_sweep_txid[65];
+        int lok = spend_broadcast_and_mine(&rt, lh, 1, lstock_sweep_txid);
+        free(lh); tx_buf_free(&lstock_sweep);
+        TEST_ASSERT(lok, "L-stock sweep confirmed");
+        per_party_recv[0] += lstock_amt - LSTOCK_SWEEP_FEE;
+        printf("  leaf %d: LSP swept L-stock %llu sats\n",
+               li, (unsigned long long)(lstock_amt - LSTOCK_SWEEP_FEE));
+
+        /* (B/C) Sweep channels A and B via offline 2-of-2 MuSig2.
+           Each TX has 2 outputs: client_X share + LSP share. */
+        for (int chan = 0; chan < 2; chan++) {
+            uint32_t client_idx = (chan == 0) ? client_a_idx : client_b_idx;
+            uint64_t chan_amt = leaf->outputs[chan].amount_sats;
+            uint64_t balanced_half = (chan_amt - CHAN_SWEEP_FEE) / 2;
+            uint64_t client_share  = balanced_half - CLIENT_BALANCE_SHIFT;
+            uint64_t lsp_share     = (chan_amt - CHAN_SWEEP_FEE) - client_share;
+            unsigned char chan_spk[34];
+            memcpy(chan_spk, leaf->outputs[chan].script_pubkey, 34);
+
+            tx_output_t outs[2];
+            memcpy(outs[0].script_pubkey, party_spk[client_idx], 34);
+            outs[0].script_pubkey_len = 34;
+            outs[0].amount_sats = client_share;
+            memcpy(outs[1].script_pubkey, party_spk[0], 34);
+            outs[1].script_pubkey_len = 34;
+            outs[1].amount_sats = lsp_share;
+
+            tx_buf_t chan_unsigned;
+            tx_buf_init(&chan_unsigned, 256);
+            TEST_ASSERT(build_unsigned_tx(&chan_unsigned, NULL,
+                                            leaf_txid_bytes,
+                                            (uint32_t)chan, 0xFFFFFFFEu,
+                                            outs, 2),
+                        "build unsigned channel sweep");
+            unsigned char sighash[32];
+            TEST_ASSERT(compute_taproot_sighash(sighash,
+                            chan_unsigned.data, chan_unsigned.len,
+                            0, chan_spk, 34, chan_amt, 0xFFFFFFFEu),
+                        "compute channel sighash");
+
+            /* MuSig2 pubkey order matches factory (client, LSP) — see
+               setup_leaf_outputs in src/factory.c:348/360. */
+            secp256k1_keypair signers[2] = { kps[client_idx], kps[0] };
+            secp256k1_pubkey pks[2];
+            secp256k1_keypair_pub(ctx, &pks[0], &signers[0]);
+            secp256k1_keypair_pub(ctx, &pks[1], &signers[1]);
+            musig_keyagg_t ka;
+            TEST_ASSERT(musig_aggregate_keys(ctx, &ka, pks, 2),
+                        "aggregate channel keys (client, LSP)");
+            unsigned char sig64[64];
+            TEST_ASSERT(musig_sign_taproot(ctx, sig64, sighash, signers, 2,
+                                             &ka, NULL),
+                        "offline 2-of-2 MuSig2 sign channel sweep");
+            tx_buf_t chan_signed;
+            tx_buf_init(&chan_signed, 256);
+            TEST_ASSERT(finalize_signed_tx(&chan_signed,
+                            chan_unsigned.data, chan_unsigned.len, sig64),
+                        "finalize channel sweep tx");
+            tx_buf_free(&chan_unsigned);
+
+            char *ch_hex = malloc(chan_signed.len * 2 + 1);
+            TEST_ASSERT(ch_hex != NULL, "ch_hex malloc");
+            hex_encode(chan_signed.data, chan_signed.len, ch_hex);
+            ch_hex[chan_signed.len * 2] = '\0';
+            char chan_sweep_txid[65];
+            int cok = spend_broadcast_and_mine(&rt, ch_hex, 1, chan_sweep_txid);
+            free(ch_hex); tx_buf_free(&chan_signed);
+            TEST_ASSERT(cok, "channel 2-of-2 sweep confirmed");
+            per_party_recv[client_idx] += client_share;
+            per_party_recv[0]          += lsp_share;
+            printf("  leaf %d ch%d: 2-of-2 swept → client%u=%llu, LSP=%llu\n",
+                   li, chan, (unsigned)(client_idx - 1),
+                   (unsigned long long)client_share,
+                   (unsigned long long)lsp_share);
+        }
+    }
+
+    TEST_ASSERT(econ_snap_post(&econ), "econ_snap_post");
+
+    uint64_t expected_deltas[5];
+    for (size_t p = 0; p < N; p++) expected_deltas[p] = per_party_recv[p];
+
+    /* Conservation: Σswept + Σsweep_fees == Σ(allocated across outputs[0..2]
+       of every leaf). Per-leaf sweep cost = LSTOCK_SWEEP_FEE + 2*CHAN_SWEEP_FEE. */
+    uint64_t sweep_fees = (uint64_t)n_leaves *
+                          (LSTOCK_SWEEP_FEE + 2 * CHAN_SWEEP_FEE);
+    uint64_t swept_sum = 0;
+    for (size_t p = 0; p < N; p++) swept_sum += per_party_recv[p];
+    uint64_t allocated_sum = 0;
+    for (int li = 0; li < n_leaves; li++) {
+        size_t nidx = f->leaf_node_indices[li];
+        allocated_sum += f->nodes[nidx].outputs[0].amount_sats;
+        allocated_sum += f->nodes[nidx].outputs[1].amount_sats;
+        allocated_sum += f->nodes[nidx].outputs[2].amount_sats;
+    }
+    TEST_ASSERT(swept_sum + sweep_fees == allocated_sum,
+                "conservation: Σswept + Σsweep_fees == Σleaf_allocations");
+    printf("  conservation OK: swept=%llu + sweep_fees=%llu == allocations=%llu\n",
+           (unsigned long long)swept_sum,
+           (unsigned long long)sweep_fees,
+           (unsigned long long)allocated_sum);
+
+    TEST_ASSERT(econ_assert_wallet_deltas(&econ, expected_deltas, 0),
+                "per-party wallet deltas match expected");
+    econ_print_summary(&econ);
+
+    factory_free(f);
+    free(f);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
+/*
+ * Arity-PS mirror of test_regtest_full_force_close_and_sweep_arity1.
+ *
+ * Topology: N = 3 (LSP + 2 clients) → 2 PS leaves, each holding 1 client.
+ * Each leaf has 2 outputs:
+ *   outputs[0] = channel — MuSig over node->signer_indices, which at a PS
+ *                leaf with 1 client is {LSP, client} (LSP first), keyagg
+ *                stored in node->keyagg, SPK = node->spending_spk.
+ *   outputs[1] = L-stock                            (LSP only)
+ *
+ * NOTE: this exercise covers the PS leaf at chain depth 0 (the initial
+ * state from build_tree). PS chain advance + sweep is left as a follow-up
+ * because it requires synchronized client-side chain progression.
+ *
+ * Conservation: Σ(swept) + Σ(sweep_fees) == Σ(allocated). Per-party wallet
+ * deltas match expected.
+ */
+int test_regtest_full_force_close_and_sweep_arityPS(void) {
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    regtest_t rt;
+    if (!regtest_init(&rt)) {
+        printf("  SKIP: bitcoind not available\n");
+        secp256k1_context_destroy(ctx);
+        return 1;
+    }
+    regtest_create_wallet(&rt, "full_fc_sweep_aps");
+    rt.scan_depth = 200;
+
+    char mine_addr[128];
+    if (!regtest_get_new_address(&rt, mine_addr, sizeof(mine_addr))) return 0;
+    if (!regtest_fund_from_faucet(&rt, 1.0))
+        regtest_mine_blocks(&rt, 101, mine_addr);
+
+    const size_t N = 3;  /* LSP + 2 clients → 2 PS leaves */
+    secp256k1_keypair kps[5];
+    factory_t *f = calloc(1, sizeof(factory_t));
+    if (!f) { secp256k1_context_destroy(ctx); return 0; }
+
+    unsigned char fund_spk[34];
+    char fund_txid[65];
+    uint32_t fund_vout = 0;
+    uint64_t fund_amount = 0;
+    if (!fund_n_party_factory(&rt, ctx, N, FACTORY_ARITY_PS, mine_addr, kps, f,
+                               fund_spk, fund_txid, &fund_vout, &fund_amount)) {
+        factory_free(f); free(f); secp256k1_context_destroy(ctx); return 0;
+    }
+    printf("  [arity=PS] factory funded: %llu sats, %zu nodes, %d leaves\n",
+           (unsigned long long)fund_amount, f->n_nodes, f->n_leaf_nodes);
+
+    /* Broadcast every signed tree node in order with correct BIP-68 spacing. */
+    char txids[FACTORY_MAX_NODES][65];
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        factory_node_t *nd = &f->nodes[i];
+        TEST_ASSERT(nd->is_signed && nd->signed_tx.len > 0, "node signed");
+        char *tx_hex = malloc(nd->signed_tx.len * 2 + 1);
+        TEST_ASSERT(tx_hex != NULL, "tx_hex malloc");
+        hex_encode(nd->signed_tx.data, nd->signed_tx.len, tx_hex);
+        int ok = regtest_send_raw_tx(&rt, tx_hex, txids[i]);
+        free(tx_hex);
+        TEST_ASSERT(ok, "broadcast tree node");
+        int blocks_to_mine = 1;
+        if (i + 1 < f->n_nodes) {
+            uint32_t cns = f->nodes[i + 1].nsequence;
+            if (!(cns & 0x80000000u)) blocks_to_mine = (int)(cns & 0xFFFF) + 1;
+        }
+        regtest_mine_blocks(&rt, blocks_to_mine, mine_addr);
+    }
+    int n_leaves = f->n_leaf_nodes;
+    for (int li = 0; li < n_leaves; li++) {
+        int conf = regtest_get_confirmations(&rt,
+            txids[f->leaf_node_indices[li]]);
+        TEST_ASSERT(conf >= 1, "leaf on chain");
+    }
+    printf("  full tree broadcast OK — %zu nodes, %d leaves confirmed\n",
+           f->n_nodes, n_leaves);
+
+    /* Build per-party P2TR destinations for all N parties. */
+    unsigned char party_spk[5][34];
+    for (int p = 0; p < (int)N; p++) {
+        secp256k1_pubkey pk;
+        secp256k1_keypair_pub(ctx, &pk, &kps[p]);
+        secp256k1_xonly_pubkey xo;
+        secp256k1_xonly_pubkey_from_pubkey(ctx, &xo, NULL, &pk);
+        build_p2tr_script_pubkey(party_spk[p], &xo);
+    }
+
+    /* Wire econ harness for all N parties. */
+    econ_ctx_t econ;
+    econ_ctx_init(&econ, &rt, ctx);
+    static const char *party_names[5] = {
+        "LSP", "client0", "client1", "client2", "client3"
+    };
+    for (size_t p = 0; p < N; p++) {
+        TEST_ASSERT(econ_register_party(&econ, p, party_names[p],
+                                         N_PARTY_SECKEYS[p]),
+                    "register party");
+    }
+    econ.factory_funding_amount = fund_amount;
+    TEST_ASSERT(econ_snap_pre(&econ), "econ_snap_pre");
+
+    const uint64_t LSTOCK_SWEEP_FEE = 300;
+    const uint64_t CHAN_SWEEP_FEE   = 400;
+
+    const uint64_t SIMULATED_PAYMENT     = 20000;
+    const uint64_t SIMULATED_ROUTING_FEE = 100;
+    const uint64_t CLIENT_BALANCE_SHIFT  = SIMULATED_PAYMENT + SIMULATED_ROUTING_FEE;
+
+    uint64_t per_party_recv[5] = {0,0,0,0,0};
+
+    for (int li = 0; li < n_leaves; li++) {
+        size_t nidx = f->leaf_node_indices[li];
+        factory_node_t *leaf = &f->nodes[nidx];
+        const char *leaf_txid = txids[nidx];
+
+        TEST_ASSERT(leaf->is_ps_leaf, "leaf is PS");
+        TEST_ASSERT(leaf->n_outputs == 2, "PS leaf has 2 outputs");
+        /* With 1 client per leaf, n_signers = 2: {LSP, client_idx}. */
+        TEST_ASSERT(leaf->n_signers == 2,
+                    "PS leaf signers = {LSP, client}");
+        TEST_ASSERT(leaf->signer_indices[0] == 0, "signer[0] is LSP");
+        uint32_t client_idx = leaf->signer_indices[1];
+        TEST_ASSERT(client_idx >= 1 && client_idx < N,
+                    "client_idx in range");
+
+        unsigned char leaf_txid_bytes[32];
+        TEST_ASSERT(hex_decode(leaf_txid, leaf_txid_bytes, 32),
+                    "decode leaf txid");
+        reverse_bytes(leaf_txid_bytes, 32);
+
+        /* (A) Sweep L-stock (vout 1) LSP-alone. */
+        uint64_t lstock_amt = leaf->outputs[1].amount_sats;
+        unsigned char lstock_spk[34];
+        memcpy(lstock_spk, leaf->outputs[1].script_pubkey, 34);
+
+        tx_buf_t lstock_sweep;
+        tx_buf_init(&lstock_sweep, 256);
+        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
+                        N_PARTY_SECKEYS[0],
+                        leaf_txid, 1, lstock_amt,
+                        lstock_spk, 34,
+                        party_spk[0], 34,
+                        LSTOCK_SWEEP_FEE, &lstock_sweep),
+                    "build L-stock sweep");
+        char *lh = malloc(lstock_sweep.len * 2 + 1);
+        TEST_ASSERT(lh != NULL, "lh malloc");
+        hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
+        lh[lstock_sweep.len * 2] = '\0';
+        char lstock_sweep_txid[65];
+        int lok = spend_broadcast_and_mine(&rt, lh, 1, lstock_sweep_txid);
+        free(lh); tx_buf_free(&lstock_sweep);
+        TEST_ASSERT(lok, "L-stock sweep confirmed");
+        per_party_recv[0] += lstock_amt - LSTOCK_SWEEP_FEE;
+        printf("  leaf %d: LSP swept L-stock %llu sats\n",
+               li, (unsigned long long)(lstock_amt - LSTOCK_SWEEP_FEE));
+
+        /* (B) Sweep channel (vout 0) via offline N-party MuSig2.
+           PS leaf channel SPK = node->spending_spk, built by add_node()
+           with pks order = {LSP=signer_indices[0], client=signer_indices[1]}
+           — LSP FIRST, opposite of arity-1/arity-2 channel keyagg order. */
+        uint64_t chan_amt = leaf->outputs[0].amount_sats;
+        uint64_t balanced_half = (chan_amt - CHAN_SWEEP_FEE) / 2;
+        uint64_t client_share  = balanced_half - CLIENT_BALANCE_SHIFT;
+        uint64_t lsp_share     = (chan_amt - CHAN_SWEEP_FEE) - client_share;
+        unsigned char chan_spk[34];
+        memcpy(chan_spk, leaf->outputs[0].script_pubkey, 34);
+
+        tx_output_t outs[2];
+        memcpy(outs[0].script_pubkey, party_spk[client_idx], 34);
+        outs[0].script_pubkey_len = 34;
+        outs[0].amount_sats = client_share;
+        memcpy(outs[1].script_pubkey, party_spk[0], 34);
+        outs[1].script_pubkey_len = 34;
+        outs[1].amount_sats = lsp_share;
+
+        tx_buf_t chan_unsigned;
+        tx_buf_init(&chan_unsigned, 256);
+        TEST_ASSERT(build_unsigned_tx(&chan_unsigned, NULL,
+                                        leaf_txid_bytes, 0, 0xFFFFFFFEu,
+                                        outs, 2),
+                    "build unsigned channel sweep");
+        unsigned char sighash[32];
+        TEST_ASSERT(compute_taproot_sighash(sighash,
+                        chan_unsigned.data, chan_unsigned.len,
+                        0, chan_spk, 34, chan_amt, 0xFFFFFFFEu),
+                    "compute channel sighash");
+
+        /* Build keyagg in signer_indices order: {LSP, client}. */
+        secp256k1_keypair signers[FACTORY_MAX_SIGNERS];
+        secp256k1_pubkey pks[FACTORY_MAX_SIGNERS];
+        for (size_t s = 0; s < leaf->n_signers; s++) {
+            uint32_t sidx = leaf->signer_indices[s];
+            signers[s] = kps[sidx];
+            secp256k1_keypair_pub(ctx, &pks[s], &signers[s]);
+        }
+        musig_keyagg_t ka;
+        TEST_ASSERT(musig_aggregate_keys(ctx, &ka, pks, leaf->n_signers),
+                    "aggregate channel keys (signer_indices order)");
+        unsigned char sig64[64];
+        TEST_ASSERT(musig_sign_taproot(ctx, sig64, sighash, signers,
+                                         leaf->n_signers, &ka, NULL),
+                    "offline N-party MuSig2 sign channel sweep");
+        tx_buf_t chan_signed;
+        tx_buf_init(&chan_signed, 256);
+        TEST_ASSERT(finalize_signed_tx(&chan_signed,
+                        chan_unsigned.data, chan_unsigned.len, sig64),
+                    "finalize channel sweep tx");
+        tx_buf_free(&chan_unsigned);
+
+        char *ch_hex = malloc(chan_signed.len * 2 + 1);
+        TEST_ASSERT(ch_hex != NULL, "ch_hex malloc");
+        hex_encode(chan_signed.data, chan_signed.len, ch_hex);
+        ch_hex[chan_signed.len * 2] = '\0';
+        char chan_sweep_txid[65];
+        int cok = spend_broadcast_and_mine(&rt, ch_hex, 1, chan_sweep_txid);
+        free(ch_hex); tx_buf_free(&chan_signed);
+        TEST_ASSERT(cok, "channel N-of-N sweep confirmed");
+        per_party_recv[client_idx] += client_share;
+        per_party_recv[0]          += lsp_share;
+        printf("  leaf %d: PS chan swept → client%u=%llu, LSP=%llu\n",
+               li, (unsigned)(client_idx - 1),
+               (unsigned long long)client_share,
+               (unsigned long long)lsp_share);
+    }
+
+    TEST_ASSERT(econ_snap_post(&econ), "econ_snap_post");
+
+    uint64_t expected_deltas[5];
+    for (size_t p = 0; p < N; p++) expected_deltas[p] = per_party_recv[p];
+
+    uint64_t sweep_fees = (uint64_t)n_leaves * (LSTOCK_SWEEP_FEE + CHAN_SWEEP_FEE);
+    uint64_t swept_sum = 0;
+    for (size_t p = 0; p < N; p++) swept_sum += per_party_recv[p];
+    uint64_t allocated_sum = 0;
+    for (int li = 0; li < n_leaves; li++) {
+        size_t nidx = f->leaf_node_indices[li];
+        allocated_sum += f->nodes[nidx].outputs[0].amount_sats;
+        allocated_sum += f->nodes[nidx].outputs[1].amount_sats;
+    }
+    TEST_ASSERT(swept_sum + sweep_fees == allocated_sum,
+                "conservation: Σswept + Σsweep_fees == Σleaf_allocations");
+    printf("  conservation OK: swept=%llu + sweep_fees=%llu == allocations=%llu\n",
+           (unsigned long long)swept_sum,
+           (unsigned long long)sweep_fees,
+           (unsigned long long)allocated_sum);
+
+    TEST_ASSERT(econ_assert_wallet_deltas(&econ, expected_deltas, 0),
+                "per-party wallet deltas match expected");
+    econ_print_summary(&econ);
+
+    factory_free(f);
+    free(f);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1117,6 +1117,8 @@ extern int test_regtest_inversion_of_timeout_default(void);
 extern int test_regtest_old_state_poisoning(void);
 extern int test_regtest_kickoff_paired_with_latest_state(void);
 extern int test_regtest_full_force_close_and_sweep_arity1(void);
+extern int test_regtest_full_force_close_and_sweep_arity2(void);
+extern int test_regtest_full_force_close_and_sweep_arityPS(void);
 extern int test_regtest_econ_arity2_baseline(void);
 extern int test_regtest_econ_arity1_baseline(void);
 extern int test_regtest_econ_arity_ps_baseline(void);
@@ -3619,6 +3621,8 @@ static void run_regtest_tests(void) {
     RUN_TEST(test_regtest_old_state_poisoning);
     RUN_TEST(test_regtest_kickoff_paired_with_latest_state);
     RUN_TEST(test_regtest_full_force_close_and_sweep_arity1);
+    RUN_TEST(test_regtest_full_force_close_and_sweep_arity2);
+    RUN_TEST(test_regtest_full_force_close_and_sweep_arityPS);
 
     printf("\n=== Economic Correctness (Chart B) ===\n");
     RUN_TEST(test_regtest_econ_arity2_baseline);


### PR DESCRIPTION
## Summary
- Mirrors the arity-1 baseline from PR #80 for the remaining two leaf shapes:
  - **arity-2** — N=5 (LSP + 4 clients), 2 leaves with 3 outputs each (chan A, chan B, L-stock). Per-leaf client pairing recovered from `node->signer_indices[1..2]`. Each channel swept via offline 2-of-2 MuSig2 in `{client, LSP}` pks order matching `setup_leaf_outputs` (`src/factory.c:348/360`).
  - **arity-PS** — N=3 (LSP + 2 clients), 2 PS leaves with 2 outputs each (chan = `node->spending_spk`, L-stock). Channel keyagg uses `signer_indices` order `{LSP, client}` — LSP first, opposite of arity-1/arity-2 (matches `setup_ps_leaf_outputs` at `src/factory.c:722` re-using `add_node`'s SPK).
- Asserts the same full-conservation identity as PR #80:
  `Σ(swept) + Σ(sweep_fees) == Σ(allocated across all leaf outputs)`
- Asserts per-party wallet deltas via `econ_assert_wallet_deltas`.

## Test plan
- [x] Built clean on the VPS (Debug, gcc).
- [x] `./test_superscalar --regtest` — all **68/68** tests pass.
- [x] Arity-2 conservation OK: `swept=496600 + sweep_fees=2200 == allocations=498800`. Per-party deltas match.
- [x] Arity-PS conservation OK: `swept=497400 + sweep_fees=1400 == allocations=498800`. Per-party deltas match.

## Follow-ups (not in this PR)
- PS chain advance + sweep at `ps_chain_len > 0` — tested at depth 0 only here. Requires synchronized client-side chain progression so left as a separate PR.