### PR TITLE
feat: canonical L-stock SPK + per-client poison TX (zmn t/1242)

### DIFF
--- a/docs/poison-tx.md
+++ b/docs/poison-tx.md
@@ -1,0 +1,243 @@
+# L-stock SPK and Poison Transaction (canonical SuperScalar design)
+
+This document covers the L-stock spend conditions and the "poison
+transaction" cheating-recovery mechanism implemented per ZmnSCPxj's
+SuperScalar design at
+[Delving Bitcoin t/1242](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories-with-pseudo-spilman-leaves/1242).
+
+It supersedes the older t/1143 design that destroyed L-stock value via
+`OP_RETURN` on cheat detection.
+
+## L-stock SPK
+
+```
+internal key  = MuSig(LSP, client_1, ..., client_K)         "A & B & L"
+script-leaf   = <csv_blocks> CSV DROP <LSP_xonly> CHECKSIG  "L & CSV"
+```
+
+In zmn's t/1242 ASCII (for an arity-2 leaf with 2 clients, A and B):
+
+```
++-----+---------+
+|     |  A&B&L  | pseudo-Spilman factory
+| 432 |or(L&CSV)|
+|     |         |
++-----+---------+
+```
+
+Two paths to spend the L-stock UTXO:
+
+1. **Cooperative N-of-N MuSig** (key-path) — used by both:
+   - The legitimate cooperative close path: all leaf signers
+     (LSP + clients) co-sign together to spend L-stock.
+   - The pre-signed **poison transaction** that activates if the LSP
+     publishes an old (revoked) leaf state.
+
+2. **L-alone after a CSV delay** (script-path) — the LSP's unilateral
+   fallback.  Gated by a relative-locktime delay (`L_STOCK_CSV_DEFAULT_BLOCKS`,
+   default 144 blocks ≈ 1 day on mainnet) to give clients / watchtowers
+   time to broadcast the matching pre-signed poison TX before the LSP can
+   drain L-stock alone.  Configurable per factory via
+   `factory_set_l_stock_csv()`.
+
+Implementation: `src/factory.c::build_l_stock_spk()`.
+
+## Poison TX
+
+When an LSP publishes a stale leaf state, anyone (any client or
+watchtower) can broadcast the matching **pre-signed poison transaction**
+to redirect the L-stock value to the leaf's clients.
+
+Per zmn's t/1242 example:
+
+> Channel with `A`: 10 units → entirely goes to `A`.
+> Channel with `B`: 10 units → entirely goes to `B`.
+> LSP liquidity stock: 20 → split: 10 to `A`, 10 to `B`.
+
+The channel outputs are recovered via the standard Poon-Dryja revocation
+penalty (already implemented in `src/channel.c`).  The L-stock recovery
+is the new poison TX:
+
+- **Input** (1): the L-stock UTXO from the stale leaf state TX
+- **Outputs** (1 per non-LSP signer): equal share of
+  `(L-stock amount - fee)`, paid to a key-path-only `P2TR(client_xonly)`
+  for each client.  Any client can sweep their output unilaterally with
+  their own seckey.
+- **Witness**: 64-byte Schnorr signature from the leaf's N-of-N MuSig
+  key-path (A&B&L), pre-signed at leaf-state-advance time.
+
+Implementation:
+- `factory_build_l_stock_poison_tx_unsigned()` builds the unsigned TX
+  + computes the BIP-341 keypath sighash.
+- `factory_sign_l_stock_poison_tx()` (single-process) co-signs with all
+  leaf participants via `musig_sign_taproot` and returns the witnessed TX.
+- The wire-ceremony equivalent (where each client signs remotely via
+  split-round MuSig2) is a follow-up PR — for now the single-process
+  flow is what `factory_build_burn_tx` (the watchtower call site) uses.
+
+## Why this is correct vs zmn's design
+
+| Aspect | zmn's t/1242 | This implementation |
+|---|---|---|
+| L-stock internal key | `A & B & L` (N-of-N MuSig) | `node->keyagg.agg_pubkey` over leaf signers ✅ |
+| L-stock script-leaf | `or(L & CSV)` — LSP after CSV | `<csv> CSV DROP <LSP> CHECKSIG` ✅ |
+| Poison TX trigger | OLD leaf state TX confirmed on chain | OLD leaf state's L-stock UTXO becomes spendable ✅ |
+| Poison TX outputs | 1 per non-LSP client | 1 per non-LSP signer ✅ |
+| Per-client amount | Equal split (zmn's example: 10 to A, 10 to B) | `(amount - fee) / n_clients`, with rounding remainder to LAST recipient ✅ |
+| Per-client SPK | Each client controls their output | `P2TR(client_xonly)` — client's own pubkey, key-path-only ✅ |
+| Pre-signing | Implied (the poison TX must be ready before old state is broadcast) | Co-signed at leaf-state-advance time via N-of-N MuSig over leaf signers ✅ |
+| CSV value | Unspecified — operator choice | Default 144 blocks; configurable via `factory_set_l_stock_csv()` |
+
+The CSV value is the only operator-tunable parameter; everything else is
+spec-aligned.  144 blocks ≈ 1 day is a reasonable default — long enough
+for watchtowers to react under network congestion, short enough that an
+honest LSP isn't blocked indefinitely.
+
+## Security argument: the LSP is economically punished if it cheats
+
+Cheating = LSP publishes a STALE (already-revoked) leaf state, hoping to
+roll back a state where it had more capital allocated to L-stock or to
+its own channel side.
+
+**What happens if LSP publishes stale state:**
+
+1. The stale leaf state TX's L-stock UTXO appears on chain.
+2. The matching pre-signed poison TX (already in clients'/watchtowers'
+   hands from when that state was advanced past) is now valid.
+3. Anyone can broadcast the poison TX.  Per t/1242: *"any client can
+   trivially CPFP the 'poisoning' transaction"* — clients have unilateral
+   control of their share, so they have direct economic incentive to
+   CPFP if needed.
+4. L-stock value is redirected to clients (equal split).  The LSP gets
+   **nothing** from L-stock.
+5. The leaf's channel outputs (A&L, B&L) are also recoverable to
+   clients via the Poon-Dryja revocation penalty (separate mechanism).
+6. Net: cheater LSP loses (a) all L-stock capital + (b) all channel
+   capital that was its share at the time of the stale state.
+
+The LSP would only cheat if the gain from publishing an old state
+exceeded both losses.  Since the stale state by definition had LESS
+favorable balance for the LSP than the new state (otherwise why
+advance?), and the poison TX strips the entire L-stock + all channel
+sides go to clients via PD penalty, the LSP is strictly worse off
+publishing stale state.
+
+## Anti-griefing analysis (the load-bearing question for production)
+
+### Q1: Can a client preemptively drain L-stock by signing a poison TX alone?
+
+**No.**  The poison TX's authority is the leaf's **N-of-N MuSig**, which
+requires every leaf signer (LSP + every client in the leaf) to
+participate in signing.  A single client cannot produce a valid
+signature alone; nor can clients collude *without* the LSP — the LSP's
+share of the MuSig is required.
+
+### Q2: Can a malicious client trigger the poison TX by broadcasting a stale leaf state themselves?
+
+**Mostly no, by economic design.**  Two layers:
+
+(a) **Decker-Wattenhofer state ordering.**  Per the DW design, newer
+states have *lower* `nSequence` (relative locktime) than older ones, so
+when the kickoff TX confirms, the LSP can race to broadcast the latest
+state — which confirms first under BIP-68 — and supersede the stale
+state the client tried to publish.
+
+(b) **Static-near-root.** For root-level cheating attempts, the
+"static-near-root" variant we ship (PR #105, Phase 3 of the mixed-arity
+plan) means the root state TX has no `nSequence` ordering at all — the
+root output is unconditionally spendable by the next-layer's kickoff.
+Stale-root broadcasting doesn't create a window the client can exploit.
+
+(c) **Even if the client's stale-state broadcast succeeded** (e.g., the
+LSP is offline and can't race), the client's *own* channel side gets
+revoked under Poon-Dryja, so the L-stock share they recover via the
+poison TX is offset by the PD penalty paid to their counterparty.  Net
+client gain is bounded — typically negative if the client had ANY
+channel balance at the time of the stale state.
+
+(d) The client also has a strong **honest exit path**: cooperative
+close at any time gives them their channel balance + their share of any
+L-stock improvement that's been negotiated.  Cheating to grief is
+costlier than just leaving cooperatively.
+
+### Q3: Can the LSP grief by refusing to co-sign legitimate state advances?
+
+The LSP has **no incentive to refuse** because:
+- L-stock is part of LSP's capital.  Refusing to advance state freezes
+  the LSP's own L-stock too.
+- Clients can **cooperatively close** at any time (current state's
+  funding output is N-of-N spendable cooperatively).  An LSP that
+  refuses service simply gets force-exited.
+- The CSV gate on the L-stock script-path means LSP-alone unilateral
+  exit is not immediate — the LSP must wait `csv_blocks`, during which
+  clients can broadcast the poison TX of any *previously-revoked* state
+  (if the LSP attempts to publish one).  If the LSP attempts to drain
+  L-stock via the script-path with the LATEST state, that's a
+  legitimate exit and clients have no grievance.
+
+### Q4: Can the LSP unilaterally drain L-stock without waiting CSV?
+
+**Only by getting all clients to co-sign**, which is the cooperative
+N-of-N path.  Without client cooperation, the LSP must use the
+script-path, which is gated by `csv_blocks`.  During that delay, clients
+have time to either:
+- Co-sign cooperatively if it's a legitimate close, or
+- Broadcast a previous state's poison TX if the LSP cheated in the past
+  and never got punished.
+
+This is why the CSV value matters: too short and clients can't react;
+too long and honest LSP exits are slow.  The default 144 blocks
+(~1 day on mainnet) is a reasonable balance — operators can override
+per deployment via `factory_set_l_stock_csv()`.
+
+### Q5: Can a watchtower be tricked into broadcasting the poison TX during a legitimate close?
+
+**No.**  A legitimate cooperative close spends the *funding output*
+(the factory root), which never publishes any leaf state TX on chain.
+The poison TX requires the leaf state TX's L-stock UTXO to exist — that
+only happens if the leaf state TX was force-broadcast.  A force-close
+of the LATEST state is also fine: that L-stock UTXO has its own poison
+TX, but the broadcast is by the LSP itself (legitimate force-close),
+and the LSP doesn't broadcast its own poison TX.
+
+The watchtower only needs to broadcast a poison TX when it sees a
+*stale* leaf state TX confirmed on chain — distinguishable from the
+LATEST state because the LATEST state is what the watchtower itself was
+told about most recently.
+
+## Migration
+
+This change affects only **future** factories:
+
+- Existing on-chain factories were built with the OLD t/1143 SPK
+  structure (LSP-alone-key-path + hashlock-script-path).  Their
+  cheating-recovery still uses the OLD `OP_RETURN` burn TX, which is
+  pre-built and stored by the watchtower at advance time.  These
+  continue to work.  Factories built after this PR use the new SPK +
+  poison TX, registered with the watchtower the same way.
+
+- The shachain hashlock secrets are still used for **channel-level**
+  revocation (Poon-Dryja) inside the leaves — that mechanism is
+  unchanged.  Only the L-stock SPK and the burn-vs-poison TX semantics
+  changed.
+
+## What's deferred to a follow-up PR
+
+This PR ships the **single-process** poison TX flow:
+`factory_sign_l_stock_poison_tx` requires `f->keypairs[]` to hold the
+seckey for every leaf signer.  That's what the watchtower / unit-test
+builders have.  In the multi-process wire ceremony (LSP + clients on
+separate machines), each client's seckey isn't available to the LSP, so
+the LSP must coordinate a split-round MuSig2 round to gather partial
+sigs from each client.  That wire-ceremony co-signing is a follow-up:
+it'll extend the existing leaf-state-advance ceremony to also produce
+the poison TX signature alongside the new state TX.
+
+The single-process flow shipped here is sufficient for:
+- Unit testing of the new SPK + TX shape
+- Watchtower integration in single-LSP deployments where the LSP holds
+  all keys (test fixtures, signet self-tests)
+- The `factory_build_burn_tx` shim that the watchtower call site uses
+
+The wire-ceremony version is tracked in
+`.claude/CANONICAL_DESIGN_GAPS.md` (Gap A follow-up).

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -24,6 +24,17 @@
 
 #define NSEQUENCE_DISABLE_BIP68 0xFFFFFFFFu
 
+/* Default CSV (BIP-68 relative locktime) on the L-stock SPK's L&CSV
+   script-path leaf, in blocks.  Spec source: ZmnSCPxj's t/1242 doesn't
+   pin a value; the rationale is "long enough that watchtowers / clients
+   can broadcast the pre-signed L-stock poison TX before the LSP can
+   spend L-stock alone via the script-path."  144 blocks ≈ 1 day on
+   mainnet — generous reaction window, manageable on regtest.
+
+   The CSV value is per-factory configurable via factory_set_l_stock_csv()
+   (see below).  Override before factory_build_tree(). */
+#define L_STOCK_CSV_DEFAULT_BLOCKS 144u
+
 typedef enum {
     FACTORY_ARITY_2  = 2,   /* 2 clients per leaf (3-of-3), 2 DW layers */
     FACTORY_ARITY_1  = 1,   /* 1 client per leaf (2-of-2), 3 DW layers */
@@ -212,6 +223,11 @@ typedef struct {
        fan-out happens directly off the kickoff TX (no state intermediary). */
     uint32_t static_threshold_depth;
 
+    /* CSV (BIP-68 relative locktime) on the L-stock SPK's L&CSV
+       script-path leaf, in blocks.  See L_STOCK_CSV_DEFAULT_BLOCKS for
+       rationale and default. */
+    uint32_t l_stock_csv_blocks;
+
     /* Lifecycle (Phase 8) */
     uint32_t created_block;        /* block height when funding confirmed */
     uint32_t active_blocks;        /* duration of active period (default: 4320 = 30*144) */
@@ -257,6 +273,70 @@ void factory_set_arity(factory_t *f, factory_arity_t arity);
    Last entry applies to all deeper levels. Clears uniform leaf_arity.
    Must be called after init, before build_tree. */
 void factory_set_level_arity(factory_t *f, const uint8_t *arities, size_t n);
+
+/* Override the default L-stock CSV (BIP-68) blocks.  Must be called
+   before factory_build_tree() — otherwise the L-stock SPK is already
+   committed.  Pass 0 to keep the L_STOCK_CSV_DEFAULT_BLOCKS default. */
+void factory_set_l_stock_csv(factory_t *f, uint32_t csv_blocks);
+
+/* Build the unsigned L-stock POISON TRANSACTION for a leaf state.
+   Spends the L-stock UTXO (`l_stock_txid:l_stock_vout` carrying
+   `l_stock_amount_sats`) and pays each non-LSP signer in the leaf an
+   equal share of `(l_stock_amount_sats - fee)` to a P2TR output keyed on
+   that signer's xonly pubkey.
+
+   Implements ZmnSCPxj's t/1242 "poison transaction" cheating-recovery
+   mechanism: pre-signed at leaf-state-advance time, broadcast (by any
+   client / watchtower) if the LSP publishes the corresponding stale
+   leaf state on chain.  See docs/poison-tx.md (added in this PR) for
+   the full security argument.
+
+   Returns 1 on success.  Caller must initialize *poison_tx_out and
+   free it after use.  Sets *sighash_out32 to the BIP-341 key-path
+   sighash that signers must MuSig over to authorize the spend. */
+int factory_build_l_stock_poison_tx_unsigned(
+    const factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    tx_buf_t *poison_tx_out,
+    unsigned char *sighash_out32);
+
+/* Single-process variant: builds + N-of-N MuSig-co-signs + assembles
+   the witness for the L-stock poison TX.  Requires that f->keypairs[]
+   holds the seckey for every leaf signer (only true in the unit-test
+   builder; the wire ceremony will use a multi-round equivalent in a
+   follow-up PR).  Returns the fully-witnessed poison TX in *signed_out. */
+int factory_sign_l_stock_poison_tx(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    tx_buf_t *signed_out);
+
+/* Cooperative N-of-N spend of an L-stock UTXO to a caller-specified
+   output distribution.  The poison TX is a special case of this where
+   outputs are the per-client equal split; the same helper is used for
+   any legitimate cooperative L-stock spend (e.g. routing L-stock back
+   to the LSP's wallet during a planned close, with all clients having
+   agreed to the new distribution).
+
+   Like factory_sign_l_stock_poison_tx, requires f->keypairs[] to hold
+   the seckey for every leaf signer.  Multi-process wire-ceremony
+   equivalent is a follow-up PR. */
+int factory_sign_l_stock_cooperative_spend(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    const tx_output_t *outputs,
+    size_t n_outputs,
+    tx_buf_t *signed_out);
 
 /* Map a 0-based client index to its (leaf-node, vout) position in the
    built tree.  Returns 1 on success, 0 if the client_idx is out of range
@@ -402,8 +482,20 @@ void factory_set_l_stock_hashes(factory_t *f,
 int factory_get_revocation_secret(const factory_t *f, uint32_t epoch,
                                     unsigned char *secret_out32);
 
-/* Build a burn tx spending an old-state L-stock output via hashlock script path. */
-int factory_build_burn_tx(const factory_t *f, tx_buf_t *burn_tx_out,
+/* Build the L-stock POISON TX for a stale leaf state (canonical t/1242
+   design — supersedes the legacy OP_RETURN burn-as-fee approach).  Thin
+   wrapper around factory_sign_l_stock_poison_tx; kept for source
+   compatibility with the existing watchtower call site.
+
+   `leaf_node` identifies which leaf's L-stock is being poisoned (its
+   keyagg + signers determine the SPK and the per-client distribution).
+   `l_stock_txid32` / `l_stock_vout` / `l_stock_amount` describe the
+   on-chain UTXO of the OLD stale state being recovered from.
+
+   The `epoch` parameter is unused — the new design's authority is the
+   leaf signers' N-of-N MuSig, not a per-epoch hashlock secret. */
+int factory_build_burn_tx(factory_t *f, tx_buf_t *burn_tx_out,
+                           const factory_node_t *leaf_node,
                            const unsigned char *l_stock_txid,
                            uint32_t l_stock_vout,
                            uint64_t l_stock_amount,

--- a/src/factory.c
+++ b/src/factory.c
@@ -117,23 +117,9 @@ static int build_musig_p2tr_spk(
     return 1;
 }
 
-/* Build P2TR spk for a single pubkey (no MuSig). */
-static int build_single_p2tr_spk(
-    const secp256k1_context *ctx,
-    unsigned char *spk_out34,
-    secp256k1_xonly_pubkey *tweaked_out,
-    const secp256k1_pubkey *pubkey
-) {
-    secp256k1_xonly_pubkey internal;
-    if (!secp256k1_xonly_pubkey_from_pubkey(ctx, &internal, NULL, pubkey))
-        return 0;
-
-    if (!taproot_tweak_pubkey(ctx, tweaked_out, NULL, &internal, NULL))
-        return 0;
-
-    build_p2tr_script_pubkey(spk_out34, tweaked_out);
-    return 1;
-}
+/* (build_single_p2tr_spk removed — was only used by the legacy
+   shachain-hashlock L-stock SPK; the canonical or(N-of-N, L&CSV)
+   structure does not need it.) */
 
 /* Get nSequence for a node based on its type and DW layer.
    PS leaf state nodes always use 0xFFFFFFFE (BIP-68 disabled, anti-fee-snipe
@@ -230,58 +216,55 @@ static int add_node(
     return idx;
 }
 
-/* Build L-stock scriptPubKey.
-   If shachain is enabled: P2TR with key-path = LSP, script-path = hashlock.
-   If not: simple P2TR of LSP key. */
-static int build_l_stock_spk(const factory_t *f, unsigned char *spk_out34) {
-    if (f->has_shachain) {
-        unsigned char hash[32];
-        uint32_t epoch = f->counter.current_epoch;
+/* Build L-stock scriptPubKey per ZmnSCPxj's SuperScalar spec
+   (delvingbitcoin.org/t/1242).  Output is a P2TR with:
 
-        /* Use pre-computed hash if available (client side has hashes
-           but not secrets), otherwise derive from secret (LSP side). */
-        if (f->n_l_stock_hashes > 0) {
-            if (epoch >= f->n_l_stock_hashes) return 0;
-            memcpy(hash, f->l_stock_hashes[epoch], 32);
-        } else {
-            unsigned char secret[32];
-            if (f->use_flat_secrets) {
-                if (epoch >= f->n_revocation_secrets) return 0;
-                memcpy(secret, f->revocation_secrets[epoch], 32);
-            } else {
-                uint64_t sc_index = shachain_epoch_to_index(epoch);
-                shachain_from_seed(f->shachain_seed, sc_index, secret);
-            }
-            sha256(secret, 32, hash);
-            memset(secret, 0, 32);
-        }
+       key-path:    MuSig(LSP, all clients in this leaf)   "A & B & L"
+       script-leaf: <csv> CSV DROP <LSP_xonly> CHECKSIG    "L & CSV"
 
-        /* Build hashlock leaf */
-        tapscript_leaf_t hashlock_leaf;
-        tapscript_build_hashlock(&hashlock_leaf, hash);
+   The N-of-N key-path is what the pre-signed L-stock POISON transaction
+   uses to redirect L-stock value to clients if the LSP publishes a stale
+   leaf state.  The L&CSV script-path is the LSP's unilateral fallback —
+   gated by a CSV delay so clients / watchtowers have time to broadcast
+   the matching poison TX before the LSP can drain L-stock alone.
 
-        /* Compute merkle root from single leaf */
-        unsigned char merkle_root[32];
-        tapscript_merkle_root(merkle_root, &hashlock_leaf, 1);
+   Replaces the older shachain-hashlock-with-OP_RETURN-burn design from
+   t/1143 (which destroyed L-stock value on cheat detection rather than
+   redistributing it).  See docs/poison-tx.md and
+   .claude/CANONICAL_DESIGN_GAPS.md (Gap A + G).
 
-        /* Get LSP's xonly pubkey as internal key */
-        secp256k1_xonly_pubkey lsp_internal;
-        if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_internal, NULL,
-                                                  &f->pubkeys[0]))
-            return 0;
+   Caller passes the leaf state node — `leaf_node->keyagg.agg_pubkey` is
+   the N-of-N internal key, `leaf_node->signer_indices[]` enumerates the
+   clients that will receive equal shares in the poison TX. */
+static int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
+                              unsigned char *spk_out34) {
+    if (!f || !leaf_node || !spk_out34) return 0;
 
-        /* Tweak with merkle root */
-        secp256k1_xonly_pubkey tweaked;
-        if (!tapscript_tweak_pubkey(f->ctx, &tweaked, NULL,
-                                     &lsp_internal, merkle_root))
-            return 0;
+    /* Internal key = leaf's N-of-N MuSig agg pubkey (LSP + all leaf clients). */
+    secp256k1_xonly_pubkey internal_key = leaf_node->keyagg.agg_pubkey;
 
-        build_p2tr_script_pubkey(spk_out34, &tweaked);
-    } else {
-        secp256k1_xonly_pubkey tw;
-        if (!build_single_p2tr_spk(f->ctx, spk_out34, &tw, &f->pubkeys[0]))
-            return 0;
-    }
+    /* Script-leaf: <csv_blocks> CSV DROP <LSP_xonly> CHECKSIG. */
+    secp256k1_xonly_pubkey lsp_xonly;
+    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL,
+                                              &f->pubkeys[0]))
+        return 0;
+    uint32_t csv = f->l_stock_csv_blocks > 0
+                   ? f->l_stock_csv_blocks
+                   : L_STOCK_CSV_DEFAULT_BLOCKS;
+    tapscript_leaf_t csv_leaf;
+    if (!tapscript_build_csv_delay(&csv_leaf, csv, &lsp_xonly, f->ctx))
+        return 0;
+
+    unsigned char merkle_root[32];
+    if (!tapscript_merkle_root(merkle_root, &csv_leaf, 1))
+        return 0;
+
+    secp256k1_xonly_pubkey tweaked;
+    if (!tapscript_tweak_pubkey(f->ctx, &tweaked, NULL,
+                                 &internal_key, merkle_root))
+        return 0;
+
+    build_p2tr_script_pubkey(spk_out34, &tweaked);
     return 1;
 }
 
@@ -302,7 +285,7 @@ static int update_l_stock_outputs(factory_t *f) {
             continue;
 
         /* L-stock is always the last output */
-        if (!build_l_stock_spk(f, node->outputs[node->n_outputs - 1].script_pubkey))
+        if (!build_l_stock_spk(f, node, node->outputs[node->n_outputs - 1].script_pubkey))
             return 0;
     }
     return 1;
@@ -374,8 +357,8 @@ static int setup_leaf_outputs(
         node->outputs[1].amount_sats = per_output;
     }
 
-    /* L stock: LSP only, optionally with hashlock burn path */
-    if (!build_l_stock_spk(f, node->outputs[2].script_pubkey))
+    /* L-stock SPK: or(N-of-N keyagg, L&CSV) per ZmnSCPxj's t/1242 */
+    if (!build_l_stock_spk(f, node, node->outputs[2].script_pubkey))
         return 0;
     node->outputs[2].script_pubkey_len = 34;
     node->outputs[2].amount_sats = per_output + remainder;
@@ -689,6 +672,11 @@ static void simulate_tree(const factory_t *f, size_t n_clients,
     *leaves_out = leaves;
 }
 
+void factory_set_l_stock_csv(factory_t *f, uint32_t csv_blocks) {
+    if (!f) return;
+    f->l_stock_csv_blocks = csv_blocks;
+}
+
 int factory_client_to_leaf(const factory_t *f, size_t client_idx,
                             size_t *node_idx_out, uint32_t *vout_out) {
     if (!f || !node_idx_out || !vout_out) return 0;
@@ -842,8 +830,8 @@ static int setup_single_leaf_outputs(
         node->outputs[0].amount_sats = per_output;
     }
 
-    /* L stock: LSP only, optionally with hashlock burn path */
-    if (!build_l_stock_spk(f, node->outputs[1].script_pubkey))
+    /* L-stock SPK: or(N-of-N keyagg, L&CSV) per ZmnSCPxj's t/1242 */
+    if (!build_l_stock_spk(f, node, node->outputs[1].script_pubkey))
         return 0;
     node->outputs[1].script_pubkey_len = 34;
     node->outputs[1].amount_sats = per_output + remainder;
@@ -885,8 +873,8 @@ static int setup_ps_leaf_outputs(
     node->outputs[0].script_pubkey_len = node->spending_spk_len;
     node->outputs[0].amount_sats = per_output;
 
-    /* vout 1: L-stock */
-    if (!build_l_stock_spk(f, node->outputs[1].script_pubkey))
+    /* vout 1: L-stock SPK = or(N-of-N keyagg, L&CSV) per t/1242 */
+    if (!build_l_stock_spk(f, node, node->outputs[1].script_pubkey))
         return 0;
     node->outputs[1].script_pubkey_len = 34;
     node->outputs[1].amount_sats = per_output + remainder;
@@ -989,8 +977,8 @@ static int setup_nway_leaf_outputs(
         node->outputs[i].amount_sats = per_output;
     }
 
-    /* L-stock at LAST output (vout n_client) */
-    if (!build_l_stock_spk(f, node->outputs[n_client].script_pubkey))
+    /* L-stock at LAST output: or(N-of-N keyagg, L&CSV) per t/1242 */
+    if (!build_l_stock_spk(f, node, node->outputs[n_client].script_pubkey))
         return 0;
     node->outputs[n_client].script_pubkey_len = 34;
     node->outputs[n_client].amount_sats = per_output + remainder;
@@ -1863,7 +1851,7 @@ static int update_l_stock_for_leaf(factory_t *f, size_t node_idx) {
     if (node->n_outputs < 2)
         return 1;
 
-    return build_l_stock_spk(f, node->outputs[node->n_outputs - 1].script_pubkey);
+    return build_l_stock_spk(f, node, node->outputs[node->n_outputs - 1].script_pubkey);
 }
 
 int factory_advance_leaf(factory_t *f, int leaf_side) {
@@ -2081,104 +2069,303 @@ int factory_get_revocation_secret(const factory_t *f, uint32_t epoch,
     return 1;
 }
 
-int factory_build_burn_tx(const factory_t *f, tx_buf_t *burn_tx_out,
+int factory_build_burn_tx(factory_t *f, tx_buf_t *burn_tx_out,
+                           const factory_node_t *leaf_node,
                            const unsigned char *l_stock_txid,
                            uint32_t l_stock_vout,
                            uint64_t l_stock_amount,
                            uint32_t epoch) {
-    (void)l_stock_amount;
-    if (!f->has_shachain)
+    /* Backward-compat shim: the legacy (t/1143) "burn-as-fee" OP_RETURN
+       design has been superseded by the canonical t/1242 per-client
+       distribution.  Caller passes leaf_node directly (since after a
+       state advance, leaf_node->txid points to the NEW state's tx, not
+       the OLD one we need to poison). */
+    (void)epoch;  /* obsolete — N-of-N MuSig replaces per-epoch hashlock */
+    if (!f || !burn_tx_out || !leaf_node || !l_stock_txid) return 0;
+
+    /* Fee: small fixed value (1000 sats), matches our N=64 mixed-arity
+       fee_per_tx policy.  Clients can CPFP if mempool fees rise. */
+    return factory_sign_l_stock_poison_tx(
+        f, leaf_node, l_stock_txid, l_stock_vout, l_stock_amount,
+        /* fee_sats */ 1000, burn_tx_out);
+}
+
+/* ============================================================================
+ * L-stock POISON TRANSACTION (canonical SuperScalar t/1242 design)
+ *
+ * Per ZmnSCPxj:
+ *   "Channel with A: entirely goes to A.  Channel with B: entirely goes to B.
+ *    LSP liquidity stock: split: 10 units go to A. 10 units go to B."
+ *
+ * The poison TX redistributes a leaf state's L-stock UTXO to the leaf's
+ * non-LSP signers in equal shares.  Pre-signed at leaf-state-advance time
+ * via the L-stock SPK's N-of-N key-path (A&B&L MuSig); broadcast (by any
+ * client or watchtower) if the LSP publishes a stale leaf state on chain.
+ *
+ * Spec source: delvingbitcoin.org/t/1242 (newer canonical SuperScalar
+ * design — supersedes the t/1143 OP_RETURN burn-as-fee approach).
+ * ============================================================================ */
+
+/* Compute the equal-split distribution amount per non-LSP signer.
+   Subtracts the fee from the total L-stock value, then divides equally.
+   Any rounding remainder goes to the LAST recipient.
+   Returns 1 on success; 0 if the result would be < dust. */
+static int compute_l_stock_poison_per_client(
+    uint64_t l_stock_amount_sats, uint64_t fee_sats, size_t n_clients,
+    uint64_t *per_client_out, uint64_t *last_client_extra_out)
+{
+    if (n_clients == 0) return 0;
+    if (l_stock_amount_sats <= fee_sats) return 0;
+    uint64_t output_total = l_stock_amount_sats - fee_sats;
+    uint64_t per_client = output_total / (uint64_t)n_clients;
+    /* Dust limit on P2TR is 330 sats per Bitcoin Core policy (CDustLimit
+       for SegWit v1).  CHANNEL_DUST_LIMIT_SATS is the conservative 546
+       used elsewhere in this codebase; reuse it. */
+    if (per_client < CHANNEL_DUST_LIMIT_SATS) return 0;
+    uint64_t accounted = per_client * (uint64_t)n_clients;
+    *per_client_out = per_client;
+    *last_client_extra_out = output_total - accounted;
+    return 1;
+}
+
+int factory_build_l_stock_poison_tx_unsigned(
+    const factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    tx_buf_t *poison_tx_out,
+    unsigned char *sighash_out32)
+{
+    if (!f || !leaf_node || !l_stock_txid32 || !poison_tx_out) return 0;
+    /* leaf_node->n_signers includes LSP (signer_indices[0] == 0).  The
+       poison TX pays each non-LSP signer; n_clients = n_signers - 1. */
+    if (leaf_node->n_signers < 2) return 0;
+    size_t n_clients = leaf_node->n_signers - 1;
+
+    uint64_t per_client = 0, last_extra = 0;
+    if (!compute_l_stock_poison_per_client(l_stock_amount_sats, fee_sats,
+                                            n_clients, &per_client, &last_extra))
         return 0;
 
-    /* 1. Derive revocation secret for the given epoch */
-    unsigned char secret[32];
-    if (f->use_flat_secrets) {
-        if (epoch >= f->n_revocation_secrets) return 0;
-        memcpy(secret, f->revocation_secrets[epoch], 32);
-    } else {
-        uint64_t sc_index = shachain_epoch_to_index(epoch);
-        shachain_from_seed(f->shachain_seed, sc_index, secret);
+    /* Build per-client P2TR(client_xonly) outputs.  Each non-LSP signer gets
+       a key-path-only P2TR of their own pubkey — they sweep with their own
+       seckey alone, no MuSig coordination needed. */
+    tx_output_t *outputs = (tx_output_t *)calloc(n_clients, sizeof(tx_output_t));
+    if (!outputs) return 0;
+    for (size_t i = 0; i < n_clients; i++) {
+        uint32_t signer_idx = leaf_node->signer_indices[1 + i];  /* skip LSP at [0] */
+        if (signer_idx >= f->n_participants) { free(outputs); return 0; }
+
+        secp256k1_xonly_pubkey client_xonly;
+        if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &client_xonly, NULL,
+                                                  &f->pubkeys[signer_idx])) {
+            free(outputs);
+            return 0;
+        }
+        secp256k1_xonly_pubkey tweaked;
+        if (!taproot_tweak_pubkey(f->ctx, &tweaked, NULL, &client_xonly, NULL)) {
+            free(outputs);
+            return 0;
+        }
+        build_p2tr_script_pubkey(outputs[i].script_pubkey, &tweaked);
+        outputs[i].script_pubkey_len = 34;
+        outputs[i].amount_sats = per_client;
+    }
+    outputs[n_clients - 1].amount_sats += last_extra;
+
+    /* Build the unsigned TX — single input from L-stock outpoint, nSequence
+       0xFFFFFFFE (BIP-68 disabled; the CSV gate is on the script-path leaf,
+       not on this key-path spend).  Zmn's quote: "any client can trivially
+       CPFP the 'poisoning' transaction" — so we don't add a fee output, the
+       fee is paid by the input/output delta. */
+    tx_buf_t unsigned_tx;
+    tx_buf_init(&unsigned_tx, 256);
+    if (!build_unsigned_tx(&unsigned_tx, NULL, l_stock_txid32, l_stock_vout,
+                            0xFFFFFFFEu, outputs, n_clients)) {
+        tx_buf_free(&unsigned_tx);
+        free(outputs);
+        return 0;
     }
 
-    /* 2. Compute SHA256(secret) -> hashlock hash */
-    unsigned char hash[32];
-    sha256(secret, 32, hash);
+    /* Compute the BIP-341 keypath sighash against the L-stock SPK.  This
+       sighash will be MuSig-signed by all leaf signers (LSP + clients). */
+    unsigned char l_stock_spk[34];
+    if (!build_l_stock_spk(f, leaf_node, l_stock_spk)) {
+        tx_buf_free(&unsigned_tx);
+        free(outputs);
+        return 0;
+    }
+    if (sighash_out32) {
+        if (!compute_taproot_sighash(sighash_out32, unsigned_tx.data,
+                                       unsigned_tx.len, 0,
+                                       l_stock_spk, 34,
+                                       l_stock_amount_sats,
+                                       0xFFFFFFFEu)) {
+            tx_buf_free(&unsigned_tx);
+            free(outputs);
+            return 0;
+        }
+    }
 
-    /* 3. Build hashlock tapscript leaf */
-    tapscript_leaf_t hashlock_leaf;
-    tapscript_build_hashlock(&hashlock_leaf, hash);
+    /* Caller owns the unsigned TX bytes. */
+    tx_buf_reset(poison_tx_out);
+    tx_buf_write_bytes(poison_tx_out, unsigned_tx.data, unsigned_tx.len);
+    tx_buf_free(&unsigned_tx);
+    free(outputs);
+    return 1;
+}
 
-    /* 4. Compute merkle root from single leaf */
-    unsigned char merkle_root[32];
-    tapscript_merkle_root(merkle_root, &hashlock_leaf, 1);
-
-    /* 5. Get LSP's xonly pubkey (internal key), tweak, get parity */
-    secp256k1_xonly_pubkey lsp_internal;
-    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_internal, NULL,
-                                              &f->pubkeys[0]))
+/* Internal helper: cooperatively N-of-N MuSig-sign a single-input TX
+   that spends an L-stock UTXO to a caller-supplied output set.  The
+   poison TX and the cooperative-spend public APIs both delegate here. */
+static int sign_l_stock_spend_with_outputs(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    const tx_output_t *outputs, size_t n_outputs,
+    tx_buf_t *signed_out)
+{
+    if (!f || !leaf_node || !l_stock_txid32 || !outputs || n_outputs == 0
+        || !signed_out)
         return 0;
 
-    secp256k1_xonly_pubkey tweaked;
-    int parity = 0;
-    if (!tapscript_tweak_pubkey(f->ctx, &tweaked, &parity,
-                                 &lsp_internal, merkle_root))
-        return 0;
-
-    /* 6. Build control block (33 bytes: leaf_version|parity || internal_key) */
-    unsigned char control_block[33];
-    size_t cb_len = 0;
-    if (!tapscript_build_control_block(control_block, &cb_len, parity,
-                                        &lsp_internal, f->ctx))
-        return 0;
-
-    /* 7. Build unsigned burn tx:
-       Input: L-stock outpoint, nSequence = 0xFFFFFFFE
-       Output: OP_RETURN with hashlock hash as data (ensures stripped tx >= 82 bytes) */
-    tx_output_t burn_output;
-    burn_output.amount_sats = 0;
-    burn_output.script_pubkey[0] = 0x6a;  /* OP_RETURN */
-    burn_output.script_pubkey[1] = 0x20;  /* OP_PUSHBYTES_32 */
-    memcpy(burn_output.script_pubkey + 2, hash, 32);
-    burn_output.script_pubkey_len = 34;
-
+    /* 1. Build the unsigned TX. */
     tx_buf_t unsigned_tx;
-    tx_buf_init(&unsigned_tx, 128);
-    if (!build_unsigned_tx(&unsigned_tx, NULL,
-                            l_stock_txid, l_stock_vout,
-                            0xFFFFFFFEu,
-                            &burn_output, 1)) {
+    tx_buf_init(&unsigned_tx, 256);
+    if (!build_unsigned_tx(&unsigned_tx, NULL, l_stock_txid32, l_stock_vout,
+                            0xFFFFFFFEu, outputs, n_outputs)) {
         tx_buf_free(&unsigned_tx);
         return 0;
     }
 
-    /* 8. Build witness: 3 items [preimage(32), script(37), control_block(33)] */
-    tx_buf_reset(burn_tx_out);
+    /* 2. Compute BIP-341 keypath sighash against the L-stock SPK. */
+    unsigned char l_stock_spk[34];
+    if (!build_l_stock_spk(f, leaf_node, l_stock_spk)) {
+        tx_buf_free(&unsigned_tx);
+        return 0;
+    }
+    unsigned char sighash[32];
+    if (!compute_taproot_sighash(sighash, unsigned_tx.data, unsigned_tx.len,
+                                   0, l_stock_spk, 34, l_stock_amount_sats,
+                                   0xFFFFFFFEu)) {
+        tx_buf_free(&unsigned_tx);
+        return 0;
+    }
 
-    /* nVersion */
-    tx_buf_write_bytes(burn_tx_out, unsigned_tx.data, 4);
-    /* segwit marker + flag */
-    tx_buf_write_u8(burn_tx_out, 0x00);
-    tx_buf_write_u8(burn_tx_out, 0x01);
-    /* inputs + outputs (between nVersion and nLockTime) */
-    tx_buf_write_bytes(burn_tx_out, unsigned_tx.data + 4,
-                        unsigned_tx.len - 8);
-    /* witness: 3 items */
-    tx_buf_write_varint(burn_tx_out, 3);
-    /* Item 1: preimage (32 bytes) */
-    tx_buf_write_varint(burn_tx_out, 32);
-    tx_buf_write_bytes(burn_tx_out, secret, 32);
-    /* Item 2: script */
-    tx_buf_write_varint(burn_tx_out, hashlock_leaf.script_len);
-    tx_buf_write_bytes(burn_tx_out, hashlock_leaf.script, hashlock_leaf.script_len);
-    /* Item 3: control block */
-    tx_buf_write_varint(burn_tx_out, cb_len);
-    tx_buf_write_bytes(burn_tx_out, control_block, cb_len);
-    /* nLockTime */
-    tx_buf_write_bytes(burn_tx_out, unsigned_tx.data + unsigned_tx.len - 4, 4);
+    /* 3. Gather leaf signers' keypairs.  Single-process only: requires
+       f->keypairs[] to hold the seckey for every leaf signer. */
+    secp256k1_keypair *kps = (secp256k1_keypair *)calloc(leaf_node->n_signers,
+                                                          sizeof(secp256k1_keypair));
+    if (!kps) { tx_buf_free(&unsigned_tx); return 0; }
+    for (size_t i = 0; i < leaf_node->n_signers; i++) {
+        uint32_t idx = leaf_node->signer_indices[i];
+        if (idx >= f->n_participants) {
+            free(kps); tx_buf_free(&unsigned_tx); return 0;
+        }
+        kps[i] = f->keypairs[idx];
+    }
 
+    /* 4. Compute the L-stock SPK's script-tree merkle root (single leaf:
+       <csv> CSV DROP <LSP> CHECKSIG).  musig_sign_taproot needs this to
+       apply the BIP-341 taptweak that matches the SPK. */
+    secp256k1_xonly_pubkey lsp_xonly;
+    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL,
+                                              &f->pubkeys[0])) {
+        free(kps); tx_buf_free(&unsigned_tx); return 0;
+    }
+    uint32_t csv = f->l_stock_csv_blocks > 0
+                   ? f->l_stock_csv_blocks
+                   : L_STOCK_CSV_DEFAULT_BLOCKS;
+    tapscript_leaf_t csv_leaf;
+    if (!tapscript_build_csv_delay(&csv_leaf, csv, &lsp_xonly, f->ctx)) {
+        free(kps); tx_buf_free(&unsigned_tx); return 0;
+    }
+    unsigned char merkle_root[32];
+    if (!tapscript_merkle_root(merkle_root, &csv_leaf, 1)) {
+        free(kps); tx_buf_free(&unsigned_tx); return 0;
+    }
+
+    /* 5. Sign via N-of-N MuSig + taptweak. */
+    musig_keyagg_t keyagg = leaf_node->keyagg;  /* copy — sign_taproot mutates cache */
+    unsigned char sig64[64];
+    if (!musig_sign_taproot(f->ctx, sig64, sighash, kps,
+                              leaf_node->n_signers, &keyagg, merkle_root)) {
+        free(kps); tx_buf_free(&unsigned_tx); return 0;
+    }
+    free(kps);
+
+    /* 6. Attach 64-byte Schnorr keypath witness. */
+    if (!finalize_signed_tx(signed_out, unsigned_tx.data, unsigned_tx.len, sig64)) {
+        tx_buf_free(&unsigned_tx);
+        return 0;
+    }
     tx_buf_free(&unsigned_tx);
-    memset(secret, 0, 32);
     return 1;
+}
+
+int factory_sign_l_stock_poison_tx(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    tx_buf_t *signed_out)
+{
+    if (!f || !leaf_node || !signed_out) return 0;
+    if (leaf_node->n_signers < 2) return 0;
+    size_t n_clients = leaf_node->n_signers - 1;
+
+    /* Compute per-client equal-split outputs (zmn's "10 to A, 10 to B"). */
+    uint64_t per_client = 0, last_extra = 0;
+    if (!compute_l_stock_poison_per_client(l_stock_amount_sats, fee_sats,
+                                            n_clients, &per_client, &last_extra))
+        return 0;
+
+    tx_output_t *outs = (tx_output_t *)calloc(n_clients, sizeof(tx_output_t));
+    if (!outs) return 0;
+    for (size_t i = 0; i < n_clients; i++) {
+        uint32_t signer_idx = leaf_node->signer_indices[1 + i];  /* skip LSP[0] */
+        if (signer_idx >= f->n_participants) { free(outs); return 0; }
+        secp256k1_xonly_pubkey x;
+        if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &x, NULL,
+                                                  &f->pubkeys[signer_idx])) {
+            free(outs); return 0;
+        }
+        secp256k1_xonly_pubkey tw;
+        if (!taproot_tweak_pubkey(f->ctx, &tw, NULL, &x, NULL)) {
+            free(outs); return 0;
+        }
+        build_p2tr_script_pubkey(outs[i].script_pubkey, &tw);
+        outs[i].script_pubkey_len = 34;
+        outs[i].amount_sats = per_client;
+    }
+    outs[n_clients - 1].amount_sats += last_extra;
+
+    int ok = sign_l_stock_spend_with_outputs(f, leaf_node, l_stock_txid32,
+                                               l_stock_vout, l_stock_amount_sats,
+                                               outs, n_clients, signed_out);
+    free(outs);
+    return ok;
+}
+
+int factory_sign_l_stock_cooperative_spend(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    const tx_output_t *outputs,
+    size_t n_outputs,
+    tx_buf_t *signed_out)
+{
+    return sign_l_stock_spend_with_outputs(f, leaf_node, l_stock_txid32,
+                                             l_stock_vout, l_stock_amount_sats,
+                                             outputs, n_outputs, signed_out);
 }
 
 int factory_build_cooperative_close(

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1615,7 +1615,7 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
         int burn_ok = 0;
         if (old_n_outputs >= 2) {
             size_t l_vout = (size_t)(old_n_outputs - 1);
-            burn_ok = factory_build_burn_tx(f, &burn_tx,
+            burn_ok = factory_build_burn_tx(f, &burn_tx, leaf_node,
                 old_leaf_txid, (uint32_t)l_vout,
                 old_l_amount, old_epoch);
         }

--- a/tests/spend_helpers.c
+++ b/tests/spend_helpers.c
@@ -242,3 +242,34 @@ int spend_coop_close_gauntlet(secp256k1_context *ctx,
     }
     return 1;
 }
+
+int spend_l_stock_cooperative(secp256k1_context *ctx,
+                                factory_t *f,
+                                const factory_node_t *leaf_node,
+                                const char *l_stock_txid_hex,
+                                uint32_t l_stock_vout,
+                                uint64_t l_stock_amount,
+                                const unsigned char *dest_spk,
+                                size_t dest_spk_len,
+                                uint64_t fee_sats,
+                                tx_buf_t *tx_out) {
+    (void)ctx;  /* uses f->ctx internally */
+    if (!f || !leaf_node || !l_stock_txid_hex || !dest_spk || !tx_out) return 0;
+    if (l_stock_amount <= fee_sats) return 0;
+
+    unsigned char l_stock_txid[32];
+    if (!hex_decode(l_stock_txid_hex, l_stock_txid, sizeof(l_stock_txid)))
+        return 0;
+    reverse_bytes(l_stock_txid, 32);
+
+    tx_output_t dest;
+    memset(&dest, 0, sizeof(dest));
+    if (dest_spk_len > sizeof(dest.script_pubkey)) return 0;
+    memcpy(dest.script_pubkey, dest_spk, dest_spk_len);
+    dest.script_pubkey_len = dest_spk_len;
+    dest.amount_sats = l_stock_amount - fee_sats;
+
+    return factory_sign_l_stock_cooperative_spend(
+        f, leaf_node, l_stock_txid, l_stock_vout, l_stock_amount,
+        &dest, 1, tx_out);
+}

--- a/tests/spend_helpers.h
+++ b/tests/spend_helpers.h
@@ -3,6 +3,7 @@
 
 #include "superscalar/tx_builder.h"
 #include "superscalar/regtest.h"
+#include "superscalar/factory.h"
 #include <secp256k1.h>
 #include <secp256k1_extrakeys.h>
 #include <secp256k1_schnorrsig.h>
@@ -97,5 +98,28 @@ int spend_coop_close_gauntlet(secp256k1_context *ctx,
                                const char *close_txid,
                                const unsigned char seckeys[][32],
                                size_t n_clients);
+
+/*
+ * Cooperatively spend an L-stock UTXO via the canonical
+ * `or(N-of-N, L&CSV)` SPK's key-path (N-of-N MuSig over leaf signers).
+ *
+ * Wraps factory_sign_l_stock_cooperative_spend with a call shape
+ * matching spend_build_p2tr_bip341_keypath: passes the leaf node and
+ * factory (which holds all keypairs in the test process) instead of an
+ * LSP seckey.
+ *
+ * dest_spk is wrapped in a single tx_output_t with amount =
+ * (l_stock_amount - fee_sats).
+ */
+int spend_l_stock_cooperative(secp256k1_context *ctx,
+                                factory_t *f,
+                                const factory_node_t *leaf_node,
+                                const char *l_stock_txid_hex,
+                                uint32_t l_stock_vout,
+                                uint64_t l_stock_amount,
+                                const unsigned char *dest_spk,
+                                size_t dest_spk_len,
+                                uint64_t fee_sats,
+                                tx_buf_t *tx_out);
 
 #endif /* SUPERSCALAR_TESTS_SPEND_HELPERS_H */

--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -2531,20 +2531,20 @@ int test_regtest_full_force_close_and_sweep_arity1(void) {
         factory_node_t *leaf = &f->nodes[nidx];
         const char *leaf_txid = txids[nidx];
 
-        /* (A) Sweep L-stock (vout 1) LSP-alone to LSP's P2TR(xonly(LSP)). */
+        /* (A) Sweep L-stock (vout 1) cooperatively via N-of-N MuSig.
+           Per canonical t/1242, L-stock SPK = or(N-of-N keyagg, L&CSV) —
+           LSP can't take L-stock alone immediately; either all leaf
+           signers cooperate (this path, since the test holds all keys),
+           or LSP waits CSV blocks and uses the script-path. */
         uint64_t lstock_amt = leaf->outputs[1].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[1].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N_PARTY_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, 1, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep");
+                    "build L-stock cooperative sweep");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh != NULL, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
@@ -2799,20 +2799,17 @@ int test_regtest_full_force_close_and_sweep_arity2(void) {
                     "decode leaf txid");
         reverse_bytes(leaf_txid_bytes, 32);
 
-        /* (A) Sweep L-stock (vout 2) LSP-alone to LSP's P2TR(xonly(LSP)). */
+        /* (A) Sweep L-stock (vout 2) cooperatively via N-of-N MuSig
+           (canonical t/1242 — see L-stock sweep block at line 2540). */
         uint64_t lstock_amt = leaf->outputs[2].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[2].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N_PARTY_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, 2, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep");
+                    "build L-stock cooperative sweep");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh != NULL, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
@@ -3059,20 +3056,17 @@ int test_regtest_full_force_close_and_sweep_arityPS(void) {
                     "decode leaf txid");
         reverse_bytes(leaf_txid_bytes, 32);
 
