### PR TITLE
refactor(factory): extract factory_client_to_leaf canonical helper

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -258,6 +258,32 @@ void factory_set_arity(factory_t *f, factory_arity_t arity);
    Must be called after init, before build_tree. */
 void factory_set_level_arity(factory_t *f, const uint8_t *arities, size_t n);
 
+/* Map a 0-based client index to its (leaf-node, vout) position in the
+   built tree.  Returns 1 on success, 0 if the client_idx is out of range
+   or doesn't appear in any leaf's signer_indices.
+
+   Behavior is arity-aware:
+
+   - Mixed-arity factories (n_level_arity > 0): walks
+     factory->leaf_node_indices[] and matches my_index = client_idx + 1
+     against each leaf's signer_indices[].  vout = position in
+     signer_indices minus 1 (signer_indices[0] == 0 is the LSP).  This
+     is the only correct mapping when leaves can hold > 2 channels.
+
+   - Uniform ARITY_1: each client owns its own leaf at vout 0.
+     node_idx = leaf_node_indices[client_idx], vout = 0.
+
+   - Uniform ARITY_2 / ARITY_PS: legacy 2-clients-per-leaf packing.
+     leaf_idx = client_idx / 2, vout = client_idx % 2.  PS leaves rely
+     on this shared-leaf chain semantic that the walk-leaves approach
+     would not reproduce.
+
+   Use this from any code that previously open-coded the mapping
+   (src/client.c::client_init_channel, src/lsp_channels.c::client_to_leaf,
+   etc.) to keep the two sides of the wire ceremony in sync. */
+int factory_client_to_leaf(const factory_t *f, size_t client_idx,
+                            size_t *node_idx_out, uint32_t *vout_out);
+
 /* Configure the static-near-root threshold (Phase 3 of mixed-arity plan).
    Depths in [0, threshold) become kickoff-only (no paired NODE_STATE, no
    DW counter, no per-state nSequence — only the per-node CLTV timeout

--- a/src/client.c
+++ b/src/client.c
@@ -159,50 +159,19 @@ int client_init_channel(channel_t *ch, secp256k1_context *ctx,
                                  const unsigned char *local_revoc_sec32,
                                  const unsigned char *local_htlc_sec32,
                                  fee_estimator_t *fee_est) {
-    /* Map client index to leaf output (arity-aware).
-       Mixed-arity (n_level_arity > 0) leaves can hold up to 8 channels,
-       so the legacy `leaf_idx = client_idx / 2; vout = client_idx % 2`
-       formula computes a leaf index that may not exist (and an output_idx
-       that's wrong).  For mixed-arity, walk leaves and match my_index
-       against signer_indices[]; the in-leaf position becomes the vout.
-       For uniform arities (ARITY_1, ARITY_2, ARITY_PS), keep the legacy
-       formula — PS leaves rely on a shared-leaf chain semantic that the
-       walk-leaves approach would not reproduce. */
+    /* Map client index to leaf output via the canonical helper.  See
+       factory.h::factory_client_to_leaf for the arity-aware semantics
+       (mixed-arity walks signer_indices; uniform arities use legacy
+       formula).  Centralizing this keeps client.c and lsp_channels.c in
+       sync — divergent open-coded copies caused the bug fixed in
+       PR #117. */
     size_t client_idx = (size_t)(my_index - 1);  /* my_index is 1-based */
     size_t node_idx;
     uint32_t vout;
