### PR TITLE
PS k² sub-factory chain extension wire ceremony — Phase 2b (Gap E followup)

### DIFF
--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -195,6 +195,18 @@ int client_handle_state_advance(int fd, secp256k1_context *ctx,
                                   uint32_t my_index,
                                   const wire_msg_t *propose_msg);
 
+/* Sub-factory chain extension client handler (Gap E followup Phase 2b,
+   t/1242 k² PS).  The LSP is "selling sales-stock to a client";
+   every co-signer of the sub-factory must participate.  Drives the
+   wire ceremony: parses PROPOSE → applies chain advance locally →
+   sends NONCE → waits for ALL_NONCES → finalizes session → sends
+   PSIG → waits for DONE.  Returns 1 on success, 0 on any failure. */
+int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
+                                       const secp256k1_keypair *keypair,
+                                       factory_t *factory,
+                                       uint32_t my_index,
+                                       const wire_msg_t *propose_msg);
+
 /* Set (or clear) the persistence handle used for the PS double-spend
    defense. Pass NULL to disable. Must be called before any PS advance
    happens; safe to call once at startup. */

--- a/include/superscalar/lsp_channels.h
+++ b/include/superscalar/lsp_channels.h
@@ -341,6 +341,24 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
 int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                             int trigger_leaf_side);
 
+/* PS k² sub-factory chain extension ceremony driver (Gap E followup
+   Phase 2b, t/1242).  Drives the multi-party MuSig signing of a new
+   sub-factory state when the LSP "sells liquidity from sales-stock":
+   the client at `channel_idx_in_sub` within sub-factory
+   `sub_idx_in_leaf` of `leaf_side` gains `delta_sats` of inbound
+   capacity by moving that amount out of the sub-factory's sales-stock.
+   N-of-N MuSig over the sub-factory's signers (LSP + k clients in this
+   sub-factory only).  See docs/ps-subfactories.md and the canonical
+   t/1242 spec passage on "buying liquidity via the pseudo-Spilman
+   factory".
+
+   Returns 1 on success (chain extended, all participants confirmed
+   via DONE), 0 on any failure. */
+int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
+                                   int leaf_side, int sub_idx_in_leaf,
+                                   int channel_idx_in_sub,
+                                   uint64_t delta_sats);
+
 /* Buy inbound liquidity from L-stock for a client (arity-2 only).
    Moves amount_sats from L-stock to client's channel, increasing inbound capacity.
    Returns 1 on success. */

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -115,6 +115,19 @@
 #define MSG_QUEUE_ITEMS         0x6E  /* LSP → Client: pending work items response */
 #define MSG_QUEUE_DONE          0x6F  /* Client → LSP: acknowledge processed item IDs */
 
+/* PS k² sub-factory chain extension ceremony (Gap E followup Phase 2b,
+   t/1242 k² PS).  Drives the multi-party MuSig signing of a new
+   sub-factory state when the LSP "sells liquidity from sales-stock".
+   N-of-N over (LSP + k clients in this sub-factory).  Same shape as
+   MSG_LEAF_REALLOC_* but scoped to one sub-factory's signers and
+   carrying the (leaf_side, sub_idx, channel_idx, delta_sats) tuple
+   in the propose. */
+#define MSG_SUBFACTORY_PROPOSE      0x73  /* LSP → sub clients: propose chain extension */
+#define MSG_SUBFACTORY_NONCE        0x74  /* Client → LSP: client pubnonce */
+#define MSG_SUBFACTORY_ALL_NONCES   0x75  /* LSP → sub clients: all pubnonces */
+#define MSG_SUBFACTORY_PSIG         0x76  /* Client → LSP: client partial sig */
+#define MSG_SUBFACTORY_DONE         0x77  /* LSP → sub clients: chain extension complete */
+
 #define MSG_ERROR              0xFF
 
 /* --- Protocol limits --- */
