### PR TITLE
fix(factory): PS leaves are 1-client-per-leaf, not 2

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -270,13 +270,14 @@ void factory_set_level_arity(factory_t *f, const uint8_t *arities, size_t n);
      signer_indices minus 1 (signer_indices[0] == 0 is the LSP).  This
      is the only correct mapping when leaves can hold > 2 channels.
 
-   - Uniform ARITY_1: each client owns its own leaf at vout 0.
-     node_idx = leaf_node_indices[client_idx], vout = 0.
+   - Uniform ARITY_1 and ARITY_PS: each client owns its own leaf at
+     vout 0.  PS leaves are built 1-client-per-leaf (n_signers=2 = LSP +
+     1 client) with chained TXs replacing the per-state DW machine; the
+     mapping is identical to arity-1 here.
 
-   - Uniform ARITY_2 / ARITY_PS: legacy 2-clients-per-leaf packing.
-     leaf_idx = client_idx / 2, vout = client_idx % 2.  PS leaves rely
-     on this shared-leaf chain semantic that the walk-leaves approach
-     would not reproduce.
+   - Uniform ARITY_2: 2 clients per leaf, layout [vout 0 = client A's
+     channel, vout 1 = client B's channel, vout 2 = L-stock]; client_idx
+     i maps to (leaf i/2, vout i%2).
 
    Use this from any code that previously open-coded the mapping
    (src/client.c::client_init_channel, src/lsp_channels.c::client_to_leaf,

--- a/src/factory.c
+++ b/src/factory.c
@@ -712,16 +712,29 @@ int factory_client_to_leaf(const factory_t *f, size_t client_idx,
         return 0;
     }
 
-    if (f->leaf_arity == FACTORY_ARITY_1) {
+    /* ARITY_1 and ARITY_PS both build 1-client-per-leaf: ARITY_1 has a leaf
+       output of [vout 0 = client channel, vout 1 = L-stock]; ARITY_PS uses
+       [vout 0 = factory-consensus channel for the chain, vout 1 = L-stock]
+       with 1 client per leaf via setup_ps_leaf_outputs.  Both are looked up
+       the same way: client i owns leaf i, channel at vout 0.
+
+       Earlier versions of this helper conflated PS with arity-2 (2 clients
+       per leaf via `client_idx/2`), which silently broke ON-CHAIN ops for
+       any client beyond #0 in a PS factory: the channel keyagg got built
+       against the wrong leaf's L-stock SPK (LSP-only), so commitment sigs
+       could never verify on chain.  Off-chain payments still worked because
+       both sides agreed on the wrong keyagg, masking the bug — caught here
+       during the canonical-design audit (.claude/CANONICAL_DESIGN_GAPS.md
+       Gap E). */
+    if (f->leaf_arity == FACTORY_ARITY_1 || f->leaf_arity == FACTORY_ARITY_PS) {
         if (client_idx >= (size_t)f->n_leaf_nodes) return 0;
         *node_idx_out = f->leaf_node_indices[client_idx];
         *vout_out = 0;
         return 1;
     }
 
-    /* ARITY_2 (and ARITY_PS via shared-leaf chain semantic): 2 clients per
-       leaf, layout [vout 0 = client A's channel, vout 1 = client B's channel
-       or PS-chain second slot, vout 2 = L-stock when present]. */
+    /* ARITY_2: 2 clients per leaf, layout [vout 0 = client A's channel,
+       vout 1 = client B's channel, vout 2 = L-stock]. */
     {
         size_t leaf_idx = client_idx / 2;
         if (leaf_idx >= (size_t)f->n_leaf_nodes) return 0;

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6514,7 +6514,39 @@ int test_factory_client_to_leaf_roundtrip(void) {
         factory_free(f); free(f);
     }
 
-    /* Shape 3: mixed-arity {2,4} at N=12.  Walk-leaves path; 2-of-3
+    /* Shape 3: ARITY_PS at N=4 — each client owns its own PS leaf at
+       vout 0 (chain root).  Catches the legacy formula bug where PS got
+       the arity-2 mapping (`client_idx/2`), which silently mapped clients
+       1,3 to L-stock outputs (LSP-only) instead of their channel slots. */
+    {
+        secp256k1_keypair kps[5];
+        factory_t *f = calloc(1, sizeof(factory_t));
+        TEST_ASSERT(f, "alloc PS factory");
+        ensure_seckeys_n();
+        for (int i = 0; i < 5; i++)
+            TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], seckeys_n[i]),
+                        "kp PS");
+        factory_init(f, ctx, kps, 5, 2, 4);
+        factory_set_arity(f, FACTORY_ARITY_PS);
+        unsigned char fake_txid[32]; memset(fake_txid, 0xDD, 32);
+        unsigned char fake_spk[34]; memset(fake_spk, 0, 34);
+        factory_set_funding(f, fake_txid, 0, 1000000, fake_spk, 34);
+        TEST_ASSERT(factory_build_tree(f), "build PS tree");
+
+        /* Spot-check: client i → leaf i, vout 0 (no client_idx/2 packing). */
+        for (size_t c = 0; c < 4; c++) {
+            size_t ni = (size_t)-1; uint32_t vo = (uint32_t)-1;
+            TEST_ASSERT(factory_client_to_leaf(f, c, &ni, &vo), "PS lookup");
+            TEST_ASSERT_EQ(ni, f->leaf_node_indices[c],
+                           "PS client→own leaf");
+            TEST_ASSERT_EQ(vo, 0, "PS vout=0 (chain root)");
+        }
+        TEST_ASSERT(verify_client_to_leaf_roundtrip(f, 4, "ARITY_PS N=4"),
+                    "PS round-trip");
+        factory_free(f); free(f);
+    }
+
+    /* Shape 4: mixed-arity {2,4} at N=12.  Walk-leaves path; 2-of-3
        sub-trees of arity-4 leaves. */
     {
         secp256k1_keypair kps[12];


### PR DESCRIPTION
## Summary

`factory_client_to_leaf` was conflating ARITY_PS with ARITY_2's 2-clients-per-leaf packing (`leaf_idx = client_idx/2; vout = client_idx%2`). But `setup_ps_leaf_outputs` builds PS leaves with `n_signers=2` (LSP + 1 client) and `n_outputs=2` [vout 0 = chain-root channel, vout 1 = L-stock]. So at ARITY_PS with N≥4 (>1 client) the legacy formula maps clients 1, 3, 5, ... to L-stock outputs (LSP-only) instead of their per-client channel slots.

The bug was **latent**: both LSP and client used the same wrong formula, so they agreed on a wrong-but-consistent keyagg for off-chain commitment signing. Off-chain payments worked. But ON-chain force-close or coop-close from clients 1, 3, 5, ... would fail — their commitment sigs against `(LSP, client_i)` wouldn't verify against the L-stock SPK on chain.

No existing test exercised the bug:
- `test_regtest_htlc_force_to_local_arity_ps` uses N=2 (1 PS leaf, 1 client) — both formulas coincidentally agree at N=2
- `test_regtest_multi_payment_arity_ps` uses N=4 but is off-chain-only

## Fix

PS leaves use the same `(client_idx, 0)` mapping as ARITY_1. Each client owns its own PS leaf; the channel SPK is the leaf's factory-consensus 2-of-2 keyagg `(LSP, client_i)`.

## Surfaced from

Canonical-design audit Gap E (`.claude/CANONICAL_DESIGN_GAPS.md`). zmn's t/1242 actually calls for **k² clients per leaf with k PS sub-factories of k clients each** (so arity-k=2 leaves should have 4 clients in 2 sub-factories of 2 clients). That bigger structural refactor is tracked as task #181 — out of scope for this PR. This PR fixes the existing 1-client-per-leaf semantic to actually work end-to-end.

## Tests

- `test_factory_client_to_leaf_roundtrip` extended with ARITY_PS N=4: asserts each client maps to its own leaf at vout 0, not the arity-2-style packing.
- All existing regtest tests verified on VPS with fresh bitcoind state:
  - `bridge_payment` 3/3 (N=5, N=64 client 0, N=64 client 8)
  - `multi_payment_arity1` 1/1
  - `multi_payment_arity_ps` 1/1
  - `wire_factory` 3/3 (arity-2, arity-1, mixed-arity)
  - `htlc_force_to_local_arity_ps` 1/1
  - `htlc_breach_arity_ps` 1/1
- Unit suite 1413/1413 (with new PS shape coverage in the round-trip test).

## Test plan

- [x] VPS regression sweep (above)
- [ ] CI green
- [ ] Add regtest test for PS at N>=4 with on-chain force-close (tracked as task #182, separate PR)