### PR TITLE
fix: poison TX multi-process crash + SECURITY GAP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 > v0.1.12 — 30/30 signet exhibition tests passed (S1–S30). Standalone watchtower penalty signing, secp256k1-zkp pin sync with CLN/wally, rotation conservation fix. 1363 unit tests, 42 regtest integration tests.
 
+> ⚠️ **Production readiness — multi-process LSPs**: real-deployment LSPs (with clients running as separate processes) currently lack the wire-ceremony poison TX defense.  The watchtower can detect breaches and broadcast the latest signed state TX, but cannot redistribute L-stock / sales-stock to clients on cheating — that defense was implemented as a single-process primitive (PR #121) and the multi-process MuSig2 ceremony equivalent is not yet wired.  See [`docs/poison-tx.md`](docs/poison-tx.md) "SECURITY-CRITICAL: multi-process production gap" for details.  Single-process / signet self-tests / `--demo` deployments have full poison TX protection and are unaffected.  Mainnet multi-process LSPs should wait for the wire-ceremony poison TX to land.
+
 Implementation of [ZmnSCPxj's SuperScalar design](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories/1143) — laddered timeout-tree-structured Decker-Wattenhofer channel factories for Bitcoin.
 
 A Bitcoin channel factory protocol combining:

--- a/docs/poison-tx.md
+++ b/docs/poison-tx.md
@@ -221,17 +221,45 @@ This change affects only **future** factories:
   unchanged.  Only the L-stock SPK and the burn-vs-poison TX semantics
   changed.
 
+## ⚠️ SECURITY-CRITICAL: multi-process production gap
+
+**`factory_sign_l_stock_poison_tx` is a single-process primitive.**  It
+requires `f->keypairs[i]` to hold every leaf signer's seckey, which is
+true ONLY in unit tests / single-process `--demo` LSPs where one
+process owns all the keys.
+
+**In multi-process production (real LSP + separate client processes):**
+- Each client's seckey lives in their own process — the LSP does NOT
+  have them.
+- Calling the poison TX builder would crash inside libsecp256k1 with
+  "illegal argument" (PR #135 added a `lsp_have_all_signer_keypairs`
+  guard that detects this and skips the build, registering the
+  watchtower with `NULL` poison_tx as graceful degradation).
+- Result: the watchtower can still detect a stale leaf / sub-factory
+  state confirming on chain and broadcast the latest signed state TX
+  (response_tx), but the L-stock or sales-stock UTXO of the stale state
+  is NOT redistributed to clients.  After CSV (default 144 blocks ≈ 1
+  day on mainnet) the LSP can unilaterally drain it via the script-path.
+
+**This breaks the t/1242 economic security argument** — without poison
+TX defense, an LSP that broadcasts a stale state can recover L-stock
+value after a CSV delay.  If the stale state had a more LSP-favorable
+distribution than the latest state, cheating becomes profitable.
+
+**Operators must NOT deploy multi-process LSPs to mainnet until the
+wire-ceremony poison TX is implemented.** Single-process / signet
+self-tests / demo deployments are unaffected (the in-process key
+availability path is exercised end-to-end by unit tests).
+
 ## What's deferred to a follow-up PR
 
-This PR ships the **single-process** poison TX flow:
-`factory_sign_l_stock_poison_tx` requires `f->keypairs[]` to hold the
-seckey for every leaf signer.  That's what the watchtower / unit-test
-builders have.  In the multi-process wire ceremony (LSP + clients on
-separate machines), each client's seckey isn't available to the LSP, so
-the LSP must coordinate a split-round MuSig2 round to gather partial
-sigs from each client.  That wire-ceremony co-signing is a follow-up:
-it'll extend the existing leaf-state-advance ceremony to also produce
-the poison TX signature alongside the new state TX.
+This PR ships the **single-process** poison TX flow only.  The
+wire-ceremony equivalent must coordinate a split-round MuSig2 round
+across all leaf signers (LSP + clients in separate processes) to
+gather partial sigs from each client over the poison TX sighash, then
+aggregate.  This is the same shape as the existing state-advance
+ceremony — a second round on a different sighash.  Estimated 2-3 days
+of plumbing (no crypto redesign).
 
 The single-process flow shipped here is sufficient for:
 - Unit testing of the new SPK + TX shape
@@ -239,5 +267,5 @@ The single-process flow shipped here is sufficient for:
   all keys (test fixtures, signet self-tests)
 - The `factory_build_burn_tx` shim that the watchtower call site uses
 
-The wire-ceremony version is tracked in
-`.claude/CANONICAL_DESIGN_GAPS.md` (Gap A follow-up).
+**Tracked in `.claude/CANONICAL_DESIGN_GAPS.md` Gap A (status:
+SECURITY-CRITICAL, BLOCKS PRODUCTION).**

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2617,7 +2617,11 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        wt_old_sstock_amount) and pays each sub-factory client an equal
        share, less fee.  Pre-signed at advance time so any client /
        watchtower can broadcast it on breach without coordination. */
-    if (mgr->watchtower && sub->ps_chain_len >= 2) {
+    /* After the first advance, ps_chain_len == 1 (chain[0] → chain[1])
+       and chain[0] is already a stale state worth watching.  Guard at
+       >= 1 (not >= 2) so we register the watchtower entry on the very
+       first advance — the original >= 2 guard was a Phase 4b bug. */
+    if (mgr->watchtower && sub->ps_chain_len >= 1) {
         tx_buf_t poison_tx;
         tx_buf_init(&poison_tx, 256);
         uint32_t old_sstock_vout = (uint32_t)wt_old_n_chans;  /* trailing */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -57,6 +57,37 @@ static int verify_revocation_secret(const secp256k1_context *ctx,
     return memcmp(d_ser, s_ser, 33) == 0;
 }
 
+/* Detect single-process mode: returns 1 only when f->keypairs[i] holds a
+   real seckey for every signer in `node` (LSP + every non-LSP signer).
+   In multi-process mode the LSP only owns its own keypair (slot 0); the
+   client keypairs are zero-filled and `factory_sign_l_stock_poison_tx`
+   would crash inside libsecp256k1 with "illegal argument".
+
+   This guard exists because the L-stock poison TX builder is a
+   single-process primitive — it requires every leaf signer's seckey
+   locally.  Multi-process LSPs must fall back to NULL poison_tx
+   (graceful degradation) until the wire-ceremony equivalent that
+   gathers per-client partial sigs over MuSig2 lands.  Tracked in
+   .claude/CANONICAL_DESIGN_GAPS.md (Gap A follow-up).  This is a
+   SECURITY GAP for multi-process deployments — the watchtower can
+   detect breaches but cannot redistribute L-stock to clients. */
+static int lsp_have_all_signer_keypairs(const secp256k1_context *ctx,
+                                          const factory_t *f,
+                                          const factory_node_t *node) {
+    if (!ctx || !f || !node) return 0;
+    for (size_t si = 0; si < node->n_signers; si++) {
+        uint32_t pidx = node->signer_indices[si];
+        if (pidx >= f->n_participants) return 0;
+        unsigned char tmp[32];
+        if (!secp256k1_keypair_sec(ctx, tmp, &f->keypairs[pidx])) return 0;
+        int all_zero = 1;
+        for (int b = 0; b < 32; b++) if (tmp[b]) { all_zero = 0; break; }
+        memset(tmp, 0, 32);
+        if (all_zero) return 0;
+    }
+    return 1;
+}
+
 /* Send the LSP's own revocation secret to a client after each commitment update.
    This enables bidirectional revocation so clients can detect LSP breaches.
    old_cn: the commitment number whose secret is being revealed. */
@@ -1618,7 +1649,19 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
         uint32_t old_epoch = f->counter.current_epoch > 0
                            ? f->counter.current_epoch - 1 : 0;
         int burn_ok = 0;
-        if (old_n_outputs >= 2) {
+        /* Multi-process guard: factory_build_burn_tx wraps
+           factory_sign_l_stock_poison_tx which crashes in libsecp256k1
+           if any leaf signer's seckey is missing.  Same SECURITY GAP
+           as the sub-factory poison TX path. */
+        int have_leaf_seckeys =
+            lsp_have_all_signer_keypairs(lsp->ctx, f, leaf_node);
+        if (!have_leaf_seckeys)
+            fprintf(stderr,
+                    "LSP advance leaf: multi-process mode — skipping "
+                    "L-stock poison TX (SECURITY GAP: clients cannot "
+                    "recover L-stock on breach without wire-ceremony "
+                    "poison TX)\n");
+        if (have_leaf_seckeys && old_n_outputs >= 2) {
             size_t l_vout = (size_t)(old_n_outputs - 1);
             burn_ok = factory_build_burn_tx(f, &burn_tx, leaf_node,
                 old_leaf_txid, (uint32_t)l_vout,
@@ -2023,9 +2066,18 @@ int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             tx_buf_init(&burn_tx, 256);
             uint32_t old_epoch = (new_epoch > 0) ? new_epoch - 1 : 0;
             size_t l_vout = (size_t)(leaf_pre[lp].old_n_outputs - 1);
-            int burn_ok = factory_build_burn_tx(f, &burn_tx, leaf_node,
-                leaf_pre[lp].old_txid, (uint32_t)l_vout,
-                leaf_pre[lp].old_l_amount, old_epoch);
+            /* Multi-process guard — see lsp_have_all_signer_keypairs. */
+            int burn_ok = 0;
+            if (lsp_have_all_signer_keypairs(lsp->ctx, f, leaf_node)) {
+                burn_ok = factory_build_burn_tx(f, &burn_tx, leaf_node,
+                    leaf_pre[lp].old_txid, (uint32_t)l_vout,
+                    leaf_pre[lp].old_l_amount, old_epoch);
+            } else {
+                fprintf(stderr,
+                        "LSP rotation: multi-process mode — skipping "
+                        "L-stock poison TX for leaf %zu (SECURITY GAP)\n",
+                        ni);
+            }
 
             uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
             size_t n_leaf_ch = 0;
@@ -2628,30 +2680,18 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         const uint64_t POISON_FEE_SATS = 1000;  /* matches PS leaf default */
         int poison_ok = 0;
 
-        /* factory_sign_l_stock_poison_tx is a single-process primitive —
-           it requires f->keypairs[i] to hold every sub-factory signer's
-           seckey, which is only true when the LSP also owns the client
-           keys (unit tests, --demo single-process LSP).  In a real
-           multi-process LSP the clients hold their own keys and we'd
-           crash inside libsecp256k1 with "illegal argument".  Detect
-           multi-process by checking whether each non-LSP signer's
-           keypair has a non-zero seckey; if any are zero, skip the
-           poison build and register the watchtower with NULL poison_tx
-           (graceful degradation — the wire-ceremony equivalent that
-           gathers per-client partial sigs is the proper long-term fix,
-           tracked in CANONICAL_DESIGN_GAPS.md). */
-        int have_all_seckeys = 1;
-        for (size_t si = 1; si < sub->n_signers; si++) {
-            uint32_t pidx = sub->signer_indices[si];
-            unsigned char tmp[32];
-            if (!secp256k1_keypair_sec(lsp->ctx, tmp, &f->keypairs[pidx])) {
-                have_all_seckeys = 0;
-                break;
-            }
-            int all_zero = 1;
-            for (int b = 0; b < 32; b++) if (tmp[b]) { all_zero = 0; break; }
-            memset(tmp, 0, 32);
-            if (all_zero) { have_all_seckeys = 0; break; }
+        /* See lsp_have_all_signer_keypairs comment: skip poison TX in
+           multi-process mode (graceful degradation, NULL poison_tx
+           registered with watchtower).  This is a SECURITY GAP — the
+           watchtower can still detect breach via response_tx broadcast
+           but cannot redistribute the sales-stock to clients.  Tracked
+           in CANONICAL_DESIGN_GAPS.md (Gap A follow-up). */
+        int have_all_seckeys = lsp_have_all_signer_keypairs(lsp->ctx, f, sub);
+        if (!have_all_seckeys) {
+            fprintf(stderr,
+                    "LSP subfactory advance: multi-process mode — skipping "
+                    "poison TX (SECURITY GAP: client cannot recover "
+                    "sales-stock on breach without wire-ceremony poison TX)\n");
         }
 
         if (have_all_seckeys &&

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2627,7 +2627,35 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         uint32_t old_sstock_vout = (uint32_t)wt_old_n_chans;  /* trailing */
         const uint64_t POISON_FEE_SATS = 1000;  /* matches PS leaf default */
         int poison_ok = 0;
-        if (wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
+
+        /* factory_sign_l_stock_poison_tx is a single-process primitive —
+           it requires f->keypairs[i] to hold every sub-factory signer's
+           seckey, which is only true when the LSP also owns the client
+           keys (unit tests, --demo single-process LSP).  In a real
+           multi-process LSP the clients hold their own keys and we'd
+           crash inside libsecp256k1 with "illegal argument".  Detect
+           multi-process by checking whether each non-LSP signer's
+           keypair has a non-zero seckey; if any are zero, skip the
+           poison build and register the watchtower with NULL poison_tx
+           (graceful degradation — the wire-ceremony equivalent that
+           gathers per-client partial sigs is the proper long-term fix,
+           tracked in CANONICAL_DESIGN_GAPS.md). */
+        int have_all_seckeys = 1;
+        for (size_t si = 1; si < sub->n_signers; si++) {
+            uint32_t pidx = sub->signer_indices[si];
+            unsigned char tmp[32];
+            if (!secp256k1_keypair_sec(lsp->ctx, tmp, &f->keypairs[pidx])) {
+                have_all_seckeys = 0;
+                break;
+            }
+            int all_zero = 1;
+            for (int b = 0; b < 32; b++) if (tmp[b]) { all_zero = 0; break; }
+            memset(tmp, 0, 32);
+            if (all_zero) { have_all_seckeys = 0; break; }
+        }
+
+        if (have_all_seckeys &&
+            wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
             poison_ok = factory_sign_l_stock_poison_tx(
                 f, sub,
                 wt_old_chain_txid, old_sstock_vout,


### PR DESCRIPTION
## Summary

Hot-fix for a CRITICAL multi-process LSP crash + documentation of the broader SECURITY GAP it surfaced.

### Audit-driven scope expansion

Initial scope (sub-factory crash from PR #134) was extended after audit found **two additional unprotected call sites** with the same crash, both pre-existing this PR:
- `lsp_advance_leaf` (line ~1623) — DW per-leaf state advance
- `lsp_realloc_leaf` (line ~2030) — Tier B rotation re-sign

Both call `factory_build_burn_tx` → `factory_sign_l_stock_poison_tx`, which crashes in libsecp256k1 when client keypairs are zero-filled (multi-process mode).  Test coverage masked this because:
- `test_multiprocess_musig_n8.sh` uses `--force-close` (no advance)
- `test_multiprocess_subfactory_advance.sh` exercised only sub-factory advance (the path #134 broke)
- Tier B rollover test runs single-process with hardcoded test seckeys 0x01..0x09 (defeats the multi-process detection)

### What changed
- **Extracted `lsp_have_all_signer_keypairs()` helper** (single-process detector via `secp256k1_keypair_sec` + all-zero check).
- **Applied at all THREE poison TX call sites**: sub-factory advance, leaf advance, Tier B rotation.
- **Loud `SECURITY GAP` warning** to stderr when the guard fires so operators see the degradation in production logs.
- **`docs/poison-tx.md`**: replaced the soft "deferred to a follow-up PR" framing with a **SECURITY-CRITICAL** section explaining the production gap and warning operators NOT to deploy multi-process LSPs to mainnet until the wire-ceremony poison TX lands.
- **`README.md`**: top-of-file production-readiness warning with link to `docs/poison-tx.md`.
- **Phase 4b chain_len fix**: `>= 2` → `>= 1` so the watchtower entry is registered on the very first sub-factory advance (was a silent miss).

### Why this is the right fix

The t/1242 economic security argument relies on poison TX making cheating economically irrational.  Without it, an LSP that broadcasts a stale state can recover L-stock value after CSV (default ~1 day on mainnet) — making the attack profitable if any earlier state had a more LSP-favorable distribution.

This isn't "graceful degradation" — **the security model doesn't apply** in multi-process mode.  Hence:
- Loud stderr warning at every advance (operators can't miss it)
- README warning at the top (deployers can't miss it)
- docs/poison-tx.md SECURITY-CRITICAL section (auditors can't miss it)

### Out of scope (the proper long-term fix)

The wire-ceremony poison TX requires a second split-round MuSig2 round during each leaf-state-advance / sub-factory chain-advance ceremony (gathering per-client partial sigs over the poison TX sighash).  The wire-message infrastructure already exists (`MSG_LEAF_*_PSIG`, `MSG_SUBFACTORY_*_PSIG`) — only the wiring is needed.  Estimated 2-3 days.

## Test plan
- [x] All 1422 unit tests pass on VPS (no regressions)
- [x] `tools/test_multiprocess_subfactory_advance.sh` passes (k=2 N=4 sub-factory + force-close)
- [x] Verified single-process `--demo` LSPs still build the poison TX (guard returns true when all keypairs present)
- [x] Verified multi-process LSPs no longer crash (guard returns false → NULL poison_tx → graceful degradation with stderr warning)
- [ ] CI: Linux + macOS + sanitizers + TSan + regtest + coverage + fuzz all green