-    if (factory->n_level_arity > 0) {
-        node_idx = (size_t)-1;
-        vout = (uint32_t)-1;
-        for (int li = 0; li < factory->n_leaf_nodes; li++) {
-            size_t ni = factory->leaf_node_indices[li];
-            const factory_node_t *leaf = &factory->nodes[ni];
-            /* signer_indices[0] == 0 (LSP); clients occupy 1..n_signers-1.
-               Their leaf-output positions are 0..n_signers-2 (L-stock
-               output is the last entry, after the per-channel outputs). */
-            for (size_t s = 1; s < leaf->n_signers; s++) {
-                if (leaf->signer_indices[s] == my_index) {
-                    node_idx = ni;
-                    vout = (uint32_t)(s - 1);
-                    break;
-                }
-            }
-            if (node_idx != (size_t)-1) break;
-        }
-        if (node_idx == (size_t)-1) {
-            fprintf(stderr, "Client %u: not found in any mixed-arity leaf "
-                    "signer_indices\n", my_index);
-            return 0;
-        }
-    } else if (factory->leaf_arity == FACTORY_ARITY_1) {
-        if (client_idx >= (size_t)factory->n_leaf_nodes) return 0;
-        node_idx = factory->leaf_node_indices[client_idx];
-        vout = 0;
-    } else {
-        size_t leaf_idx = client_idx / 2;
-        if (leaf_idx >= (size_t)factory->n_leaf_nodes) return 0;
-        node_idx = factory->leaf_node_indices[leaf_idx];
-        vout = (uint32_t)(client_idx % 2);
+    if (!factory_client_to_leaf(factory, client_idx, &node_idx, &vout)) {
+        fprintf(stderr, "Client %u: factory_client_to_leaf failed\n",
+                my_index);
+        return 0;
     }
 
     const factory_node_t *state_node = &factory->nodes[node_idx];

--- a/src/factory.c
+++ b/src/factory.c
@@ -689,6 +689,48 @@ static void simulate_tree(const factory_t *f, size_t n_clients,
     *leaves_out = leaves;
 }
 
+int factory_client_to_leaf(const factory_t *f, size_t client_idx,
+                            size_t *node_idx_out, uint32_t *vout_out) {
+    if (!f || !node_idx_out || !vout_out) return 0;
+
+    if (f->n_level_arity > 0) {
+        /* Mixed-arity factories: walk leaves and match by signer_indices.
+           Leaves can hold up to 8 channels; the legacy formula below
+           computes leaves that may not exist and outputs that are wrong. */
+        uint32_t my_index = (uint32_t)(client_idx + 1);  /* signer_indices is 1-based */
+        for (int li = 0; li < f->n_leaf_nodes; li++) {
+            size_t ni = f->leaf_node_indices[li];
+            const factory_node_t *leaf = &f->nodes[ni];
+            for (size_t s = 1; s < leaf->n_signers; s++) {
+                if (leaf->signer_indices[s] == my_index) {
+                    *node_idx_out = ni;
+                    *vout_out = (uint32_t)(s - 1);
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+
+    if (f->leaf_arity == FACTORY_ARITY_1) {
+        if (client_idx >= (size_t)f->n_leaf_nodes) return 0;
+        *node_idx_out = f->leaf_node_indices[client_idx];
+        *vout_out = 0;
+        return 1;
+    }
+
+    /* ARITY_2 (and ARITY_PS via shared-leaf chain semantic): 2 clients per
+       leaf, layout [vout 0 = client A's channel, vout 1 = client B's channel
+       or PS-chain second slot, vout 2 = L-stock when present]. */
+    {
+        size_t leaf_idx = client_idx / 2;
+        if (leaf_idx >= (size_t)f->n_leaf_nodes) return 0;
+        *node_idx_out = f->leaf_node_indices[leaf_idx];
+        *vout_out = (uint32_t)(client_idx % 2);
+        return 1;
+    }
+}
+
 void factory_set_level_arity(factory_t *f, const uint8_t *arities, size_t n) {
     if (n > FACTORY_MAX_LEVELS) n = FACTORY_MAX_LEVELS;
     memcpy(f->level_arity, arities, n);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -105,49 +105,17 @@ void lsp_send_revocation(lsp_channel_mgr_t *mgr, lsp_t *lsp,
  */
 
 /* Map client index (0-based) to factory state node and vout.
-   Uses factory's leaf_node_indices[] for arity-agnostic lookup.
-
-   Mixed-arity (n_level_arity > 0) leaves can hold up to 8 channels, so the
-   legacy `leaf_idx = client_idx / 2; vout = client_idx % 2` formula
-   computes a leaf index that may not exist, AND it would disagree with
-   the client side (src/client.c::client_init_channel uses a leaf-walk
-   for mixed-arity).  Without this match the LSP and client build
-   different funding SPKs / different channels, MuSig commitment sigs
-   never verify, and channels for any client beyond #0 are non-functional.
-   For uniform arities (ARITY_1, ARITY_2, ARITY_PS) keep the legacy
-   formula — PS leaves rely on its shared-leaf chain semantics. */
+   Thin wrapper around the canonical factory_client_to_leaf helper —
+   keeps the LSP and client side in sync (divergence here was the
+   PR #117 bug class).  On lookup failure (out-of-range client_idx, or
+   not present in any mixed-arity leaf), returns (node_idx=0,
+   vout=UINT32_MAX) so callers' n_outputs bounds check rejects the
+   entry instead of accessing a wrong leaf. */
 static void client_to_leaf(size_t client_idx, const factory_t *factory,
                             size_t *node_idx_out, uint32_t *vout_out) {
-    if (factory->n_level_arity > 0) {
-        uint32_t my_index = (uint32_t)(client_idx + 1);  /* 1-based in signer_indices */
-        for (int li = 0; li < factory->n_leaf_nodes; li++) {
-            size_t ni = factory->leaf_node_indices[li];
-            const factory_node_t *leaf = &factory->nodes[ni];
-            for (size_t s = 1; s < leaf->n_signers; s++) {
-                if (leaf->signer_indices[s] == my_index) {
-                    *node_idx_out = ni;
-                    *vout_out = (uint32_t)(s - 1);
-                    return;
-                }
-            }
-        }
-        /* Not found — fall through to fallback so callers' n_outputs
-           bounds check rejects this entry instead of accessing wrong leaf. */
+    if (!factory_client_to_leaf(factory, client_idx, node_idx_out, vout_out)) {
         *node_idx_out = 0;
         *vout_out = UINT32_MAX;
-        return;
-    }
-    if (factory->leaf_arity == FACTORY_ARITY_1) {
-        /* Arity-1: each client has its own leaf node, channel at vout 0 */
-        *node_idx_out = (client_idx < (size_t)factory->n_leaf_nodes)
-            ? factory->leaf_node_indices[client_idx] : 0;
-        *vout_out = 0;
-    } else {
-        /* Arity-2 (and ARITY_PS via shared-leaf chain): 2 clients per leaf */
-        size_t leaf_idx = client_idx / 2;
-        *node_idx_out = (leaf_idx < (size_t)factory->n_leaf_nodes)
-            ? factory->leaf_node_indices[leaf_idx] : 0;
-        *vout_out = (uint32_t)(client_idx % 2);
     }
 }
 

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6373,3 +6373,182 @@ int test_factory_static_near_root_backward_compat(void) {
     free(f_b);
     return 1;
 }
+
+/* factory_client_to_leaf — canonical helper round-trip across every
+   supported factory shape.  Catches the bug class fixed in PRs #116/#117
+   (divergent open-coded mappings on the LSP and client sides) by asserting
+   that every client maps to a (node_idx, vout) that:
+     - points to an existing leaf node
+     - has vout < leaf->n_outputs
+     - leaf's signer_indices contains client_idx + 1 (the LSP-side check).
+   And that the mapping is 1:1 (no two clients land on the same slot).
+
+   Verifies arity-1, arity-2, mixed-arity {2,4}, mixed-arity {2,4,8}.
+   PS isn't covered here because factory_set_arity(PS) shares the
+   ARITY_2 codepath; the dedicated PS regtest tests
+   (test_regtest_multi_payment_arity_ps) exercise it end-to-end. */
+static int verify_client_to_leaf_roundtrip(factory_t *f, size_t n_clients,
+                                            const char *label) {
+    /* Track which (node_idx, vout) pairs have been assigned. */
+    typedef struct { size_t node; uint32_t vout; int taken; } slot_t;
+    slot_t *taken = calloc(n_clients * 2, sizeof(slot_t));
+    if (!taken) return 0;
+
+    for (size_t c = 0; c < n_clients; c++) {
+        size_t node_idx = (size_t)-1;
+        uint32_t vout = (uint32_t)-1;
+        if (!factory_client_to_leaf(f, c, &node_idx, &vout)) {
+            fprintf(stderr, "[%s] client %zu: factory_client_to_leaf returned 0\n",
+                    label, c);
+            free(taken);
+            return 0;
+        }
+        if (node_idx >= f->n_nodes) {
+            fprintf(stderr, "[%s] client %zu: node_idx %zu out of range\n",
+                    label, c, node_idx);
+            free(taken);
+            return 0;
+        }
+        const factory_node_t *leaf = &f->nodes[node_idx];
+        if (vout >= leaf->n_outputs) {
+            fprintf(stderr, "[%s] client %zu: vout %u >= leaf n_outputs %zu\n",
+                    label, c, vout, leaf->n_outputs);
+            free(taken);
+            return 0;
+        }
+
+        /* Mixed-arity sanity: signer_indices should contain my_index. */
+        if (f->n_level_arity > 0) {
+            uint32_t my_index = (uint32_t)(c + 1);
+            int found = 0;
+            for (size_t s = 1; s < leaf->n_signers; s++) {
+                if (leaf->signer_indices[s] == my_index) { found = 1; break; }
+            }
+            if (!found) {
+                fprintf(stderr, "[%s] client %zu: my_index=%u not in leaf "
+                        "signer_indices\n", label, c, my_index);
+                free(taken);
+                return 0;
+            }
+        }
+
+        /* 1:1 check */
+        for (size_t k = 0; k < n_clients * 2; k++) {
+            if (taken[k].taken &&
+                taken[k].node == node_idx && taken[k].vout == vout) {
+                fprintf(stderr, "[%s] client %zu collides with prior client "
+                        "at (node=%zu, vout=%u)\n", label, c, node_idx, vout);
+                free(taken);
+                return 0;
+            }
+        }
+        for (size_t k = 0; k < n_clients * 2; k++) {
+            if (!taken[k].taken) {
+                taken[k].node = node_idx;
+                taken[k].vout = vout;
+                taken[k].taken = 1;
+                break;
+            }
+        }
+    }
+    free(taken);
+    return 1;
+}
+
+int test_factory_client_to_leaf_roundtrip(void) {
+    secp256k1_context *ctx = test_ctx();
+
+    /* Shape 1: arity-1 at N=4 — each client owns its own leaf at vout 0. */
+    {
+        secp256k1_keypair kps[5];
+        factory_t *f = calloc(1, sizeof(factory_t));
+        TEST_ASSERT(f, "alloc arity-1 factory");
+        ensure_seckeys_n();
+        for (int i = 0; i < 5; i++)
+            TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], seckeys_n[i]),
+                        "kp arity-1");
+        factory_init(f, ctx, kps, 5, 2, 4);
+        factory_set_arity(f, FACTORY_ARITY_1);
+        unsigned char fake_txid[32]; memset(fake_txid, 0xBB, 32);
+        unsigned char fake_spk[34]; memset(fake_spk, 0, 34);
+        factory_set_funding(f, fake_txid, 0, 1000000, fake_spk, 34);
+        TEST_ASSERT(factory_build_tree(f), "build arity-1 tree");
+
+        /* Spot-check known mapping: client i → leaf i, vout 0. */
+        for (size_t c = 0; c < 4; c++) {
+            size_t ni = (size_t)-1; uint32_t vo = (uint32_t)-1;
+            TEST_ASSERT(factory_client_to_leaf(f, c, &ni, &vo), "arity-1 lookup");
+            TEST_ASSERT_EQ(ni, f->leaf_node_indices[c], "arity-1 client→leaf");
+            TEST_ASSERT_EQ(vo, 0, "arity-1 vout=0");
+        }
+        TEST_ASSERT(verify_client_to_leaf_roundtrip(f, 4, "arity-1 N=4"),
+                    "arity-1 round-trip");
+        factory_free(f); free(f);
+    }
+
+    /* Shape 2: arity-2 at N=4 — legacy formula, 2 clients per leaf. */
+    {
+        secp256k1_keypair kps[5];
+        factory_t *f = calloc(1, sizeof(factory_t));
+        TEST_ASSERT(f, "alloc arity-2 factory");
+        ensure_seckeys_n();
+        for (int i = 0; i < 5; i++)
+            TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], seckeys_n[i]),
+                        "kp arity-2");
+        factory_init(f, ctx, kps, 5, 2, 4);  /* default arity-2 */
+        unsigned char fake_txid[32]; memset(fake_txid, 0xCC, 32);
+        unsigned char fake_spk[34]; memset(fake_spk, 0, 34);
+        factory_set_funding(f, fake_txid, 0, 1000000, fake_spk, 34);
+        TEST_ASSERT(factory_build_tree(f), "build arity-2 tree");
+
+        /* Spot-check: client 0 → leaf 0 vout 0, client 1 → leaf 0 vout 1, ... */
+        for (size_t c = 0; c < 4; c++) {
+            size_t ni = (size_t)-1; uint32_t vo = (uint32_t)-1;
+            TEST_ASSERT(factory_client_to_leaf(f, c, &ni, &vo), "arity-2 lookup");
+            TEST_ASSERT_EQ(ni, f->leaf_node_indices[c / 2],
+                           "arity-2 client→leaf");
+            TEST_ASSERT_EQ(vo, (uint32_t)(c % 2), "arity-2 vout");
+        }
+        TEST_ASSERT(verify_client_to_leaf_roundtrip(f, 4, "arity-2 N=4"),
+                    "arity-2 round-trip");
+        factory_free(f); free(f);
+    }
+
+    /* Shape 3: mixed-arity {2,4} at N=12.  Walk-leaves path; 2-of-3
+       sub-trees of arity-4 leaves. */
+    {
+        secp256k1_keypair kps[12];
+        factory_t *f = calloc(1, sizeof(factory_t));
+        TEST_ASSERT(f, "alloc mixed {2,4} factory");
+        uint8_t arities[2] = { 2, 4 };
+        TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 12, arities, 2,
+                                                  5000000),
+                    "setup mixed {2,4}");
+        TEST_ASSERT(factory_build_tree(f), "build mixed {2,4}");
+        TEST_ASSERT(verify_client_to_leaf_roundtrip(f, 11, "mixed {2,4} N=11"),
+                    "mixed {2,4} round-trip");
+        factory_free(f); free(f);
+    }
+
+    /* Shape 4: mixed-arity {2,4,8} at N=16.  Three-level fan-out with
+       arity-8 leaves. */
+    {
+        const size_t N = 17;  /* 1 LSP + 16 clients */
+        secp256k1_keypair *kps = calloc(N, sizeof(secp256k1_keypair));
+        factory_t *f = calloc(1, sizeof(factory_t));
+        TEST_ASSERT(kps && f, "alloc mixed {2,4,8} factory");
+        uint8_t arities[3] = { 2, 4, 8 };
+        TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, N, arities, 3,
+                                                  10000000),
+                    "setup mixed {2,4,8}");
+        TEST_ASSERT(factory_build_tree(f), "build mixed {2,4,8}");
+        TEST_ASSERT(verify_client_to_leaf_roundtrip(f, 16, "mixed {2,4,8} N=16"),
+                    "mixed {2,4,8} round-trip");
+        factory_free(f);
+        free(f);
+        free(kps);
+    }
+
+    secp256k1_context_destroy(ctx);
+    return 1;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1671,6 +1671,7 @@ extern int test_factory_static_near_root_basic(void);
 extern int test_factory_static_near_root_n128_arity_2_4_8_static_2(void);
 extern int test_factory_static_near_root_node_nsequence(void);
 extern int test_factory_static_near_root_backward_compat(void);
