### PR TITLE
feat(factory): FACTORY_MAX_OUTPUTS 8 → 16 (mixed-arity Phase 1)

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -12,7 +12,13 @@
 #include <secp256k1_extrakeys.h>
 
 #define FACTORY_MAX_NODES   512
-#define FACTORY_MAX_OUTPUTS  8
+/* FACTORY_MAX_OUTPUTS: max outputs per tree node. Sized for arity-15 leaves
+ * (15 client channels + 1 L-stock = 16 outputs) under the upcoming N-way
+ * mixed-arity work (Phase 2 of mixed-arity implementation plan). Internal
+ * state nodes use up to N child outputs. Memory cost: per-node growth from
+ * 8 × tx_output_t to 16 × tx_output_t; at 506 nodes (max PS factory at
+ * N=128) that's ~50KB extra per factory_t — acceptable. */
+#define FACTORY_MAX_OUTPUTS 16
 #define FACTORY_MAX_SIGNERS 128
 #define FACTORY_MAX_LEAVES  128
 


### PR DESCRIPTION
## Summary

Phase 1 of the mixed-arity + static-near-root plan. Bumps \`FACTORY_MAX_OUTPUTS\` from 8 to 16 to accommodate arity-N leaves up to arity-15 with L-stock.

## Why

- Arity-N leaves need N+1 outputs (N client channels + 1 L-stock)
- Today's cap of 8 limits leaf to arity-7 max
- For canonical \`{2,4,8}\` mixed-arity at N=64, an arity-8 leaf needs 9 outputs (overflows current cap)
- Phase 2 (true N-way interior + N-way leaves) requires this prereq

## Cost

- \`factory_node_t::outputs[]\` grows from 8 × tx_output_t to 16 × tx_output_t
- \`factory_node_t::child_indices[]\` doubles
- Per-node ~100 bytes growth
- At 506 nodes (max PS at N=128): ~50KB extra per \`factory_t\`
- Acceptable; no allocation pattern changes

## Verification

- All consumers use the \`FACTORY_MAX_OUTPUTS\` macro (no hardcoded 8s)
- No behavior change at current arities (≤7); arrays are over-sized
- Sanitizers must pass (memory layout change)

## Release status

v0.1.14 stays SUSPENDED.

## Test plan

- [ ] Linux green
- [ ] macOS green
- [ ] sanitizers green (most important — memory layout change)
- [ ] TSan green
- [ ] regtest green
- [ ] coverage green

Plan reference: \`~/.claude/plans/mutable-fluttering-wren.md\`