### PR TITLE
Lift FACTORY_ARITY_2 restriction on lsp_realloc_leaf + buy_liquidity (Gap C-followup)

### DIFF
--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2076,27 +2076,32 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                       int leaf_side, const uint64_t *amounts, size_t n_amounts) {
     factory_t *f = &lsp->factory;
 
-    /* Only for arity-2 (each leaf = 2 clients, 3-of-3 signing) */
-    if (f->leaf_arity != FACTORY_ARITY_2) {
-        fprintf(stderr, "LSP realloc: only supported for arity-2 leaves\n");
-        return 0;
-    }
+    /* Generalized to N-of-N MuSig.  Works for any leaf arity where the
+       leaf node has at least one client signer + the LSP (so n_signers
+       >= 2).  Pre-PR-#123 this was gated to FACTORY_ARITY_2 (3-of-3);
+       lifting that gate was Gap C-followup from the canonical-design
+       audit.  PS leaves (n_signers=2, n_outputs=2 = 1 channel + L-stock
+       OR 1 channel without L-stock post-advance) and arity-1 leaves
+       (n_signers=2, n_outputs=2 = 1 channel + L-stock) are now
+       supported in addition to arity-2 (n_signers=3, n_outputs=3). */
     if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) return 0;
 
     size_t node_idx = f->leaf_node_indices[leaf_side];
     factory_node_t *node = &f->nodes[node_idx];
 