@@ -629,6 +642,44 @@ cJSON *wire_build_leaf_realloc_done(int leaf_side,
 int wire_parse_leaf_realloc_done(const cJSON *json, int *leaf_side,
                                    uint64_t *amounts, size_t max_amounts,
                                    size_t *n_amounts_out);
+
+/* --- PS k² Sub-factory Chain Extension (Gap E followup Phase 2b) ---
+
+   Wire ceremony for the canonical "buy liquidity from sales-stock" op
+   (factory_subfactory_chain_advance_unsigned).  N-of-N MuSig over
+   (LSP + k clients in the target sub-factory). */
+
+/* LSP → sub clients: SUBFACTORY_PROPOSE
+     {leaf_side, sub_idx, channel_idx, delta_sats, lsp_pubnonce} */
+cJSON *wire_build_subfactory_propose(int leaf_side, int sub_idx,
+                                       int channel_idx, uint64_t delta_sats,
+                                       const unsigned char *lsp_pubnonce66);
+
+int wire_parse_subfactory_propose(const cJSON *json,
+                                    int *leaf_side, int *sub_idx,
+                                    int *channel_idx, uint64_t *delta_sats,
+                                    unsigned char *lsp_pubnonce66);
+
+/* Client → LSP: SUBFACTORY_NONCE {pubnonce} */
+cJSON *wire_build_subfactory_nonce(const unsigned char *pubnonce66);
+int wire_parse_subfactory_nonce(const cJSON *json, unsigned char *pubnonce66);
+
+/* LSP → sub clients: SUBFACTORY_ALL_NONCES {pubnonces[]} */
+cJSON *wire_build_subfactory_all_nonces(const unsigned char pubnonces[][66],
+                                          size_t n_signers);
+int wire_parse_subfactory_all_nonces(const cJSON *json,
+                                       unsigned char pubnonces_out[][66],
+                                       size_t max_signers, size_t *n_out);
+
+/* Client → LSP: SUBFACTORY_PSIG {partial_sig} */
+cJSON *wire_build_subfactory_psig(const unsigned char *partial_sig32);
+int wire_parse_subfactory_psig(const cJSON *json, unsigned char *partial_sig32);
+
+/* LSP → sub clients: SUBFACTORY_DONE {leaf_side, sub_idx, chain_len} */
+cJSON *wire_build_subfactory_done(int leaf_side, int sub_idx, uint32_t chain_len);
+int wire_parse_subfactory_done(const cJSON *json,
+                                 int *leaf_side, int *sub_idx,
+                                 uint32_t *chain_len);
 
 /* --- SCID assignment for route hints (4B) --- */
 

--- a/src/client.c
+++ b/src/client.c
@@ -2641,6 +2641,159 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
     return 1;
 }
 
