### PR TITLE
PS k² sub-factories — Phase 1 foundation (Gap E followup)

### DIFF
--- a/docs/ps-subfactories.md
+++ b/docs/ps-subfactories.md
@@ -1,0 +1,166 @@
+# Pseudo-Spilman k² sub-factories
+
+## Background
+
+ZmnSCPxj's t/1242 SuperScalar spec describes PS leaves as containing
+**k² clients distributed across k pseudo-Spilman sub-factories**, with
+**k clients per sub-factory** and the LSP holding "sales stock" inside
+each sub-factory that can be dynamically chained into new client
+channels.
+
+Quote from t/1242 (post #16 / canonical spec):
+
+> *"For arity of `k`, leaves would have `k²` clients and `k`
+> pseudo-Spilman channel factories with `k` clients each."*
+
+> *"The advantages... is that the pseudo-Spilman factory does not
+> require an additional decrementing-`nSequence` layer."*
+
+The **rationale** is reducing total nSequence delay: more clients per
+leaf → fewer DW layers needed for a target client count → lower CSV
+budget → tighter `final_cltv_delta` for incoming HTLCs.
+
+Worked example for k=2:
+```
+PS leaf (4 clients = k²)
+├── sub-factory 1 ─ chain[0]: A&L channel + B&L channel + (A,B,L) sales-stock
+└── sub-factory 2 ─ chain[0]: C&L channel + D&L channel + (C,D,L) sales-stock
+```
+
+Each sub-factory's sales-stock can be chained: when client A wants more
+inbound liquidity, the LSP chains a new (A&L, B&L, sales-stock) state
+where A&L gains capacity from sales-stock.
+
+## Pre-PR state (as of `a34c29f`)
+
+- PS leaves are **1-client-per-leaf** (`n_signers=2`, `n_outputs=2` =
+  channel + L-stock).  Set by `setup_ps_leaf_outputs` in `src/factory.c`.
+- Chain advance in `factory_advance_leaf_unsigned` (PS branch, line ~1912)
+  flips `n_outputs` from 2 to 1 and decreases the channel amount by
+  `fee_per_tx`.  No sub-factories.
+- `compute_leaf_count(n, FACTORY_ARITY_PS)` returns `n` (one leaf per
+  client).  `compute_tree_depth` likewise.
+- `factory_client_to_leaf` for PS maps client `i` directly to leaf `i`,
+  vout 0.
+- No `subfactory_t` / `nested_factory_t` infrastructure exists.
+
+## Target post-spec state
+
+Each PS leaf with `k² > 1` will:
+
+- Have `k+1` outputs: `k` sub-factory entry-points + 1 L-stock
+- Spawn `k` **NODE_PS_SUBFACTORY** child nodes, one per sub-factory
+- Each sub-factory has `k+2` signers (LSP + k clients) and produces a
+  chain[0] TX with `k+1` outputs: `k` per-client channels + 1
+  sales-stock output
+- Sub-factory chain extension (the "buy liquidity from sales-stock" op)
+  spends the sub-factory's prior chain TX → new chain TX with adjusted
+  channel amounts (one channel grew, sales-stock shrunk), same shape
+
+`compute_leaf_count(n, FACTORY_ARITY_PS, k=K)` becomes `ceil(n / K²)`.
+`compute_tree_depth` shortens correspondingly.  At k=2 with N=64
+clients: 64 / 4 = 16 leaves → depth 4 vs the current 64 leaves →
+depth 6.  Lowers nSequence budget by exactly the count zmn names as
+the rationale.
+
+## Phased delivery
+
+This is a multi-day architectural piece.  Splitting into discrete,
+mergeable phases:
+
+### Phase 1 — Foundation (this PR)
+
+**Scope:**
+- New CLI/factory config: `factory_set_ps_subfactory_arity(f, k)`.
+  Default `k=1` preserves current 1-client-per-leaf behavior.
+- New node type: `NODE_PS_SUBFACTORY`.
+- New struct fields on `factory_node_t`:
+  - `int n_subfactories` (k for PS leaves with k>1, else 0)
+  - `int subfactory_node_indices[FACTORY_MAX_SUBFACTORIES]` (entries point into `f->nodes[]`)
+- Tree builder: when `k > 1`, `setup_ps_leaf_outputs` becomes
+  `setup_ps_leaf_with_subfactories`:
+  - Leaf has `k+1` outputs (k sub-factory entry SPKs + L-stock).
+  - For each sub-factory, append a `NODE_PS_SUBFACTORY` to `f->nodes[]`
+    with `parent_index = leaf, parent_vout = i`, `n_signers = k+1`
+    (LSP + k clients in this sub-factory), `n_outputs = k+1` (k
+    channels + sales-stock), keyagg = MuSig(LSP, those k clients).
+- `compute_leaf_count` / `compute_tree_depth` / `simulate_tree`
+  generalize for `k > 1`: leaf count = `ceil(n / k²)`, depth scales
+  accordingly.
+- `factory_client_to_leaf`: for PS with k>1, maps client `i` to
+  `(leaf = i / k², subfactory = (i % k²) / k, channel_in_sub = i % k)`,
+  returns `(node_idx, vout)` of the sub-factory's channel output.
+- `factory_sign_all` requires no changes — it iterates all
+  `f->n_nodes` so the new sub-factory nodes get signed automatically.
+- Unit test `test_factory_ps_k2_build` at k=2, N=4:
+  - Expect: 1 leaf node, 2 sub-factory nodes, all signed.
+  - Verify each sub-factory has 2 client signers + LSP, 3 outputs.
+  - Verify the leaf's outputs[0..1] SPKs match sub-factory entry keyaggs.
+
+**Out of scope** (deferred to Phase 2+):
+- Sub-factory chain extension ceremony (the dynamic "sell from
+  sales-stock" op).
+- Sub-factory state advance over the wire (multi-party MuSig with
+  sub-factory's k+1 signers — a smaller cousin of Tier B).
+- Watchtower per-sub-factory state poison TX.
+- On-chain regtest force-close + sweep at k=2.
+
+### Phase 2 — Sub-factory chain extension
+
+Implement `lsp_subfactory_chain_advance(mgr, lsp, leaf_idx, sub_idx,
+client_idx_in_sub, amount_to_buy)` that drives a multi-party ceremony
+to chain a new sub-factory state with adjusted channel amounts.
+
+This mirrors Tier B's bundled MuSig but scoped to one sub-factory's
+signers (LSP + k clients).  New wire messages
+`MSG_SUBFACTORY_PROPOSE / NONCE_BUNDLE / ALL_NONCES / PSIG_BUNDLE /
+DONE` (or possibly reuse `MSG_PATH_*` infrastructure with a
+sub-factory scope tag).
+
+### Phase 3 — On-chain force-close + sweep at k=2
+
+Regtest test: build k=2 N=4 factory, broadcast leaf + sub-factory
+chain[0] TXs, each client sweeps their channel output with their own
+seckey (similar to existing PS sweep tests).  Conservation + per-party
+deltas verified via `econ_helpers`.
+
+### Phase 4 — Persist + watchtower
+
+Store sub-factory state in the persist DB (new table or extension of
+existing tree_nodes).  Register sub-factory state TXs with watchtower
+for breach detection.  Per-sub-factory poison TX on stale-state
+broadcast.
+
+### Phase 5 — Mixed config + signet
+
+CLI `--ps-subfactory-arity 2` flag, deployment script using k=2 + N=16
+(4 leaves of 4 clients each = 16 clients with depth 2 vs depth 4 today).
+Signet end-to-end campaign.
+
+## Why this PR is foundation-only
+
+Honest scoping after research: each phase is genuinely a non-trivial
+day's work.  Phase 1 alone touches:
+
+- New struct field + node type
+- Tree builder conditionals
+- 4 helper functions (compute_leaf_count, compute_tree_depth,
+  simulate_tree, factory_client_to_leaf) that all need k² support
+- New unit test at k=2
+
+That's a coherent "foundation lands" PR.  Phase 2 (chain extension) is
+itself a new wire ceremony similar to Tier B's complexity and deserves
+its own focused review.  Phase 3 (on-chain test) requires Phase 2 to
+exist before the test can do anything useful.
+
+Shipping the foundation first lets reviewers evaluate the data
+structures + tree shape against the t/1242 spec before the dynamic
+extension ceremony commits to a particular protocol direction.
+
+## Cross-references
+
+- `docs/pseudo-spilman.md` — the existing 1-client-per-leaf design
+- `docs/factory-arity.md` — mixed-arity tree shapes
+- `docs/rotation-ceremony.md` — Tier B ceremony (template for Phase 2)
+- t/1242 thread on Delving Bitcoin
+- `.claude/CANONICAL_DESIGN_GAPS.md` Gap E followup (task #181)

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -77,7 +77,25 @@ typedef struct {
 /* Fill config with compiled-in defaults. */
 void factory_config_default(factory_config_t *cfg);
 
-typedef enum { NODE_KICKOFF, NODE_STATE } factory_node_type_t;
+/* Node types in a factory tree.
+
+   NODE_KICKOFF / NODE_STATE — the canonical Decker-Wattenhofer kickoff
+     + state pair that interior factory nodes use.
+
+   NODE_PS_SUBFACTORY — Pseudo-Spilman sub-factory child of a PS leaf
+     (only used when ps_subfactory_arity > 1, the canonical k² shape
+     from t/1242).  Spends one of the parent leaf's vouts.  Its own
+     outputs are k client channels + 1 sales-stock output that the LSP
+     can chain into new client channels via the dynamic extension
+     ceremony (Phase 2 of docs/ps-subfactories.md).
+     For k=1 (current default), this type is unused — PS leaves
+     remain 1-client-per-leaf and the leaf node directly owns the
+     channel + L-stock outputs. */
+typedef enum {
+    NODE_KICKOFF,
+    NODE_STATE,
+    NODE_PS_SUBFACTORY
+} factory_node_type_t;
 
 /* Factory lifecycle states (Phase 8) */
 typedef enum {
@@ -140,6 +158,25 @@ typedef struct {
     int ps_chain_len;            /* number of state advances (0 = initial state) */
     unsigned char ps_prev_txid[32];    /* txid (internal byte order) of the prior chain TX */
     uint64_t ps_prev_chan_amount;      /* amount_sats of the channel output spent by current TX */
+
+    /* PS sub-factory wiring (only used when ps_subfactory_arity > 1, the
+       canonical k² shape from t/1242).
+
+       On a PS LEAF node (is_ps_leaf == 1) with k>1: n_subfactories == k
+       and subfactory_node_indices[0..k-1] point into f->nodes[] at the
+       k sub-factory child nodes.  The leaf node's outputs[0..k-1] are
+       the entry-point SPKs for each sub-factory, and outputs[k] is the
+       leaf-level L-stock.
+
+       On a NODE_PS_SUBFACTORY node: n_subfactories == 0, parent_index
+       points back to the leaf, parent_vout indicates which leaf vout
+       this sub-factory occupies.  The sub-factory's own outputs[0..k-1]
+       are the per-client channel SPKs and outputs[k] is the sub-factory's
+       sales-stock SPK.
+
+       For k=1 (default) both fields are 0. */
+    int n_subfactories;
+    int subfactory_node_indices[FACTORY_MAX_OUTPUTS];
 
     /* Static-near-root variant (Phase 3 of mixed-arity plan).
        1 = kickoff-only node, no paired NODE_STATE, no DW counter contribution.
@@ -228,6 +265,22 @@ typedef struct {
        rationale and default. */
     uint32_t l_stock_csv_blocks;
 
+    /* PS sub-factory arity (k) for the canonical k² PS leaf shape from
+       t/1242 (docs/ps-subfactories.md, Gap E followup, task #181).
+
+       k=1 (default): 1-client-per-PS-leaf, no sub-factories — current
+                      historical behavior, preserves all existing tests.
+       k>1: each PS leaf hosts k sub-factories of k clients each (k²
+            clients per leaf total).  Each sub-factory is a unidirectional
+            PS chain rooted at one of the leaf's vouts, with the LSP
+            holding "sales-stock" that can be dynamically chained into
+            new client channels.
+
+       Only meaningful when leaf_arity == FACTORY_ARITY_PS.  Phase 1 of
+       the implementation (this PR) builds the structure + signs the
+       initial state; Phase 2 adds the dynamic chain extension ceremony. */
+    uint32_t ps_subfactory_arity;
+
     /* Lifecycle (Phase 8) */
     uint32_t created_block;        /* block height when funding confirmed */
     uint32_t active_blocks;        /* duration of active period (default: 4320 = 30*144) */
@@ -278,6 +331,15 @@ void factory_set_level_arity(factory_t *f, const uint8_t *arities, size_t n);
    before factory_build_tree() — otherwise the L-stock SPK is already
    committed.  Pass 0 to keep the L_STOCK_CSV_DEFAULT_BLOCKS default. */
 void factory_set_l_stock_csv(factory_t *f, uint32_t csv_blocks);
+
+/* Set PS sub-factory arity k for the canonical k² PS leaf shape from
+   t/1242.  k=1 (default) preserves 1-client-per-PS-leaf behavior; k>1
+   makes each PS leaf host k sub-factories of k clients each (k²
+   clients per leaf total).  Only meaningful for FACTORY_ARITY_PS;
+   ignored otherwise.  Must be called before factory_build_tree().
+   Bounded by FACTORY_MAX_OUTPUTS-1 (need room for the leaf-level
+   L-stock output as the last vout). */
+void factory_set_ps_subfactory_arity(factory_t *f, uint32_t k);
 
 /* Build the unsigned L-stock POISON TRANSACTION for a leaf state.
    Spends the L-stock UTXO (`l_stock_txid:l_stock_vout` carrying

--- a/src/factory.c
+++ b/src/factory.c
@@ -502,6 +502,11 @@ int factory_init_with_config(factory_t *f, secp256k1_context *ctx,
         dw_layer_init(&f->leaf_layers[i], step_blocks, states_per_layer);
     f->per_leaf_enabled = 0;
     f->placement_mode = PLACEMENT_TIMEZONE_CLUSTER;
+
+    /* k=1 default for PS sub-factory arity (1-client-per-PS-leaf, no
+       sub-factories — preserves all historical PS test behavior).
+       Override with factory_set_ps_subfactory_arity() before build. */
+    f->ps_subfactory_arity = 1;
     return 1;
 }
 
@@ -539,6 +544,11 @@ void factory_init_from_pubkeys(factory_t *f, secp256k1_context *ctx,
         dw_layer_init(&f->leaf_layers[i], step_blocks, states_per_layer);
     f->per_leaf_enabled = 0;
     f->placement_mode = PLACEMENT_TIMEZONE_CLUSTER;
+
+    /* k=1 default for PS sub-factory arity (1-client-per-PS-leaf, no
+       sub-factories — preserves all historical PS test behavior).
+       Override with factory_set_ps_subfactory_arity() before build. */
+    f->ps_subfactory_arity = 1;
 }
 
 void factory_set_arity(factory_t *f, factory_arity_t arity) {
@@ -675,6 +685,17 @@ static void simulate_tree(const factory_t *f, size_t n_clients,
 void factory_set_l_stock_csv(factory_t *f, uint32_t csv_blocks) {
     if (!f) return;
     f->l_stock_csv_blocks = csv_blocks;
+}
+
+void factory_set_ps_subfactory_arity(factory_t *f, uint32_t k) {
+    if (!f) return;
+    /* Cap at FACTORY_MAX_OUTPUTS - 1 so the leaf's k sub-factory entry
+       outputs + 1 L-stock output fit within FACTORY_MAX_OUTPUTS.  k=0
+       is treated as k=1 (no sub-factories). */
+    if (k == 0) k = 1;
+    if (k > (uint32_t)(FACTORY_MAX_OUTPUTS - 1))
+        k = (uint32_t)(FACTORY_MAX_OUTPUTS - 1);
+    f->ps_subfactory_arity = k;
 }
 
 int factory_client_to_leaf(const factory_t *f, size_t client_idx,

--- a/src/factory.c
+++ b/src/factory.c
@@ -555,8 +555,9 @@ void factory_set_arity(factory_t *f, factory_arity_t arity) {
     f->leaf_arity = arity;
     f->n_level_arity = 0;  /* clear variable arity */
     size_t nc = (f->n_participants > 1) ? f->n_participants - 1 : 1;
-    int n_leaves = compute_leaf_count(nc, arity);
-    int tree_depth = compute_tree_depth(nc, arity);
+    size_t cap = ps_leaf_capacity(f);
+    int n_leaves = compute_leaf_count_psk(nc, arity, cap);
+    int tree_depth = compute_tree_depth_psk(nc, arity, cap);
     /* For arity-only (no variable arity set), threshold defaults to 0
        so this is a no-op for backward compat. */
     int n_layers = dw_n_layers_for(tree_depth, f->static_threshold_depth);
@@ -578,10 +579,25 @@ static int arity_at_depth(const factory_t *f, int depth) {
     return (int)f->level_arity[f->n_level_arity - 1];
 }
 
-/* Determine if a subtree of `nc` clients is a leaf at a level whose arity is `a`. */
-static int subtree_is_leaf(int a, size_t nc) {
-    /* arity-1 / PS: 1 client per leaf */
-    if (a == 1 || a == FACTORY_ARITY_PS) return (nc <= 1);
+/* PS-leaf capacity for the canonical k² shape (t/1242).  Returns k²
+   when the factory is configured for PS with sub-factories (k>1), else
+   1 (current 1-client-per-PS-leaf historical behavior).  Helper used
+   by tree-shape calculations below. */
+static size_t ps_leaf_capacity(const factory_t *f) {
+    if (!f) return 1;
+    uint32_t k = f->ps_subfactory_arity;
+    if (k <= 1) return 1;
+    return (size_t)k * (size_t)k;
+}
+
+/* Determine if a subtree of `nc` clients is a leaf at a level whose
+   arity is `a`.  For PS with k²-sub-factories enabled, leaves hold up
+   to k² clients; otherwise PS holds 1 client per leaf (legacy). */
+static int subtree_is_leaf(const factory_t *f, int a, size_t nc) {
+    /* arity-1: 1 client per leaf */
+    if (a == 1) return (nc <= 1);
+    /* PS: 1 client per leaf at k=1, k² clients per leaf at k>1 */
+    if (a == FACTORY_ARITY_PS) return (nc <= ps_leaf_capacity(f));
     /* arity-A (A >= 2): up to A clients per leaf */
     return (nc <= (size_t)a);
 }
@@ -662,7 +678,7 @@ static void simulate_tree(const factory_t *f, size_t n_clients,
         if (nc == 0) continue;
         if (d > max_depth) max_depth = d;
         int a = arity_at_depth(f, d);
-        if (subtree_is_leaf(a, nc)) {
+        if (subtree_is_leaf(f, a, nc)) {
             leaves++;
         } else {
             size_t parts[FACTORY_MAX_OUTPUTS];
@@ -696,6 +712,23 @@ void factory_set_ps_subfactory_arity(factory_t *f, uint32_t k) {
     if (k > (uint32_t)(FACTORY_MAX_OUTPUTS - 1))
         k = (uint32_t)(FACTORY_MAX_OUTPUTS - 1);
     f->ps_subfactory_arity = k;
+
+    /* If we're a PS factory, the leaf capacity changed → recompute
+       n_leaf_nodes and re-init the DW counter.  For non-PS factories
+       (e.g. arity-2 with sub-factory-arity set to a stray non-default)
+       the value is meaningless and we leave the leaf count untouched. */
+    if (f->leaf_arity != FACTORY_ARITY_PS) return;
+
+    size_t nc = (f->n_participants > 1) ? f->n_participants - 1 : 1;
+    size_t cap = ps_leaf_capacity(f);
+    int n_leaves = compute_leaf_count_psk(nc, FACTORY_ARITY_PS, cap);
+    int tree_depth = compute_tree_depth_psk(nc, FACTORY_ARITY_PS, cap);
+    int n_layers = dw_n_layers_for(tree_depth, f->static_threshold_depth);
+    f->n_leaf_nodes = n_leaves;
+    dw_counter_init(&f->counter, n_layers, f->step_blocks, f->states_per_layer);
+    for (int i = 0; i < n_leaves; i++)
+        dw_layer_init(&f->leaf_layers[i], f->step_blocks, f->states_per_layer);
+    f->per_leaf_enabled = 0;
 }
 
 int factory_client_to_leaf(const factory_t *f, size_t client_idx,
@@ -721,11 +754,31 @@ int factory_client_to_leaf(const factory_t *f, size_t client_idx,
         return 0;
     }
 
-    /* ARITY_1 and ARITY_PS both build 1-client-per-leaf: ARITY_1 has a leaf
-       output of [vout 0 = client channel, vout 1 = L-stock]; ARITY_PS uses
-       [vout 0 = factory-consensus channel for the chain, vout 1 = L-stock]
-       with 1 client per leaf via setup_ps_leaf_outputs.  Both are looked up
-       the same way: client i owns leaf i, channel at vout 0.
+    /* ARITY_PS with k>1 sub-factories (canonical t/1242 k² shape):
+       client i lives on leaf i/k² in sub-factory (i%k²)/k as the
+       (i%k)-th channel output of that sub-factory's chain[0] TX. */
+    if (f->leaf_arity == FACTORY_ARITY_PS && f->ps_subfactory_arity > 1) {
+        size_t k = (size_t)f->ps_subfactory_arity;
+        size_t cap = k * k;
+        size_t leaf_idx = client_idx / cap;
+        size_t sub_idx_in_leaf = (client_idx % cap) / k;
+        size_t channel_in_sub = client_idx % k;
+        if (leaf_idx >= (size_t)f->n_leaf_nodes) return 0;
+        const factory_node_t *leaf =
+            &f->nodes[f->leaf_node_indices[leaf_idx]];
+        if ((int)sub_idx_in_leaf >= leaf->n_subfactories) return 0;
+        int sub_node = leaf->subfactory_node_indices[sub_idx_in_leaf];
+        if (sub_node < 0) return 0;
+        *node_idx_out = (size_t)sub_node;
+        *vout_out = (uint32_t)channel_in_sub;
+        return 1;
+    }
+
+    /* ARITY_1 and ARITY_PS (k=1) both build 1-client-per-leaf: ARITY_1 has a
+       leaf output of [vout 0 = client channel, vout 1 = L-stock]; ARITY_PS
+       uses [vout 0 = factory-consensus channel for the chain, vout 1 =
+       L-stock] with 1 client per leaf via setup_ps_leaf_outputs.  Both are
+       looked up the same way: client i owns leaf i, channel at vout 0.
 
        Earlier versions of this helper conflated PS with arity-2 (2 clients
        per leaf via `client_idx/2`), which silently broke ON-CHAIN ops for
@@ -780,8 +833,9 @@ void factory_set_static_near_root(factory_t *f, uint32_t threshold) {
     if (f->n_level_arity > 0) {
         simulate_tree(f, nc, &depth, &n_leaves);
     } else {
-        depth = compute_tree_depth(nc, f->leaf_arity);
-        n_leaves = compute_leaf_count(nc, f->leaf_arity);
+        size_t cap = ps_leaf_capacity(f);
+        depth = compute_tree_depth_psk(nc, f->leaf_arity, cap);
+        n_leaves = compute_leaf_count_psk(nc, f->leaf_arity, cap);
     }
     int n_layers = dw_n_layers_for(depth, threshold);
     f->n_leaf_nodes = n_leaves;
@@ -907,6 +961,136 @@ static int setup_ps_leaf_outputs(
     return 1;
 }
 
+/* Set up a PS leaf with k² sub-factory shape (canonical t/1242).
+
+   Layout:
+     leaf node (NODE_STATE, n_signers = 1 + n_leaf_clients):
+       outputs[0..k-1] = sub-factory entry SPKs (MuSig(LSP, sub-factory clients))
+       outputs[k]      = L-stock SPK (or(N-of-N over all k² clients, L&CSV))
+       n_subfactories  = k
+
+     for each sub-factory si in 0..k-1 (NODE_PS_SUBFACTORY):
+       n_signers = 1 + n_clients_in_sub  (LSP + k sub-factory clients)
+       parent    = leaf, parent_vout = si
+       outputs[0..k-1] = MuSig(LSP, client_j) channel SPKs
+       outputs[k]      = sub-factory's "sales-stock" SPK (same shape as L-stock,
+                          keyed on the sub-factory's own keyagg)
+
+   Each sub-factory is itself a unidirectional PS chain primitive (the
+   LSP holds sales-stock; future Phase 2 will implement the dynamic
+   chain extension that lets the LSP move sales-stock value into a
+   client's channel).  At Phase 1 we just sign chain[0] of each
+   sub-factory and stop there. */
+static int setup_ps_leaf_with_subfactories(
+    factory_t *f,
+    int leaf_node_idx,
+    const uint32_t *leaf_client_indices,
+    size_t n_leaf_clients,
+    uint64_t input_amount
+) {
+    if (!f) return 0;
+    factory_node_t *leaf = &f->nodes[leaf_node_idx];
+    uint32_t k = f->ps_subfactory_arity;
+    if (k <= 1) return 0;
+    if (n_leaf_clients == 0) return 0;
+    if (n_leaf_clients > (size_t)k * (size_t)k) return 0;
+
+    /* Distribute clients into k sub-factories: ceil(n / k) clients each
+       (last sub-factory gets the remainder when n_leaf_clients < k²). */
+    size_t per_sub = (n_leaf_clients + k - 1) / k;
+    if (per_sub > k) per_sub = k;
+    if (per_sub == 0) return 0;
+
+    /* k sub-factory entry vouts + 1 L-stock vout. */
+    size_t n_outputs = (size_t)k + 1;
+    if (n_outputs > f->config.max_outputs_per_node) {
+        fprintf(stderr, "Factory: PS k=%u leaf needs %zu outputs > max %u\n",
+                k, n_outputs, f->config.max_outputs_per_node);
+        return 0;
+    }
+    if (input_amount <= f->fee_per_tx) return 0;
+    uint64_t output_total = input_amount - f->fee_per_tx;
+    uint64_t per_output = output_total / n_outputs;
+    uint64_t remainder = output_total - per_output * n_outputs;
+    if (per_output < CHANNEL_DUST_LIMIT_SATS) {
+        fprintf(stderr, "Factory: PS k=%u leaf per-output %llu below dust\n",
+                k, (unsigned long long)per_output);
+        return 0;
+    }
+
+    /* Set leaf-node fields BEFORE creating sub-factory children (their
+       add_node calls populate child_indices on the leaf). */
+    leaf->n_outputs = n_outputs;
+    leaf->is_ps_leaf = 1;
+    leaf->ps_chain_len = 0;
+    memset(leaf->ps_prev_txid, 0, 32);
+    leaf->ps_prev_chan_amount = 0;
+    leaf->n_subfactories = (int)k;
+
+    for (uint32_t si = 0; si < k; si++) {
+        size_t start_client = (size_t)si * per_sub;
+        if (start_client >= n_leaf_clients) {
+            /* Empty sub-factory — happens only if n_leaf_clients < k²
+               and we've exhausted clients before the last sub-factory.
+               Not canonical k² but tolerated for non-power-of-k² N. */
+            leaf->subfactory_node_indices[si] = -1;
+            /* Spend leaf vout to a 0-value placeholder won't work — just
+               require canonical k² N.  Reject. */
+            fprintf(stderr, "Factory: PS k=%u leaf has empty sub-factory %u "
+                    "(n_leaf_clients=%zu, per_sub=%zu) — require canonical k² N\n",
+                    k, si, n_leaf_clients, per_sub);
+            return 0;
+        }
+        size_t end_client = start_client + per_sub;
+        if (end_client > n_leaf_clients) end_client = n_leaf_clients;
+        size_t n_in_sub = end_client - start_client;
+
+        uint32_t sub_signers[FACTORY_MAX_SIGNERS];
+        sub_signers[0] = 0;
+        for (size_t ci = 0; ci < n_in_sub; ci++)
+            sub_signers[ci + 1] = leaf_client_indices[start_client + ci];
+
+        int sub_idx = add_node(f, NODE_PS_SUBFACTORY,
+                                sub_signers, n_in_sub + 1,
+                                leaf_node_idx, si,
+                                -1,    /* no DW layer for sub-factory */
+                                0);    /* no per-node CLTV at this phase */
+        if (sub_idx < 0) {
+            fprintf(stderr, "Factory: add sub-factory node %u failed\n", si);
+            return 0;
+        }
+        leaf->subfactory_node_indices[si] = sub_idx;
+
+        /* Wire leaf's vout[si] → sub-factory's spending_spk. */
+        memcpy(leaf->outputs[si].script_pubkey,
+               f->nodes[sub_idx].spending_spk, 34);
+        leaf->outputs[si].script_pubkey_len = 34;
+        leaf->outputs[si].amount_sats = per_output;
+
+        /* Set up sub-factory's own outputs: per-client channels + sales-stock.
+           Reuses setup_nway_leaf_outputs which produces exactly that shape:
+           k MuSig(LSP, client_i) channels + 1 L-stock (= sales-stock when
+           applied to a sub-factory's keyagg).  Mark the sub-factory as a
+           PS leaf so existing PS-aware code paths handle it correctly. */
+        if (!setup_nway_leaf_outputs(f, &f->nodes[sub_idx],
+                                       sub_signers + 1, n_in_sub,
+                                       per_output)) {
+            fprintf(stderr, "Factory: sub-factory %u channel setup failed\n", si);
+            return 0;
+        }
+        f->nodes[sub_idx].input_amount = per_output;
+        f->nodes[sub_idx].is_ps_leaf = 1;
+        f->nodes[sub_idx].ps_chain_len = 0;
+    }
+
+    /* Leaf-level L-stock at the LAST output. */
+    if (!build_l_stock_spk(f, leaf, leaf->outputs[k].script_pubkey))
+        return 0;
+    leaf->outputs[k].script_pubkey_len = 34;
+    leaf->outputs[k].amount_sats = per_output + remainder;
+    return 1;
+}
+
 /* ---- Generalized N-participant tree builder ---- */
 
 #define TIMEOUT_STEP_BLOCKS 5
@@ -915,14 +1099,19 @@ static int setup_ps_leaf_outputs(
    n_clients = n_participants - 1 (excluding LSP).
    Arity-2:  each leaf holds 2 clients → ceil(log2(ceil(n_clients/2))) splits.
    Arity-1:  each leaf holds 1 client  → ceil(log2(n_clients)) splits.
-   Arity-PS: same as arity-1 (1 client per leaf, PS chain replaces leaf DW layer).
-   Returns 0 for a single leaf (1 or 2 clients depending on arity). */
-static int compute_tree_depth(size_t n_clients, factory_arity_t arity) {
+   Arity-PS: each leaf holds ps_leaf_cap clients (1 at k=1, k² at k>1).
+   Returns 0 for a single leaf. */
+static int compute_tree_depth_psk(size_t n_clients, factory_arity_t arity,
+                                    size_t ps_leaf_cap) {
     size_t n_leaves;
-    if (arity == FACTORY_ARITY_1 || arity == FACTORY_ARITY_PS)
+    if (arity == FACTORY_ARITY_1)
         n_leaves = n_clients;
-    else
+    else if (arity == FACTORY_ARITY_PS) {
+        if (ps_leaf_cap < 1) ps_leaf_cap = 1;
+        n_leaves = (n_clients + ps_leaf_cap - 1) / ps_leaf_cap;
+    } else {
         n_leaves = (n_clients + 1) / 2;  /* ceil(n_clients / 2) */
+    }
 
     if (n_leaves <= 1) return 0;
     int depth = 0;
@@ -931,12 +1120,29 @@ static int compute_tree_depth(size_t n_clients, factory_arity_t arity) {
     return depth;
 }
 
+/* Backwards-compat shim: assumes ps_leaf_cap = 1 (legacy 1-client-per-PS-leaf). */
+static int compute_tree_depth(size_t n_clients, factory_arity_t arity) {
+    return compute_tree_depth_psk(n_clients, arity, 1);
+}
+
 /* Compute number of leaf nodes.
-   Arity-2: ceil(n_clients / 2).  Arity-1 / Arity-PS: n_clients. */
-static int compute_leaf_count(size_t n_clients, factory_arity_t arity) {
-    if (arity == FACTORY_ARITY_1 || arity == FACTORY_ARITY_PS)
+   Arity-2: ceil(n_clients / 2).
+   Arity-1: n_clients.
+   Arity-PS: ceil(n_clients / ps_leaf_cap)  (k² for canonical k>1, else 1). */
+static int compute_leaf_count_psk(size_t n_clients, factory_arity_t arity,
+                                    size_t ps_leaf_cap) {
+    if (arity == FACTORY_ARITY_1)
         return (int)n_clients;
+    if (arity == FACTORY_ARITY_PS) {
+        if (ps_leaf_cap < 1) ps_leaf_cap = 1;
+        return (int)((n_clients + ps_leaf_cap - 1) / ps_leaf_cap);
+    }
     return (int)((n_clients + 1) / 2);
+}
+
+/* Backwards-compat shim: assumes ps_leaf_cap = 1 (legacy 1-client-per-PS-leaf). */
+static int compute_leaf_count(size_t n_clients, factory_arity_t arity) {
+    return compute_leaf_count_psk(n_clients, arity, 1);
 }
 
 /* Set up N-way leaf outputs for arity A >= 2.
@@ -1077,7 +1283,7 @@ static int build_subtree(
        only enough clients to be a leaf, we fall back to the non-static
        state-paired path. */
     int cur_arity = arity_at_depth(f, depth);
-    int is_leaf = subtree_is_leaf(cur_arity, n_clients);
+    int is_leaf = subtree_is_leaf(f, cur_arity, n_clients);
     if (is_leaf) is_static = 0;
 
     if (is_static) {
@@ -1183,10 +1389,22 @@ static int build_subtree(
         f->nodes[st_idx].input_amount = ko_out_amount;
 
         if (cur_arity == FACTORY_ARITY_PS) {
-            /* Pseudo-Spilman leaf: 1 client, chained TXs instead of DW nSequence */
-            if (!setup_ps_leaf_outputs(f, &f->nodes[st_idx],
-                                       client_indices[0], ko_out_amount))
-                return 0;
+            uint32_t k = f->ps_subfactory_arity;
+            if (k > 1) {
+                /* Canonical k² PS leaf (t/1242): k sub-factories of k clients.
+                   The leaf's k+1 outputs are k sub-factory entries + L-stock;
+                   each sub-factory gets its own NODE_PS_SUBFACTORY child. */
+                if (!setup_ps_leaf_with_subfactories(f, st_idx,
+                                                      client_indices, n_clients,
+                                                      ko_out_amount))
+                    return 0;
+            } else {
+                /* Legacy 1-client-per-PS-leaf: chained TXs replace the leaf
+                   DW nSequence, no sub-factories. */
+                if (!setup_ps_leaf_outputs(f, &f->nodes[st_idx],
+                                           client_indices[0], ko_out_amount))
+                    return 0;
+            }
         } else if (n_clients == 1) {
             if (!setup_single_leaf_outputs(f, &f->nodes[st_idx],
                                            client_indices[0], ko_out_amount))
@@ -1302,8 +1520,9 @@ int factory_build_tree(factory_t *f) {
     if (f->n_level_arity > 0) {
         simulate_tree(f, n_clients, &tree_depth, &n_leaves);
     } else {
-        tree_depth = compute_tree_depth(n_clients, f->leaf_arity);
-        n_leaves = compute_leaf_count(n_clients, f->leaf_arity);
+        size_t cap = ps_leaf_capacity(f);
+        tree_depth = compute_tree_depth_psk(n_clients, f->leaf_arity, cap);
+        n_leaves = compute_leaf_count_psk(n_clients, f->leaf_arity, cap);
     }
     /* Phase 3: respect static_threshold_depth — only non-static depths get
        DW layers. */

--- a/src/factory.c
+++ b/src/factory.c
@@ -438,6 +438,11 @@ static int compute_node_sighash(const factory_t *f, const factory_node_t *node,
 /* Forward declarations for helpers used in init/set_arity */
 static int compute_tree_depth(size_t n_clients, factory_arity_t arity);
 static int compute_leaf_count(size_t n_clients, factory_arity_t arity);
+static int compute_tree_depth_psk(size_t n_clients, factory_arity_t arity,
+                                    size_t ps_leaf_cap);
+static int compute_leaf_count_psk(size_t n_clients, factory_arity_t arity,
+                                    size_t ps_leaf_cap);
+static size_t ps_leaf_capacity(const factory_t *f);
 
 /* Compute the DW counter n_layers given a tree depth and the static-near-root
    threshold (Phase 3 of mixed-arity plan).  Depths [0, threshold) are

--- a/src/factory.c
+++ b/src/factory.c
@@ -961,6 +961,16 @@ static int setup_ps_leaf_outputs(
     return 1;
 }
 
+/* Forward decl — defined below for the n-way leaf path; reused here for
+   sub-factory output setup (sub-factory shape == k channels + 1 sales-stock
+   == n-way leaf with n = k clients). */
+static int setup_nway_leaf_outputs(
+    factory_t *f,
+    factory_node_t *node,
+    const uint32_t *client_indices,
+    size_t n_client,
+    uint64_t input_amount);
+
 /* Set up a PS leaf with k² sub-factory shape (canonical t/1242).
 
    Layout:

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5249,6 +5249,146 @@ int test_factory_ps_leaf_build(void) {
     return 1;
 }
 
+/* Canonical k² PS sub-factory shape from t/1242 (Gap E followup, task #181).
+
+   Builds a 5-participant PS factory (LSP + 4 clients) with k=2 sub-factory
+   arity.  Per the spec, this should produce:
+     - 1 PS leaf (k² = 4 = n_clients, single leaf with all clients)
+     - leaf.n_signers = 5 (LSP + 4 clients)
+     - leaf.n_outputs = k+1 = 3 (2 sub-factory entries + 1 L-stock)
+     - leaf.n_subfactories = 2
+     - 2 NODE_PS_SUBFACTORY child nodes:
+         sub-factory 0: signers [LSP, A, B], outputs = 3 (A&L, B&L, sales-stock)
+         sub-factory 1: signers [LSP, C, D], outputs = 3 (C&L, D&L, sales-stock)
+
+   Verifies:
+     - tree shape (node count, leaf count, sub-factory count)
+     - sub-factory keyaggs include the right signers
+     - leaf's outputs[0..1] SPKs match sub-factories' spending_spk
+     - factory_sign_all + factory_verify_all both pass (every sub-factory's
+       chain[0] is signed by N-of-N MuSig and verifies against the leaf's
+       output SPK)
+     - factory_client_to_leaf maps each client to the right (sub-factory,
+       channel-vout). */
+int test_factory_ps_subfactory_k2_n4(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[5];
+    for (int i = 0; i < 5; i++) {
+        unsigned char sk[32] = {0};
+        sk[31] = (unsigned char)(i + 1);
+        sk[0]  = 0xCC;
+        TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], sk), "keypair");
+    }
+
+    /* funding SPK: P2TR of 5-of-5 aggregate */
+    unsigned char fund_spk[34];
+    {
+        secp256k1_pubkey pks[5];
+        for (int i = 0; i < 5; i++)
+            secp256k1_keypair_pub(ctx, &pks[i], &kps[i]);
+        musig_keyagg_t ka;
+        musig_aggregate_keys(ctx, &ka, pks, 5);
+        unsigned char ser[32];
+        secp256k1_xonly_pubkey_serialize(ctx, ser, &ka.agg_pubkey);
+        unsigned char tweak[32];
+        sha256_tagged("TapTweak", ser, 32, tweak);
+        secp256k1_pubkey tweaked_pk;
+        secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tweaked_pk, &ka.cache, tweak);
+        secp256k1_xonly_pubkey fund_tw;
+        secp256k1_xonly_pubkey_from_pubkey(ctx, &fund_tw, NULL, &tweaked_pk);
+        build_p2tr_script_pubkey(fund_spk, &fund_tw);
+    }
+
+    unsigned char fake_txid[32];
+    memset(fake_txid, 0xDD, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+    factory_init(f, ctx, kps, 5, 6, 10);
+    factory_set_arity(f, FACTORY_ARITY_PS);
+    factory_set_ps_subfactory_arity(f, 2);  /* k=2 → k²=4 clients per leaf */
+    factory_set_funding(f, fake_txid, 0, 1000000, fund_spk, 34);
+
+    /* Sanity: setting k=2 should have collapsed to 1 leaf (4/4=1). */
+    TEST_ASSERT_EQ(f->n_leaf_nodes, 1, "k=2 N=4 → 1 leaf");
+
+    TEST_ASSERT(factory_build_tree(f), "build k² PS tree");
+
+    /* Tree shape: 1 leaf with 2 sub-factories.  Single-leaf factories have
+       a kickoff/state pair (no interior splits when n_leaves==1):
+         node 0: root kickoff
+         node 1: leaf (state)
+         node 2: sub-factory 0
+         node 3: sub-factory 1
+       Total: 4 nodes. */
+    TEST_ASSERT_EQ((int)f->n_nodes, 4, "4 nodes (kickoff + leaf + 2 subs)");
+
+    /* Verify leaf node */
+    size_t leaf_idx = f->leaf_node_indices[0];
+    factory_node_t *leaf = &f->nodes[leaf_idx];
+    TEST_ASSERT(leaf->is_ps_leaf, "leaf is_ps_leaf");
+    TEST_ASSERT_EQ((int)leaf->n_signers, 5, "leaf n_signers = 5 (LSP+4)");
+    TEST_ASSERT_EQ((int)leaf->n_outputs, 3, "leaf n_outputs = k+1 = 3");
+    TEST_ASSERT_EQ(leaf->n_subfactories, 2, "leaf has 2 sub-factories");
+
+    /* Verify each sub-factory */
+    for (int si = 0; si < 2; si++) {
+        int sub_node_idx = leaf->subfactory_node_indices[si];
+        TEST_ASSERT(sub_node_idx >= 0, "sub-factory node index valid");
+        factory_node_t *sub = &f->nodes[sub_node_idx];
+        TEST_ASSERT(sub->type == NODE_PS_SUBFACTORY, "sub type is NODE_PS_SUBFACTORY");
+        TEST_ASSERT_EQ((int)sub->n_signers, 3, "sub n_signers = LSP+2 = 3");
+        TEST_ASSERT_EQ((int)sub->n_outputs, 3, "sub n_outputs = k+1 = 3 (2 chan + sales)");
+        TEST_ASSERT(sub->parent_index == (int)leaf_idx, "sub parent is leaf");
+        TEST_ASSERT_EQ((int)sub->parent_vout, si, "sub parent_vout matches index");
+        /* LSP is signer slot 0 */
+        TEST_ASSERT_EQ((int)sub->signer_indices[0], 0, "sub signer[0] = LSP");
+        /* Clients on sub 0 should be 1, 2 (i.e. participant 1 and 2) */
+        if (si == 0) {
+            TEST_ASSERT_EQ((int)sub->signer_indices[1], 1, "sub0 client A = pid 1");
+            TEST_ASSERT_EQ((int)sub->signer_indices[2], 2, "sub0 client B = pid 2");
+        } else {
+            TEST_ASSERT_EQ((int)sub->signer_indices[1], 3, "sub1 client C = pid 3");
+            TEST_ASSERT_EQ((int)sub->signer_indices[2], 4, "sub1 client D = pid 4");
+        }
+        /* Leaf's outputs[si] SPK must equal sub-factory's spending_spk */
+        TEST_ASSERT(memcmp(leaf->outputs[si].script_pubkey,
+                            sub->spending_spk, 34) == 0,
+                    "leaf vout SPK == sub-factory spending_spk");
+    }
+
+    /* factory_client_to_leaf must route each client to its sub-factory channel. */
+    for (size_t ci = 0; ci < 4; ci++) {
+        size_t out_node;
+        uint32_t out_vout;
+        TEST_ASSERT(factory_client_to_leaf(f, ci, &out_node, &out_vout),
+                    "client_to_leaf returns ok");
+        int expected_sub_node = leaf->subfactory_node_indices[ci / 2];
+        uint32_t expected_vout = (uint32_t)(ci % 2);
+        TEST_ASSERT_EQ((int)out_node, expected_sub_node,
+                        "client maps to expected sub-factory node");
+        TEST_ASSERT_EQ((int)out_vout, (int)expected_vout,
+                        "client maps to expected channel vout");
+    }
+
+    /* Sign and verify EVERY node — proves chain[0] of each sub-factory is
+       a valid N-of-N MuSig signature against the leaf's vout SPK. */
+    TEST_ASSERT(factory_sign_all(f), "sign k² PS factory");
+    TEST_ASSERT(factory_verify_all(f), "verify k² PS factory");
+
+    /* Each sub-factory's signed_tx must be populated. */
+    for (int si = 0; si < 2; si++) {
+        factory_node_t *sub = &f->nodes[leaf->subfactory_node_indices[si]];
+        TEST_ASSERT(sub->is_signed, "sub-factory signed");
+        TEST_ASSERT(sub->signed_tx.len > 0, "sub-factory signed_tx populated");
+    }
+
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* Build, sign, verify, and advance a PS factory at N=64 (1 LSP + 63 clients).
  * This is the scale test — the existing PS tests use N=3 (2 clients), which
  * doesn't exercise the interior-tree layers or the 64-way MuSig ceremony.

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1655,6 +1655,7 @@ extern int test_factory_config_default(void);
 
 /* Pseudo-Spilman Leaves */
 extern int test_factory_ps_leaf_build(void);
+extern int test_factory_ps_subfactory_k2_n4(void);
 extern int test_factory_ps_leaf_build_n64(void);
 extern int test_factory_ps_build_n128(void);
 extern int test_factory_ps_leaf_advance(void);
@@ -3425,6 +3426,7 @@ static void run_unit_tests(void) {
 
     printf("\n=== Pseudo-Spilman Leaves ===\n");
     RUN_TEST(test_factory_ps_leaf_build);
+    RUN_TEST(test_factory_ps_subfactory_k2_n4);
     RUN_TEST(test_factory_ps_leaf_build_n64);
     RUN_TEST(test_factory_ps_build_n128);
     RUN_TEST(test_factory_ps_leaf_advance);


### PR DESCRIPTION
## Summary

Closes the structural-foundation portion of **Gap E followup** (task #181) — implementing zmn's canonical k² Pseudo-Spilman sub-factory shape from t/1242:

> *"For arity of \`k\`, leaves would have \`k²\` clients and \`k\` pseudo-Spilman channel factories with \`k\` clients each."* — t/1242

Pre-PR: PS leaves were 1-client-per-leaf (corrected from a prior 2-client-shared bug in PR #119). Post-PR: PS leaves can hold k² clients distributed across k sub-factories of k clients each, when \`factory_set_ps_subfactory_arity(f, k)\` is called with k>1. At k=1 (default) all behavior is byte-identical to pre-PR — zero regression for existing PS tests.

## What's in this PR

### Foundation (data + types)
- \`include/superscalar/factory.h\`: \`NODE_PS_SUBFACTORY\` enum, \`factory_node_t::n_subfactories\` + \`subfactory_node_indices[]\`, \`factory_t::ps_subfactory_arity\`
- Public setter \`factory_set_ps_subfactory_arity(f, k)\` — caps at \`FACTORY_MAX_OUTPUTS - 1\`, recomputes \`n_leaf_nodes\` + DW counter

### Tree builder
- \`subtree_is_leaf\` takes \`f\` and uses \`ps_leaf_capacity(f)\` (= k² at k>1, else 1)
- \`compute_leaf_count_psk\` / \`compute_tree_depth_psk\` accept explicit \`ps_leaf_cap\`; existing helpers are thin shims at cap=1
- \`factory_set_arity\` / \`factory_set_static_near_root\` / \`factory_build_tree\` route through the \`_psk\` versions
- New \`setup_ps_leaf_with_subfactories\` creates k \`NODE_PS_SUBFACTORY\` child nodes and wires the leaf's k+1 outputs (k sub-factory entries + 1 L-stock)
- Each sub-factory: k+1 outputs (k per-client channels + 1 sales-stock) via \`setup_nway_leaf_outputs\`
- \`build_subtree\` dispatches on \`ps_subfactory_arity > 1\`

### Client mapping
- \`factory_client_to_leaf\` for PS k>1: client \`i\` → leaf \`i/k²\`, sub-factory \`(i%k²)/k\`, channel \`i%k\`. Returns the sub-factory's node index and the channel vout.

### Test
\`tests/test_factory.c::test_factory_ps_subfactory_k2_n4\` builds a 5-participant (LSP + 4 clients) factory at k=2, asserts:
- 1 PS leaf, n_signers=5, n_outputs=3, n_subfactories=2
- 2 NODE_PS_SUBFACTORY children with correct signer indices, parent_index, parent_vout
- Leaf's outputs[si] SPK matches sub-factory[si].spending_spk
- factory_client_to_leaf routes all 4 clients to their (sub-factory, channel-vout) pairs
- factory_sign_all + factory_verify_all pass (each sub-factory's chain[0] is a valid N-of-N MuSig sig)

### Design doc
\`docs/ps-subfactories.md\` — full 5-phase delivery plan, t/1242 spec quotes, architectural diagram, scope honesty.

## Phased delivery (this PR is Phase 1 of 5)

- **Phase 1** (this PR): structural foundation + initial signing + unit test ✅
- **Phase 2** (follow-up PR): sub-factory chain extension ceremony — the dynamic "buy liquidity from sales-stock" op (similar scope to Tier B's bundled MuSig)
- **Phase 3** (follow-up PR): on-chain force-close + sweep regtest at k=2
- **Phase 4** (follow-up PR): persist + watchtower per-sub-factory state
- **Phase 5** (follow-up PR): mixed config + signet end-to-end

See \`docs/ps-subfactories.md\` for the full plan.

## Test plan

- [x] Build clean on VPS (\`cmake --build\`)
- [x] **1416/1416** unit tests pass (was 1415, +1 new k² test)
- [x] Existing PS tests at k=1 pass unchanged
- [ ] CI green on this PR

## Refs

- \`docs/ps-subfactories.md\` — design + 5-phase plan
- \`.claude/CANONICAL_DESIGN_GAPS.md\` Gap E followup, task #181
- Builds on PRs #122 (Tier B) and #123 (lift arity-2 restriction)