### PR TITLE
fix(test): activate test_regtest_htlc_in_flight_spendability + fix run_htlc_in_flight bookkeeping

### DIFF
--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -992,8 +992,15 @@ static int run_htlc_in_flight(regtest_t *rt, secp256k1_context *ctx,
     TEST_ASSERT(htlc_out_amt == htlc_amt, "htlc: amount matches");
     TEST_ASSERT(htlc_spk_len == 34, "htlc: output is P2TR");
 
-    /* Register the preimage so channel_build_htlc_success_tx can find it. */
-    channel_fulfill_htlc(&lsp_ch, lsp_htlc_id, preimage);
+    /* Register the preimage so channel_build_htlc_success_tx can find it.
+       NOTE: do NOT call channel_fulfill_htlc — that advances commitment_number
+       as a side effect, which would cause channel_rebuild_htlc_leaves to
+       derive HTLC keys with a DIFFERENT per_commitment_point than was used
+       to build the on-chain commitment, producing a witness program hash
+       mismatch.  Mirror test_regtest_htlc_success (test_channel.c) by
+       writing the preimage directly. */
+    (void)lsp_htlc_id;
+    memcpy(lsp_ch.htlcs[0].payment_preimage, preimage, 32);
 
     /* Build + broadcast HTLC-success tx.  channel_build_htlc_success_tx
        sets nSequence=to_self_delay (=csv=10) for HTLC_RECEIVED.  BIP-68
@@ -1191,21 +1198,22 @@ int test_regtest_rotation_all_arities(void) {
 }
 
 int test_regtest_htlc_in_flight_spendability(void) {
-    /* HTLC-in-flight resolution is covered by test_regtest_htlc_success
-       (test_channel.c) and test_regtest_htlc_timeout for the
-       single-channel preimage and CLTV paths.
-
-       The in-process two-channel re-implementation `run_htlc_in_flight`
-       (above) reproducibly fails with `mempool-script-verify-flag-failed
-       (Witness program hash mismatch)`. Real protocol-level bug in how
-       the two-channel test setup derives htlc_basepoint keys vs the
-       single-channel pattern. Investigation notes are in
-       .claude/CAMPAIGN4_FORCE_CLOSE_N64_JOURNAL.md (never committed).
-       Tracked as a separate task — needs ~2-4 hr focused debug. */
-    (void)run_htlc_in_flight;
-    printf("  covered by test_regtest_htlc_success + test_regtest_htlc_timeout\n");
-    printf("  TODO: fix run_htlc_in_flight witness-key derivation mismatch\n");
-    return 1;
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    regtest_t rt;
+    if (!regtest_init(&rt)) {
+        printf("  SKIP: bitcoind not available\n");
+        secp256k1_context_destroy(ctx);
+        return 1;
+    }
+    regtest_create_wallet(&rt, "htlc_inflight_spend");
+    char mine_addr[128];
+    if (!regtest_get_new_address(&rt, mine_addr, sizeof(mine_addr))) return 0;
+    if (!regtest_fund_from_faucet(&rt, 1.0))
+        regtest_mine_blocks(&rt, 101, mine_addr);
+    int ok = run_htlc_in_flight(&rt, ctx, mine_addr);
+    secp256k1_context_destroy(ctx);
+    return ok;
 }
 
 int test_regtest_ps_chain_close_spendability(void) {


### PR DESCRIPTION
## Summary

Activates the `test_regtest_htlc_in_flight_spendability` test that has been
a stub since its inception, and fixes the underlying bug in
`run_htlc_in_flight` that the original author had punted on.

## The bug

`run_htlc_in_flight` called `channel_fulfill_htlc` to register the
preimage before invoking `channel_build_htlc_success_tx`. But
`channel_fulfill_htlc` (src/channel.c:1708) advances
`ch->commitment_number` as a side effect.

That made `channel_rebuild_htlc_leaves` derive the HTLC's
per-commitment-point at `commit_num=N+1` — producing different
`local_htlc_xonly`, `remote_htlc_xonly`, and `revocation_xonly` than
were used to build the on-chain commitment at `commit_num=N`. The
witness control block reproduced the wrong merkle root, and the on-chain
script verifier rejected the HTLC-success TX with:

```
mempool-script-verify-flag-failed (Witness program hash mismatch)
```

## Diagnostic

Instrumentation in `channel_build_commitment_tx_impl` and
`channel_rebuild_htlc_leaves` (since reverted) confirmed:

```
HTLC_DIAG[BUILD]   commit_num=1 rev=48100416 lhtlc=3b8b5309 rhtlc=8544d15c ...
HTLC_DIAG[REBUILD] commit_num=2 rev=60697d8d lhtlc=28cd6083 rhtlc=095a7a36 ...
```

Identical inputs, different `commit_num` → different keys → mismatch.

## The fix

Mirror `test_regtest_htlc_success` (test_channel.c, line 2024) which
writes the preimage directly via:

```c
memcpy(ch.htlcs[0].payment_preimage, preimage, 32);
```

instead of calling `channel_fulfill_htlc`. This avoids the unwanted
commitment_number advance. After the fix:

```
HTLC_DIAG[BUILD]   commit_num=1 rev=24778b95 lhtlc=b7994498 ...
HTLC_DIAG[REBUILD] commit_num=1 rev=24778b95 lhtlc=b7994498 ...
```

Identical keys. Witness verifies. HTLC-success TX confirms on chain.

## Result

```
test_regtest_htlc_in_flight_spendability...
  HTLC: commitment (with HTLC output) confirmed b996f163...
  HTLC: success tx resolved 5000 sats via preimage: be77edf4... ✓
 OK
Results: 1/1 passed
```

## Why this is JUST a test fix (no production change)

The bug was in test scaffolding. `channel_fulfill_htlc` is correctly
designed for the in-protocol HTLC-fulfill path: it advances the
commitment number because in BOLT-2 production use you negotiate a NEW
commitment after fulfillment. The test misused it. Production code
unchanged.

## Test plan

- [x] `test_regtest_htlc_in_flight_spendability` passes on VPS regtest
- [x] No production code touched
- [ ] Full CI run on this PR