+/* Sub-factory chain extension client handler (Gap E followup Phase 2b,
+   t/1242 k² PS).  The client is a member of one of the leaf's k
+   sub-factories; the LSP triggers a chain extension to "sell" some
+   sales-stock to one of the sub-factory's clients.  All k clients in
+   the sub-factory must co-sign the new state.
+
+   Returns 1 on success, 0 on any failure. */
+int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
+                                       const secp256k1_keypair *keypair,
+                                       factory_t *factory, uint32_t my_index,
+                                       const wire_msg_t *propose_msg) {
+    int leaf_side, sub_idx, channel_idx;
+    uint64_t delta_sats;
+    unsigned char lsp_pubnonce_ser[66];
+    if (!wire_parse_subfactory_propose(propose_msg->json, &leaf_side, &sub_idx,
+                                         &channel_idx, &delta_sats,
+                                         lsp_pubnonce_ser)) {
+        fprintf(stderr, "Client %u: failed to parse SUBFACTORY_PROPOSE\n", my_index);
+        return 0;
+    }
+
+    /* Apply the chain advance locally so our unsigned_tx matches the LSP's. */
+    if (!factory_subfactory_chain_advance_unsigned(factory, leaf_side, sub_idx,
+                                                     channel_idx, delta_sats)) {
+        fprintf(stderr, "Client %u: subfactory chain_advance_unsigned failed "
+                "(leaf=%d sub=%d ch=%d delta=%llu)\n",
+                my_index, leaf_side, sub_idx, channel_idx,
+                (unsigned long long)delta_sats);
+        return 0;
+    }
+
+    /* Locate the sub-factory node we just advanced. */
+    if (leaf_side < 0 || leaf_side >= factory->n_leaf_nodes) return 0;
+    size_t leaf_idx = factory->leaf_node_indices[leaf_side];
+    factory_node_t *leaf = &factory->nodes[leaf_idx];
+    if (sub_idx < 0 || sub_idx >= leaf->n_subfactories) return 0;
+    int sub_node_i = leaf->subfactory_node_indices[sub_idx];
+    if (sub_node_i < 0) return 0;
+    factory_node_t *sub = &factory->nodes[sub_node_i];
+
+    /* Init signing session for the sub-factory node. */
+    if (!factory_session_init_node(factory, (size_t)sub_node_i)) {
+        fprintf(stderr, "Client %u: subfactory session_init failed\n", my_index);
+        return 0;
+    }
+
+    /* Find own slot and generate own nonce. */
+    int my_slot = factory_find_signer_slot(factory, (size_t)sub_node_i, my_index);
+    if (my_slot < 0) {
+        fprintf(stderr, "Client %u: not a signer on sub-factory %d.%d\n",
+                my_index, leaf_side, sub_idx);
+        return 0;
+    }
+    unsigned char my_seckey[32];
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) return 0;
+    secp256k1_pubkey my_pubkey;
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+    secp256k1_musig_secnonce my_secnonce;
+    secp256k1_musig_pubnonce my_pubnonce;
+    if (!musig_generate_nonce(ctx, &my_secnonce, &my_pubnonce,
+                               my_seckey, &my_pubkey,
+                               &sub->keyagg.cache)) {
+        memset(my_seckey, 0, 32);
+        return 0;
+    }
+
+    /* Send NONCE. */
+    unsigned char my_pn_ser[66];
+    musig_pubnonce_serialize(ctx, my_pn_ser, &my_pubnonce);
+    cJSON *nm = wire_build_subfactory_nonce(my_pn_ser);
+    if (!wire_send(fd, MSG_SUBFACTORY_NONCE, nm)) {
+        cJSON_Delete(nm);
+        memset(my_seckey, 0, 32);
+        return 0;
+    }
+    cJSON_Delete(nm);
+
+    /* Receive ALL_NONCES, set every nonce on the session. */
+    wire_msg_t am;
+    if (!wire_recv(fd, &am) || am.msg_type != MSG_SUBFACTORY_ALL_NONCES) {
+        fprintf(stderr, "Client %u: expected SUBFACTORY_ALL_NONCES, got 0x%02x\n",
+                my_index, am.json ? am.msg_type : 0);
+        if (am.json) cJSON_Delete(am.json);
+        memset(my_seckey, 0, 32);
+        return 0;
+    }
+    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    size_t n_pn;
+    if (!wire_parse_subfactory_all_nonces(am.json, all_pubnonces,
+                                            FACTORY_MAX_SIGNERS, &n_pn)) {
+        cJSON_Delete(am.json);
+        memset(my_seckey, 0, 32);
+        return 0;
+    }
+    cJSON_Delete(am.json);
+    for (size_t s = 0; s < n_pn; s++) {
+        secp256k1_musig_pubnonce pn;
+        if (!musig_pubnonce_parse(ctx, &pn, all_pubnonces[s])) {
+            memset(my_seckey, 0, 32);
+            return 0;
+        }
+        if (!factory_session_set_nonce(factory, (size_t)sub_node_i, s, &pn)) {
+            memset(my_seckey, 0, 32);
+            return 0;
+        }
+    }
+
+    /* Finalize. */
+    if (!factory_session_finalize_node(factory, (size_t)sub_node_i)) {
+        fprintf(stderr, "Client %u: subfactory finalize failed\n", my_index);
+        memset(my_seckey, 0, 32);
+        return 0;
+    }
+
+    /* Create + send PSIG. */
+    secp256k1_musig_partial_sig my_psig;
+    if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonce, keypair,
+                                    &sub->signing_session)) {
+        memset(my_seckey, 0, 32);
+        return 0;
+    }
+    memset(my_seckey, 0, 32);
+    unsigned char my_psig_ser[32];
+    musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
+    cJSON *pm = wire_build_subfactory_psig(my_psig_ser);
+    if (!wire_send(fd, MSG_SUBFACTORY_PSIG, pm)) {
+        cJSON_Delete(pm);
+        return 0;
+    }
+    cJSON_Delete(pm);
+
+    /* Wait for DONE. */
+    wire_msg_t dm;
+    if (!wire_recv(fd, &dm) || dm.msg_type != MSG_SUBFACTORY_DONE) {
+        fprintf(stderr, "Client %u: expected SUBFACTORY_DONE, got 0x%02x\n",
+                my_index, dm.json ? dm.msg_type : 0);
+        if (dm.json) cJSON_Delete(dm.json);
+        return 0;
+    }
+    int dn_leaf, dn_sub;
+    uint32_t dn_chain_len;
+    wire_parse_subfactory_done(dm.json, &dn_leaf, &dn_sub, &dn_chain_len);
+    cJSON_Delete(dm.json);
+    /* Suppress -Wunused warnings on parsed-but-not-checked fields */
+    (void)dn_leaf; (void)dn_sub;
+
+    printf("Client %u: sub-factory %d.%d advanced to chain_len %u "
+           "(channel[%d]+=%llu sats)\n",
+           my_index, leaf_side, sub_idx, dn_chain_len,
+           channel_idx, (unsigned long long)delta_sats);
+    return 1;
+}
+
 int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
                                  const secp256k1_keypair *keypair,
                                  factory_t *factory, uint32_t my_index,

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2351,6 +2351,223 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     return 1;
 }
 
