### PR TITLE
PS k² sub-factory persist load on LSP restart — Phase 4c

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 20
+#define PERSIST_SCHEMA_VERSION 21
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -79,6 +79,32 @@ int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
 int persist_load_ps_chain(persist_t *p, uint32_t factory_id, uint32_t leaf_node_idx,
                            tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
                            uint64_t *amounts_out, int max_chain);
+
+/* --- Pseudo-Spilman SUB-FACTORY chain persistence (k² shape) --- */
+
+/* Save one sub-factory chain entry. Each entry has per-channel amounts plus
+   the trailing sales-stock amount (the sub-factory analogue of the L-stock
+   on the parent leaf). channel_amounts[]: amount per child channel,
+   length = n_channels. The sales_stock vout is the last output. */
+int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
+                                          uint32_t sub_node_idx, int chain_pos,
+                                          const unsigned char *txid_display,
+                                          const unsigned char *signed_tx, size_t signed_tx_len,
+                                          uint64_t sales_stock_amount_sats,
+                                          const uint64_t *channel_amounts, int n_channels);
+
+/* Load all sub-factory chain entries for a sub-factory node in chain_pos order.
+   chain_txs_out: caller-allocated tx_buf_t[max_chain].
+   txids_out: caller-allocated [max_chain][32] internal-order txids.
+   sales_stock_out: caller-allocated uint64_t[max_chain] sales-stock amounts.
+   channel_amounts_out: caller-allocated uint64_t[max_chain][max_channels].
+   n_channels_out: caller-allocated int[max_chain] number of channels per entry.
+   Returns number of entries loaded, 0 on no entries or error. */
+int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t sub_node_idx,
+                                    tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
+                                    uint64_t *sales_stock_out,
+                                    uint64_t (*channel_amounts_out)[16],
+                                    int *n_channels_out, int max_chain);
 
 /* --- Client-side PS double-spend defense --- */
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2553,31 +2553,40 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
-    /* Step 10: Persist sub-factory chain entry (Phase 4a — durability).
+    /* Step 10: Persist sub-factory chain entry (Phase 4a save +
+       Phase 4c per-channel amounts) into the dedicated v21
+       `ps_subfactory_chains` table.
 
-       Reuses the existing ps_leaf_chains table (PRIMARY KEY (factory_id,
-       leaf_node_idx, chain_pos)) — `leaf_node_idx` here is the
-       sub-factory's node index in f->nodes[], `chain_pos` is the
-       0-based chain position (= ps_chain_len - 1 after the bump),
-       `chan_amount_sats` stores the sales-stock amount (the value
-       being chained from), and `signed_tx_hex` stores the new chain
-       state for breach-recovery + restart.  Identical pattern to how
-       lsp_advance_leaf persists 1-client-per-PS-leaf entries; the
-       same table works for k² sub-factories because the schema is
-       generic on (node_idx, chain_pos). */
+       Per-channel amounts are stored as CSV alongside the trailing
+       sales-stock amount so factory_recovery_load can rebuild
+       sub->outputs[] exactly on LSP restart — without per-channel
+       persistence the recovered sub-factory would not know how to
+       sweep individual client balances after a crash.
+
+       The table is keyed (factory_id, sub_node_idx, chain_pos), where
+       sub_node_idx is the sub-factory's f->nodes[] index — this is
+       schema-distinct from the leaf-level ps_leaf_chains keyed on
+       leaf_node_idx, even though the index spaces happen not to
+       collide today. */
     if (mgr->persist) {
         extern void reverse_bytes(unsigned char *, size_t);
         unsigned char txid_display[32];
         memcpy(txid_display, sub->txid, 32);
         reverse_bytes(txid_display, 32);
         size_t sstock_vout = sub->n_outputs - 1;
-        persist_save_ps_chain_entry(
+        uint64_t chan_amounts[16] = {0};
+        int n_chans = (int)sstock_vout;
+        if (n_chans > 16) n_chans = 16;
+        for (int ci = 0; ci < n_chans; ci++)
+            chan_amounts[ci] = sub->outputs[ci].amount_sats;
+        persist_save_subfactory_chain_entry(
             (persist_t *)mgr->persist, /* factory_id = */ 0,
             (uint32_t)sub_node_i,
             sub->ps_chain_len - 1,
             txid_display,
             sub->signed_tx.data, sub->signed_tx.len,
-            sub->outputs[sstock_vout].amount_sats);
+            sub->outputs[sstock_vout].amount_sats,
+            chan_amounts, n_chans);
     }
 
     /* Step 11: Broadcast DONE to all sub-factory clients. */

