### PR TITLE
fix(tools): reset_regtest.sh — start bitcoind with rpcuser/rpcpass auth

### DIFF
--- a/tools/reset_regtest.sh
+++ b/tools/reset_regtest.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 # Reset regtest chain to get fresh block subsidies
+#
+# regtest_init() in src/regtest.c hardcodes rpcuser=rpcuser, rpcpassword=rpcpass
+# (the literal strings — they are throwaway regtest credentials, not secrets).
+# So bitcoind MUST be started with those credentials or every regtest test
+# silently SKIPs because the auth handshake fails.
+#
+# This script forces those credentials on every restart so the test suite can
+# always connect via the same auth path.
+
+RPCUSER="rpcuser"
+RPCPASS="rpcpass"
+
+# bitcoin-cli wrapper that uses the credentials we'll start bitcoind with.
+# Used everywhere except the initial stop (where cookie auth is also valid).
+btccli_auth() {
+    bitcoin-cli -regtest -rpcuser="$RPCUSER" -rpcpassword="$RPCPASS" "$@"
+}
 
 echo "=== Stopping bitcoind ==="
-bitcoin-cli -regtest stop 2>/dev/null
-# Wait for regtest bitcoind to exit (don't kill non-regtest instances)
+# Try auth-based stop first (matches what we'll restart with), fall back to cookie.
+btccli_auth stop 2>/dev/null || bitcoin-cli -regtest stop 2>/dev/null
+# Wait for regtest bitcoind to exit (don't kill non-regtest instances).
 for i in $(seq 1 15); do
-    bitcoin-cli -regtest ping 2>/dev/null || break
+    btccli_auth ping 2>/dev/null || bitcoin-cli -regtest ping 2>/dev/null || break
     sleep 1
 done
 
@@ -13,14 +31,18 @@ echo "=== Removing regtest data ==="
 rm -rf "$HOME/.bitcoin/regtest"
 
 echo "=== Starting bitcoind ==="
-bitcoind -regtest -daemon -txindex -fallbackfee=0.00001
+# CRITICAL: -rpcuser/-rpcpassword must match what regtest_init() in
+# src/regtest.c uses, otherwise every regtest test SKIPs. See header comment.
+bitcoind -regtest -daemon -txindex -fallbackfee=0.00001 \
+    -rpcuser="$RPCUSER" -rpcpassword="$RPCPASS"
 sleep 2
 
 echo "=== Verifying ==="
-if bitcoin-cli -regtest getblockchaininfo | grep -q '"chain"'; then
-    bitcoin-cli -regtest getblockchaininfo | grep -E '"chain"|"blocks"'
+if btccli_auth getblockchaininfo | grep -q '"chain"'; then
+    btccli_auth getblockchaininfo | grep -E '"chain"|"blocks"'
     echo "=== Done ==="
 else
-    echo "FAIL: bitcoind did not start"
+    echo "FAIL: bitcoind did not start, or rpcuser/rpcpass auth failed"
+    echo "Check: bitcoind log under \$HOME/.bitcoin/regtest/debug.log"
     exit 1
 fi


### PR DESCRIPTION
## Summary

\`regtest_init()\` in \`src/regtest.c\` hardcodes \`rpcuser=rpcuser\` and \`rpcpassword=rpcpass\` (literal strings — throwaway regtest credentials, not secrets). Previous \`tools/reset_regtest.sh\` started bitcoind without those flags, so bitcoind only accepted cookie auth. Test code couldn't connect; every regtest cell silently SKIPped.

## How this was discovered

During phase 2 item #3 agent run (PR #91 — PS chain-advance sweep). Agent reset bitcoind via \`reset_regtest.sh\`, which appeared to "succeed", but every subsequent regtest test skipped. Two phase 2 agents wasted iteration budget on this. Saved to memory as \`feedback_vps_regtest_reset.md\` so future agents could work around it.

## The fix

- Add \`-rpcuser=rpcuser -rpcpassword=rpcpass\` to the bitcoind startup
- New \`btccli_auth()\` wrapper uses those creds for verification
- Stop call falls back to cookie auth for compatibility with externally-started bitcoind
- Header comment documents the credential coupling so it's not accidentally broken again

## Verification on VPS

\`\`\`
$ bash tools/reset_regtest.sh
=== Stopping bitcoind ===
=== Removing regtest data ===
=== Starting bitcoind ===
=== Verifying ===
  "chain": "regtest",
  "blocks": 0,
=== Done ===

$ build/test_superscalar --regtest --filter=test_regtest_basic_dw
[faucet] height=203  balance=5149.0000 BTC
==============================
Results: 1/1 passed
\`\`\`

Before the fix: \`Results: 0/1 passed (1 skipped)\`. After: actually runs.

## Release status

v0.1.14 stays SUSPENDED. This is pure tooling — no test or production code touched.

## Test plan

- [ ] CI green (script-only change, no test code touched)
- [x] VPS smoke test: reset + run regtest cell confirms connection works