### PR TITLE
docs+default: PS-first canonical positioning (mixed-arity Phase 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ superscalar_lsp [OPTIONS]
 |------|----------|---------|-------------|
 | `--port` | PORT | 9735 | Listen port |
 | `--clients` | N | 4 | Number of clients |
-| `--arity` | N | 2 | Leaf arity: 1 (per-client leaves) or 2 (paired leaves) |
+| `--arity` | N | 3 | Leaf arity: 3 (Pseudo-Spilman, canonical) — 1 (legacy DW), 2 (legacy DW). Comma-list for mixed `3,4,8`. |
 | `--amount` | SATS | 100000 | Funding amount |
 | `--network` | MODE | regtest | regtest / signet / testnet / mainnet |
 | `--daemon` | — | off | Long-lived daemon mode |

--- a/docs/factory-arity.md
+++ b/docs/factory-arity.md
@@ -1,34 +1,54 @@
 # Factory arity: picking the right tree shape
 
-SuperScalar factories are Decker–Wattenhofer trees. Each internal level's
-branching factor ("arity") is configurable independently of the others
-via the `--arity` CLI flag. Picking the wrong shape at large client
-counts stacks too much BIP-68 CSV delay along the exit path and pushes
-HTLC `final_cltv_expiry` past BOLT's 2016-block ceiling — clients
-routed through the factory then refuse to accept forwards because the
-worst-case exit time exceeds what they consider safe. This doc explains
-the tradeoff and recommends shapes.
+SuperScalar factories are timeout-tree-structured Decker–Wattenhofer
+trees with **Pseudo-Spilman (PS) leaves** as the canonical leaf
+mechanism. Each internal level's branching factor ("arity") is
+configurable independently of the others via the `--arity` CLI flag.
+Picking the wrong shape at large client counts stacks too much BIP-68
+CSV delay along the exit path and pushes HTLC `final_cltv_expiry` past
+BOLT's 2016-block ceiling — clients routed through the factory then
+refuse to accept forwards because the worst-case exit time exceeds what
+they consider safe. This doc explains the tradeoff and recommends
+shapes.
 
 **See also:** [docs/pseudo-spilman.md](pseudo-spilman.md) — design and
-non-revocability contract for PS (`FACTORY_ARITY_PS`) leaves: why they
-have no revocation keys, and how the `client_ps_signed_inputs` persist
-table prevents double-signing.
+non-revocability contract for PS leaves: why they have no revocation
+keys, and how the `client_ps_signed_inputs` persist table prevents
+double-signing.
 
-## The three arity types
+## Pseudo-Spilman is the canonical leaf
 
-| Value | Meaning | Primary use |
-|-------|---------|-------------|
-| `1`   | Single-client leaves, 2-of-2 DW with per-leaf independent counter | Low-uptime clients; smallest exit blast radius per client |
-| `2`   | Two-client leaves, 3-of-3 DW with shared state | "Best arity for leaf nodes" per ZmnSCPxj — smallest online cohort (2 clients + LSP) for leaf updates |
-| `3` / `FACTORY_ARITY_PS` | Pseudo-Spilman chained leaves, 2-of-2 with TX chaining instead of DW nSequence | LSP-unidirectional liquidity sales; zero CLTV delta contribution |
-| `4`+  | Wide branching for mid-tree / near-root levels | Caps tree depth as client count scales |
+For new deployments, **use `--arity 3` (Pseudo-Spilman)** at the leaf
+level. PS is the headline ZmnSCPxj design and offers strict advantages
+over the older Decker-Wattenhofer leaf mechanisms:
 
-Arities `1`, `2`, and `3` describe distinct leaf/state mechanisms. Values
-`>= 4` are pure branching factors applied at interior tree levels —
-they don't change the leaf state machine, just how many children fan
-out at that level.
+| Property | DW arity-1/-2 (legacy) | PS arity-3 (canonical) |
+|---|---|---|
+| Per-leaf CSV consumption per state advance | High (decrementing nSequence) | **Zero** (TX chaining) |
+| Per-state revocation keys + watchtower | Required | **Not needed** for leaf state |
+| Inner BOLT-2 HTLCs (bidirectional) | Yes | **Yes** (verified in regtest) |
+| Number of state advances before exhaustion | Bounded by `states_per_layer × DW_MAX_LAYERS` | **Bounded only by channel amount** (one fee per advance) |
+| Online cohort for state advance | Leaf cohort (1 or 2 clients + LSP) | Leaf cohort (1 client + LSP) |
 
-## The ZmnSCPxj recommended shape
+**Migration / legacy:** `--arity 1` (single-client DW) and `--arity 2`
+(two-client DW) remain implemented for backward compatibility with
+older deployments. New deployments should not use them.
+
+## The arity types
+
+| Value | Mechanism | Status |
+|-------|-----------|--------|
+| `3` / `FACTORY_ARITY_PS` | **Pseudo-Spilman chained leaves** — TX chaining instead of DW nSequence; zero per-leaf CSV; chain-level non-revocability | **Canonical, recommended for all new deployments** |
+| `2` | Two-client leaves, 3-of-3 DW with shared state | Legacy (kept for migration) |
+| `1` | Single-client leaves, 2-of-2 DW with per-leaf independent counter | Legacy (kept for migration) |
+| `4`+ | Wide branching for mid-tree / near-root levels (interior fan-out, no leaf semantics) | Caps tree depth as client count scales |
+
+Arities `1`, `2`, and `3` describe distinct leaf/state mechanisms.
+Values `≥ 4` are pure branching factors applied at interior tree
+levels — they don't change the leaf state machine, just how many
+children fan out at that level.
+
+## ZmnSCPxj's canonical recommendation
 
 From the Delving Bitcoin thread ([t/1242](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories-with-pseudo-spilman-leaves/1242)):
 
@@ -39,80 +59,112 @@ From the Delving Bitcoin thread ([t/1242](https://delvingbitcoin.org/t/superscal
 > nSequences) … a root timeout-sig-tree that backs multiple
 > timeout-tree-structured Decker-Wattenhofer mechanisms."
 
-And:
-
 > "Kickoff nodes may also have an arity of 1 … this reduces the number of
 > affected clients if one client wants to unilaterally exit."
 
-Reason to prefer higher arity mid-tree and at the root: every additional
-DW state layer contributes `step_blocks * (states_per_layer - 1)` blocks
-of BIP-68 CSV to the exit path. Deep trees of uniform low arity stack
-this delay linearly in tree depth. Mid-tree wide branching collapses
-multiple levels into one, capping total depth.
+The canonical SuperScalar shape combines:
 
-## The math at our target scale
+1. **Low-arity leaves** (PS for new deployments; arity-2 DW for legacy)
+2. **Wider arity mid-tree** (e.g. `4`, `8`) to cap total tree depth
+3. **Static near-root** — kickoff-only nodes near the root with no DW
+   state transitions, only CLTV timeouts
+
+Reason to prefer higher arity mid-tree and at the root: every DW state
+layer contributes `step_blocks * (states_per_layer - 1)` blocks of
+BIP-68 CSV to the exit path. Deep trees of uniform low arity stack
+this delay linearly in tree depth. Mid-tree wide branching collapses
+multiple levels into one, capping total depth. Static-near-root removes
+state transitions from the levels closest to the root, eliminating
+their CSV contribution entirely.
+
+## Current implementation status (v0.1.x)
+
+**As of this document's commit, the implementation is undergoing a
+phased upgrade to deliver the full canonical design:**
+
+- ✅ PS leaves at any N (proven on regtest at N=2-32 with full per-party
+  accounting; unit-tested at N=64 and N=128)
+- ✅ DW arity-1 and arity-2 leaves (legacy)
+- ⚠️ **TRUE N-way interior branching: NOT YET IMPLEMENTED.** Currently
+  the builder treats arities ≥4 as a leaf-size hint only; the resulting
+  tree is binary regardless of `--arity 2,4,8` input. This is being
+  fixed in the upcoming "Phase 2" work
+  ([implementation plan](https://github.com/8144225309/SuperScalar/pull/_TBD_)).
+- ⚠️ **Static-near-root variant: NOT YET IMPLEMENTED.** Coming in
+  "Phase 3" of the same work.
+
+Until N-way + static-near-root land, the supported deployment ceiling
+is **N=16 clients per factory** with uniform `--arity 3` (PS). Beyond
+N=16 you need either:
+- Multiple factories of ≤16 clients each (works today), OR
+- Wait for Phase 2/3 to land for single-factory N>16 with mixed arity
+
+The deployment table below shows the **target shapes** once N-way + static-near-root are implemented. Use the "Today" column for current capability.
+
+## Recommended shapes (target vs today)
+
+| Client count | Today (canonical) | Target (after N-way + static) | Notes |
+|---|---|---|---|
+| ≤ 8 | `--arity 3` (uniform PS) | same | Depth stays shallow; no mixed needed |
+| 9-16 | `--arity 3` (uniform PS) | same | Still under BOLT 2016 with binary interior |
+| 17-32 | run multiple factories of ≤16 each | `--arity 3,4` (PS leaves + arity-4 mid) | Adds one fan-out level |
+| 33-64 | run multiple factories of ≤16 each | `--arity 3,4,8` | ZmnSCPxj's canonical mid-tree shape |
+| 65-127 | run multiple factories of ≤16 each | `--arity 3,4,8 --static-near-root 1` or `--arity 3,2,4,8` | Static gate at root for further depth reduction |
+
+**Today, uniform `--arity 3` is safe up to 16 clients per factory on
+mainnet.** For higher client counts, the supported scale path is to run
+multiple factories.
+
+## CSV budget math
 
 With `FACTORY_MAX_SIGNERS = 128` (1 LSP + up to 127 clients) and mainnet
 defaults (`step_blocks = 144`, `states_per_layer = 4`, giving
 `144 * (4-1) = 432` blocks of CSV per layer):
 
-| Shape | Tree depth | Worst-path CSV | vs BOLT 2016-block ceiling |
-|-------|-----------|----------------|-----------------------------|
-| Uniform arity-2, 127 clients | 7 layers | ~3024 blocks (~21 days) | **EXCEEDS** |
-| Mixed 2 / 4 / 8 (leaf / mid / root), 127 clients | 4 layers | ~1728 blocks (~12 days) | Under, but tight |
-| Uniform arity-2, 16 clients | 4 layers | ~1728 blocks | Under |
-| Uniform arity-2, 8 clients | 3 layers | ~1296 blocks | Under |
+| Shape | Tree depth | DW layers | Worst-path CSV | vs BOLT 2016 |
+|---|---|---|---|---|
+| Uniform PS, 16 clients | 4 layers | 4 | ~1728 blocks | Under |
+| Uniform PS, 8 clients | 3 layers | 3 | ~1296 blocks | Under |
+| Uniform PS, 64 clients (binary today) | 6 layers | 6 | ~2592 blocks | **EXCEEDS** |
+| Uniform PS, 128 clients (binary today) | 7 layers | 7 | ~3024 blocks | **EXCEEDS** |
+| **Target:** PS leaves + `{2,4,8}` interior, 64 clients | 3 layers | 3 | ~1296 blocks | Under (after Phase 2) |
+| **Target:** PS + `{2,4,8}` + `static_near_root=1`, 128 clients | 4 layers | 3 | ~1296 blocks | Under (after Phase 3) |
+| **Target:** PS + `{2,4,8}` + `static_near_root=2`, 128 clients | 4 layers | 2 | ~864 blocks | Generous slack (after Phase 3) |
 
-**Uniform arity-2 is safe up to ~16 clients on mainnet.** Beyond that,
-mixed arity is required for the `final_cltv_expiry` budget to hold.
-On regtest with `step_blocks = 10`, uniform arity-2 is fine at any
-supported client count — but that's a test artifact, not a property of
-the design.
+Regtest and testnet deployments use `step_blocks = 10` (not 144), so
+CSV budget is non-binding at any client count — but that's a test
+artifact, not a property of the design.
 
-## Setting the arity
+## Setting the arity (current capability)
 
 Single arity (applies uniformly):
 
 ```
-superscalar_lsp --arity 2 --clients 8 ...
+superscalar_lsp --arity 3 --clients 16 ...
 ```
 
-Mixed per-level (comma-separated, deepest → shallowest, the last entry
-applies to all deeper levels):
+Mixed per-level CLI accepts the syntax today but the builder collapses
+to binary internal tree. After Phase 2 lands, this will produce the
+TRUE N-way fan-out:
 
 ```
-# 127 clients, mixed 2/4/8 — ZmnSCPxj's recommended shape:
-superscalar_lsp --arity 2,4,8 --clients 127 ...
-
-# 32 clients, mixed 2/4:
-superscalar_lsp --arity 2,4 --clients 32 ...
+# Target after Phase 2 — 64 clients, mixed PS leaves + arity-4 mid + arity-8 root:
+superscalar_lsp --arity 3,4,8 --clients 64 ...
 ```
 
-Supported values are 1–16 per level. Values `1`, `2`, and `3` (PS) are
-the leaf-mechanism choices; `4`+ are pure branching factors for
-interior levels.
+Supported values today are 1–16 per level. The CLI should reject
+shape combinations that would exceed BOLT 2016 (Phase 4 work).
 
-## Recommendation by deployment
+## Implementation pointers
 
-| Client count | Recommended `--arity` | Why |
-|-------------|----------------------|-----|
-| ≤ 8 | `2` (uniform) | Depth stays shallow; no need for mixed |
-| 9–16 | `2` (uniform) | Still under BOLT ceiling |
-| 17–32 | `2,4` | One extra level of fan-out at the root |
-| 33–64 | `2,4,8` | ZmnSCPxj's canonical mid-tree shape |
-| 65–127 | `2,4,8` or `2,2,4,8` | Add a leaf-kickoff layer for exit isolation |
-
-Regtest and testnet deployments at any client count may use uniform
-arity-2 — the `step_blocks` scaling makes the CSV budget nonbinding.
-
-## Implementation
-
-- `include/superscalar/factory.h:185-190` — `uint8_t level_arity[FACTORY_MAX_LEVELS=8]`.
-- `src/factory.c:606-622` — `factory_set_level_arity()` populates it and
-  re-initializes the DW counter from the resulting depth.
-- `src/factory.c:554-560` — `arity_at_depth()` lookup; last entry wraps.
-- `src/factory.c:849-895` — `build_subtree()` branches per depth.
-- `tools/superscalar_lsp.c:1261-1290` — `--arity` parsing (comma or single).
+- `include/superscalar/factory.h:15` — `FACTORY_MAX_OUTPUTS = 8` (will
+  bump to 16 in Phase 1 to support arity-15 leaves with L-stock)
+- `include/superscalar/factory.h:185-190` — `uint8_t level_arity[FACTORY_MAX_LEVELS=8]`
+- `src/factory.c:606-622` — `factory_set_level_arity()` populates per-level arity
+- `src/factory.c:554-560` — `arity_at_depth()` lookup; last entry wraps deeper levels
+- `src/factory.c:781-939` — `build_subtree()` (currently binary; Phase 2 makes N-way)
+- `src/factory.c:564-604` — `simulate_tree()` (currently binary; Phase 2 makes N-way)
+- `tools/superscalar_lsp.c:1036` — default `leaf_arity` (currently 2; updated to 3 in Phase 0)
 
 ## Caveats
 
@@ -125,3 +177,6 @@ arity-2 — the `step_blocks` scaling makes the CSV budget nonbinding.
   `states_per_layer = 4`. Changing either rescales the budget; the
   mixed-arity guidance stays directionally correct but the specific
   recommended shapes shift.
+- DW arity-1 and arity-2 leaves remain in the codebase and are tested,
+  but new deployments should default to `--arity 3` (PS) per the
+  canonical design.

--- a/docs/lsp-operator-guide.md
+++ b/docs/lsp-operator-guide.md
@@ -138,7 +138,7 @@ Press **Ctrl+C**. The LSP will:
 | `--port` | 9735 | Listen port for client connections |
 | `--clients` | 4 | Number of clients to accept before starting ceremony |
 | `--amount` | 100000 | Factory funding amount in satoshis |
-| `--arity` | 2 | Leaf arity: `1` = one client per leaf, `2` = paired leaves |
+| `--arity` | 3 | Leaf arity: `3` = Pseudo-Spilman (canonical, default). `1`/`2` = legacy DW. Comma-separated for mixed (e.g. `3,4,8`). |
 | `--network` | regtest | Bitcoin network: regtest / signet / testnet / mainnet |
 | `--daemon` | off | Long-lived mode (handles reconnections, Ctrl+C for close) |
 | `--demo` | off | Run scripted payment sequence then close |

--- a/docs/pseudo-spilman.md
+++ b/docs/pseudo-spilman.md
@@ -6,20 +6,44 @@ design, and that is correct. This doc records why.
 
 ## Background
 
-SuperScalar leaves come in three arities. See
-[docs/factory-arity.md](factory-arity.md) for picking between them at
+**Pseudo-Spilman (PS, arity 3) is the canonical SuperScalar leaf
+mechanism.** All new deployments should default to it. The DW arity-1
+and arity-2 leaves remain implemented for backward compatibility but
+are not recommended for new factories.
+
+See [docs/factory-arity.md](factory-arity.md) for picking shapes at
 deployment time; this doc focuses on the state-invalidation mechanism.
 
-| Arity constant | Leaf shape | State ordering |
-|---|---|---|
-| `FACTORY_ARITY_1` | Single client + LSP, 2-of-2 | Decker–Wattenhofer (decrementing nSequence) |
-| `FACTORY_ARITY_2` | Two clients + LSP, 3-of-3 | Decker–Wattenhofer (decrementing nSequence) |
-| `FACTORY_ARITY_PS` | LSP-unidirectional, 2-of-2 | Pseudo-Spilman (TX chaining) |
+| Arity constant | Leaf shape | State ordering | Status |
+|---|---|---|---|
+| `FACTORY_ARITY_PS` | LSP + client, 2-of-2 with chained TX advances | Pseudo-Spilman (TX chaining) | **Canonical, default** |
+| `FACTORY_ARITY_2` | Two clients + LSP, 3-of-3 | Decker–Wattenhofer (decrementing nSequence) | Legacy |
+| `FACTORY_ARITY_1` | Single client + LSP, 2-of-2 | Decker–Wattenhofer (decrementing nSequence) | Legacy |
 
 The PS leaf design is from ZmnSCPxj. References:
 
 - Bitcoin Optech "SuperScalar" deepdive
 - Delving Bitcoin "SuperScalar" thread t/1242
+
+## When to use PS vs DW
+
+**Use PS (`--arity 3`) for:**
+- All new factory deployments
+- Any deployment expecting many state advances per channel (PS adds
+  per-advance fee but no CSV consumption; DW exhausts the state machine
+  after `states_per_layer × DW_MAX_LAYERS` advances and forces rotation)
+- Any deployment where the simpler trust model (no revocation keys, no
+  watchtower for leaf state) is preferred
+
+**Use DW arity-1 / arity-2 only for:**
+- Migrating existing deployments that pre-date PS support
+- Interop with peers that don't yet implement PS
+
+**Both PS and DW leaves support bidirectional inner BOLT-2 channels** —
+the "PS is unidirectional" framing in older docs refers only to
+leaf-level state advances (which only the LSP triggers), NOT to HTLC
+flow. Verified by regtest tests `test_regtest_htlc_force_to_local_arity_ps`
+and `test_regtest_htlc_breach_arity_ps`.
 
 ## Why PS is non-revocable
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -284,7 +284,8 @@ static void usage(const char *prog) {
         "  --jit-amount SATS   Per-client JIT channel funding amount (default: funding/clients)\n"
         "  --no-jit            Disable JIT channel fallback\n"
         "  --states-per-layer N States per DW layer (default 4, range 2-256)\n"
-        "  --arity N|N,N,...   Leaf arity: 1, 2, or 3=PS (default 2). Comma-separated for per-level.\n"
+        "  --arity N|N,N,...   Leaf arity: 1=DW(legacy), 2=DW(legacy), 3=PS(canonical, default).\n"
+        "                       Comma-separated for per-level mixed arity (e.g. 3,4,8).\n"
         "  --force-close       After factory creation (+ demo), broadcast tree and wait for confirmations\n"
         "  --test-burn         After factory creation (+ demo), broadcast tree and burn L-stock via shachain\n"
         "  --test-htlc-force-close  After demo: add pending HTLC, force-close, broadcast HTLC timeout TX\n"
@@ -1033,7 +1034,8 @@ int main(int argc, char *argv[]) {
     int64_t jit_amount_arg = -1;     /* -1 = auto (funding_sats / n_clients) */
     int no_jit = 0;
     int states_per_layer = 4;        /* DW states per layer (2-256, default 4) */
-    int leaf_arity = 2;              /* 1 or 2, default arity-2 */
+    int leaf_arity = 3;              /* default Pseudo-Spilman per docs/factory-arity.md
+                                        (1, 2 = legacy DW; 3 = PS canonical) */
     uint8_t level_arities[FACTORY_MAX_LEVELS];
     size_t n_level_arity = 0;        /* 0 = uniform leaf_arity */
     int force_close = 0;


### PR DESCRIPTION
## Summary

Phase 0 of the mixed-arity + static-near-root implementation plan. Sets Pseudo-Spilman (\`--arity 3\`) as the canonical leaf mechanism per ZmnSCPxj's SuperScalar design. DW arity-1/2 stay implemented for backward compatibility but stop being recommended for new deployments.

## What changed

| File | Change |
|---|---|
| \`docs/factory-arity.md\` | Rewritten PS-first; canonical-vs-legacy table; honest current-status callout (binary collapse acknowledged); updated CSV budget table with target vs today |
| \`docs/pseudo-spilman.md\` | New "When to use PS vs DW" section + correction to "PS is unidirectional" framing (verified bidirectional via existing tests) |
| \`README.md\` + \`docs/lsp-operator-guide.md\` | \`--arity\` default 2 → 3 in operator docs |
| \`tools/superscalar_lsp.c:1036\` | \`leaf_arity\` default 2 → 3; help text updated |

## What this PR does NOT do

- Does NOT implement true N-way interior branching (that's Phase 2)
- Does NOT implement static-near-root (that's Phase 3)
- Does NOT remove DW arity-1/2 leaf code (kept for legacy interop)
- Does NOT change CSV budget or scale ceiling (still N=16 per factory until Phase 2/3 land)

## Why first

Sets the PS-first narrative for everything that follows. Doc + default-flag change has near-zero regression risk. All existing tests that explicitly pass \`--arity\` are unaffected.

## Release status

v0.1.14 stays SUSPENDED. This work goes into main but no tag.

## Test plan

- [ ] CI green on Linux / macOS / sanitizers / TSan / regtest / coverage
- [ ] All existing tests pass unchanged (default flip doesn't affect tests with explicit \`--arity\`)

## Plan reference

See \`~/.claude/plans/mutable-fluttering-wren.md\` for the full 6-phase plan.