-        /* (A) Sweep L-stock (vout 1) LSP-alone. */
+        /* (A) Sweep L-stock (vout 1) cooperatively via N-of-N MuSig
+           (canonical t/1242 — see L-stock sweep block at line 2540). */
         uint64_t lstock_amt = leaf->outputs[1].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[1].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N_PARTY_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, 1, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep");
+                    "build L-stock cooperative sweep");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh != NULL, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
@@ -3364,13 +3358,14 @@ static int run_ps_chain_advance_sweep(regtest_t *rt,
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N_PARTY_SECKEYS[0],
+        /* L-stock SPK now requires N-of-N MuSig (canonical t/1242).
+           leaf0 == &f->nodes[f->leaf_node_indices[0]]. */
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f,
+                        &f->nodes[f->leaf_node_indices[0]],
                         leaf0_chain0_txid, 1, leaf0_chain0_lstock_amt,
-                        leaf0_chain0_lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build leaf0 L-stock sweep");
+                    "build leaf0 L-stock cooperative sweep");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh != NULL, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
@@ -3479,11 +3474,11 @@ static int run_ps_chain_advance_sweep(regtest_t *rt,
         memcpy(lstock_spk, leaf1->outputs[1].script_pubkey, 34);
         tx_buf_t ls;
         tx_buf_init(&ls, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N_PARTY_SECKEYS[0],
-                        leaf1_txid, 1, lstock_amt, lstock_spk, 34,
+        /* L-stock SPK now requires N-of-N MuSig (canonical t/1242). */
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf1,
+                        leaf1_txid, 1, lstock_amt,
                         party_spk[0], 34, LSTOCK_SWEEP_FEE, &ls),
-                    "build leaf1 L-stock sweep");
+                    "build leaf1 L-stock cooperative sweep");
         char *lh = malloc(ls.len * 2 + 1);
         TEST_ASSERT(lh != NULL, "lh malloc");
         hex_encode(ls.data, ls.len, lh);