+extern int test_factory_client_to_leaf_roundtrip(void);
 
 /* Wire TLV Foundation (Mainnet Gap #8) */
 extern int test_tlv_encode_decode(void);
@@ -3440,6 +3441,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_static_near_root_n128_arity_2_4_8_static_2);
     RUN_TEST(test_factory_static_near_root_node_nsequence);
     RUN_TEST(test_factory_static_near_root_backward_compat);
+    RUN_TEST(test_factory_client_to_leaf_roundtrip);
 
     printf("\n=== Wire TLV Foundation (Mainnet Gap #8) ===\n");
     RUN_TEST(test_tlv_encode_decode);


### PR DESCRIPTION
## Summary

Two open-coded copies of \"client_idx → (leaf, vout)\" mapping — `src/client.c::client_init_channel` and `src/lsp_channels.c::client_to_leaf` — were each fixed separately in PRs #116 and #117 after the gated walk-leaves correction was added. As separate copies they could drift again. This PR extracts a single canonical helper `factory_client_to_leaf` in `factory.c` and delegates both call sites to it.

**Pure refactor.** No behavior change from the post-#117 state.

## Why

Surfaced during the canonical-design gap audit (Gap C in `.claude/CANONICAL_DESIGN_GAPS.md` — never-shipped tracking doc). The audit confirmed:

- **client.c::client_init_channel** — refactored here ✓
- **lsp_channels.c::client_to_leaf** — refactored here ✓
- **lsp_channels.c:2019 in `lsp_channels_buy_liquidity`** — gated by an explicit `FACTORY_ARITY_2`-only check at line 1991, so unreachable for mixed-arity factories. Lifting that restriction is tangled with Gap E (PS sub-factory structure) and tracked as a separate follow-up, not a drop-in fix here.

## Helper behavior (unchanged from PR #117)

- **Mixed-arity** (`n_level_arity > 0`): walk `factory->leaf_node_indices` and match `my_index = client_idx + 1` against `signer_indices[]`; `vout = position - 1`.
- **ARITY_1**: each client owns its own leaf at vout 0.
- **ARITY_2 / ARITY_PS**: legacy 2-clients-per-leaf packing (PS leaves rely on a shared-leaf chain semantic the walk-leaves approach would not reproduce).

## Test plan

New unit test `test_factory_client_to_leaf_roundtrip` exercises the helper across every supported shape (arity-1 N=4, arity-2 N=4, mixed {2,4} N=11, mixed {2,4,8} N=16) and asserts:
- mapping returns success
- `(node_idx, vout)` is in-range and points to an existing leaf with `vout < n_outputs`
- mixed-arity: `signer_indices` contains `my_index`
- mapping is 1:1 across all clients

Verified on VPS:
- [x] 1413/1413 unit tests pass (was 1412 + this new test)
- [x] 3/3 bridge_payment regtest pass (N=5, N=64 client 0, N=64 client 8)
- [x] 3/3 wire_factory regtest pass (arity-2, arity-1, mixed-arity)
- [x] `multi_payment_arity1` + `multi_payment_arity_ps` both pass with fresh regtest state
- [ ] CI green