### PR TITLE
PS k² sub-factory chain extension multi-process regtest — Phase 2c (Gap E followup)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1449,6 +1449,15 @@ int client_run_with_channels(secp256k1_context *ctx,
     uint32_t static_threshold_depth =
         (snr_item && cJSON_IsNumber(snr_item)) ? (uint32_t)snr_item->valuedouble : 0;
 
+    /* PS k² sub-factory arity (Gap E followup, t/1242).  Backward-
+       compatible: missing field = k=1 (legacy 1-client-per-PS-leaf).
+       Without this the client builds a divergent tree when the LSP
+       configured --ps-subfactory-arity K>1 — same divergence mode that
+       broke --static-near-root before its FACTORY_PROPOSE field landed. */
+    cJSON *psa_item = cJSON_GetObjectItem(msg.json, "ps_subfactory_arity");
+    uint32_t ps_subfactory_arity_in =
+        (psa_item && cJSON_IsNumber(psa_item)) ? (uint32_t)psa_item->valuedouble : 0;
+
     /* Parse placement + economic mode (optional, backward-compatible) */
     cJSON *pm_item = cJSON_GetObjectItem(msg.json, "placement_mode");
     int placement_mode = (pm_item && cJSON_IsNumber(pm_item)) ? (int)pm_item->valuedouble : 0;
@@ -1581,6 +1590,12 @@ int client_run_with_channels(secp256k1_context *ctx,
        DW counter shape based on f->level_arity / f->leaf_arity. */
     if (static_threshold_depth > 0)
         factory_set_static_near_root(factory, static_threshold_depth);
+    /* Apply ps_subfactory_arity after the arity restore — the setter
+       short-circuits when leaf_arity != FACTORY_ARITY_PS, so arity must
+       come first.  k>1 reshapes the tree to the canonical k² PS shape
+       from t/1242 (k sub-factories of k clients each per leaf). */
+    if (ps_subfactory_arity_in > 1)
+        factory_set_ps_subfactory_arity(factory, ps_subfactory_arity_in);
     if (n_parsed_hashes > 0)
         factory_set_l_stock_hashes(factory, parsed_l_stock_hashes, n_parsed_hashes);
     free(parsed_l_stock_hashes);

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -290,6 +290,11 @@ int lsp_run_factory_creation(lsp_t *lsp,
         memcpy(saved_level_arity, f->level_arity,
                saved_n_level_arity * sizeof(uint8_t));
     uint32_t saved_static_threshold = f->static_threshold_depth;
+    /* Same survival rationale: --ps-subfactory-arity K (canonical k² PS
+       shape) is set on the CLI before lsp_run_factory_creation runs.
+       Without this save, k>1 silently collapses to k=1 (legacy 1-client-
+       per-PS-leaf), losing the entire k² structure. */
+    uint32_t saved_ps_subfactory_arity = f->ps_subfactory_arity;
     /* fee_per_tx must also survive: the N=64 mixed-arity factory needs
        1000 sats/tx (interior state nodes are wider — 240+ vB — and 200
        sats falls below regtest mempool min relay).  Preserving here lets
@@ -324,6 +329,11 @@ int lsp_run_factory_creation(lsp_t *lsp,
        the DW counter shape based on f->level_arity / f->leaf_arity. */
     if (saved_static_threshold > 0)
         factory_set_static_near_root(f, saved_static_threshold);
+    /* ps_subfactory_arity also needs to follow arity restore — the setter
+       short-circuits when leaf_arity != FACTORY_ARITY_PS, so the arity
+       restore must precede it. */
+    if (saved_ps_subfactory_arity > 1)
+        factory_set_ps_subfactory_arity(f, saved_ps_subfactory_arity);
     /* Restore fee_per_tx if caller had bumped it above the init default.
        factory_build_tree below may further override from the fee estimator
        (see factory.c:1233), but in absence of an estimator this restore is

--- a/src/wire.c
+++ b/src/wire.c
@@ -626,6 +626,12 @@ cJSON *wire_build_factory_propose(const factory_t *f) {
     if (f->static_threshold_depth > 0)
         cJSON_AddNumberToObject(j, "static_threshold_depth",
                                 (double)f->static_threshold_depth);
+    /* PS k² sub-factory arity (Gap E followup, t/1242).  Only emitted
+       when k>1 to avoid bloat for the common 1-client-per-PS-leaf case;
+       missing field on the parser side defaults to k=1. */
+    if (f->ps_subfactory_arity > 1)
+        cJSON_AddNumberToObject(j, "ps_subfactory_arity",
+                                (double)f->ps_subfactory_arity);
     cJSON_AddNumberToObject(j, "placement_mode", (double)f->placement_mode);
     cJSON_AddNumberToObject(j, "economic_mode", (double)f->economic_mode);
 

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1883,6 +1883,21 @@ handle_message:
             break;
         }
 
+        case MSG_SUBFACTORY_PROPOSE: {
+            /* Phase 2c (Gap E followup): LSP "selling sales-stock" to a
+               client.  Delegate to client_handle_subfactory_advance;
+               handles MSG_SUBFACTORY_NONCE → ALL_NONCES → PSIG → DONE
+               internally for one sub-factory's k+1 signers (LSP + k
+               clients in this sub-factory). */
+            wire_msg_t propose_msg = { .msg_type = msg.msg_type, .json = msg.json };
+            if (!client_handle_subfactory_advance(fd, ctx, keypair, factory,
+                                                    my_index, &propose_msg)) {
+                fprintf(stderr, "Client %u: sub-factory advance failed\n", my_index);
+            }
+            cJSON_Delete(msg.json);
+            break;
+        }
+
         /* -------------------------------------------------------------------
          * Splice protocol — LSP-initiated quiescence and funding replacement
          * ----------------------------------------------------------------- */

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -3076,16 +3076,9 @@ accept_new_factory:
         factory_set_static_near_root(&lsp_p->factory, static_near_root);
     /* PS k² sub-factory arity: applied AFTER arity configuration so the
        leaf-count + DW counter recompute correctly for k>1. */
-    if (ps_subfactory_arity_arg > 0) {
+    if (ps_subfactory_arity_arg > 0)
         factory_set_ps_subfactory_arity(&lsp_p->factory,
                                           (uint32_t)ps_subfactory_arity_arg);
-        printf("LSP: PS sub-factory arity = %u (factory.ps_subfactory_arity now %u, "
-               "leaf_arity=%d, n_leaf_nodes=%d)\n",
-               ps_subfactory_arity_arg,
-               lsp_p->factory.ps_subfactory_arity,
-               (int)lsp_p->factory.leaf_arity,
-               lsp_p->factory.n_leaf_nodes);
-    }
     lsp_p->factory.placement_mode = (placement_mode_t)placement_mode_arg;
     lsp_p->factory.economic_mode = (economic_mode_t)economic_mode_arg;
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -3076,9 +3076,16 @@ accept_new_factory:
         factory_set_static_near_root(&lsp_p->factory, static_near_root);
     /* PS k² sub-factory arity: applied AFTER arity configuration so the
        leaf-count + DW counter recompute correctly for k>1. */
-    if (ps_subfactory_arity_arg > 0)
+    if (ps_subfactory_arity_arg > 0) {
         factory_set_ps_subfactory_arity(&lsp_p->factory,
                                           (uint32_t)ps_subfactory_arity_arg);
+        printf("LSP: PS sub-factory arity = %u (factory.ps_subfactory_arity now %u, "
+               "leaf_arity=%d, n_leaf_nodes=%d)\n",
+               ps_subfactory_arity_arg,
+               lsp_p->factory.ps_subfactory_arity,
+               (int)lsp_p->factory.leaf_arity,
+               lsp_p->factory.n_leaf_nodes);
+    }
     lsp_p->factory.placement_mode = (placement_mode_t)placement_mode_arg;
     lsp_p->factory.economic_mode = (economic_mode_t)economic_mode_arg;
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -307,6 +307,8 @@ static void usage(const char *prog) {
         "  --test-ps-advance   After demo: advance all PS leaves (chain_pos 0->1), verify amounts, force-close\n"
         "  --test-leaf-advance After demo: advance left leaf only, force-close (proves per-leaf independence)\n"
         "  --test-tier-b-rollover After demo: drive states_per_layer+1 leaf-0 advances to trigger root rollover; verify Tier B ceremony (Gap B+F)\n"
+        "  --test-subfactory-advance After demo: drive a sub-factory chain extension via lsp_subfactory_chain_advance (requires --arity 3 --ps-subfactory-arity K, K>1)\n"
+        "  --ps-subfactory-arity K  PS sub-factory arity k (canonical k² PS shape from t/1242).  k=1 (default) = 1-client-per-PS-leaf; k>1 = k clients per sub-factory, k sub-factories per leaf, k² clients per leaf.\n"
         "  --test-partial-rotation After demo: 1 client goes offline, partial rotation with 3/4, dist TX on old factory\n"
         "  --test-dual-factory After demo: create second factory, show two ACTIVE in ladder, force-close both\n"
         "  --test-dw-exhibition After demo: full DW lifecycle (multi-advance + PTLC close + cross-factory contrast)\n"
@@ -1097,6 +1099,8 @@ int main(int argc, char *argv[]) {
     int test_batch_rebalance = 0;
     int test_realloc = 0;
     int test_tier_b_rollover = 0;  /* Tier B (Gap B+F) — drive root rollover */
+    int test_subfactory_advance = 0;  /* Phase 2c — drive sub-factory chain extension */
+    int ps_subfactory_arity_arg = 0;  /* k for PS k² sub-factories (0 = default k=1) */
     int test_jit = 0;
     int test_lsps2 = 0;
     int test_bolt12 = 0;
@@ -1245,6 +1249,10 @@ int main(int argc, char *argv[]) {
             test_realloc = 1;
         else if (strcmp(argv[i], "--test-tier-b-rollover") == 0)
             test_tier_b_rollover = 1;
+        else if (strcmp(argv[i], "--test-subfactory-advance") == 0)
+            test_subfactory_advance = 1;
+        else if (strcmp(argv[i], "--ps-subfactory-arity") == 0 && i + 1 < argc)
+            ps_subfactory_arity_arg = atoi(argv[++i]);
         else if (strcmp(argv[i], "--test-jit") == 0)
             test_jit = 1;
         else if (strcmp(argv[i], "--test-lsps2") == 0)
@@ -3066,6 +3074,11 @@ accept_new_factory:
        AFTER arity configuration so the DW counter is correctly resized. */
     if (static_near_root > 0)
         factory_set_static_near_root(&lsp_p->factory, static_near_root);
+    /* PS k² sub-factory arity: applied AFTER arity configuration so the
+       leaf-count + DW counter recompute correctly for k>1. */
+    if (ps_subfactory_arity_arg > 0)
+        factory_set_ps_subfactory_arity(&lsp_p->factory,
+                                          (uint32_t)ps_subfactory_arity_arg);
     lsp_p->factory.placement_mode = (placement_mode_t)placement_mode_arg;
     lsp_p->factory.economic_mode = (economic_mode_t)economic_mode_arg;
 
@@ -3286,7 +3299,7 @@ accept_new_factory:
         force_close || test_burn ||
         test_htlc_force_close || test_multi_htlc_force_close || test_full_settlement ||
         test_rebalance || test_batch_rebalance || test_realloc ||
-        test_tier_b_rollover ||
+        test_tier_b_rollover || test_subfactory_advance ||
         test_dual_factory || test_dw_exhibition || test_splice || test_bridge || test_jit || test_bolt12 ||
         test_buy_liquidity || test_large_factory || test_ps_advance) {
         /* Set fee policy before init (init preserves these across memset) */

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -1143,6 +1143,93 @@
            verification (the new-epoch signed TXs must be valid).
 
            Requires arity-1 (DW leaves) — PS chains never trigger rc=-1. */
+        /* === PS k² Sub-factory Chain Extension Test (Phase 2c) ===
+
+           Drives a single sub-factory chain extension via
+           lsp_subfactory_chain_advance.  Requires --arity 3 (PS) and
+           --ps-subfactory-arity K with K>1 so the factory has actual
+           sub-factory child nodes to extend. */
+        if (test_subfactory_advance) {
+            printf("\n=== PS K² SUB-FACTORY CHAIN EXTENSION TEST ===\n");
+            fflush(stdout);
+            int sub_pass = 1;
+
+            if (lsp_p->factory.leaf_arity != FACTORY_ARITY_PS ||
+                lsp_p->factory.ps_subfactory_arity <= 1) {
+                printf("  SKIP: --test-subfactory-advance requires --arity 3 "
+                       "and --ps-subfactory-arity K (K>1)\n");
+                printf("PS K² SUB-FACTORY TEST: SKIP\n");
+            } else if (lsp_p->factory.n_leaf_nodes < 1) {
+                printf("  SKIP: no leaves built\n");
+                printf("PS K² SUB-FACTORY TEST: SKIP\n");
+            } else {
+                /* Pick leaf 0, sub-factory 0, channel 0; transfer 50000 sats
+                   from sales-stock to channel 0. */
+                size_t leaf0_idx = lsp_p->factory.leaf_node_indices[0];
+                factory_node_t *leaf = &lsp_p->factory.nodes[leaf0_idx];
+                if (leaf->n_subfactories < 1) {
+                    printf("  SKIP: leaf 0 has no sub-factories\n");
+                    printf("PS K² SUB-FACTORY TEST: SKIP\n");
+                } else {
+                    int sub0_node_i = leaf->subfactory_node_indices[0];
+                    factory_node_t *sub0 =
+                        &lsp_p->factory.nodes[sub0_node_i];
+                    int chain_before = sub0->ps_chain_len;
+                    uint64_t ch0_before = sub0->outputs[0].amount_sats;
+                    uint64_t sstock_before =
+                        sub0->outputs[sub0->n_outputs - 1].amount_sats;
+                    uint64_t delta = 50000;
+
+                    printf("  pre-extension: chain_len=%d, ch[0]=%llu, "
+                           "sales-stock=%llu, delta=%llu\n",
+                           chain_before, (unsigned long long)ch0_before,
+                           (unsigned long long)sstock_before,
+                           (unsigned long long)delta);
+                    fflush(stdout);
+
+                    int rc = lsp_subfactory_chain_advance(mgr, lsp_p,
+                                                           /*leaf_side=*/0,
+                                                           /*sub_idx=*/0,
+                                                           /*channel_idx=*/0,
+                                                           delta);
+                    if (rc != 1) {
+                        printf("  FAIL: lsp_subfactory_chain_advance returned %d\n", rc);
+                        sub_pass = 0;
+                    } else if (sub0->ps_chain_len != chain_before + 1) {
+                        printf("  FAIL: chain_len did not increment "
+                               "(was %d, now %d)\n",
+                               chain_before, sub0->ps_chain_len);
+                        sub_pass = 0;
+                    } else if (sub0->outputs[0].amount_sats !=
+                                ch0_before + delta) {
+                        printf("  FAIL: ch[0] did not grow by delta "
+                               "(was %llu, now %llu)\n",
+                               (unsigned long long)ch0_before,
+                               (unsigned long long)sub0->outputs[0].amount_sats);
+                        sub_pass = 0;
+                    } else if (!sub0->is_signed) {
+                        printf("  FAIL: chain[N+1] is not signed\n");
+                        sub_pass = 0;
+                    } else {
+                        printf("  post-extension: chain_len=%d, ch[0]=%llu, "
+                               "sales-stock=%llu (signed=%d)\n",
+                               sub0->ps_chain_len,
+                               (unsigned long long)sub0->outputs[0].amount_sats,
+                               (unsigned long long)sub0->outputs[sub0->n_outputs - 1].amount_sats,
+                               sub0->is_signed);
+                    }
+                }
+                printf("PS K² SUB-FACTORY TEST: %s\n", sub_pass ? "PASS" : "FAIL");
+            }
+            fflush(stdout);
+            if (!sub_pass) {
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+        }
+
         if (test_tier_b_rollover) {
             printf("\n=== TIER B STATE-ADVANCE ROLLOVER TEST ===\n");
             fflush(stdout);

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -1178,7 +1178,12 @@
                     uint64_t ch0_before = sub0->outputs[0].amount_sats;
                     uint64_t sstock_before =
                         sub0->outputs[sub0->n_outputs - 1].amount_sats;
-                    uint64_t delta = 50000;
+                    /* Pick delta well under sales-stock capacity.  At
+                       funding=400k with k=2 N=4 the per-output budget
+                       is ~44k after 3 fee rounds; 10k leaves comfortable
+                       headroom and exercises the cryptographic flow
+                       without bumping into dust limits. */
+                    uint64_t delta = 10000;
 
                     printf("  pre-extension: chain_len=%d, ch[0]=%llu, "
                            "sales-stock=%llu, delta=%llu\n",

--- a/tools/test_multiprocess_subfactory_advance.sh
+++ b/tools/test_multiprocess_subfactory_advance.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# test_multiprocess_subfactory_advance.sh — multi-process k² PS sub-factory
+# chain extension end-to-end on regtest (Phase 2c of the k² PS work).
+#
+# Spawns 1 LSP daemon + 4 superscalar_client daemons (5 distinct OS
+# processes), builds a k=2 N=4 PS factory with sub-factories, then drives
+# a single sub-factory chain extension via lsp_subfactory_chain_advance:
+# the LSP "sells" 50000 sats of sales-stock to client 0 of sub-factory 0,
+# the k+1 signers (LSP + 2 clients on that sub-factory) co-sign the new
+# state via the MSG_SUBFACTORY_* multi-party MuSig ceremony.
+#
+# This is the multi-process counterpart to the in-process unit test
+# tests/test_factory.c::test_factory_ps_subfactory_chain_extension.
+# That test proves cryptographic + state-machine correctness in a single
+# process holding all keypairs; this test proves the wire transport
+# composes end-to-end across separate OS processes that each hold only
+# their own keypair, against real bitcoind regtest.
+#
+# Why arity=3 (PS) + ps_subfactory_arity=2: PS leaves with k>1 produce
+# k² clients per leaf with k sub-factories of k clients each.  At N=4
+# clients we get exactly 1 leaf with 2 sub-factories (canonical k² shape).
+#
+# Usage: bash tools/test_multiprocess_subfactory_advance.sh [BUILD_DIR]
+#
+# BUILD_DIR defaults to /root/SuperScalar/build.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+# 1 LSP + 4 clients = 5 processes.  At k=2 PS, n_participants=5 →
+# leaf has k²=4 clients in 2 sub-factories of 2 clients each.
+N_CLIENTS="${N_CLIENTS:-4}"
+PS_SUB_ARITY="${PS_SUB_ARITY:-2}"
+
+FUNDING_SATS=400000
+LSP_PORT=29948                # different from N=8 (29945) and tier-b (29947)
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "0000000000000000000000000000000000000000000000000000000000000005"
+    "0000000000000000000000000000000000000000000000000000000000000006"
+    "0000000000000000000000000000000000000000000000000000000000000007"
+    "0000000000000000000000000000000000000000000000000000000000000008"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+if [ ! -f "$REGTEST_CONF" ]; then
+    REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+fi
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+
+TMPDIR=$(mktemp -d /tmp/ss-subfactory.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"
+LSP_LOG="$TMPDIR/lsp.log"
+
+PIDS=()
+
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    for pid in "${PIDS[@]:-}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do
+        kill -9 "$pid" 2>/dev/null || true
+    done
+    cp "$LSP_LOG" /tmp/subfactory_last_lsp.log 2>/dev/null || true
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        cp "$TMPDIR/client_${i}.log" "/tmp/subfactory_last_client_${i}.log" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR"
+    echo "  Preserved logs:"
+    echo "    /tmp/subfactory_last_lsp.log"
+    echo "    /tmp/subfactory_last_client_{0..$((N_CLIENTS - 1))}.log"
+}
+trap cleanup EXIT
+
+echo "=== Multi-process PS k² sub-factory chain extension (regtest) ==="
+echo "  build dir         : $BUILD_DIR"
+echo "  N clients         : $N_CLIENTS  (1 LSP + $N_CLIENTS clients = $((N_CLIENTS + 1)) procs)"
+echo "  PS sub arity (k)  : $PS_SUB_ARITY  (canonical k² = $((PS_SUB_ARITY * PS_SUB_ARITY)) clients per leaf)"
+echo "  funding           : $FUNDING_SATS sats"
+echo "  bitcoind          : $REGTEST_CONF"
+echo ""
+echo "  Test will: build factory → trigger lsp_subfactory_chain_advance →"
+echo "  verify each sub-factory client co-signed via MSG_SUBFACTORY_* wire"
+echo "  ceremony → broadcast post-extension factory tree on-chain."
+
+# --- Sanity ---
+for bin in "$LSP_BIN" "$CLIENT_BIN"; do
+    if [ ! -x "$bin" ]; then
+        echo "FAIL: missing binary $bin"
+        exit 1
+    fi
+done
+
+# --- bitcoind regtest reset ---
+echo ""
+echo "--- bitcoind regtest reset ---"
+
+REGTEST_DATADIR=$(grep -E '^datadir=' "$REGTEST_CONF" 2>/dev/null | head -1 | cut -d= -f2)
+if [ -n "$REGTEST_DATADIR" ]; then
+    REGTEST_REGTEST_DIR="$REGTEST_DATADIR/regtest"
+else
+    REGTEST_REGTEST_DIR="$HOME/.bitcoin/regtest"
+fi
+
+$BCLI stop 2>/dev/null || true
+sleep 2
+if pgrep -f "bitcoind.*regtest" > /dev/null; then
+    pkill -f "bitcoind.*regtest" 2>/dev/null || true
+    sleep 2
+fi
+
+DATADIR_OWNER=$(stat -c %U "$REGTEST_DATADIR" 2>/dev/null || echo "$USER")
+if [ "$DATADIR_OWNER" = "bitcoin" ]; then
+    sudo -u bitcoin sh -c "rm -rf '$REGTEST_REGTEST_DIR'" 2>/dev/null || \
+        rm -rf "$REGTEST_REGTEST_DIR"
+    sudo -u bitcoin bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+else
+    rm -rf "$REGTEST_REGTEST_DIR"
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+fi
+
+for i in $(seq 1 30); do
+    $BCLI getblockchaininfo &>/dev/null && break
+    sleep 1
+done
+if ! $BCLI getblockchaininfo &>/dev/null; then
+    echo "FAIL: bitcoind failed to start"
+    exit 1
+fi
+echo "  bitcoind reachable, fresh chain at height $($BCLI getblockcount)"
+
+$BCLI createwallet "" 2>/dev/null || $BCLI loadwallet "" 2>/dev/null || true
+WALLET_NAME="ss_subfactory_miner"
+$BCLI createwallet "$WALLET_NAME" 2>/dev/null || $BCLI loadwallet "$WALLET_NAME" 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet="$WALLET_NAME" getnewaddress)
+echo "  miner wallet ready"
+
+# --- LSP daemon ---
+echo ""
+echo "--- LSP daemon (--demo --test-subfactory-advance --force-close) ---"
+
+stdbuf -oL "$LSP_BIN" \
+    --network regtest \
+    --port "$LSP_PORT" \
+    --seckey "$LSP_SECKEY" \
+    --clients "$N_CLIENTS" \
+    --arity 3 \
+    --ps-subfactory-arity "$PS_SUB_ARITY" \
+    --amount "$FUNDING_SATS" \
+    --step-blocks 1 \
+    --demo \
+    --test-subfactory-advance \
+    --force-close \
+    --db "$LSP_DB" \
+    --cli-path "$(which bitcoin-cli)" \
+    --rpcuser rpcuser --rpcpassword rpcpass \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+PIDS+=("$LSP_PID")
+echo "  LSP started (PID=$LSP_PID, log=$LSP_LOG)"
+
+for i in $(seq 1 30); do
+    grep -q "listening on port" "$LSP_LOG" 2>/dev/null && break
+    sleep 1
+    if ! kill -0 "$LSP_PID" 2>/dev/null; then
+        echo "FAIL: LSP died before listening"
+        tail -40 "$LSP_LOG"
+        exit 1
+    fi
+done
+if ! grep -q "listening on port" "$LSP_LOG" 2>/dev/null; then
+    echo "FAIL: LSP did not start listening within 30s"
+    tail -40 "$LSP_LOG"
+    exit 1
+fi
+echo "  LSP listening on port $LSP_PORT"
+
+# --- Client daemons ---
+echo ""
+echo "--- $N_CLIENTS client daemons ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    CLIENT_LOG="$TMPDIR/client_${i}.log"
+    CLIENT_DB="$TMPDIR/client_${i}.db"
+    stdbuf -oL "$CLIENT_BIN" \
+        --seckey "${CLIENT_SECKEYS[$i]}" \
+        --host 127.0.0.1 --port "$LSP_PORT" \
+        --network regtest \
+        --lsp-pubkey "$LSP_PUBKEY" \
+        --daemon \
+        --db "$CLIENT_DB" \
+        --cli-path "$(which bitcoin-cli)" \
+        --rpcuser rpcuser --rpcpassword rpcpass \
+        > "$CLIENT_LOG" 2>&1 &
+    CPID=$!
+    PIDS+=("$CPID")
+    echo "  client[$i] started (PID=$CPID)"
+    sleep 0.4
+done
+
+# --- Background block miner (BIP68 timelock progression) ---
+echo ""
+echo "--- Driving ceremony (mining 1 block / 2s in background) ---"
+(
+    while kill -0 "$LSP_PID" 2>/dev/null; do
+        $BCLI generatetoaddress 1 "$MINE_ADDR" > /dev/null 2>&1 || true
+        sleep 2
+    done
+) &
+MINER_PID=$!
+PIDS+=("$MINER_PID")
+
+# --- Wait for LSP to complete ---
+echo ""
+echo "--- Waiting for sub-factory advance ceremony to complete (timeout 600s) ---"
+WAITED=0
+LSP_EXIT=""
+while [ "$WAITED" -lt 600 ]; do
+    if ! kill -0 "$LSP_PID" 2>/dev/null; then
+        wait "$LSP_PID" 2>/dev/null || true
+        LSP_EXIT=$?
+        break
+    fi
+    if [ $((WAITED % 20)) -eq 0 ]; then
+        SUB_PROGRESS=$(grep -c "sub-factory.*chain extended\|PS K² SUB-FACTORY TEST" "$LSP_LOG" 2>/dev/null || echo 0)
+        echo "  ... ${WAITED}s elapsed, sub-factory markers in LSP log: $SUB_PROGRESS"
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+done
+
+if [ -z "$LSP_EXIT" ]; then
+    echo "FAIL: LSP did not exit within 600s"
+    tail -120 "$LSP_LOG"
+    exit 1
+fi
+
+echo ""
+echo "--- LSP exit=$LSP_EXIT ---"
+if [ "$LSP_EXIT" -ne 0 ]; then
+    echo "FAIL: LSP exited non-zero (exit $LSP_EXIT)"
+    tail -120 "$LSP_LOG"
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        echo ""
+        echo "=== client[$i] log tail (40 lines) ==="
+        tail -40 "$TMPDIR/client_${i}.log" 2>/dev/null || true
+    done
+    exit 1
+fi
+
+# --- Verify ceremony markers ---
+echo ""
+echo "=== Verifying sub-factory ceremony fired and completed ==="
+
+if ! grep -q "PS K² SUB-FACTORY CHAIN EXTENSION TEST" "$LSP_LOG"; then
+    echo "FAIL: LSP log missing test header"
+    tail -60 "$LSP_LOG"
+    exit 1
+fi
+echo "  test header present"
+
+if ! grep -q "sub-factory.*chain extended" "$LSP_LOG"; then
+    echo "FAIL: sub-factory chain extension never fired"
+    tail -80 "$LSP_LOG"
+    exit 1
+fi
+CE_LINE=$(grep "sub-factory.*chain extended" "$LSP_LOG" | head -1)
+echo "  $CE_LINE"
+
+if ! grep -q "PS K² SUB-FACTORY TEST: PASS" "$LSP_LOG"; then
+    echo "FAIL: PS K² SUB-FACTORY TEST did not PASS"
+    grep -E "PS K²|FAIL|sub-factory" "$LSP_LOG" | head -20
+    exit 1
+fi
+echo "  PS K² SUB-FACTORY TEST: PASS"
+
+# --- Per-client participation ---
+echo ""
+echo "=== Verifying clients participated in sub-factory ceremony ==="
+PARTICIPATED=0
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    LOG="$TMPDIR/client_${i}.log"
+    if grep -q "sub-factory.*advanced to chain_len" "$LOG" 2>/dev/null; then
+        PARTICIPATED=$((PARTICIPATED + 1))
+        SA=$(grep "sub-factory.*advanced to chain_len" "$LOG" | head -1)
+        echo "  client[$i]: participated — $SA"
+    else
+        echo "  client[$i]: no sub-factory advance marker (may be in different sub-factory)"
+    fi
+done
+
+# At k=2 N=4 only 2 of the 4 clients (sub-factory 0's clients) participate.
+# That's correct — sub-factory 1's clients don't see this ceremony.
+if [ "$PARTICIPATED" -lt "$PS_SUB_ARITY" ]; then
+    echo "FAIL: expected >= $PS_SUB_ARITY clients to participate (sub-factory 0 has $PS_SUB_ARITY clients)"
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        echo ""
+        echo "=== client[$i] log tail (40 lines) ==="
+        tail -40 "$TMPDIR/client_${i}.log" 2>/dev/null || true
+    done
+    exit 1
+fi
+echo ""
+echo "  $PARTICIPATED clients on sub-factory 0 logged completion (>= $PS_SUB_ARITY required)"
+
+echo ""
+echo "=== PASS: Multi-process k² PS sub-factory chain extension ==="
+echo "  - $((N_CLIENTS + 1)) distinct OS processes"
+echo "  - k=$PS_SUB_ARITY → 1 leaf with $PS_SUB_ARITY sub-factories of $PS_SUB_ARITY clients each"
+echo "  - LSP-driven sub-factory chain extension over MSG_SUBFACTORY_*"
+echo "  - $PARTICIPATED clients confirmed completion"
+echo "  - Post-extension factory tree force-closed on-chain"


### PR DESCRIPTION
## Summary

Phase 2c of the canonical k² PS sub-factory work from t/1242 (Gap E followup, task #181). End-to-end verifies the wire ceremony shipped in PR #126 by spawning 1 LSP + 4 client daemons (5 distinct OS processes), building a k=2 N=4 PS factory, then driving a sub-factory chain extension over real \`MSG_SUBFACTORY_*\` traffic on regtest.

## What's in this PR

### CLI plumbing
- \`tools/superscalar_lsp.c\`: \`--ps-subfactory-arity K\` (configures factory for k>1) and \`--test-subfactory-advance\` (triggers \`lsp_subfactory_chain_advance\` after channel setup)
- \`tools/superscalar_client.c\`: \`MSG_SUBFACTORY_PROPOSE\` case dispatches to \`client_handle_subfactory_advance\`
- \`tools/superscalar_lsp_pre_daemon_tests.inc\`: new test block that picks leaf 0, sub-factory 0, channel 0, transfers 10000 sats from sales-stock, and asserts amount/chain_len/signed_tx invariants

### Multi-process bash test
\`tools/test_multiprocess_subfactory_advance.sh\`: 1 LSP + 4 clients at \`--arity 3 --ps-subfactory-arity 2\`. Verifies LSP log shows \"sub-factory N.M chain extended\" and at least 2 clients on sub-factory 0 log \"sub-factory N.M advanced to chain_len\" (clients on sub-factory 1 correctly don't see this ceremony). Then \`--force-close\` broadcasts the post-extension tree on regtest.

### Three latent bugs surfaced + fixed during multi-process bring-up

1. **\`lsp_run_factory_creation\` reset \`ps_subfactory_arity\`** (\`src/lsp.c\`). The function save/restores arity, level_arity, static_threshold across an internal \`factory_init_from_pubkeys\` reset, but \`ps_subfactory_arity\` was missing — k>1 silently collapsed to k=1 once the ceremony started. Added to the save/restore dance.

2. **\`FACTORY_PROPOSE\` wire didn't carry \`ps_subfactory_arity\`** (\`src/wire.c\` + \`src/client.c\`). Without it, clients fell back to k=1 and built divergent 14-node trees vs the LSP's 4-node k² tree. MuSig nonce exchange failed because clients sent nonces for node indices (5, 6, 8) that don't exist in the LSP's tree. Same divergence mode that bit \`--static-near-root\` before its FACTORY_PROPOSE field landed. Added wire emission (when k>1) + client parse + apply via \`factory_set_ps_subfactory_arity\` after arity restore.

3. **Test delta exceeded sales-stock budget**. At funding=400k with k=2 N=4, the per-output budget after 3 fee rounds (root + leaf + sub-factory) is ~44k. Original delta=50000 caused chain_advance_unsigned to reject. Reduced to 10000.

## Test results (VPS)

- ✅ Build clean
- ✅ **1418/1418** unit tests pass — zero regression
- ✅ **Multi-process k² PS sub-factory chain extension PASSES end-to-end on regtest:**
  - LSP: \`sub-factory 0.0 chain extended to len 1 (client[0]+=10000 sats)\`
  - Client 1, 2 on sub-factory 0: \`sub-factory 0.0 advanced to chain_len 1 (channel[0]+=10000 sats)\`
  - Clients 3, 4 on sub-factory 1: correctly NOT involved
  - Post-extension factory tree force-closed on regtest (4 nodes confirmed)
- ⏳ CI in flight on this PR

## Why this matters

After PRs #124, #125, #126 the k² sub-factory feature has structural foundation, primitive, and wire ceremony. This PR proves all three compose end-to-end across separate OS processes against bitcoind — the canonical \"buy liquidity from sales-stock\" op from t/1242 actually executes over the network with the right signers and produces a valid Bitcoin TX.

## Refs

- \`docs/ps-subfactories.md\` Phase 2c
- \`.claude/CANONICAL_DESIGN_GAPS.md\` Gap E followup, task #181
- Builds on PRs #122 (Tier B), #123 (lift arity-2), #124 (k² Phase 1), #125 (k² Phase 2 primitive), #126 (k² Phase 2b wire)