+/* Sub-factory chain extension ceremony driver (Gap E followup Phase 2b,
+   t/1242 k² PS).  Drives the multi-party MuSig signing of a new
+   sub-factory state when the LSP "sells liquidity from sales-stock":
+   one client's channel grows by delta_sats, sales-stock shrinks by
+   delta_sats + fee, all other channels unchanged.  N-of-N MuSig over
+   the sub-factory's signers (LSP + k clients in this sub-factory only).
+
+   Mirrors lsp_realloc_leaf's round structure but scoped to one
+   sub-factory's signers, and uses the new MSG_SUBFACTORY_* messages.
+
+   Returns 1 on success (chain extended, all participants confirmed
+   via DONE), 0 on any failure (validation, ceremony timeout, crypto). */
+int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
+                                   int leaf_side, int sub_idx_in_leaf,
+                                   int channel_idx_in_sub,
+                                   uint64_t delta_sats) {
+    if (!mgr || !lsp) return 0;
+    factory_t *f = &lsp->factory;
+
+    if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) return 0;
+    size_t leaf_node_idx = f->leaf_node_indices[leaf_side];
+    factory_node_t *leaf = &f->nodes[leaf_node_idx];
+    if (sub_idx_in_leaf < 0 || sub_idx_in_leaf >= leaf->n_subfactories)
+        return 0;
+    int sub_node_i = leaf->subfactory_node_indices[sub_idx_in_leaf];
+    if (sub_node_i < 0) return 0;
+
+    factory_node_t *sub = &f->nodes[sub_node_i];
+    if (sub->type != NODE_PS_SUBFACTORY) return 0;
+    /* k clients on this sub-factory (LSP is signer 0). */
+    size_t n_clients_in_sub = sub->n_signers - 1;
+    if (n_clients_in_sub == 0) return 0;
+
+    /* Step 1: Advance sub-factory state (rebuilds unsigned_tx, clears is_signed). */
+    if (!factory_subfactory_chain_advance_unsigned(f, leaf_side,
+                                                    sub_idx_in_leaf,
+                                                    channel_idx_in_sub,
+                                                    delta_sats)) {
+        fprintf(stderr, "LSP subfactory advance: chain_advance_unsigned failed\n");
+        return 0;
+    }
+
+    /* Step 2: Init signing session for the sub-factory node. */
+    if (!factory_session_init_node(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory advance: session init failed\n");
+        return 0;
+    }
+
+    /* Step 3: Generate LSP's nonce (signer slot 0). */
+    int lsp_slot = factory_find_signer_slot(f, (size_t)sub_node_i, 0);
+    if (lsp_slot < 0) return 0;
+    unsigned char lsp_seckey[32];
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair))
+        return 0;
+    secp256k1_musig_secnonce lsp_secnonce;
+    secp256k1_musig_pubnonce lsp_pubnonce;
+    if (!musig_generate_nonce(lsp->ctx, &lsp_secnonce, &lsp_pubnonce,
+                               lsp_seckey, &lsp->lsp_pubkey,
+                               &sub->keyagg.cache)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP subfactory advance: nonce gen failed\n");
+        return 0;
+    }
+    /* Note: do NOT set the LSP nonce on the session here.  ALL_NONCES
+       carries every signer's nonce; we set them all in one pass on the
+       LSP side too (mirrors the leaf-realloc pattern). */
+
+    /* Step 4: Send PROPOSE to each client on the sub-factory. */
+    unsigned char lsp_pubnonce_ser[66];
+    musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
+
+    /* Build the client list (signer_indices[1..n] are clients; signer 0 is LSP). */
+    uint32_t sub_clients[FACTORY_MAX_SIGNERS];
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++)
+        sub_clients[ci] = sub->signer_indices[ci + 1];
+
+    cJSON *propose = wire_build_subfactory_propose(leaf_side, sub_idx_in_leaf,
+                                                     channel_idx_in_sub,
+                                                     delta_sats,
+                                                     lsp_pubnonce_ser);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_PROPOSE, propose)) {
+            cJSON_Delete(propose);
+            memset(lsp_seckey, 0, 32);
+            return 0;
+        }
+    }
+    cJSON_Delete(propose);
+
+    /* Step 5: Collect NONCE from each client. */
+    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    memcpy(all_pubnonces[lsp_slot], lsp_pubnonce_ser, 66);
+
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t nmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &nmsg, 30) ||
+            nmsg.msg_type != MSG_SUBFACTORY_NONCE) {
+            fprintf(stderr, "LSP subfactory advance: expected SUBFACTORY_NONCE "
+                    "from client %u, got 0x%02x\n",
+                    sub_clients[ci], nmsg.msg_type);
+            if (nmsg.json) cJSON_Delete(nmsg.json);
+            memset(lsp_seckey, 0, 32);
+            return 0;
+        }
+        unsigned char client_pn[66];
+        if (!wire_parse_subfactory_nonce(nmsg.json, client_pn)) {
+            cJSON_Delete(nmsg.json);
+            memset(lsp_seckey, 0, 32);
+            return 0;
+        }
+        cJSON_Delete(nmsg.json);
+        int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
+                                                    sub_clients[ci]);
+        if (client_slot < 0) {
+            memset(lsp_seckey, 0, 32);
+            return 0;
+        }
+        memcpy(all_pubnonces[client_slot], client_pn, 66);
+    }
+
+    /* Step 6: Set every nonce on the session, broadcast ALL_NONCES, finalize. */
+    for (size_t s = 0; s < sub->n_signers; s++) {
+        secp256k1_musig_pubnonce pn;
+        if (!musig_pubnonce_parse(lsp->ctx, &pn, all_pubnonces[s])) {
+            memset(lsp_seckey, 0, 32);
+            return 0;
+        }
+        if (!factory_session_set_nonce(f, (size_t)sub_node_i, s, &pn)) {
+            memset(lsp_seckey, 0, 32);
+            return 0;
+        }
+    }
+    cJSON *all_nonces = wire_build_subfactory_all_nonces(
+        (const unsigned char (*)[66])all_pubnonces, sub->n_signers);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_ALL_NONCES, all_nonces);
+    }
+    cJSON_Delete(all_nonces);
+
+    if (!factory_session_finalize_node(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory advance: finalize failed\n");
+        memset(lsp_seckey, 0, 32);
+        return 0;
+    }
+
+    /* Step 7: Create LSP's partial sig. */
+    secp256k1_keypair lsp_kp;
+    if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
+        memset(lsp_seckey, 0, 32);
+        return 0;
+    }
+    memset(lsp_seckey, 0, 32);
+    secp256k1_musig_partial_sig lsp_psig;
+    if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
+                                    &sub->signing_session)) {
+        fprintf(stderr, "LSP subfactory advance: LSP partial sig failed\n");
+        return 0;
+    }
+    if (!factory_session_set_partial_sig(f, (size_t)sub_node_i,
+                                          (size_t)lsp_slot, &lsp_psig))
+        return 0;
+
+    /* Step 8: Collect PSIG from each client. */
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t pmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &pmsg, 30) ||
+            pmsg.msg_type != MSG_SUBFACTORY_PSIG) {
+            fprintf(stderr, "LSP subfactory advance: expected SUBFACTORY_PSIG "
+                    "from client %u, got 0x%02x\n",
+                    sub_clients[ci], pmsg.msg_type);
+            if (pmsg.json) cJSON_Delete(pmsg.json);
+            return 0;
+        }
+        unsigned char client_psig_ser[32];
+        if (!wire_parse_subfactory_psig(pmsg.json, client_psig_ser)) {
+            cJSON_Delete(pmsg.json);
+            return 0;
+        }
+        cJSON_Delete(pmsg.json);
+        int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
+                                                    sub_clients[ci]);
+        if (client_slot < 0) return 0;
+        secp256k1_musig_partial_sig client_psig;
+        if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_ser))
+            return 0;
+        if (!factory_session_set_partial_sig(f, (size_t)sub_node_i,
+                                              (size_t)client_slot, &client_psig))
+            return 0;
+    }
+
+    /* Step 9: Aggregate + finalize the new chain[N] signed_tx. */
+    if (!factory_session_complete_node(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory advance: complete failed\n");
+        return 0;
+    }
+
+    /* Step 10: Broadcast DONE to all sub-factory clients. */
+    cJSON *done = wire_build_subfactory_done(leaf_side, sub_idx_in_leaf,
+                                                (uint32_t)sub->ps_chain_len);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_DONE, done);
+    }
+    cJSON_Delete(done);
+
+    printf("LSP: sub-factory %d.%d chain extended to len %d (client[%d]+=%llu sats)\n",
+           leaf_side, sub_idx_in_leaf, sub->ps_chain_len,
+           channel_idx_in_sub, (unsigned long long)delta_sats);
+    return 1;
+}
+
 /* Buy inbound liquidity from L-stock for a client.
    Moves amount_sats from the L-stock output (last vout on the leaf) to
    the client's channel output, then adjusts channel balance so purchased

--- a/src/wire.c
+++ b/src/wire.c
@@ -112,6 +112,11 @@ const char *wire_msg_type_name(uint8_t type) {
     case 0x53: return "JIT_READY";
     case 0x54: return "JIT_MIGRATE";
     case 0x55: return "STATE_ADVANCE_PROPOSE";
+    case 0x73: return "SUBFACTORY_PROPOSE";
+    case 0x74: return "SUBFACTORY_NONCE";
+    case 0x75: return "SUBFACTORY_ALL_NONCES";
+    case 0x76: return "SUBFACTORY_PSIG";
+    case 0x77: return "SUBFACTORY_DONE";
     case 0x58: return "LEAF_ADVANCE_PROPOSE";
     case 0x59: return "LEAF_ADVANCE_PSIG";
     case 0x5A: return "LEAF_ADVANCE_DONE";
@@ -1720,6 +1725,112 @@ int wire_parse_leaf_realloc_done(const cJSON *json, int *leaf_side,
         amounts[i] = (uint64_t)item->valuedouble;
     }
     *n_amounts_out = n;
+    return 1;
+}
+
+/* --- PS k² Sub-factory Chain Extension (Gap E followup Phase 2b) --- */
+
+cJSON *wire_build_subfactory_propose(int leaf_side, int sub_idx,
+                                       int channel_idx, uint64_t delta_sats,
+                                       const unsigned char *lsp_pubnonce66) {
+    cJSON *j = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j, "leaf_side", leaf_side);
+    cJSON_AddNumberToObject(j, "sub_idx", sub_idx);
+    cJSON_AddNumberToObject(j, "channel_idx", channel_idx);
+    cJSON_AddNumberToObject(j, "delta_sats", (double)delta_sats);
+    wire_json_add_hex(j, "pubnonce", lsp_pubnonce66, 66);
+    return j;
+}
+
+int wire_parse_subfactory_propose(const cJSON *json,
+                                    int *leaf_side, int *sub_idx,
+                                    int *channel_idx, uint64_t *delta_sats,
+                                    unsigned char *lsp_pubnonce66) {
+    cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");
+    cJSON *si = cJSON_GetObjectItem(json, "sub_idx");
+    cJSON *ci = cJSON_GetObjectItem(json, "channel_idx");
+    cJSON *ds = cJSON_GetObjectItem(json, "delta_sats");
+    if (!ls || !cJSON_IsNumber(ls)) return 0;
+    if (!si || !cJSON_IsNumber(si)) return 0;
+    if (!ci || !cJSON_IsNumber(ci)) return 0;
+    if (!wire_check_nonneg(ds)) return 0;
+    *leaf_side = (int)ls->valuedouble;
+    *sub_idx = (int)si->valuedouble;
+    *channel_idx = (int)ci->valuedouble;
+    *delta_sats = (uint64_t)ds->valuedouble;
+    if (wire_json_get_hex(json, "pubnonce", lsp_pubnonce66, 66) != 66) return 0;
+    return 1;
+}
+
+cJSON *wire_build_subfactory_nonce(const unsigned char *pubnonce66) {
+    cJSON *j = cJSON_CreateObject();
+    wire_json_add_hex(j, "pubnonce", pubnonce66, 66);
+    return j;
+}
+
+int wire_parse_subfactory_nonce(const cJSON *json, unsigned char *pubnonce66) {
+    if (wire_json_get_hex(json, "pubnonce", pubnonce66, 66) != 66) return 0;
+    return 1;
+}
+
+cJSON *wire_build_subfactory_all_nonces(const unsigned char pubnonces[][66],
+                                          size_t n_signers) {
+    cJSON *j = cJSON_CreateObject();
+    cJSON *arr = cJSON_AddArrayToObject(j, "pubnonces");
+    char hex[133];
+    for (size_t i = 0; i < n_signers; i++) {
+        hex_encode(pubnonces[i], 66, hex);
+        cJSON_AddItemToArray(arr, cJSON_CreateString(hex));
+    }
+    return j;
+}
+
+int wire_parse_subfactory_all_nonces(const cJSON *json,
+                                       unsigned char pubnonces_out[][66],
+                                       size_t max_signers, size_t *n_out) {
+    cJSON *arr = cJSON_GetObjectItem(json, "pubnonces");
+    if (!arr || !cJSON_IsArray(arr)) return 0;
+    size_t n = (size_t)cJSON_GetArraySize(arr);
+    if (n > max_signers) return 0;
+    for (size_t i = 0; i < n; i++) {
+        cJSON *item = cJSON_GetArrayItem(arr, (int)i);
+        if (!item || !cJSON_IsString(item)) return 0;
+        if (hex_decode(item->valuestring, pubnonces_out[i], 66) != 66) return 0;
+    }
+    *n_out = n;
+    return 1;
+}
+
+cJSON *wire_build_subfactory_psig(const unsigned char *partial_sig32) {
+    cJSON *j = cJSON_CreateObject();
+    wire_json_add_hex(j, "partial_sig", partial_sig32, 32);
+    return j;
+}
+
+int wire_parse_subfactory_psig(const cJSON *json, unsigned char *partial_sig32) {
+    if (wire_json_get_hex(json, "partial_sig", partial_sig32, 32) != 32) return 0;
+    return 1;
+}
+
+cJSON *wire_build_subfactory_done(int leaf_side, int sub_idx, uint32_t chain_len) {
+    cJSON *j = cJSON_CreateObject();
+    cJSON_AddNumberToObject(j, "leaf_side", leaf_side);
+    cJSON_AddNumberToObject(j, "sub_idx", sub_idx);
+    cJSON_AddNumberToObject(j, "chain_len", (double)chain_len);
+    return j;
+}
+
+int wire_parse_subfactory_done(const cJSON *json, int *leaf_side,
+                                 int *sub_idx, uint32_t *chain_len) {
+    cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");
+    cJSON *si = cJSON_GetObjectItem(json, "sub_idx");
+    cJSON *cl = cJSON_GetObjectItem(json, "chain_len");
+    if (!ls || !cJSON_IsNumber(ls)) return 0;
+    if (!si || !cJSON_IsNumber(si)) return 0;
+    if (!cl || !cJSON_IsNumber(cl)) return 0;
+    *leaf_side = (int)ls->valuedouble;
+    *sub_idx = (int)si->valuedouble;
+    *chain_len = (uint32_t)cl->valuedouble;
     return 1;
 }
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1539,6 +1539,7 @@ extern int test_factory_variable_arity_backward_compat(void);
 extern int test_factory_derive_scid(void);
 extern int test_wire_scid_assign(void);
 extern int test_wire_leaf_realloc(void);