-    if (node->n_signers != 3) {
-        fprintf(stderr, "LSP realloc: leaf node %zu has %zu signers, expected 3\n",
+    if (node->n_signers < 2) {
+        fprintf(stderr, "LSP realloc: leaf node %zu has %zu signers, need >= 2\n",
                 node_idx, node->n_signers);
         return 0;
     }
 
-    /* Get both client participant indices */
-    uint32_t clients[2];
-    size_t n_clients = factory_get_subtree_clients(f, (int)node_idx, clients, 2);
-    if (n_clients != 2) {
-        fprintf(stderr, "LSP realloc: expected 2 clients on leaf, got %zu\n", n_clients);
+    /* Get all client participant indices on this leaf (may be 1..N-1). */
+    uint32_t clients[FACTORY_MAX_SIGNERS];
+    size_t n_clients = factory_get_subtree_clients(f, (int)node_idx, clients,
+                                                     FACTORY_MAX_SIGNERS);
+    if (n_clients != node->n_signers - 1) {
+        fprintf(stderr, "LSP realloc: leaf %zu has %zu signers but %zu clients found\n",
+                node_idx, node->n_signers, n_clients);
         return 0;
     }
 
@@ -2150,12 +2155,12 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
-    /* Step 5: Send REALLOC_PROPOSE to both clients */
+    /* Step 5: Send REALLOC_PROPOSE to all clients on this leaf */
     unsigned char lsp_pubnonce_ser[66];
     musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
     cJSON *propose = wire_build_leaf_realloc_propose(leaf_side, amounts, n_amounts,
                                                       lsp_pubnonce_ser);
-    for (int ci = 0; ci < 2; ci++) {
+    for (size_t ci = 0; ci < n_clients; ci++) {
         /* client_fds indexed by client_idx - 1 (participant_idx 1-based) */
         size_t fd_idx = (size_t)(clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_LEAF_REALLOC_PROPOSE, propose)) {
@@ -2166,11 +2171,11 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
     cJSON_Delete(propose);
 
-    /* Step 6: Recv REALLOC_NONCE from both clients, set their nonces */
-    unsigned char all_pubnonces[3][66];
+    /* Step 6: Recv REALLOC_NONCE from each client, set their nonces */
+    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
     memcpy(all_pubnonces[lsp_slot], lsp_pubnonce_ser, 66);
 
-    for (int ci = 0; ci < 2; ci++) {
+    for (size_t ci = 0; ci < n_clients; ci++) {
         size_t fd_idx = (size_t)(clients[ci] - 1);
         wire_msg_t nonce_msg;
         if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx], &nonce_msg, 30) ||
@@ -2209,10 +2214,10 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         memcpy(all_pubnonces[client_slot], client_pn_ser, 66);
     }
 
-    /* Step 7: Send REALLOC_ALL_NONCES to both clients */
+    /* Step 7: Send REALLOC_ALL_NONCES to all clients on this leaf */
     cJSON *all_nonces = wire_build_leaf_realloc_all_nonces(
         (const unsigned char (*)[66])all_pubnonces, node->n_signers);
-    for (int ci = 0; ci < 2; ci++) {
+    for (size_t ci = 0; ci < n_clients; ci++) {
         size_t fd_idx = (size_t)(clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_LEAF_REALLOC_ALL_NONCES, all_nonces)) {
             cJSON_Delete(all_nonces);
@@ -2246,8 +2251,8 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (!factory_session_set_partial_sig(f, node_idx, (size_t)lsp_slot, &lsp_psig))
         return 0;
 
-    /* Step 10: Recv REALLOC_PSIG from both clients */
-    for (int ci = 0; ci < 2; ci++) {
+    /* Step 10: Recv REALLOC_PSIG from each client */
+    for (size_t ci = 0; ci < n_clients; ci++) {
         size_t fd_idx = (size_t)(clients[ci] - 1);
         wire_msg_t psig_msg;
         if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx], &psig_msg, 30) ||
@@ -2282,26 +2287,40 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
-    /* Step 12: Update channel amounts in lsp_channel_entry_t */
-    for (int ci = 0; ci < 2; ci++) {
-        size_t fd_idx = (size_t)(clients[ci] - 1);
-        if (fd_idx < mgr->n_channels) {
-            lsp_channel_entry_t *entry = &mgr->entries[fd_idx];
-            /* The leaf outputs map to: output 0 = channel A, output 1 = channel B,
-               output 2 = L-stock.  Update funding amount based on this client's output. */
-            entry->channel.funding_amount = amounts[ci];  /* sats, matching channel_init */
-            /* Recalculate using lsp_balance_pct (matching channel init logic) */
-            uint16_t pct = mgr->lsp_balance_pct;
-            if (pct == 0) pct = 50;
-            if (pct > 100) pct = 100;
-            fee_estimator_static_t _fe_realloc;
-            fee_estimator_t *_fe_ra = mgr->fee ? (fee_estimator_t *)mgr->fee : NULL;
-            if (!_fe_ra) { fee_estimator_static_init(&_fe_realloc, 1000); _fe_ra = &_fe_realloc.base; }
-            uint64_t commit_fee_ra = fee_for_commitment_tx(_fe_ra, 0);
-            uint64_t usable_ra = amounts[ci] > commit_fee_ra ? amounts[ci] - commit_fee_ra : 0;
-            entry->channel.local_amount = (usable_ra * pct) / 100;
-            entry->channel.remote_amount = usable_ra - entry->channel.local_amount;
-        }
+    /* Step 12: Update channel amounts in lsp_channel_entry_t.
+
+       Generic mapping: each client owns the leaf output at the vout
+       returned by client_to_leaf().  L-stock (if present) is at the
+       last vout.  We update each client's funding_amount from the new
+       outputs[client_vout].  This is correct for any leaf arity:
+         - arity-1: 1 client at vout 0, L-stock at vout 1
+         - arity-2: 2 clients at vouts 0/1, L-stock at vout 2
+         - arity-N: N clients at vouts 0..N-1, L-stock at vout N
+         - PS leaves: 1 client at vout 0, L-stock at vout 1 (pre-advance)
+                       or 1 client at vout 0 only (post-advance). */
+    for (size_t ci = 0; ci < n_clients; ci++) {
+        size_t client_idx_zero = (size_t)(clients[ci] - 1);
+        if (client_idx_zero >= mgr->n_channels) continue;
+
+        size_t client_node;
+        uint32_t client_vout;
+        if (!factory_client_to_leaf(f, client_idx_zero, &client_node, &client_vout)) continue;
+        if (client_vout >= n_amounts) continue;
+        uint64_t client_amt = amounts[client_vout];
+
+        lsp_channel_entry_t *entry = &mgr->entries[client_idx_zero];
+        entry->channel.funding_amount = client_amt;  /* sats, matching channel_init */
+        /* Recalculate using lsp_balance_pct (matching channel init logic) */
+        uint16_t pct = mgr->lsp_balance_pct;
+        if (pct == 0) pct = 50;
+        if (pct > 100) pct = 100;
+        fee_estimator_static_t _fe_realloc;
+        fee_estimator_t *_fe_ra = mgr->fee ? (fee_estimator_t *)mgr->fee : NULL;
+        if (!_fe_ra) { fee_estimator_static_init(&_fe_realloc, 1000); _fe_ra = &_fe_realloc.base; }
+        uint64_t commit_fee_ra = fee_for_commitment_tx(_fe_ra, 0);
+        uint64_t usable_ra = client_amt > commit_fee_ra ? client_amt - commit_fee_ra : 0;
+        entry->channel.local_amount = (usable_ra * pct) / 100;
+        entry->channel.remote_amount = usable_ra - entry->channel.local_amount;
     }
 
     /* Step 13: Send REALLOC_DONE to both clients */
@@ -2332,18 +2351,19 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     return 1;
 }
 
-/* Buy inbound liquidity from L-stock for a client (arity-2 only).
-   Moves amount_sats from L-stock (output 2) to client's channel output,
-   then adjusts channel balance so purchased sats become LSP local_amount
-   (= client's inbound capacity). Returns 1 on success. */
+/* Buy inbound liquidity from L-stock for a client.
+   Moves amount_sats from the L-stock output (last vout on the leaf) to
+   the client's channel output, then adjusts channel balance so purchased
+   sats become LSP local_amount (= client's inbound capacity).
+
+   Generalized in PR #123 (Gap C-followup) to work for any leaf arity
+   that has an L-stock output (i.e., n_outputs >= 2 — at least 1 channel
+   + L-stock).  PS leaves post-advance (n_outputs == 1, no L-stock) are
+   correctly rejected. */
 int lsp_channels_buy_liquidity(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                 size_t client_idx, uint64_t amount_sats) {
     if (!mgr || !lsp) return 0;
     factory_t *f = &lsp->factory;
-    if (f->leaf_arity != FACTORY_ARITY_2) {
-        fprintf(stderr, "buy_liquidity: only supported for arity-2\n");
-        return 0;
-    }
     if (client_idx >= mgr->n_channels || amount_sats == 0) {
         fprintf(stderr, "buy_liquidity: invalid client %zu or amount 0\n", client_idx);
         return 0;
@@ -2354,29 +2374,49 @@ int lsp_channels_buy_liquidity(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     uint32_t vout;
     client_to_leaf(client_idx, f, &node_idx, &vout);
     factory_node_t *ln = &f->nodes[node_idx];
-    if (ln->n_outputs < 3) {
-        fprintf(stderr, "buy_liquidity: leaf has %zu outputs, need 3\n", ln->n_outputs);
+    if (ln->n_outputs < 2) {
+        fprintf(stderr, "buy_liquidity: leaf %zu has %zu outputs, need >= 2 (channels + L-stock)\n",
+                node_idx, ln->n_outputs);
+        return 0;
+    }
+
+    /* L-stock is the LAST output on the leaf (canonical layout for both
+       uniform-arity and mixed-arity factories). */
+    size_t lstock_vout = ln->n_outputs - 1;
+    if (vout == lstock_vout) {
+        fprintf(stderr, "buy_liquidity: client %zu maps to L-stock vout, not a channel\n", client_idx);
         return 0;
     }
 
     /* Validate L-stock has enough (keep >= 546 dust) */
-    uint64_t lstock = ln->outputs[2].amount_sats;
+    uint64_t lstock = ln->outputs[lstock_vout].amount_sats;
     if (lstock < 546 + amount_sats) {
         fprintf(stderr, "buy_liquidity: amount %llu exceeds L-stock %llu (dust limit)\n",
                 (unsigned long long)amount_sats, (unsigned long long)lstock);
         return 0;
     }
 
+    /* Find which leaf_side this client's leaf is at.  We need this for
+       lsp_realloc_leaf which takes leaf_side (index into
+       f->leaf_node_indices[]), not raw node_idx. */
+    int leaf_side = -1;
+    for (int i = 0; i < f->n_leaf_nodes; i++) {
+        if (f->leaf_node_indices[i] == node_idx) { leaf_side = i; break; }
+    }
+    if (leaf_side < 0) {
+        fprintf(stderr, "buy_liquidity: node %zu not found in leaf_node_indices\n", node_idx);
+        return 0;
+    }
+
     /* Build new amounts: add to client's output, subtract from L-stock */
-    int leaf_side = (int)(client_idx / 2);
-    uint64_t new_amounts[3];
-    for (size_t k = 0; k < 3; k++)
+    uint64_t new_amounts[FACTORY_MAX_OUTPUTS];
+    for (size_t k = 0; k < ln->n_outputs; k++)
         new_amounts[k] = ln->outputs[k].amount_sats;
     new_amounts[vout] += amount_sats;
-    new_amounts[2] -= amount_sats;
+    new_amounts[lstock_vout] -= amount_sats;
 
     /* Perform the reallocation (DW advance + MuSig2 re-sign) */
-    if (!lsp_realloc_leaf(mgr, lsp, leaf_side, new_amounts, 3)) {
+    if (!lsp_realloc_leaf(mgr, lsp, leaf_side, new_amounts, ln->n_outputs)) {
         fprintf(stderr, "buy_liquidity: realloc failed\n");
         return 0;
     }

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -4994,6 +4994,105 @@ int test_leaf_realloc_signing(void) {
     return 1;
 }
 
+/* Mirror of test_leaf_realloc_signing for arity-1 leaves (LSP + 1 client,
+   n_signers=2, n_outputs=2 = 1 channel + L-stock).  Proves the per-node
+   MuSig primitives that lsp_realloc_leaf wraps work at the smallest non-
+   arity-2 configuration.  Without the FACTORY_ARITY_2 gate lift in PR
+   #123, lsp_realloc_leaf rejected this configuration outright. */
+int test_leaf_realloc_signing_arity1(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[5];
+    if (!make_keypairs(ctx, kps)) return 0;
+
+    unsigned char fund_spk[34];
+    secp256k1_xonly_pubkey fund_tweaked;
+    TEST_ASSERT(compute_funding_spk(ctx, kps, fund_spk, &fund_tweaked),
+                "compute funding spk");
+
+    unsigned char fake_txid[32];
+    memset(fake_txid, 0xAA, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    if (!f) return 0;
+    factory_init(f, ctx, kps, 5, 2, 4);
+    factory_set_arity(f, FACTORY_ARITY_1);
+    f->placement_mode = PLACEMENT_SEQUENTIAL;
+    factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+    TEST_ASSERT(factory_sign_all(f), "initial sign all");
+
+    /* Advance leaf 0 (per-leaf DW counter). */
+    int rc = factory_advance_leaf_unsigned(f, 0);
+    TEST_ASSERT(rc == 1, "advance leaf 0 (rc=1, normal advance)");
+
+    size_t node_idx = f->leaf_node_indices[0];
+    factory_node_t *node = &f->nodes[node_idx];
+
+    /* Arity-1 leaf: 2 signers (LSP + 1 client), 2 outputs (channel + L-stock). */
+    TEST_ASSERT_EQ((long)node->n_signers, 2L, "arity-1 leaf has 2 signers");
+    TEST_ASSERT_EQ((long)node->n_outputs, 2L, "arity-1 leaf has 2 outputs");
+
+    /* Realloc: shift 10% from channel to L-stock. */
+    uint64_t total = 0;
+    for (size_t i = 0; i < node->n_outputs; i++)
+        total += node->outputs[i].amount_sats;
+    uint64_t shift = node->outputs[0].amount_sats / 10;
+    uint64_t new_amounts[2] = {
+        node->outputs[0].amount_sats - shift,
+        node->outputs[1].amount_sats + shift
+    };
+    TEST_ASSERT(factory_set_leaf_amounts(f, 0, new_amounts, 2), "set amounts");
+    TEST_ASSERT_EQ((long)(new_amounts[0] + new_amounts[1]), (long)total,
+                    "conservation");
+
+    /* Init signing session for the leaf node. */
+    TEST_ASSERT(factory_session_init_node(f, node_idx), "session init");
+
+    /* Generate nonces for both signers (LSP + client). */
+    secp256k1_musig_secnonce secnonces[2];
+    for (size_t i = 0; i < node->n_signers; i++) {
+        uint32_t participant = node->signer_indices[i];
+        unsigned char seckey[32];
+        secp256k1_pubkey pk;
+        TEST_ASSERT(secp256k1_keypair_sec(ctx, seckey, &kps[participant]), "get seckey");
+        TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[participant]), "get pubkey");
+
+        secp256k1_musig_pubnonce pubnonce;
+        TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i], &pubnonce,
+                                           seckey, &pk, &node->keyagg.cache),
+                    "gen nonce");
+        TEST_ASSERT(factory_session_set_nonce(f, node_idx, i, &pubnonce), "set nonce");
+        memset(seckey, 0, 32);
+    }
+
+    TEST_ASSERT(factory_session_finalize_node(f, node_idx), "finalize");
+
+    /* Create + set partial sigs for both signers. */
+    for (size_t i = 0; i < node->n_signers; i++) {
+        uint32_t participant = node->signer_indices[i];
+        secp256k1_musig_partial_sig psig;
+        TEST_ASSERT(musig_create_partial_sig(ctx, &psig, &secnonces[i],
+                                               &kps[participant],
+                                               &node->signing_session),
+                    "create psig");
+        TEST_ASSERT(factory_session_set_partial_sig(f, node_idx, i, &psig), "set psig");
+    }
+
+    /* Aggregate. */
+    TEST_ASSERT(factory_session_complete_node(f, node_idx), "complete node");
+    TEST_ASSERT(node->is_signed, "node is signed");
+    TEST_ASSERT(node->signed_tx.len > 0, "signed_tx populated");
+
+    /* Verify the post-realloc amounts persisted. */
+    TEST_ASSERT_EQ((long)node->outputs[0].amount_sats, (long)new_amounts[0], "final amt[0]");
+    TEST_ASSERT_EQ((long)node->outputs[1].amount_sats, (long)new_amounts[1], "final amt[1]");
+
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* --- Factory Config Tests (Mainnet Gap #6) --- */
 
 int test_factory_config_custom(void) {

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1541,6 +1541,7 @@ extern int test_wire_scid_assign(void);
 extern int test_wire_leaf_realloc(void);
 extern int test_factory_set_leaf_amounts(void);
 extern int test_leaf_realloc_signing(void);
+extern int test_leaf_realloc_signing_arity1(void);
 extern int test_persist_dw_counter_with_leaves_4(void);
 extern int test_persist_file_reopen_round_trip(void);
 
@@ -3310,6 +3311,7 @@ static void run_unit_tests(void) {
     printf("\n=== Leaf-Level Fund Reallocation ===\n");
     RUN_TEST(test_factory_set_leaf_amounts);
     RUN_TEST(test_leaf_realloc_signing);
+    RUN_TEST(test_leaf_realloc_signing_arity1);
 
     RUN_TEST(test_persist_dw_counter_with_leaves_4);
     RUN_TEST(test_persist_file_reopen_round_trip);


### PR DESCRIPTION
## Summary

Closes **Gap C-followup** from the canonical-design audit (task #180).

Pre-PR: \`lsp_realloc_leaf\` and \`lsp_channels_buy_liquidity\` were hardcoded to \`FACTORY_ARITY_2\` only (LSP + 2 clients, 3-of-3 MuSig, 3 outputs). Mixed-arity, arity-1, and PS-leaf factories couldn't use either function in production — they returned 0 with \`"only supported for arity-2"\`.

Post-PR: both functions work for any leaf arity. The wire helpers and client-side handler already accepted variable signer/output counts, so this is a pure LSP-side generalization.

## Changes

### \`src/lsp_channels.c::lsp_realloc_leaf\`
- Removes \`FACTORY_ARITY_2\` gate
- Removes \`n_signers != 3\` assertion (replaced with \`n_signers >= 2\`)
- Replaces \`clients[2]\` + \`for (ci < 2)\` loops with \`clients[FACTORY_MAX_SIGNERS]\` + N-of-N loops over actual client count
- Widens \`all_pubnonces[3][66]\` to \`all_pubnonces[FACTORY_MAX_SIGNERS][66]\`
- Generalizes the channel-amounts update step to use \`factory_client_to_leaf()\` for each client's (vout, amount) instead of arity-2-specific \`amounts[ci]\` indexing

### \`src/lsp_channels.c::lsp_channels_buy_liquidity\`
- Removes \`FACTORY_ARITY_2\` gate
- Replaces hardcoded \`outputs[2]\` (L-stock at vout 2) with \`outputs[ln->n_outputs - 1]\` (L-stock at last vout — canonical layout)
- Replaces hardcoded \`leaf_side = client_idx / 2\` with a scan of \`f->leaf_node_indices[]\` to find the matching leaf
- Sizes \`new_amounts[]\` to \`ln->n_outputs\` instead of hardcoded 3
- Correctly rejects PS-leaf-post-advance configuration (\`n_outputs == 1\`, no L-stock) with a clear error message

### Tests

\`tests/test_factory.c::test_leaf_realloc_signing_arity1\` — mirror of the existing arity-2 test but for arity-1 leaves (\`n_signers=2\`, \`n_outputs=2\` = 1 channel + L-stock). Exercises the per-node MuSig pipeline that \`lsp_realloc_leaf\` wraps: session init, nonce gen, finalize, partial sigs, aggregate. Verifies a 10%-shift realloc persists with conservation and produces a valid \`signed_tx\`.

## Why this matters

After PR #122 (Tier B), this is the next-largest production-readiness gap. Without the lift:
- Mixed-arity \`{2,4,8}\` factories (the canonical N=64 production shape from Campaign #3) couldn't realloc or buy-liquidity at all
- Arity-1 deployments couldn't realloc
- PS deployments couldn't buy-liquidity (pre-advance) or realloc

After the lift, all configurations work. The wire helpers (\`wire_build_leaf_realloc_propose / NONCE / ALL_NONCES / PSIG / DONE\`) and \`client_handle_leaf_realloc\` already accepted variable counts, so no protocol-side changes were needed.

## Test plan

- [x] Build clean on VPS
- [x] **1415/1415** unit tests pass (was 1414, +1 new arity-1 test)
- [x] Existing arity-2 \`test_leaf_realloc_signing\` still passes (no regression)
- [ ] CI green on this PR

## Refs

- \`.claude/CANONICAL_DESIGN_GAPS.md\` Gap C-followup
- Task #180
- Builds on PR #122 (Tier B) just merged as 63643eb