### PR TITLE
fix(lsp): require slot_hints on non-regtest to prevent fund-loss

### DIFF
--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -52,6 +52,14 @@ typedef struct {
        NULL = use equal split (initial creation). */
     const uint64_t *dist_client_amounts;
     size_t dist_n_client_amounts;
+
+    /* When set, lsp_accept_clients refuses to proceed unless every client's
+       HELLO included a valid slot_hint forming a permutation of 1..n_clients.
+       Without slot_hints the funding-address derivation depends on TCP accept
+       order — non-deterministic across restarts, which is a fund-loss risk
+       (Campaign #3 stranded 6.5M signet sats this way). Enable on all
+       non-regtest deployments. Default: 0 (off, regtest-friendly). */
+    int require_slot_hints;
 } lsp_t;
 
 /* Initialize LSP state. Returns 1 on success, 0 on failure. */

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -178,7 +178,13 @@ int lsp_accept_clients(lsp_t *lsp) {
 
     /* If every client sent a valid slot_hint forming a permutation of
        1..n_clients, reorder client_pubkeys/client_fds to match. This makes
-       the funding-address keyagg deterministic across restarts. */
+       the funding-address keyagg deterministic across restarts.
+
+       If require_slot_hints is set (production deployments), refuse to
+       proceed without a valid permutation — operator forgot to pass
+       --participant-id to clients. This avoids the silent fund-loss
+       Campaign #3 hit: connect-order-dependent funding addresses get
+       stranded on every restart. */
     {
         int all_hinted = 1;
         int seen[FACTORY_MAX_SIGNERS] = {0};
@@ -186,6 +192,16 @@ int lsp_accept_clients(lsp_t *lsp) {
             int s = hello_slot_hints[i];
             if (s < 1 || (size_t)s > lsp->n_clients || seen[s]) { all_hinted = 0; break; }
             seen[s] = 1;
+        }
+        if (lsp->require_slot_hints && !all_hinted) {
+            fprintf(stderr, "LSP: ERROR — require_slot_hints is set but not all "
+                    "clients supplied a valid slot_hint forming a permutation "
+                    "of 1..%zu. Funding-address derivation would be "
+                    "non-deterministic across restarts (fund-loss risk). "
+                    "Each client must launch with --participant-id N "
+                    "(unique value 1..%zu).\n",
+                    lsp->n_clients, lsp->n_clients);
+            goto accept_fail;
         }
         if (all_hinted && lsp->n_clients > 0) {
             for (size_t target = 0; target < lsp->n_clients; target++) {

--- a/tools/signet_setup.sh
+++ b/tools/signet_setup.sh
@@ -589,6 +589,7 @@ cmd_start_client() {
                 --passphrase "${KEYFILE_PASSPHRASE:-superscalar}" \
                 --network signet \
                 --port $LSP_PORT \
+                --participant-id 1 \
                 --daemon \
                 --db "$CLIENTDB" \
             > "$LOGDIR/client.log" 2>&1 &
@@ -626,6 +627,7 @@ cmd_start_client2() {
                 --passphrase "${KEYFILE_PASSPHRASE:-superscalar}" \
                 --network signet \
                 --port $LSP_PORT \
+                --participant-id 2 \
                 --daemon \
                 --db "$CLIENT2DB" \
             > "$LOGDIR/client2.log" 2>&1 &
@@ -684,11 +686,17 @@ _start_demo_clients() {
         local DBFILE="$DATADIR/client${i}.db"
         local LOGFILE="$LOGDIR/${LOGPFX}_client${i}.log"
 
+        # --participant-id N is REQUIRED on non-regtest networks to make the
+        # funding-address keyagg deterministic across restarts.  Without it,
+        # connect-order non-determinism strands funds.  Campaign #3 lost
+        # 6.5M signet sats this way.  signet_setup.sh assigns id = client
+        # number (1..N) so the LSP can sort consistently every restart.
         "$SCBIN/superscalar_client" \
                 --keyfile "$KEYFILE" \
                 --passphrase "${KEYFILE_PASSPHRASE:-superscalar}" \
                 --network "$NET" \
                 --port "$PORT" \
+                --participant-id "$i" \
                 --db "$DBFILE" \
                 $LSP_PUBKEY_ARG \
                 $EXTRA_ARGS \

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2147,6 +2147,10 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
             g_lsp = lsp_rp;
+            /* Recovery path uses persisted state — require_slot_hints would
+               only kick in for new client reconnections; honor same policy
+               as fresh launch so deployments stay consistent. */
+            lsp_rp->require_slot_hints = (strcmp(network, "regtest") != 0);
             lsp_rp->use_nk = 1;
             memcpy(lsp_rp->nk_seckey, lsp_seckey, 32);
 
@@ -2552,6 +2556,13 @@ accept_new_factory:
     if (max_connections_arg > 0)
         lsp_p->max_connections = max_connections_arg;
     rate_limiter_init(&lsp_p->rate_limiter, max_conn_rate_arg, 60, max_handshakes_arg);
+
+    /* On non-regtest networks, REQUIRE every client to send a slot_hint in
+       HELLO (via --participant-id N). Without it, the funding-address
+       derivation depends on TCP accept order — non-deterministic across
+       restarts, which strands funds. Campaign #3 stranded 6.5M signet sats
+       this way. Regtest skips the check since tests use ephemeral funding. */
+    lsp_p->require_slot_hints = (strcmp(network, "regtest") != 0);
 
     /* Enable NK (server-authenticated) noise handshake */
     lsp_p->use_nk = 1;


### PR DESCRIPTION
## Summary

- Closes the silent fund-loss path that stranded **6.5M signet sats** in Campaign #3
- Makes the PR #109 slot_hint mechanism **mandatory** on signet/mainnet
- Regtest stays lenient (test fixtures keep working unchanged)

## The bug

The 65-party MuSig2 funding-address keyagg is sensitive to participant order. Without slot_hints, the LSP orders pubkeys by TCP accept order — non-deterministic across restarts. Same N clients reconnecting after an LSP restart land in a different order → keyagg → different funding address → previously-funded address has no live channel anymore. Funds get stranded.

PR #109 added the `slot_hint` HELLO field so each client can declare its slot, but enforcement was opportunistic: if any one client forgot `--participant-id`, the LSP silently fell back to connect-order. Campaign #3 hit this exact path.

## The fix

`lsp_t::require_slot_hints` flag. When set, `lsp_accept_clients` refuses HELLO unless every client supplies a valid slot_hint forming a `1..n_clients` permutation, with an explicit error pointing the operator at `--participant-id`. Defaults to off to preserve regtest test fixtures; `tools/superscalar_lsp.c` flips it on for any non-regtest network at both fresh-launch and recovery-path entries.

`tools/signet_setup.sh` updated to pass `--participant-id N` at all three client-launch sites (single-client, client2, demo loop).

## Test plan

- [x] Clean build on VPS (CMake)
- [x] 1412/1412 unit tests pass (regtest path = `require_slot_hints=0`, no behavior change)
- [x] N=64 mixed-arity {2,4,8} static_threshold=1 lifecycle still 1/1
- [ ] CI green
- [ ] Smoke-test on signet manually after merge to confirm clients pick up the new flag and LSP refuses without it

## Risk

Low. Production signet/mainnet deployments today are already supposed to pass `--participant-id` per docs; this just hardens what was advisory. Worst case the LSP refuses to accept a misconfigured client and the operator fixes the launch script.