--- a/src/persist.c
+++ b/src/persist.c
@@ -832,6 +832,32 @@ int persist_open(persist_t *p, const char *path) {
             NULL, NULL, NULL);
     }
 
+    /* v21 migration: PS sub-factory chain entries (k² shape).
+       Each PS leaf can host k sub-factories, each of k client channels. The
+       sub-factory is itself a chained sequence (sales-stock model) where each
+       row carries per-channel amounts plus the trailing sales-stock amount.
+       channel_amounts_csv: comma-separated decimal sat amounts for each child
+       channel vout (parsed at load time).
+       Separate from ps_leaf_chains because:
+         - sub-factories have N+1 outputs (N channels + sales-stock), not 1
+         - per-channel amounts must persist exactly to drive correct sweep
+         - decoupled schema lets future sub-factory metadata grow without
+           touching the (stable, audited) ps_leaf_chains layout. */
+    if (db_version < 21) {
+        sqlite3_exec(p->db,
+            "CREATE TABLE IF NOT EXISTS ps_subfactory_chains ("
+            "  factory_id INTEGER NOT NULL,"
+            "  sub_node_idx INTEGER NOT NULL,"
+            "  chain_pos INTEGER NOT NULL,"
+            "  txid TEXT NOT NULL,"
+            "  signed_tx_hex TEXT NOT NULL,"
+            "  sales_stock_amount_sats INTEGER NOT NULL,"
+            "  channel_amounts_csv TEXT NOT NULL,"
+            "  PRIMARY KEY (factory_id, sub_node_idx, chain_pos)"
+            ");",
+            NULL, NULL, NULL);
+    }
+
     /* Record the current version if not already present */
     if (db_version < PERSIST_SCHEMA_VERSION) {
         char vsql[128];
@@ -1108,6 +1134,127 @@ int persist_load_ps_chain(persist_t *p, uint32_t factory_id, uint32_t leaf_node_
     return count;
 }
 
+/* --- PS sub-factory chain persistence (v21, k² shape) --- */
+
+int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
+                                          uint32_t sub_node_idx, int chain_pos,
+                                          const unsigned char *txid_display,
+                                          const unsigned char *signed_tx, size_t signed_tx_len,
+                                          uint64_t sales_stock_amount_sats,
+                                          const uint64_t *channel_amounts, int n_channels)
+{
+    if (!p || !p->db || !channel_amounts || n_channels <= 0 || n_channels > 16) return 0;
+
+    char txid_hex[65];
+    hex_encode(txid_display, 32, txid_hex);
+
+    size_t hex_len = signed_tx_len * 2 + 1;
+    char *tx_hex = malloc(hex_len);
+    if (!tx_hex) return 0;
+    hex_encode(signed_tx, signed_tx_len, tx_hex);
+
+    /* Build CSV: "amt0,amt1,...,amtN-1" — max 16 entries × 21 chars/u64 + commas + NUL. */
+    char csv[16 * 22 + 1];
+    int off = 0;
+    for (int i = 0; i < n_channels; i++) {
+        int n = snprintf(csv + off, sizeof(csv) - off, "%s%llu",
+                         i ? "," : "", (unsigned long long)channel_amounts[i]);
+        if (n < 0 || (size_t)(off + n) >= sizeof(csv)) { free(tx_hex); return 0; }
+        off += n;
+    }
+
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "INSERT OR REPLACE INTO ps_subfactory_chains "
+        "(factory_id, sub_node_idx, chain_pos, txid, signed_tx_hex, "
+        " sales_stock_amount_sats, channel_amounts_csv) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?);";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        free(tx_hex);
+        return 0;
+    }
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_int(stmt, 2, (int)sub_node_idx);
+    sqlite3_bind_int(stmt, 3, chain_pos);
+    sqlite3_bind_text(stmt, 4, txid_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 5, tx_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(stmt, 6, (sqlite3_int64)sales_stock_amount_sats);
+    sqlite3_bind_text(stmt, 7, csv, -1, SQLITE_TRANSIENT);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    free(tx_hex);
+    return ok;
+}
+
+int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t sub_node_idx,
+                                    tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
+                                    uint64_t *sales_stock_out,
+                                    uint64_t (*channel_amounts_out)[16],
+                                    int *n_channels_out, int max_chain)
+{
+    if (!p || !p->db || !chain_txs_out || !txids_out || !sales_stock_out ||
+        !channel_amounts_out || !n_channels_out || max_chain <= 0)
+        return 0;
+
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "SELECT chain_pos, txid, signed_tx_hex, sales_stock_amount_sats, channel_amounts_csv "
+        "FROM ps_subfactory_chains "
+        "WHERE factory_id=? AND sub_node_idx=? ORDER BY chain_pos ASC;";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_int(stmt, 2, (int)sub_node_idx);
+
+    int count = 0;
+    while (sqlite3_step(stmt) == SQLITE_ROW && count < max_chain) {
+        int pos = sqlite3_column_int(stmt, 0);
+        if (pos != count) break;  /* gap → corrupt */
+
+        const char *txid_hex = (const char *)sqlite3_column_text(stmt, 1);
+        const char *tx_hex   = (const char *)sqlite3_column_text(stmt, 2);
+        if (!txid_hex || !tx_hex) break;
+
+        unsigned char txid_display[32];
+        if (!hex_decode(txid_hex, txid_display, 32)) break;
+        memcpy(txids_out[count], txid_display, 32);
+        reverse_bytes(txids_out[count], 32);
+
+        size_t tx_hex_len = strlen(tx_hex);
+        size_t tx_len = tx_hex_len / 2;
+        tx_buf_init(&chain_txs_out[count], (int)tx_len);
+        if (!hex_decode(tx_hex, chain_txs_out[count].data, tx_len)) {
+            tx_buf_free(&chain_txs_out[count]);
+            break;
+        }
+        chain_txs_out[count].len = tx_len;
+
+        sales_stock_out[count] = (uint64_t)sqlite3_column_int64(stmt, 3);
+
+        const char *csv = (const char *)sqlite3_column_text(stmt, 4);
+        if (!csv) {
+            tx_buf_free(&chain_txs_out[count]);
+            break;
+        }
+        /* Parse CSV → channel_amounts_out[count][...]; cap at 16. */
+        int nc = 0;
+        const char *q = csv;
+        while (*q && nc < 16) {
+            char *end = NULL;
+            unsigned long long v = strtoull(q, &end, 10);
+            if (end == q) break;
+            channel_amounts_out[count][nc++] = (uint64_t)v;
+            q = end;
+            if (*q == ',') q++;
+        }
+        n_channels_out[count] = nc;
+
+        count++;
+    }
+    sqlite3_finalize(stmt);
+    return count;
+}
+
 /* --- Client-side PS double-spend defense (v20) --- */
 
 int persist_check_ps_signed_input(persist_t *p, uint32_t factory_id,
@@ -1350,14 +1497,26 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
        factory_build_tree produces chain[0] (unsigned). If any advances were
        persisted, replay them so ps_chain_len / ps_prev_txid / signed_tx are
        current. Without this a restart would try to spend the already-spent
-       chain[0] output on the next advance. */
+       chain[0] output on the next advance.
+
+       For k² sub-factory shape (ps_subfactory_arity > 1): each PS leaf hosts
+       k sub-factory children whose state lives in the v21 ps_subfactory_chains
+       table. After restoring leaf-level state we also walk subfactory_node_indices[]
+       and restore each sub-factory's chain — preserving per-channel amounts so
+       force-close / sweep can target the correct outputs after a restart. */
     if (leaf_arity == FACTORY_ARITY_PS) {
         #define PS_RESTORE_MAX 4096
         tx_buf_t       *chain_txs  = calloc(PS_RESTORE_MAX, sizeof(tx_buf_t));
         unsigned char (*chain_ids)[32] = calloc(PS_RESTORE_MAX, 32);
         uint64_t       *chain_amts = calloc(PS_RESTORE_MAX, sizeof(uint64_t));
+        /* Sub-factory load buffers: per-entry trailing sales-stock + per-channel
+           amounts (cap 16 channels per sub-factory, matches FACTORY_MAX_OUTPUTS). */
+        uint64_t       *sub_sstock  = calloc(PS_RESTORE_MAX, sizeof(uint64_t));
+        uint64_t      (*sub_chans)[16] = calloc(PS_RESTORE_MAX, sizeof(uint64_t[16]));
+        int            *sub_n_chans = calloc(PS_RESTORE_MAX, sizeof(int));
 
-        if (chain_txs && chain_ids && chain_amts) {
+        if (chain_txs && chain_ids && chain_amts &&
+            sub_sstock && sub_chans && sub_n_chans) {
             for (int li = 0; li < f->n_leaf_nodes; li++) {
                 size_t node_idx = f->leaf_node_indices[li];
                 factory_node_t *node = &f->nodes[node_idx];
@@ -1367,46 +1526,110 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
                     (uint32_t)node_idx, chain_txs, chain_ids, chain_amts,
                     PS_RESTORE_MAX);
 
-                if (count <= 0) continue;
+                if (count > 0) {
+                    /* chain[0] txid is node->txid as set by factory_build_tree
+                       (segwit txid excludes witness, so unsigned == signed txid). */
+                    unsigned char chain0_txid[32];
+                    memcpy(chain0_txid, node->txid, 32);
+                    uint64_t chain0_amount = node->outputs[0].amount_sats;
 
-                /* chain[0] txid is node->txid as set by factory_build_tree
-                   (segwit txid excludes witness, so unsigned == signed txid). */
-                unsigned char chain0_txid[32];
-                memcpy(chain0_txid, node->txid, 32);
-                uint64_t chain0_amount = node->outputs[0].amount_sats;
+                    node->ps_chain_len = count;
+                    node->n_outputs    = 1;
 
-                node->ps_chain_len = count;
-                node->n_outputs    = 1;
+                    if (count == 1) {
+                        memcpy(node->ps_prev_txid, chain0_txid, 32);
+                        node->ps_prev_chan_amount = chain0_amount;
+                    } else {
+                        memcpy(node->ps_prev_txid, chain_ids[count - 2], 32);
+                        node->ps_prev_chan_amount = chain_amts[count - 2];
+                    }
 
-                if (count == 1) {
-                    memcpy(node->ps_prev_txid, chain0_txid, 32);
-                    node->ps_prev_chan_amount = chain0_amount;
-                } else {
-                    memcpy(node->ps_prev_txid, chain_ids[count - 2], 32);
-                    node->ps_prev_chan_amount = chain_amts[count - 2];
+                    memcpy(node->txid, chain_ids[count - 1], 32);
+                    node->outputs[0].amount_sats = chain_amts[count - 1];
+
+                    /* Restore latest signed TX */
+                    tx_buf_free(&node->signed_tx);
+                    tx_buf_t *last = &chain_txs[count - 1];
+                    tx_buf_init(&node->signed_tx, (int)last->len);
+                    memcpy(node->signed_tx.data, last->data, last->len);
+                    node->signed_tx.len = last->len;
+                    node->is_signed = 1;
+
+                    for (int j = 0; j < count; j++) tx_buf_free(&chain_txs[j]);
+
+                    printf("persist: PS leaf %d restored to chain_len=%d "
+                           "(%lu sats)\n", li, count,
+                           (unsigned long)node->outputs[0].amount_sats);
                 }
 
-                memcpy(node->txid, chain_ids[count - 1], 32);
-                node->outputs[0].amount_sats = chain_amts[count - 1];
+                /* Sub-factory recovery (k² shape, v21).
+                   Walk the leaf's subfactory_node_indices[] and restore each
+                   sub-factory's chain.  Each entry restores the sub-factory's
+                   per-channel amounts + sales-stock + signed_tx + ps_prev_*
+                   linkage.  Without per-channel amounts, post-restart sweep
+                   would not know how to attribute outputs to clients. */
+                for (int si = 0; si < node->n_subfactories; si++) {
+                    int sub_node_i = node->subfactory_node_indices[si];
+                    if (sub_node_i < 0 || (size_t)sub_node_i >= f->n_nodes) continue;
+                    factory_node_t *sub = &f->nodes[sub_node_i];
 
-                /* Restore latest signed TX */
-                tx_buf_free(&node->signed_tx);
-                tx_buf_t *last = &chain_txs[count - 1];
-                tx_buf_init(&node->signed_tx, (int)last->len);
-                memcpy(node->signed_tx.data, last->data, last->len);
-                node->signed_tx.len = last->len;
-                node->is_signed = 1;
+                    int sub_count = persist_load_subfactory_chain(p, factory_id,
+                        (uint32_t)sub_node_i,
+                        chain_txs, chain_ids, sub_sstock, sub_chans, sub_n_chans,
+                        PS_RESTORE_MAX);
+                    if (sub_count <= 0) continue;
 
-                for (int j = 0; j < count; j++) tx_buf_free(&chain_txs[j]);
+                    /* Linkage parents (chain[0] is the sub's existing
+                       node->txid built by factory_build_tree). */
+                    unsigned char sub_chain0_txid[32];
+                    memcpy(sub_chain0_txid, sub->txid, 32);
 
-                printf("persist: PS leaf %d restored to chain_len=%d "
-                       "(%lu sats)\n", li, count,
-                       (unsigned long)node->outputs[0].amount_sats);
+                    sub->ps_chain_len = sub_count;
+
+                    /* Per-output amounts: n channels + 1 sales-stock vout. */
+                    int last = sub_count - 1;
+                    int nc = sub_n_chans[last];
+                    if (nc < 0) nc = 0;
+                    if (nc > FACTORY_MAX_OUTPUTS - 1) nc = FACTORY_MAX_OUTPUTS - 1;
+                    sub->n_outputs = (size_t)(nc + 1);
+                    for (int ci = 0; ci < nc; ci++)
+                        sub->outputs[ci].amount_sats = sub_chans[last][ci];
+                    sub->outputs[nc].amount_sats = sub_sstock[last];
+
+                    /* ps_prev_* tracks the sales-stock UTXO being spent by the
+                       latest chain TX (mirrors lsp_subfactory_chain_advance). */
+                    if (sub_count == 1) {
+                        memcpy(sub->ps_prev_txid, sub_chain0_txid, 32);
+                        sub->ps_prev_chan_amount = sub->outputs[nc].amount_sats;
+                    } else {
+                        memcpy(sub->ps_prev_txid, chain_ids[last - 1], 32);
+                        sub->ps_prev_chan_amount = sub_sstock[last - 1];
+                    }
+
+                    memcpy(sub->txid, chain_ids[last], 32);
+
+                    tx_buf_free(&sub->signed_tx);
+                    tx_buf_t *latest = &chain_txs[last];
+                    tx_buf_init(&sub->signed_tx, (int)latest->len);
+                    memcpy(sub->signed_tx.data, latest->data, latest->len);
+                    sub->signed_tx.len = latest->len;
+                    sub->is_signed = 1;
+
+                    for (int j = 0; j < sub_count; j++) tx_buf_free(&chain_txs[j]);
+
+                    printf("persist: PS sub-factory leaf=%d sub=%d restored to "
+                           "chain_len=%d (sales-stock %lu sats, %d channels)\n",
+                           li, si, sub_count,
+                           (unsigned long)sub->outputs[nc].amount_sats, nc);
+                }
             }
         }
         free(chain_txs);
         free(chain_ids);
         free(chain_amts);
+        free(sub_sstock);
+        free(sub_chans);
+        free(sub_n_chans);
         #undef PS_RESTORE_MAX
     }
 

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -243,13 +243,14 @@ int test_offer_decode_bad_checksum(void)
 }
 
 /* Schema version smoke test (v2=HD wallet, v3=BOLT 12 offers, v4=pending_cs,
- * v5=hd_utxos.reserved) */
+ * v5=hd_utxos.reserved, ..., v20=client_ps_signed_inputs,
+ * v21=ps_subfactory_chains with per-channel amounts) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 20, "schema version is 20 (v20 adds client_ps_signed_inputs)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 21, "schema version is 21 (v21 adds ps_subfactory_chains)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1163,6 +1163,7 @@ extern int test_regtest_lsp_restart_recovery(void);
 /* Phase 13: Persistence (SQLite) */
 extern int test_persist_open_close(void);
 extern int test_persist_ps_subfactory_chain_round_trip(void);
