### PR TITLE
PS k² sub-factory watchtower coverage — Phase 4b

### DIFF
--- a/include/superscalar/watchtower.h
+++ b/include/superscalar/watchtower.h
@@ -15,6 +15,11 @@
 typedef enum {
     WATCH_COMMITMENT,      /* Channel commitment breach — build penalty tx */
     WATCH_FACTORY_NODE,    /* Factory state breach — broadcast latest state tx */
+    WATCH_SUBFACTORY_NODE, /* PS sub-factory chain breach (k² shape) — broadcast
+                              latest sub-factory chain TX + poison TX that
+                              distributes stale sales-stock to clients.  Unlike
+                              FACTORY_NODE, sub-factory clients are not directly
+                              on-chain so no auto-settle. */
     WATCH_FORCE_CLOSE      /* Force-close: sweep expired HTLC timeout outputs */
 } watchtower_entry_type_t;
 
@@ -58,6 +63,16 @@ typedef struct {
     size_t burn_tx_len;
     uint32_t *leaf_channel_ids;   /* channel indices on this leaf (for auto-settle) */
     size_t n_leaf_channels;       /* number of channels on this leaf */
+
+    /* WATCH_SUBFACTORY_NODE additional fields.
+       The sub-factory analogue of L-stock is a "sales-stock" output (the
+       trailing vout of each chain TX).  When stale state confirms, the
+       poison TX (carried in burn_tx/burn_tx_len above — same field name,
+       different semantics) distributes the stale sales-stock to the
+       sub-factory's clients pro-rata to their per-channel amounts. */
+    uint64_t *sub_channel_amounts; /* heap-allocated per-channel amounts at chain[N-1] */
+    size_t n_sub_channels;
+    uint64_t sub_sales_stock_amount;
 
     /* Reorg resistance: penalty broadcast tracking.
        After penalty broadcast, entry is KEPT (not removed) until penalty
@@ -173,6 +188,25 @@ int watchtower_watch_factory_node_with_channels(watchtower_t *wt,
     const unsigned char *response_tx, size_t response_tx_len,
     const unsigned char *burn_tx, size_t burn_tx_len,
     const uint32_t *channel_ids, size_t n_channels);
+
+/* Watch for an old PS sub-factory chain entry (k² shape).
+   sub_node_idx: f->nodes[] index of the NODE_PS_SUBFACTORY node.
+   old_chain_txid32: txid (internal byte order) of the stale chain[N-1] TX.
+   response_tx: latest signed chain[N] TX to broadcast on breach.
+   poison_tx: TX that spends old chain[N-1]'s sales-stock and distributes
+              it to clients (Gap A poison response — may be NULL during
+              early integration; future PR adds the actual builder).
+   channel_amounts: per-channel amounts at chain[N-1] (used by analytics
+                    + by the poison TX builder once wired).  Length =
+                    n_channels.  Copied internally.
+   sales_stock_amount: amount on the trailing sales-stock vout of chain[N-1]. */
+int watchtower_watch_subfactory_node(watchtower_t *wt,
+    uint32_t sub_node_idx,
+    const unsigned char *old_chain_txid32,
+    const unsigned char *response_tx, size_t response_tx_len,
+    const unsigned char *poison_tx, size_t poison_tx_len,
+    const uint64_t *channel_amounts, size_t n_channels,
+    uint64_t sales_stock_amount);
 
 /* Register a force-closed commitment for HTLC timeout sweeping.
    After a legitimate force-close (not breach), HTLCs need to be swept

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2384,6 +2384,20 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     size_t n_clients_in_sub = sub->n_signers - 1;
     if (n_clients_in_sub == 0) return 0;
 
+    /* Snapshot the soon-to-be-stale chain[N-1] state for the watchtower
+       (Phase 4b).  Once factory_subfactory_chain_advance_unsigned runs,
+       sub->txid / sub->outputs[] reflect the new chain[N] state, so the
+       previous txid + per-channel amounts must be captured first. */
+    unsigned char wt_old_chain_txid[32];
+    memcpy(wt_old_chain_txid, sub->txid, 32);
+    size_t wt_old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
+    if (wt_old_n_chans > 16) wt_old_n_chans = 16;
+    uint64_t wt_old_chan_amounts[16] = {0};
+    for (size_t ci = 0; ci < wt_old_n_chans; ci++)
+        wt_old_chan_amounts[ci] = sub->outputs[ci].amount_sats;
+    uint64_t wt_old_sstock_amount = (sub->n_outputs > 0)
+        ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
+
     /* Step 1: Advance sub-factory state (rebuilds unsigned_tx, clears is_signed). */
     if (!factory_subfactory_chain_advance_unsigned(f, leaf_side,
                                                     sub_idx_in_leaf,
@@ -2587,6 +2601,23 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             sub->signed_tx.data, sub->signed_tx.len,
             sub->outputs[sstock_vout].amount_sats,
             chan_amounts, n_chans);
+    }
+
+    /* Step 10b: Register the now-stale chain[N-1] with the watchtower
+       (Phase 4b).  If the LSP later attempts to confirm chain[N-1] on
+       the chain (rolling sub-factory state back), the watchtower will
+       broadcast our latest signed chain[N] and the poison TX (when the
+       builder lands in a follow-up PR; passed NULL here for now).
+       Per-channel amounts at chain[N-1] are recorded so the future
+       poison-TX builder can attribute outputs back to clients. */
+    if (mgr->watchtower && sub->ps_chain_len >= 2) {
+        watchtower_watch_subfactory_node(mgr->watchtower,
+            (uint32_t)sub_node_i,
+            wt_old_chain_txid,
+            sub->signed_tx.data, sub->signed_tx.len,
+            /* poison_tx */ NULL, 0,
+            wt_old_chan_amounts, wt_old_n_chans,
+            wt_old_sstock_amount);
     }
 
     /* Step 11: Broadcast DONE to all sub-factory clients. */

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -568,6 +568,77 @@ int watchtower_check(watchtower_t *wt) {
             continue;
         }
 
+        if (e->type == WATCH_SUBFACTORY_NODE) {
+            /* PS sub-factory chain breach (k² shape).
+               Stale chain[N-1] confirmed; we broadcast the latest chain[N]
+               (which spends a UTXO that no longer exists on-chain after
+               the stale state confirms — but this is the same shape as
+               the FACTORY_NODE response, retained for symmetry until the
+               poison TX builder lands).  We then broadcast the poison TX
+               that distributes the stale sales-stock to clients pro-rata.
+
+               Unlike WATCH_FACTORY_NODE we do NOT auto-settle channels —
+               sub-factory clients live inside the sub-factory chain TX,
+               not as separately registered channels in wt->channels[].
+               Their per-channel claims are encoded in the poison TX
+               outputs, not in independent commitment TXs. */
+            printf("SUB-FACTORY BREACH on node %u (txid: %s, %zu channels, "
+                   "sales-stock %llu sats)!\n",
+                   e->channel_id, txid_hex, e->n_sub_channels,
+                   (unsigned long long)e->sub_sales_stock_amount);
+            fflush(stdout);
+
+            char sub_resp_txid[65] = {0};
+
+            if (e->response_tx && e->response_tx_len > 0) {
+                char *resp_hex = (char *)malloc(e->response_tx_len * 2 + 1);
+                if (resp_hex) {
+                    hex_encode(e->response_tx, e->response_tx_len, resp_hex);
+                    char resp_txid[65];
+                    if (wt->chain->send_raw_tx(wt->chain, resp_hex, resp_txid)) {
+                        printf("  Sub-factory response tx broadcast: %s\n", resp_txid);
+                        memcpy(sub_resp_txid, resp_txid, 64);
+                        sub_resp_txid[64] = '\0';
+                        penalties_broadcast++;
+                        if (wt->db && wt->db->db)
+                            persist_log_broadcast(wt->db, resp_txid,
+                                                  "subfactory_response", resp_hex, "ok");
+                    } else {
+                        fprintf(stderr, "  Sub-factory response tx broadcast failed\n");
+                        if (wt->db && wt->db->db)
+                            persist_log_broadcast(wt->db, "?",
+                                                  "subfactory_response", resp_hex, "failed");
+                    }
+                    free(resp_hex);
+                }
+            }
+
+            if (e->burn_tx && e->burn_tx_len > 0) {
+                char *poison_hex = (char *)malloc(e->burn_tx_len * 2 + 1);
+                if (poison_hex) {
+                    hex_encode(e->burn_tx, e->burn_tx_len, poison_hex);
+                    char poison_txid[65];
+                    if (wt->chain->send_raw_tx(wt->chain, poison_hex, poison_txid)) {
+                        printf("  Sub-factory poison tx broadcast: %s\n", poison_txid);
+                        if (wt->db && wt->db->db)
+                            persist_log_broadcast(wt->db, poison_txid,
+                                                  "subfactory_poison", poison_hex, "ok");
+                    } else {
+                        fprintf(stderr, "  Sub-factory poison tx broadcast failed\n");
+                        if (wt->db && wt->db->db)
+                            persist_log_broadcast(wt->db, "?",
+                                                  "subfactory_poison", poison_hex, "failed");
+                    }
+                    free(poison_hex);
+                }
+            }
+
+            e->penalty_broadcast = 1;
+            memcpy(e->penalty_txid, sub_resp_txid, 65);
+            i++;
+            continue;
+        }
+
         /* WATCH_COMMITMENT: build and broadcast penalty tx */
         printf("BREACH DETECTED on channel %u, commitment %llu (txid: %s)!\n",
                e->channel_id, (unsigned long long)e->commit_num, txid_hex);
@@ -1156,17 +1227,80 @@ int watchtower_watch_factory_node_with_channels(watchtower_t *wt,
     return 1;
 }
 
+int watchtower_watch_subfactory_node(watchtower_t *wt,
+    uint32_t sub_node_idx,
+    const unsigned char *old_chain_txid32,
+    const unsigned char *response_tx, size_t response_tx_len,
+    const unsigned char *poison_tx, size_t poison_tx_len,
+    const uint64_t *channel_amounts, size_t n_channels,
+    uint64_t sales_stock_amount)
+{
+    if (!wt || !old_chain_txid32 || !response_tx || response_tx_len == 0) return 0;
+    if (wt->n_entries >= wt->entries_cap) return 0;
+
+    watchtower_entry_t *e = &wt->entries[wt->n_entries];
+    memset(e, 0, sizeof(*e));
+    e->type = WATCH_SUBFACTORY_NODE;
+    e->channel_id = sub_node_idx;
+    e->commit_num = 0;
+    memcpy(e->txid, old_chain_txid32, 32);
+
+    e->response_tx = (unsigned char *)malloc(response_tx_len);
+    if (!e->response_tx) return 0;
+    memcpy(e->response_tx, response_tx, response_tx_len);
+    e->response_tx_len = response_tx_len;
+
+    /* Poison TX: distributes stale sales-stock to clients on breach.
+       Optional during early integration; the actual poison-TX builder
+       lands in a follow-up PR.  Reuses the burn_tx[] storage in the
+       entry (same shape — pre-built TX to broadcast on breach). */
+    if (poison_tx && poison_tx_len > 0) {
+        e->burn_tx = (unsigned char *)malloc(poison_tx_len);
+        if (!e->burn_tx) {
+            free(e->response_tx);
+            e->response_tx = NULL;
+            return 0;
+        }
+        memcpy(e->burn_tx, poison_tx, poison_tx_len);
+        e->burn_tx_len = poison_tx_len;
+    }
+
+    /* Per-channel amounts at chain[N-1] — needed by analytics + by the
+       poison TX builder once wired.  Copied so caller's buffer is free
+       to be reused. */
+    if (channel_amounts && n_channels > 0) {
+        e->sub_channel_amounts = (uint64_t *)malloc(n_channels * sizeof(uint64_t));
+        if (!e->sub_channel_amounts) {
+            free(e->response_tx);  e->response_tx = NULL;
+            free(e->burn_tx);       e->burn_tx = NULL;
+            return 0;
+        }
+        memcpy(e->sub_channel_amounts, channel_amounts,
+               n_channels * sizeof(uint64_t));
+        e->n_sub_channels = n_channels;
+    }
+    e->sub_sales_stock_amount = sales_stock_amount;
+
+    wt->n_entries++;
+    return 1;
+}
+
 void watchtower_cleanup(watchtower_t *wt) {
     if (!wt) return;
     for (size_t i = 0; i < wt->n_entries; i++) {
         free(wt->entries[i].leaf_channel_ids);
         free(wt->entries[i].htlc_outputs);
         wt->entries[i].htlc_outputs = NULL;
-        if (wt->entries[i].type == WATCH_FACTORY_NODE) {
+        if (wt->entries[i].type == WATCH_FACTORY_NODE ||
+            wt->entries[i].type == WATCH_SUBFACTORY_NODE) {
             free(wt->entries[i].response_tx);
             wt->entries[i].response_tx = NULL;
             free(wt->entries[i].burn_tx);
             wt->entries[i].burn_tx = NULL;
+        }
+        if (wt->entries[i].type == WATCH_SUBFACTORY_NODE) {
+            free(wt->entries[i].sub_channel_amounts);
+            wt->entries[i].sub_channel_amounts = NULL;
         }
     }
     free(wt->entries);
@@ -1236,11 +1370,16 @@ void watchtower_clear_entries(watchtower_t *wt) {
         entry_unregister_scripts(wt, &wt->entries[i]);
         free(wt->entries[i].htlc_outputs);
         wt->entries[i].htlc_outputs = NULL;
-        if (wt->entries[i].type == WATCH_FACTORY_NODE) {
+        if (wt->entries[i].type == WATCH_FACTORY_NODE ||
+            wt->entries[i].type == WATCH_SUBFACTORY_NODE) {
             free(wt->entries[i].response_tx);
             wt->entries[i].response_tx = NULL;
             free(wt->entries[i].burn_tx);
             wt->entries[i].burn_tx = NULL;
+        }
+        if (wt->entries[i].type == WATCH_SUBFACTORY_NODE) {
+            free(wt->entries[i].sub_channel_amounts);
+            wt->entries[i].sub_channel_amounts = NULL;
         }
     }
     wt->n_entries = 0;

--- a/tests/test_client_watchtower.c
+++ b/tests/test_client_watchtower.c
@@ -286,6 +286,73 @@ int test_factory_node_watch(void) {
     return 1;
 }
 
+/* Test 5b: watchtower_watch_subfactory_node creates entry with response,
+   poison TX, and per-channel amounts (Phase 4b) */
+int test_subfactory_node_watch(void) {
+    watchtower_t wt;
+    fee_estimator_static_t fee;
+    fee_estimator_static_init(&fee, 1000);
+    watchtower_init(&wt, 1, NULL, (fee_estimator_t *)&fee, NULL);
+
+    unsigned char old_chain_txid[32];
+    memset(old_chain_txid, 0x77, 32);
+
+    /* Fake "latest sub-factory chain TX" as response */
+    unsigned char response[80];
+    memset(response, 0x88, 80);
+
+    /* Fake "poison TX" that distributes stale sales-stock to clients */
+    unsigned char poison[60];
+    memset(poison, 0x99, 60);
+
+    /* k=3 channels at chain[N-1] with distinct amounts */
+    uint64_t channel_amounts[3] = { 25000, 15000, 30000 };
+    uint64_t sales_stock = 12345;
+
+    int ok = watchtower_watch_subfactory_node(&wt, /* sub_node_idx */ 7,
+                                                old_chain_txid,
+                                                response, 80,
+                                                poison, 60,
+                                                channel_amounts, 3,
+                                                sales_stock);
+    TEST_ASSERT(ok == 1, "watchtower_watch_subfactory_node should succeed");
+    TEST_ASSERT(wt.n_entries == 1, "should have 1 entry");
+    TEST_ASSERT(wt.entries[0].type == WATCH_SUBFACTORY_NODE,
+                "entry type should be WATCH_SUBFACTORY_NODE");
+    TEST_ASSERT(wt.entries[0].channel_id == 7, "sub_node_idx should be 7");
+    TEST_ASSERT(memcmp(wt.entries[0].txid, old_chain_txid, 32) == 0,
+                "stale txid should match");
+    TEST_ASSERT(wt.entries[0].response_tx_len == 80,
+                "response_tx_len should be 80");
+    TEST_ASSERT(memcmp(wt.entries[0].response_tx, response, 80) == 0,
+                "response_tx data should match");
+    TEST_ASSERT(wt.entries[0].burn_tx_len == 60,
+                "poison_tx (stored as burn_tx) len should be 60");
+    TEST_ASSERT(memcmp(wt.entries[0].burn_tx, poison, 60) == 0,
+                "poison_tx data should match");
+    TEST_ASSERT(wt.entries[0].n_sub_channels == 3, "n_sub_channels should be 3");
+    TEST_ASSERT(wt.entries[0].sub_channel_amounts[0] == 25000, "channel[0] amount");
+    TEST_ASSERT(wt.entries[0].sub_channel_amounts[1] == 15000, "channel[1] amount");
+    TEST_ASSERT(wt.entries[0].sub_channel_amounts[2] == 30000, "channel[2] amount");
+    TEST_ASSERT(wt.entries[0].sub_sales_stock_amount == 12345,
+                "sales-stock amount");
+
+    /* Verify NULL poison TX path (early integration before builder lands) */
+    int ok2 = watchtower_watch_subfactory_node(&wt, /* sub_node_idx */ 8,
+                                                 old_chain_txid,
+                                                 response, 80,
+                                                 NULL, 0,
+                                                 channel_amounts, 3,
+                                                 sales_stock);
+    TEST_ASSERT(ok2 == 1, "NULL poison_tx path should succeed");
+    TEST_ASSERT(wt.n_entries == 2, "should have 2 entries");
+    TEST_ASSERT(wt.entries[1].burn_tx == NULL, "no poison TX stored when NULL");
+    TEST_ASSERT(wt.entries[1].burn_tx_len == 0, "no poison TX len when NULL");
+
+    watchtower_cleanup(&wt);
+    return 1;
+}
+
 /* Test 6: factory node entry coexists with commitment entries */
 int test_factory_and_commitment_entries(void) {
     watchtower_t wt;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1359,6 +1359,7 @@ extern int test_bidirectional_revocation(void);
 extern int test_client_watch_revoked_commitment(void);
 extern int test_lsp_revoke_and_ack_wire(void);
 extern int test_factory_node_watch(void);
+extern int test_subfactory_node_watch(void);
 extern int test_factory_and_commitment_entries(void);
 extern int test_htlc_penalty_watch(void);
 
@@ -3132,6 +3133,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_client_watch_revoked_commitment);
     RUN_TEST(test_lsp_revoke_and_ack_wire);
     RUN_TEST(test_factory_node_watch);
+    RUN_TEST(test_subfactory_node_watch);
     RUN_TEST(test_factory_and_commitment_entries);
     RUN_TEST(test_htlc_penalty_watch);
 


### PR DESCRIPTION
## Summary

Phase 4c (PR #131) made sub-factory chain state durable across LSP restarts via the v21 `ps_subfactory_chains` table.  This PR (Phase 4b) extends the watchtower to actually defend against the breach scenario that durability was tracking: LSP confirming a stale chain[N-1] on-chain after chain[N] was already broadcast to clients, rolling back sub-factory state.

### What changed
- **New entry type** `WATCH_SUBFACTORY_NODE` in `watchtower_entry_type_t` alongside `WATCH_FACTORY_NODE` / `WATCH_COMMITMENT` / `WATCH_FORCE_CLOSE`.
- **New per-entry fields** for sub-factory semantics: `sub_channel_amounts[]` (per-channel amounts at chain[N-1]), `n_sub_channels`, `sub_sales_stock_amount`. The poison TX reuses the existing `burn_tx` storage — same shape (pre-built TX broadcast on breach), different semantics.
- **New API** `watchtower_watch_subfactory_node()` mirrors `watchtower_watch_factory_node_with_channels()` but for sub-factory semantics. No auto-settle — sub-factory clients live inside the chain TX, not as separate registered channels.
- **`watchtower_check()`** main loop gets a new branch for `WATCH_SUBFACTORY_NODE`: on breach detection (stale chain[N-1] confirms), broadcast `response_tx` (chain[N]) + `poison_tx`, log via `persist_log_broadcast` with `subfactory_response` / `subfactory_poison` type tags, mark `penalty_broadcast=1` for reorg resistance.
- **`lsp_subfactory_chain_advance`** snapshots the soon-to-be-stale chain[N-1] state (txid, per-channel amounts, sales-stock) BEFORE the advance rebuilds `sub->outputs[]`, then registers it with the watchtower AFTER the persist save.
- **`watchtower_cleanup` / `watchtower_clear_entries`** free the new `sub_channel_amounts` allocation.
- **Unit test** `test_subfactory_node_watch` covers both the with-poison and NULL-poison code paths and asserts every per-channel amount + sales-stock amount round-trip exactly.

### Out of scope (follow-up PRs)
1. Actual poison-TX **builder** — today the watchtower stores `NULL` and only broadcasts `response_tx` on breach. The Gap A poison-TX shape is already specified in `docs/`; this PR wires the plumbing so the builder slots in cleanly when it lands.
2. Re-registering sub-factory chains with the watchtower on LSP **restart**. The persist_load side (Phase 4c) restores everything needed; calling `watchtower_watch_subfactory_node()` during the LSP startup sequence will tie it together.

## Test plan
- [x] Build clean on VPS (Ubuntu, gcc) after rebase on main with Phase 4c included
- [x] All 1421 unit tests pass (was 1420 before — new `test_subfactory_node_watch` added)
- [x] `test_subfactory_node_watch` validates both with-poison and NULL-poison entry creation paths
- [x] Existing `test_factory_node_watch` and `test_factory_and_commitment_entries` still pass (no regression to PS leaf coverage)
- [ ] CI: Linux + macOS + sanitizers + TSan + regtest + coverage + fuzz all green