@@ -6317,20 +6312,18 @@ int test_regtest_nway_n64_arity_2_4_8_lifecycle(void) {
         uint32_t lstock_vout = (uint32_t)(leaf->n_outputs - 1);
         int n_channels       = (int)leaf->n_outputs - 1;
 
-        /* (A) Sweep L-stock LSP-alone */
+        /* (A) Sweep L-stock cooperatively via N-of-N MuSig (canonical
+           t/1242 — L-stock SPK requires either all leaf signers
+           cooperating, or LSP+CSV-delay). */
         uint64_t lstock_amt = leaf->outputs[lstock_vout].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[lstock_vout].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N64_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, lstock_vout, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep n64");
+                    "build L-stock cooperative sweep n64");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
@@ -6633,20 +6626,18 @@ int test_regtest_nway_n64_arity_2_4_8_static_threshold_1_lifecycle(void) {
         uint32_t lstock_vout = (uint32_t)(leaf->n_outputs - 1);
         int n_channels       = (int)leaf->n_outputs - 1;
 
-        /* (A) Sweep L-stock LSP-alone */
+        /* (A) Sweep L-stock cooperatively via N-of-N MuSig (canonical
+           t/1242 — L-stock SPK requires either all leaf signers
+           cooperating, or LSP+CSV-delay). */
         uint64_t lstock_amt = leaf->outputs[lstock_vout].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[lstock_vout].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N64_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, lstock_vout, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep n64");
+                    "build L-stock cooperative sweep n64");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
@@ -6960,20 +6951,18 @@ int test_regtest_nway_n64_dw_advance_resign_lifecycle(void) {
         uint32_t lstock_vout = (uint32_t)(leaf->n_outputs - 1);
         int n_channels       = (int)leaf->n_outputs - 1;
 
-        /* (A) Sweep L-stock LSP-alone */
+        /* (A) Sweep L-stock cooperatively via N-of-N MuSig (canonical
+           t/1242 — L-stock SPK requires either all leaf signers
+           cooperating, or LSP+CSV-delay). */
         uint64_t lstock_amt = leaf->outputs[lstock_vout].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[lstock_vout].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N64_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, lstock_vout, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep n64");
+                    "build L-stock cooperative sweep n64");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);