+extern int test_persist_ps_subfactory_chain_v21_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -2952,6 +2953,7 @@ static void run_unit_tests(void) {
     printf("\n=== Persistence (Phase 13) ===\n");
     RUN_TEST(test_persist_open_close);
     RUN_TEST(test_persist_ps_subfactory_chain_round_trip);
+    RUN_TEST(test_persist_ps_subfactory_chain_v21_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -145,6 +145,115 @@ int test_persist_ps_subfactory_chain_round_trip(void) {
     return ok;
 }
 
+/* ---- v21: PS sub-factory chain entry round-trip with per-channel amounts ----
+
+   The v21 ps_subfactory_chains table replaces the Phase 4a workaround of
+   reusing ps_leaf_chains.  Each entry now carries:
+     - sales_stock_amount_sats (the trailing vout amount, as before)
+     - channel_amounts_csv (per-client channel amounts — new in v21)
+
+   Without per-channel persistence, a restart of the LSP could not rebuild
+   sub->outputs[] correctly and post-restart sweep would not be able to
+   attribute outputs to clients.
+
+   Saves three chain entries, each with a different channel count + mix
+   of amounts, then loads back and asserts every field round-trips
+   exactly. */
+int test_persist_ps_subfactory_chain_v21_round_trip(void) {
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, NULL), "open in-memory");
+
+    const uint32_t factory_id = 0;
+    const uint32_t sub_node_idx = 137;
+
+    /* 3 entries — varying n_channels (2, 4, 3) and varying amounts. */
+    unsigned char txids[3][32];
+    unsigned char signed_txs[3][96];
+    size_t signed_tx_lens[3] = { 24, 60, 80 };
+    uint64_t sstock_amounts[3] = { 100000, 75000, 50000 };
+    int n_channels[3] = { 2, 4, 3 };
+    uint64_t channel_amounts[3][16] = {
+        { 25000, 25000 },
+        { 15000, 20000, 18000, 22000 },
+        { 30000, 10000, 10000 },
+    };
+    for (int i = 0; i < 3; i++) {
+        memset(txids[i], 0xC0 + i, 32);
+        memset(signed_txs[i], 0xD0 + i, signed_tx_lens[i]);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT(persist_save_subfactory_chain_entry(
+                        &db, factory_id, sub_node_idx, i,
+                        txids[i],
+                        signed_txs[i], signed_tx_lens[i],
+                        sstock_amounts[i],
+                        channel_amounts[i], n_channels[i]),
+                    "save v21 sub-factory entry");
+    }
+
+    /* Load back. NOTE: do NOT pre-init loaded_txs[]; persist_load_*
+       calls tx_buf_init internally and pre-allocation would leak. */
+    tx_buf_t loaded_txs[3] = {0};
+    unsigned char loaded_txids[3][32];
+    uint64_t loaded_sstock[3];
+    uint64_t loaded_channels[3][16];
+    int loaded_n_channels[3];
+    int n_loaded = persist_load_subfactory_chain(&db, factory_id, sub_node_idx,
+                                                    loaded_txs, loaded_txids,
+                                                    loaded_sstock, loaded_channels,
+                                                    loaded_n_channels, 3);
+
+    int ok = 1;
+    if (n_loaded != 3) {
+        printf("  FAIL: v21 n_loaded=%d expected 3\n", n_loaded);
+        ok = 0;
+    } else {
+        for (int i = 0; i < 3; i++) {
+            if (memcmp(loaded_txids[i], txids[i], 32) != 0) {
+                printf("  FAIL: v21 chain[%d] txid mismatch\n", i);
+                ok = 0;
+            }
+            if (loaded_txs[i].len != signed_tx_lens[i]) {
+                printf("  FAIL: v21 chain[%d] tx len %zu != %zu\n",
+                       i, loaded_txs[i].len, signed_tx_lens[i]);
+                ok = 0;
+            } else if (memcmp(loaded_txs[i].data, signed_txs[i],
+                                signed_tx_lens[i]) != 0) {
+                printf("  FAIL: v21 chain[%d] tx bytes mismatch\n", i);
+                ok = 0;
+            }
+            if (loaded_sstock[i] != sstock_amounts[i]) {
+                printf("  FAIL: v21 chain[%d] sales-stock %llu != %llu\n",
+                       i, (unsigned long long)loaded_sstock[i],
+                       (unsigned long long)sstock_amounts[i]);
+                ok = 0;
+            }
+            if (loaded_n_channels[i] != n_channels[i]) {
+                printf("  FAIL: v21 chain[%d] n_channels %d != %d\n",
+                       i, loaded_n_channels[i], n_channels[i]);
+                ok = 0;
+            } else {
+                for (int ci = 0; ci < n_channels[i]; ci++) {
+                    if (loaded_channels[i][ci] != channel_amounts[i][ci]) {
+                        printf("  FAIL: v21 chain[%d] channel[%d] %llu != %llu\n",
+                               i, ci,
+                               (unsigned long long)loaded_channels[i][ci],
+                               (unsigned long long)channel_amounts[i][ci]);
+                        ok = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    for (int i = 0; i < n_loaded && i < 3; i++)
+        tx_buf_free(&loaded_txs[i]);
+
+    persist_close(&db);
+    return ok;
+}
+
 /* ---- Test 1: Open/close in-memory database ---- */
 
 int test_persist_open_close(void) {


### PR DESCRIPTION
## Summary

Phase 4a (PR #130) added save-side persistence for sub-factory chain state but only stored the trailing sales-stock amount.  Reloading would have lost per-channel amounts, leaving a restarted LSP unable to attribute outputs to clients on sweep — half a feature.

This PR finishes durability for the k² PS sub-factory shape.

### What changed
- **New v21 schema** `ps_subfactory_chains (factory_id, sub_node_idx, chain_pos)` with `txid`, `signed_tx_hex`, `sales_stock_amount_sats`, and a new `channel_amounts_csv` column carrying per-channel amounts.  Decoupled from `ps_leaf_chains` so each schema can evolve independently.
- **New helpers** `persist_save_subfactory_chain_entry` + `persist_load_subfactory_chain` mirror the existing PS chain helpers but include the per-channel amount vector.
- **`lsp_subfactory_chain_advance`** now writes via the new helper, sourcing per-channel amounts directly from `sub->outputs[0..n-1]`.
- **`factory_recovery_load`** extends its existing PS leaf restore loop to walk `subfactory_node_indices[]` and rebuild each sub-factory's `ps_chain_len`, `ps_prev_*`, `signed_tx`, `txid`, and `outputs[]` (channels + sales-stock) from the loaded entries.
- **Round-trip test** `test_persist_ps_subfactory_chain_v21_round_trip` saves three entries with mixed channel counts (2, 4, 3) and amounts, then asserts every field round-trips exactly.
- **Schema-version smoke test** updated to assert v21.

### Why this matters
After this PR an LSP can crash mid-flight in a k² shape, restart cleanly, and continue answering sub-factory chain advances against the exact same per-channel state the clients last saw.  Without per-channel persistence a restart would lose the breakdown of who-owns-what within each sub-factory, breaking sweep attribution on later force-close.

Phase 4b (watchtower per-sub-factory state) follows in a separate PR.

## Test plan
- [x] Build clean on VPS (Ubuntu, gcc)
- [x] All 1420 unit tests pass (was 1419/1420 with hardcoded v20 assertion before fix)
- [x] New `test_persist_ps_subfactory_chain_v21_round_trip` passes
- [x] Existing `test_persist_ps_subfactory_chain_round_trip` (Phase 4a, reuses ps_leaf_chains) still passes
- [ ] CI: Linux + macOS + sanitizers + TSan + regtest + coverage all green