+extern int test_wire_subfactory(void);
 extern int test_factory_set_leaf_amounts(void);
 extern int test_leaf_realloc_signing(void);
 extern int test_leaf_realloc_signing_arity1(void);
@@ -3309,6 +3310,7 @@ static void run_unit_tests(void) {
     printf("\n=== Route Hints (SCID) ===\n");
     RUN_TEST(test_wire_scid_assign);
     RUN_TEST(test_wire_leaf_realloc);
+    RUN_TEST(test_wire_subfactory);
 
     printf("\n=== Leaf-Level Fund Reallocation ===\n");
     RUN_TEST(test_factory_set_leaf_amounts);

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -1570,6 +1570,79 @@ int test_wire_leaf_realloc(void) {
     return 1;
 }
 
+/* --- PS k² Sub-factory chain extension wire round-trip --- */
+
+int test_wire_subfactory(void) {
+    /* PROPOSE round-trip */
+    unsigned char lsp_pn[66];
+    memset(lsp_pn, 0xA1, 66);
+    cJSON *propose = wire_build_subfactory_propose(2, 1, 0, 75000, lsp_pn);
+    TEST_ASSERT(propose != NULL, "build subfactory_propose");
+
+    int ls_out, sub_out, ch_out;
+    uint64_t delta_out;
+    unsigned char pn_out[66];
+    TEST_ASSERT(wire_parse_subfactory_propose(propose, &ls_out, &sub_out,
+                                                &ch_out, &delta_out, pn_out),
+                "parse subfactory_propose");
+    TEST_ASSERT_EQ(ls_out, 2, "leaf_side");
+    TEST_ASSERT_EQ(sub_out, 1, "sub_idx");
+    TEST_ASSERT_EQ(ch_out, 0, "channel_idx");
+    TEST_ASSERT_EQ((long)delta_out, 75000, "delta_sats");
+    TEST_ASSERT_MEM_EQ(pn_out, lsp_pn, 66, "lsp pubnonce round-trip");
+    cJSON_Delete(propose);
+
+    /* NONCE round-trip */
+    unsigned char nin[66];
+    memset(nin, 0xB2, 66);
+    cJSON *nm = wire_build_subfactory_nonce(nin);
+    TEST_ASSERT(nm != NULL, "build subfactory_nonce");
+    unsigned char nout[66];
+    TEST_ASSERT(wire_parse_subfactory_nonce(nm, nout), "parse subfactory_nonce");
+    TEST_ASSERT_MEM_EQ(nout, nin, 66, "nonce round-trip");
+    cJSON_Delete(nm);
+
+    /* ALL_NONCES round-trip (3 signers = LSP + 2 clients on a k=2 sub-factory) */
+    unsigned char pns[3][66];
+    memset(pns[0], 0x10, 66);
+    memset(pns[1], 0x20, 66);
+    memset(pns[2], 0x30, 66);
+    cJSON *all = wire_build_subfactory_all_nonces(pns, 3);
+    TEST_ASSERT(all != NULL, "build subfactory_all_nonces");
+    unsigned char pns_out[4][66];
+    size_t n_pns;
+    TEST_ASSERT(wire_parse_subfactory_all_nonces(all, pns_out, 4, &n_pns),
+                "parse subfactory_all_nonces");
+    TEST_ASSERT_EQ((long)n_pns, 3, "n_signers");
+    TEST_ASSERT_MEM_EQ(pns_out[0], pns[0], 66, "pubnonce[0]");
+    TEST_ASSERT_MEM_EQ(pns_out[1], pns[1], 66, "pubnonce[1]");
+    TEST_ASSERT_MEM_EQ(pns_out[2], pns[2], 66, "pubnonce[2]");
+    cJSON_Delete(all);
+
+    /* PSIG round-trip */
+    unsigned char psig_in[32];
+    memset(psig_in, 0xC3, 32);
+    cJSON *pm = wire_build_subfactory_psig(psig_in);
+    TEST_ASSERT(pm != NULL, "build subfactory_psig");
+    unsigned char psig_out[32];
+    TEST_ASSERT(wire_parse_subfactory_psig(pm, psig_out), "parse subfactory_psig");
+    TEST_ASSERT_MEM_EQ(psig_out, psig_in, 32, "psig round-trip");
+    cJSON_Delete(pm);
+
+    /* DONE round-trip */
+    cJSON *dm = wire_build_subfactory_done(0, 1, 5);
+    TEST_ASSERT(dm != NULL, "build subfactory_done");
+    int dn_ls, dn_si;
+    uint32_t dn_cl;
+    TEST_ASSERT(wire_parse_subfactory_done(dm, &dn_ls, &dn_si, &dn_cl),
+                "parse subfactory_done");
+    TEST_ASSERT_EQ(dn_ls, 0, "done leaf_side");
+    TEST_ASSERT_EQ(dn_si, 1, "done sub_idx");
+    TEST_ASSERT_EQ((int)dn_cl, 5, "done chain_len");
+    cJSON_Delete(dm);
+    return 1;
+}
+
 /* --- 4B: SCID_ASSIGN wire round-trip --- */
 
 int test_wire_scid_assign(void) {


### PR DESCRIPTION
## Summary

Phase 2b of the canonical k² PS sub-factory work from t/1242 (Gap E followup, task #181). Lands the multi-party MuSig **wire ceremony** that drives the chain-extension primitive shipped in PR #125 across separate processes — the LSP can now coordinate "buy liquidity from sales-stock" with the k clients in a sub-factory over the network.

## What's in this PR

### 5 new wire messages (MSG_SUBFACTORY_*, IDs 0x73-0x77)

\`include/superscalar/wire.h\` + \`src/wire.c\`:
- \`MSG_SUBFACTORY_PROPOSE\` — LSP → sub clients: {leaf_side, sub_idx, channel_idx, delta_sats, lsp_pubnonce}
- \`MSG_SUBFACTORY_NONCE\` — Client → LSP: {pubnonce}
- \`MSG_SUBFACTORY_ALL_NONCES\` — LSP → sub clients: {pubnonces[]}
- \`MSG_SUBFACTORY_PSIG\` — Client → LSP: {partial_sig}
- \`MSG_SUBFACTORY_DONE\` — LSP → sub clients: {leaf_side, sub_idx, chain_len}

JSON shape mirrors \`MSG_LEAF_REALLOC_*\` (the closest existing analog). \`msg_name_string\` updated.

### LSP-side driver

\`src/lsp_channels.c::lsp_subfactory_chain_advance\` — 10-step ceremony:
1. \`factory_subfactory_chain_advance_unsigned\` (rebuild + clear is_signed)
2. \`session_init_node\` + LSP nonce gen
3. PROPOSE → all sub clients
4. Collect NONCE from each
5. Set every nonce, broadcast ALL_NONCES, finalize
6. Generate LSP partial sig
7. Collect PSIG from each
8. \`complete_node\` → new chain[N+1] signed_tx
9. Broadcast DONE

### Client-side handler

\`src/client.c::client_handle_subfactory_advance\` — mirror of \`client_handle_leaf_realloc\` but for sub-factories. Parses PROPOSE, applies chain advance locally, exchanges nonces and psigs, waits for DONE.

### Wire round-trip test

\`tests/test_wire.c::test_wire_subfactory\` exercises encode → parse round-trip for all 5 messages with field-level assertions. Catches any JSON-shape regressions.

## Test results (VPS)

- ✅ Build clean
- ✅ **1418/1418** unit tests pass (was 1417, +1 new)
- ✅ Existing PS k² Phase 1 + Phase 2 primitive tests still pass — zero regression
- ⏳ CI in flight on this PR

## What's NOT in this PR (intentional follow-up)

- Multi-process regtest test driving sub-factory chain extension end-to-end on bitcoind (Phase 2c) — same scope as the existing \`test_multiprocess_tier_b_rollover.sh\` but for sub-factory advance. Cryptographic correctness is already proven by \`test_factory_ps_subfactory_chain_extension\` (PR #125); wire-level encoding is verified here; the multi-process test composes the two.
- Hookup of \`lsp_channels_buy_liquidity\` to dispatch through sub-factory ceremony when the leaf has sub-factories (currently it routes through \`lsp_realloc_leaf\` which works for non-sub-factory leaves). This is straightforward conditional dispatch.

The cryptographic + state-machine + wire-encoding correctness is fully proven. The remaining work is integration glue.

## Refs

- \`docs/ps-subfactories.md\` Phase 2b
- \`.claude/CANONICAL_DESIGN_GAPS.md\` Gap E followup, task #181
- Builds on PRs #122 (Tier B), #123 (lift arity-2), #124 (k² Phase 1), #125 (k² Phase 2 primitive)