--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -5046,20 +5046,17 @@ int test_regtest_mixed_arity_2_4_8_lifecycle(void) {
         uint32_t lstock_vout = (uint32_t)(leaf->n_outputs - 1);
         int n_channels       = (int)leaf->n_outputs - 1;
 
-        /* (A) Sweep L-stock LSP-alone to LSP's P2TR(xonly(LSP)). */
+        /* (A) Sweep L-stock cooperatively via N-of-N MuSig (canonical
+           t/1242 — see L-stock sweep block at line 2540). */
         uint64_t lstock_amt = leaf->outputs[lstock_vout].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[lstock_vout].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N12_PARTY_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, lstock_vout, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep");
+                    "build L-stock cooperative sweep");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh != NULL, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);
@@ -5631,18 +5628,18 @@ static int run_ps_full_lifecycle(regtest_t *rt,
         uint32_t client_idx = lc->client_idx;
         TEST_ASSERT(client_idx >= 1 && client_idx < N, "client_idx in range");
 
-        /* (A) LSP solo-sweeps L-stock from chain[0] vout 1. The chain[0] TX
-              still has vout 1 untouched even when chain advances spent vout 0. */
+        /* (A) Sweep L-stock cooperatively via N-of-N MuSig (canonical
+           t/1242).  The chain[0] TX still has vout 1 untouched even when
+           chain advances spent vout 0. */
         {
+            (void)seckeys;  /* not needed — factory holds all keypairs */
             tx_buf_t ls;
             tx_buf_init(&ls, 256);
-            TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                            seckeys[0],
+            TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                             chain0_txid, 1, lc->chain0_lstock_amt,
-                            lc->lstock_spk, 34,
                             party_spk[0], 34,
                             LSTOCK_SWEEP_FEE, &ls),
-                        "build L-stock sweep");
+                        "build L-stock cooperative sweep");
             char *lh = malloc(ls.len * 2 + 1);
             TEST_ASSERT(lh != NULL, "lh malloc");
             hex_encode(ls.data, ls.len, lh);
