### PR TITLE
fix(factory): properly compact build_subtree when split returns empty children

### DIFF
--- a/src/factory.c
+++ b/src/factory.c
@@ -1034,34 +1034,44 @@ static int build_subtree(
         f->nodes[ko_idx].is_static_only = 1;
         f->nodes[ko_idx].input_amount = input_amount;
 
-        /* Kickoff has n_parts outputs, one per child.  Distribute the input
-           amount minus one fee evenly among children. */
+        /* Compute fee + budget. Count non-empty children up front so budget is
+           split correctly even if split_clients_for_arity ever returned an
+           empty slot (it currently never does for shapes that reach this
+           branch — interior, non-leaf — but the contract is enforced
+           defensively in case it changes). */
         uint64_t fee = f->fee_per_tx;
         if (input_amount <= fee) return 0;
         uint64_t kickoff_budget = input_amount - fee;
-        uint64_t per_child_budget = kickoff_budget / n_parts;
-        uint64_t budget_remainder = kickoff_budget - per_child_budget * n_parts;
 
-        f->nodes[ko_idx].n_outputs = n_parts;
+        size_t n_actual = 0;
+        for (size_t k = 0; k < n_parts; k++)
+            if (parts[k] > 0) n_actual++;
+        if (n_actual == 0) return 0;
+
+        uint64_t per_child_budget = kickoff_budget / n_actual;
+        uint64_t budget_remainder = kickoff_budget - per_child_budget * n_actual;
+
+        f->nodes[ko_idx].n_outputs = n_actual;
         /* Outputs will be filled after children are created (need their spk). */
 
-        /* Recurse into each child, remembering its kickoff node index. */
-        int child_ko_indices[FACTORY_MAX_OUTPUTS];
+        /* Recurse into each non-empty child, writing into compacted indices
+           so the second loop can iterate 0..n_actual-1 without gaps. */
+        int child_ko_indices[FACTORY_MAX_OUTPUTS] = {0};
+        size_t n_built = 0;
         size_t client_offset = 0;
         for (size_t k = 0; k < n_parts; k++) {
+            if (parts[k] == 0) continue;
+
             uint64_t child_budget = per_child_budget;
-            if (k == n_parts - 1) child_budget += budget_remainder;
+            if (n_built == n_actual - 1) child_budget += budget_remainder;
 
             size_t saved_n_nodes = f->n_nodes;
-            if (parts[k] == 0) {
-                f->nodes[ko_idx].n_outputs--;
-                continue;
-            }
             if (!build_subtree(f, client_indices + client_offset, parts[k],
-                               ko_idx, (uint32_t)k, depth + 1, max_depth,
+                               ko_idx, (uint32_t)n_built, depth + 1, max_depth,
                                child_budget, leaf_counter))
                 return 0;
-            child_ko_indices[k] = (int)saved_n_nodes;
+            child_ko_indices[n_built] = (int)saved_n_nodes;
+            n_built++;
             client_offset += parts[k];
         }
 
@@ -1069,9 +1079,9 @@ static int build_subtree(
            is itself a static node, its first node is the static kickoff;
            when it's a regular subtree, its first node is the regular kickoff.
            Either way we point at child_ko_indices[k]->spending_spk. */
-        for (size_t k = 0; k < f->nodes[ko_idx].n_outputs; k++) {
+        for (size_t k = 0; k < n_actual; k++) {
             uint64_t child_budget = per_child_budget;
-            if (k == f->nodes[ko_idx].n_outputs - 1) child_budget += budget_remainder;
+            if (k == n_actual - 1) child_budget += budget_remainder;
             f->nodes[ko_idx].outputs[k].amount_sats = child_budget;
             memcpy(f->nodes[ko_idx].outputs[k].script_pubkey,
                    f->nodes[child_ko_indices[k]].spending_spk, 34);
@@ -1147,43 +1157,50 @@ static int build_subtree(
             return 0;
         }
 
-        /* State node has n_parts outputs, one per child */
+        /* Count non-empty children up front so budget is split correctly even
+           if split_clients_for_arity ever returns an empty slot (it currently
+           never does for shapes that reach this branch — interior, non-leaf —
+           but the contract is enforced defensively in case it changes). */
         if (ko_out_amount <= fee) return 0;
         uint64_t state_budget = ko_out_amount - fee;
-        /* Distribute state budget evenly among children, with remainder to last */
-        uint64_t per_child_budget = state_budget / n_parts;
-        uint64_t budget_remainder = state_budget - per_child_budget * n_parts;
+
+        size_t n_actual = 0;
+        for (size_t k = 0; k < n_parts; k++)
+            if (parts[k] > 0) n_actual++;
+        if (n_actual == 0) return 0;
+
+        uint64_t per_child_budget = state_budget / n_actual;
+        uint64_t budget_remainder = state_budget - per_child_budget * n_actual;
 
         f->nodes[st_idx].input_amount = ko_out_amount;
-        f->nodes[st_idx].n_outputs = n_parts;
+        f->nodes[st_idx].n_outputs = n_actual;
         /* Outputs will be filled after children are created (need their spk) */
 
-        /* Recurse into each child, remembering its kickoff node index */
-        int child_ko_indices[FACTORY_MAX_OUTPUTS];
+        /* Recurse into each non-empty child, writing into compacted indices
+           so the second loop can iterate 0..n_actual-1 without gaps. */
+        int child_ko_indices[FACTORY_MAX_OUTPUTS] = {0};
+        size_t n_built = 0;
         size_t client_offset = 0;
         for (size_t k = 0; k < n_parts; k++) {
+            if (parts[k] == 0) continue;
+
             uint64_t child_budget = per_child_budget;
-            if (k == n_parts - 1) child_budget += budget_remainder;
+            if (n_built == n_actual - 1) child_budget += budget_remainder;
 
             size_t saved_n_nodes = f->n_nodes;
-            if (parts[k] == 0) {
-                /* Empty child: shouldn't happen with split_clients_for_arity,
-                   but guard against it. Drop the slot. */
-                f->nodes[st_idx].n_outputs--;
-                continue;
-            }
             if (!build_subtree(f, client_indices + client_offset, parts[k],
-                               st_idx, (uint32_t)k, depth + 1, max_depth,
+                               st_idx, (uint32_t)n_built, depth + 1, max_depth,
                                child_budget, leaf_counter))
                 return 0;
-            child_ko_indices[k] = (int)saved_n_nodes;
+            child_ko_indices[n_built] = (int)saved_n_nodes;
+            n_built++;
             client_offset += parts[k];
         }
 
         /* Wire state outputs to each child's kickoff spending_spk */
-        for (size_t k = 0; k < f->nodes[st_idx].n_outputs; k++) {
+        for (size_t k = 0; k < n_actual; k++) {
             uint64_t child_budget = per_child_budget;
-            if (k == f->nodes[st_idx].n_outputs - 1) child_budget += budget_remainder;
+            if (k == n_actual - 1) child_budget += budget_remainder;
             f->nodes[st_idx].outputs[k].amount_sats = child_budget;
             memcpy(f->nodes[st_idx].outputs[k].script_pubkey,
                    f->nodes[child_ko_indices[k]].spending_spk, 34);


### PR DESCRIPTION
## Summary

Both branches of `build_subtree` (static-near-root + regular kickoff/state
pair) had matching latent bugs in their handling of empty children from
`split_clients_for_arity`. cppcheck flagged the static-near-root branch
(`src/factory.c:1077: Uninitialized variable: child_ko_indices`); the
regular branch has the same bug pattern but happens to be older code
that cppcheck didn't flag.

In current code these defensive guards are unreachable — `split_clients_for_arity`
only ever returns a zero-sized child on shapes that reach the LEAF branch,
never the interior branches that contain this code. But the defensive
code itself was buggy:

1. `child_ko_indices[k]` was only assigned when `parts[k] != 0`, leaving
   gaps when the empty-child branch fired. The second loop then read the
   uninitialized slot via the outer index `k`.
2. `n_outputs` was decremented mid-loop instead of being computed from
   the count of non-zero parts up front, so the kickoff/state node's
   output count + budget split could disagree with the actual children.
3. `parent_vout` was the OUTER index `k` rather than the compacted
   index, so any later child would mis-point at the wrong parent vout.

This is a SuperScalar reference implementation; defensive code paths
must be correct, not just unreachable.

## Fix

Count non-empty parts up front into `n_actual`, set `n_outputs` from that,
recompute per-child + remainder budgets against `n_actual`, and use
`n_built` (a separate compacting write index) for both `child_ko_indices[]`
and the recursive call's `parent_vout`. Applied identically to both
branches.

Belt-and-suspenders: `child_ko_indices[FACTORY_MAX_OUTPUTS] = {0}`
initializer silences the cppcheck warning even on the unreachable path.

## Test plan

- [x] 1412/1412 unit tests pass on VPS (cmake --build . + ./test_superscalar --unit)
- [x] cppcheck warning resolved (will be confirmed when CI runs on this PR)
- [ ] Regtest pass (CI)
- [ ] Once merged, rebase #109 and #110 — both should then go fully green

## Why this PR exists

PR #109 (N=64 scaling pack) and #110 (signet_setup `--lsp-pubkey`) both
inherit a Static Analysis failure from main introduced by the
static-near-root merge (#105). Rather than ship a one-line cosmetic
silencing of cppcheck, this PR fixes the underlying latent bug
properly so subsequent PRs can merge with all-green CI.