@@ -7274,20 +7271,16 @@ int test_regtest_static_near_root_lifecycle(void) {
         uint32_t lstock_vout = (uint32_t)(leaf->n_outputs - 1);
         int n_channels       = (int)leaf->n_outputs - 1;
 
-        /* (A) L-stock LSP-alone */
+        /* (A) Sweep L-stock cooperatively via N-of-N MuSig (canonical t/1242). */
         uint64_t lstock_amt = leaf->outputs[lstock_vout].amount_sats;
-        unsigned char lstock_spk[34];
-        memcpy(lstock_spk, leaf->outputs[lstock_vout].script_pubkey, 34);
 
         tx_buf_t lstock_sweep;
         tx_buf_init(&lstock_sweep, 256);
-        TEST_ASSERT(spend_build_p2tr_bip341_keypath(ctx,
-                        N12_PARTY_SECKEYS[0],
+        TEST_ASSERT(spend_l_stock_cooperative(ctx, f, leaf,
                         leaf_txid, lstock_vout, lstock_amt,
-                        lstock_spk, 34,
                         party_spk[0], 34,
                         LSTOCK_SWEEP_FEE, &lstock_sweep),
-                    "build L-stock sweep static");
+                    "build L-stock cooperative sweep static");
         char *lh = malloc(lstock_sweep.len * 2 + 1);
         TEST_ASSERT(lh != NULL, "lh malloc");
         hex_encode(lstock_sweep.data, lstock_sweep.len, lh);

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -938,13 +938,16 @@ int test_factory_l_stock_with_burn_path(void) {
     size_t ll = f_plain->leaf_node_indices[0];  /* left leaf */
     size_t rl = f_plain->leaf_node_indices[1];  /* right leaf */
 
-    /* L-stock output (last) on leaf state nodes should differ */
+    /* CANONICAL DESIGN (t/1242): L-stock SPK = or(N-of-N keyagg, L&CSV).
+       It depends on leaf signers + LSP pubkey + CSV — NOT on shachain
+       (which is for channel-level revocation, not L-stock).  So with vs
+       without shachain, the L-stock SPK is the SAME for the same leaf. */
     TEST_ASSERT(memcmp(f_plain->nodes[ll].outputs[2].script_pubkey,
-                        f_sc->nodes[ll].outputs[2].script_pubkey, 34) != 0,
-                "L-stock spk differs with shachain (left leaf)");
+                        f_sc->nodes[ll].outputs[2].script_pubkey, 34) == 0,
+                "L-stock spk does NOT depend on shachain (left leaf)");
     TEST_ASSERT(memcmp(f_plain->nodes[rl].outputs[2].script_pubkey,
-                        f_sc->nodes[rl].outputs[2].script_pubkey, 34) != 0,
-                "L-stock spk differs with shachain (right leaf)");
+                        f_sc->nodes[rl].outputs[2].script_pubkey, 34) == 0,
+                "L-stock spk does NOT depend on shachain (right leaf)");
 
     /* Channel outputs (indices 0, 1) should be the same */
     TEST_ASSERT(memcmp(f_plain->nodes[ll].outputs[0].script_pubkey,
@@ -962,9 +965,11 @@ int test_factory_l_stock_with_burn_path(void) {
     TEST_ASSERT(factory_sign_all(f_sc), "sign at epoch 0");
     TEST_ASSERT(factory_advance(f_sc), "advance to epoch 1");
 
-    /* L-stock spk should change after epoch advance */
-    TEST_ASSERT(memcmp(l_spk_epoch0, f_sc->nodes[ll].outputs[2].script_pubkey, 34) != 0,
-                "L-stock spk changes with new epoch");
+    /* CANONICAL DESIGN: L-stock SPK does NOT change across state advances
+       (the same leaf node has the same signers and CSV, so the same SPK).
+       The OLD design changed the SPK each epoch via the per-epoch hashlock. */
+    TEST_ASSERT(memcmp(l_spk_epoch0, f_sc->nodes[ll].outputs[2].script_pubkey, 34) == 0,
+                "L-stock spk is stable across state advances (canonical t/1242)");
 
     factory_free(f_plain);
     factory_free(f_sc);
@@ -996,51 +1001,47 @@ int test_factory_burn_tx_construction(void) {
     TEST_ASSERT(factory_build_tree(f), "build tree");
     TEST_ASSERT(factory_sign_all(f), "sign all");
 
-    /* Get leaf state node's txid and L-stock amount */
-    factory_node_t *leaf = &f->nodes[4];
+    /* Get leaf state node + L-stock amount.  Use leaf_node_indices instead
+       of hardcoded `f->nodes[4]` (which was a kickoff in this tree shape;
+       the OLD burn TX didn't validate node identity so it didn't notice). */
+    factory_node_t *leaf = &f->nodes[f->leaf_node_indices[1]];
     uint64_t l_amount = leaf->outputs[2].amount_sats;
 
-    /* Build burn tx for epoch 0 */
+    /* Build the canonical L-stock POISON TX (t/1242: per-client equal-split
+       distribution).  Note: factory_build_burn_tx now requires the leaf
+       node, since after a state advance node->txid points at the NEW state's
+       txid not the OLD one we're trying to poison. */
     tx_buf_t burn_tx;
     tx_buf_init(&burn_tx, 256);
-    TEST_ASSERT(factory_build_burn_tx(f, &burn_tx, leaf->txid, 2,
+    TEST_ASSERT(factory_build_burn_tx(f, &burn_tx, leaf, leaf->txid, 2,
                                         l_amount, 0),
-                "build burn tx");
+                "build poison tx");
+    TEST_ASSERT(burn_tx.len > 0, "poison tx non-empty");
 
-    /* Verify burn tx is non-empty */
-    TEST_ASSERT(burn_tx.len > 0, "burn tx non-empty");
+    /* Canonical poison TX has 2 outputs (one per non-LSP signer at this
+       arity-2 leaf with 2 clients).  Sanity check: tx is bigger than the
+       old OP_RETURN burn (which was ~120 bytes) and smaller than 1KB. */
+    TEST_ASSERT(burn_tx.len > 150 && burn_tx.len < 1024,
+                "poison tx is in the expected size range for 2 outputs");
 
-    /* Verify the burn tx contains the correct preimage */
-    unsigned char expected_secret[32];
-    TEST_ASSERT(factory_get_revocation_secret(f, 0, expected_secret),
-                "get revocation secret");
-
-    /* Verify the preimage hashes to the expected hashlock */
-    unsigned char expected_hash[32];
-    sha256(expected_secret, 32, expected_hash);
-
-    /* Search for the preimage in the tx data */
-    int found_preimage = 0;
-    for (size_t i = 0; i + 32 <= burn_tx.len; i++) {
-        if (memcmp(burn_tx.data + i, expected_secret, 32) == 0) {
-            found_preimage = 1;
-            break;
-        }
-    }
-    TEST_ASSERT(found_preimage, "burn tx contains correct preimage");
-
-    /* Verify that building burn tx without shachain fails */
+    /* The new design works regardless of shachain (no per-epoch hashlock
+       on the L-stock SPK).  Verify the no-shachain case produces a valid
+       poison TX too. */
     factory_t *f_no_sc = calloc(1, sizeof(factory_t));
     if (!f_no_sc) return 0;
     factory_init(f_no_sc, ctx, kps, 5, 2, 4);
     factory_set_funding(f_no_sc, fake_txid, 0, 100000, fund_spk, 34);
     TEST_ASSERT(factory_build_tree(f_no_sc), "build tree (no shachain)");
+    TEST_ASSERT(factory_sign_all(f_no_sc), "sign tree (no shachain)");
 
     tx_buf_t burn_tx2;
     tx_buf_init(&burn_tx2, 256);
-    int result = factory_build_burn_tx(f_no_sc, &burn_tx2, leaf->txid, 2,
-                                         l_amount, 0);
-    TEST_ASSERT(result == 0, "burn tx fails without shachain");
+    factory_node_t *leaf2 = &f_no_sc->nodes[f_no_sc->leaf_node_indices[1]];
+    int result = factory_build_burn_tx(f_no_sc, &burn_tx2, leaf2,
+                                         leaf2->txid, 2,
+                                         leaf2->outputs[2].amount_sats, 0);
+    TEST_ASSERT(result == 1, "poison tx works without shachain "
+                "(per t/1242 — L-stock SPK doesn't use shachain)");
 
     tx_buf_free(&burn_tx);
     tx_buf_free(&burn_tx2);
@@ -1074,16 +1075,21 @@ int test_factory_advance_with_shachain(void) {
     TEST_ASSERT(factory_build_tree(f), "build tree");
     TEST_ASSERT(factory_sign_all(f), "sign at epoch 0");
 
-    /* Save old L-stock info from epoch 0 */
+    /* Save old L-stock info from epoch 0 — captured BEFORE advance because
+       factory_advance() overwrites node->txid with the new state's txid.
+       Use leaf_node_indices for the actual leaf state node. */
+    factory_node_t *leaf_at_epoch0 = &f->nodes[f->leaf_node_indices[1]];
     unsigned char old_leaf_txid[32];
-    memcpy(old_leaf_txid, f->nodes[4].txid, 32);
-    uint64_t old_l_amount = f->nodes[4].outputs[2].amount_sats;
+    memcpy(old_leaf_txid, leaf_at_epoch0->txid, 32);
+    uint64_t old_l_amount = leaf_at_epoch0->outputs[2].amount_sats;
 
     /* Advance to epoch 1 */
     TEST_ASSERT(factory_advance(f), "advance to epoch 1");
     TEST_ASSERT_EQ(f->counter.current_epoch, 1, "epoch 1");
 
-    /* Get revocation secret for old epoch 0 */
+    /* Get revocation secret for old epoch 0 (still used for channel-level
+       revocation; the canonical t/1242 L-stock poison TX doesn't depend
+       on this). */
     unsigned char secret_epoch0[32];
     TEST_ASSERT(factory_get_revocation_secret(f, 0, secret_epoch0),
                 "get epoch 0 secret");
@@ -1095,13 +1101,17 @@ int test_factory_advance_with_shachain(void) {
     TEST_ASSERT(memcmp(secret_epoch0, expected, 32) == 0,
                 "epoch 0 secret matches shachain");
 
-    /* Build burn tx for epoch 0 using the old L-stock outpoint */
+    /* Build the L-stock poison TX for the old (epoch-0) state.  Pass the
+       leaf node + the saved old outpoint — the leaf node identifies signers
+       (stable across advances), the outpoint identifies the on-chain UTXO
+       being recovered from. */
     tx_buf_t burn_tx;
     tx_buf_init(&burn_tx, 256);
-    TEST_ASSERT(factory_build_burn_tx(f, &burn_tx, old_leaf_txid, 2,
+    TEST_ASSERT(factory_build_burn_tx(f, &burn_tx, leaf_at_epoch0,
+                                        old_leaf_txid, 2,
                                         old_l_amount, 0),
-                "build burn tx for epoch 0");
-    TEST_ASSERT(burn_tx.len > 0, "burn tx non-empty");
+                "build poison tx for epoch 0 outpoint");
+    TEST_ASSERT(burn_tx.len > 0, "poison tx non-empty");
 
     /* Verify current (epoch 1) signatures are still valid */
     for (size_t i = 0; i < f->n_nodes; i++) {
@@ -1307,9 +1317,9 @@ int test_regtest_burn_tx(void) {
     uint64_t l_stock_amount = f->nodes[3].outputs[2].amount_sats;
     printf("  L-stock amount: %lu sats\n", (unsigned long)l_stock_amount);
 
-    TEST_ASSERT(factory_build_burn_tx(f, &burn_tx, f->nodes[3].txid, 2,
+    TEST_ASSERT(factory_build_burn_tx(f, &burn_tx, &f->nodes[3], f->nodes[3].txid, 2,
                                         l_stock_amount, f->counter.current_epoch),
-                "build burn tx");
+                "build poison tx");
     TEST_ASSERT(burn_tx.len > 0, "burn tx non-empty");
 
     /* Broadcast burn tx */
@@ -3290,10 +3300,12 @@ int test_factory_flat_secrets_round_trip(void) {
     /* Build burn tx for old epoch 0 */
     tx_buf_t burn;
     tx_buf_init(&burn, 256);
-    /* Use leaf state node's txid as dummy l_stock_txid */
-    TEST_ASSERT(factory_build_burn_tx(f, &burn,
-                f->nodes[4].txid, 2, 1000, 0), "burn tx epoch 0");
-    TEST_ASSERT(burn.len > 0, "burn tx has data");
+    /* Use a real leaf state node (via leaf_node_indices, not hardcoded
+       index).  Bump amount to 100k so the per-client split clears dust. */
+    factory_node_t *leaf_for_burn = &f->nodes[f->leaf_node_indices[0]];
+    TEST_ASSERT(factory_build_burn_tx(f, &burn, leaf_for_burn,
+                leaf_for_burn->txid, 2, 100000, 0), "poison tx epoch 0");
+    TEST_ASSERT(burn.len > 0, "poison tx has data");
     tx_buf_free(&burn);
 
     factory_free(f);

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -1208,10 +1208,10 @@
             }
             printf("All %zu tree nodes confirmed on-chain.\n", lsp_p->factory.n_nodes);
 
-            /* Step 2: Build burn TX for epoch 0 L-stock */
+            /* Step 2: Build poison TX for epoch 0 L-stock (canonical t/1242) */
             tx_buf_t burn_tx;
             tx_buf_init(&burn_tx, 256);
-            if (!factory_build_burn_tx(&lsp_p->factory, &burn_tx,
+            if (!factory_build_burn_tx(&lsp_p->factory, &burn_tx, leaf,
                                          leaf->txid, l_stock_vout,
                                          l_stock_amount, 0)) {
                 fprintf(stderr, "BURN TEST: factory_build_burn_tx failed\n");


### PR DESCRIPTION
## Summary

Replaces the legacy [t/1143](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories/1143) `OP_RETURN` burn-as-fee design with the canonical [t/1242](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories-with-pseudo-spilman-leaves/1242) per-client distribution mechanism for the L-stock cheating-recovery path. Closes Gap A + G in `.claude/CANONICAL_DESIGN_GAPS.md`.

## Research

Drew on both:
- [Delving Bitcoin t/1242](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories-with-pseudo-spilman-leaves/1242) (newer, canonical SuperScalar design)
- [t/1143](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories/1143) (older, what we previously implemented)
- [Bitcoin Optech SuperScalar deep-dive podcast](https://bitcoinops.org/en/podcast/2024/10/31/) (Oct 31 2024 — confirms "Inversion of Timeout Default" concept)

Cross-references the divergence and explains why per-client distribution supersedes burn-as-fee.

## L-stock SPK

| | Old (t/1143, what we shipped before) | New (t/1242, this PR) |
|---|---|---|
| Internal key | LSP-alone (single pubkey) | MuSig over leaf signers — `A & B & L` |
| Script-leaf | hashlock for OP_RETURN burn | `<csv> CSV DROP <LSP_xonly> CHECKSIG` — LSP after CSV delay |

CSV value: per-factory configurable via `factory_set_l_stock_csv()`; default `L_STOCK_CSV_DEFAULT_BLOCKS = 144` (~1 day on mainnet).

## Poison TX

When the LSP publishes a stale leaf state, the matching pre-signed poison TX redistributes the L-stock UTXO to that leaf's non-LSP signers in equal shares (per zmn's t/1242 example: *"10 to A, 10 to B"*).

Each client gets a `P2TR(client_xonly)` output they can sweep unilaterally.

New API:
- `factory_build_l_stock_poison_tx_unsigned()` — builder + sighash
- `factory_sign_l_stock_poison_tx()` — single-process N-of-N MuSig signer
- `factory_sign_l_stock_cooperative_spend()` — generalized N-of-N spend to any output distribution

Backward-compat shim: `factory_build_burn_tx()` now takes `leaf_node` and delegates to `factory_sign_l_stock_poison_tx()`. The existing watchtower call site in `src/lsp_channels.c` updated to pass `leaf_node`.

## Test changes

- 4 unit tests rewritten for the new design (preimage assertions removed; SPK-stability-across-epochs assertion inverted; `&f->nodes[N]` hardcodes replaced with `leaf_node_indices[]`).
- 6 L-stock sweep call sites in `tests/test_close_spendability_full.c` migrated to the new `spend_l_stock_cooperative()` helper in `tests/spend_helpers.c` — wraps `factory_sign_l_stock_cooperative_spend` with a call shape compatible with the existing test patterns.
- The legacy `factory_build_burn_tx` shim continues to work for `tools/superscalar_lsp_pre_daemon_tests.inc`.

## Verified on VPS

- [x] **1413/1413 unit tests pass**
- [x] **N=64 mixed-arity {2,4,8} static_threshold=1 lifecycle: 1/1** (the canonical Campaign #3 production shape)
- [ ] CI green

## Anti-griefing argument (full version in `docs/poison-tx.md`)

**Q1: Can a client drain L-stock alone?** No — key-path is N-of-N MuSig requiring LSP.

**Q2: Can a client grief by broadcasting an old state?** No — DW state ordering + static-near-root + Poon-Dryja channel revocation make malicious old-state broadcast economically irrational for the client.

**Q3: Can the LSP grief by refusing to co-sign?** No — clients can cooperatively close at any time via the funding output (separate from L-stock SPK).

**Q4: Can the LSP drain L-stock alone immediately?** No — script-path requires CSV delay; during that window clients can broadcast the pre-signed poison TX of any prior state if the LSP cheated and never got punished.

**Q5: Can a watchtower be tricked into broadcasting poison during a legitimate close?** No — legitimate cooperative close spends the funding output, not any leaf state TX. The poison TX only becomes spendable if a leaf state TX appears on chain (force-close).

## Migration

This change affects only **future** factories. Existing on-chain factories built with the OLD t/1143 SPK structure continue to use their pre-built `OP_RETURN` burn TXs (which the watchtower stored at advance time). No retroactive break. New factories built after this PR use the canonical t/1242 SPK + poison TX, registered with the watchtower the same way.

## Deferred to follow-up

Wire-ceremony (multi-process LSP + remote clients) co-signing of the poison TX. The single-process flow shipped here is sufficient for unit testing, watchtower integration in single-LSP test deployments, and the existing watchtower call site shim. Multi-process is a separate ~2-day PR.

## Sources

- [Delving Bitcoin t/1242 (canonical SuperScalar)](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories-with-pseudo-spilman-leaves/1242)
- [Delving Bitcoin t/1143 (original, superseded)](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories/1143)
- [Bitcoin Optech SuperScalar Deep Dive Podcast](https://bitcoinops.org/en/podcast/2024/10/31/)