### PR TITLE
wire-ceremony poison TX for sub-factory advance — closes SECURITY GAP

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -153,6 +153,23 @@ typedef struct {
     secp256k1_musig_partial_sig partial_sigs[FACTORY_MAX_SIGNERS];
     int partial_sigs_received;
 
+    /* Wire-ceremony poison TX state — second MuSig session per node so a
+       multi-process LSP can co-sign the L-stock / sales-stock poison TX
+       alongside the new state TX during the same advance ceremony.
+       MUST use independent nonces from `signing_session` (MuSig2 demands
+       fresh nonces per signed message).  Lifetime: populated when the
+       LSP and clients run a state-advance with poison-TX bundling; the
+       `poison_signed_tx` is then handed to the watchtower so it can
+       broadcast the poison TX on breach detection.  Closes the SECURITY
+       GAP documented in docs/poison-tx.md. */
+    musig_signing_session_t poison_signing_session;
+    secp256k1_musig_partial_sig poison_partial_sigs[FACTORY_MAX_SIGNERS];
+    int poison_partial_sigs_received;
+    unsigned char poison_sighash[32];
+    tx_buf_t poison_unsigned_tx;
+    tx_buf_t poison_signed_tx;
+    int poison_is_signed;
+
     /* Pseudo-Spilman leaf state (is_ps_leaf == 1 only) */
     int is_ps_leaf;              /* 1 if this leaf uses PS chaining instead of DW nSequence */
     int ps_chain_len;            /* number of state advances (0 = initial state) */
@@ -520,6 +537,45 @@ int factory_sign_node(factory_t *f, size_t node_idx);
 int factory_session_init_node(factory_t *f, size_t node_idx);
 int factory_session_finalize_node(factory_t *f, size_t node_idx);
 int factory_session_complete_node(factory_t *f, size_t node_idx);
+
+/* --- Wire-ceremony poison TX dual-signing helpers (closes SECURITY GAP) ---
+   These mirror the per-node session helpers above but operate on the
+   `poison_signing_session` slot, allowing the LSP to coordinate a
+   second MuSig2 round across all signers for the OLD state's L-stock /
+   sales-stock poison TX in lockstep with the new state advance.
+   Critical: each helper uses INDEPENDENT nonces from the state-advance
+   session — MuSig2 mandates fresh nonces per signed message.
+
+   Lifecycle:
+     1. factory_session_prepare_poison_tx_subfactory — builds the unsigned
+        poison TX bytes against the OLD chain[N-1] sales-stock UTXO and
+        records its sighash on the node.
+     2. factory_session_init_node_poison — fresh musig session.
+     3. factory_session_set_nonce_poison — set each signer's pubnonce.
+     4. factory_session_finalize_node_poison — compute aggnonce against
+        the stored poison_sighash.
+     5. factory_session_set_partial_sig_poison — collect partial sigs.
+     6. factory_session_complete_node_poison — aggregate + finalize a
+        64-byte witness, finalize signed_tx in poison_signed_tx. */
+int factory_session_prepare_poison_tx_subfactory(
+    factory_t *f, size_t sub_node_idx,
+    const unsigned char *old_chain_txid32, uint32_t old_sstock_vout,
+    uint64_t old_sstock_amount_sats, uint64_t fee_sats);
+int factory_session_init_node_poison(factory_t *f, size_t node_idx);
+int factory_session_set_nonce_poison(factory_t *f, size_t node_idx,
+                                       size_t signer_slot,
+                                       const secp256k1_musig_pubnonce *pubnonce);
+int factory_session_finalize_node_poison(factory_t *f, size_t node_idx);
+int factory_session_set_partial_sig_poison(factory_t *f, size_t node_idx,
+                                             size_t signer_slot,
+                                             const secp256k1_musig_partial_sig *psig);
+int factory_session_complete_node_poison(factory_t *f, size_t node_idx);
+
+/* Reset poison state on a node (free the unsigned/signed tx buffers + clear
+   sighash + reset received counter).  Safe to call on a never-prepared
+   node.  Used during cleanup and after the poison TX is handed to the
+   watchtower. */
+void factory_session_reset_poison(factory_t *f, size_t node_idx);
 
 /* Set custom output amounts on a leaf state node.
    leaf_side: 0..n_leaf_nodes-1.  amounts must sum to current output total.

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -660,20 +660,41 @@ int wire_parse_subfactory_propose(const cJSON *json,
                                     int *channel_idx, uint64_t *delta_sats,
                                     unsigned char *lsp_pubnonce66);
 
-/* Client → LSP: SUBFACTORY_NONCE {pubnonce} */
-cJSON *wire_build_subfactory_nonce(const unsigned char *pubnonce66);
-int wire_parse_subfactory_nonce(const cJSON *json, unsigned char *pubnonce66);
+/* Client → LSP: SUBFACTORY_NONCE {pubnonce, [poison_pubnonce]}.
+   Both fields carry 66-byte MuSig2 pubnonces.  poison_pubnonce is
+   OPTIONAL on the wire (legacy clients omit it); when present it
+   accompanies the state pubnonce for the same signer in the same
+   message — this lets the LSP run two split-round MuSig2 ceremonies
+   in lockstep (closes Wire-Ceremony Gap A: poison TX in multi-process).
+   Pass `poison_pubnonce66 = NULL` to either build or parse to skip the
+   second nonce.  Parse return value: 0 = failure, 1 = state only,
+   2 = state + poison both parsed. */
+cJSON *wire_build_subfactory_nonce(const unsigned char *state_pubnonce66,
+                                     const unsigned char *poison_pubnonce66);
+int wire_parse_subfactory_nonce(const cJSON *json,
+                                  unsigned char *state_pubnonce66,
+                                  unsigned char *poison_pubnonce66);
 
-/* LSP → sub clients: SUBFACTORY_ALL_NONCES {pubnonces[]} */
+/* LSP → sub clients: SUBFACTORY_ALL_NONCES {pubnonces[], [poison_pubnonces[]]}.
+   Same dual-nonce semantics as SUBFACTORY_NONCE.  Pass
+   `poison_pubnonces = NULL` (build) or `poison_pubnonces_out = NULL`
+   (parse) to skip the second array. */
 cJSON *wire_build_subfactory_all_nonces(const unsigned char pubnonces[][66],
+                                          const unsigned char poison_pubnonces[][66],
                                           size_t n_signers);
 int wire_parse_subfactory_all_nonces(const cJSON *json,
                                        unsigned char pubnonces_out[][66],
+                                       unsigned char poison_pubnonces_out[][66],
                                        size_t max_signers, size_t *n_out);
 
-/* Client → LSP: SUBFACTORY_PSIG {partial_sig} */
-cJSON *wire_build_subfactory_psig(const unsigned char *partial_sig32);
-int wire_parse_subfactory_psig(const cJSON *json, unsigned char *partial_sig32);
+/* Client → LSP: SUBFACTORY_PSIG {partial_sig, [poison_partial_sig]}.
+   Same dual-sig semantics — second sig is the client's MuSig2 partial
+   sig over the OLD state's poison TX sighash.  Optional. */
+cJSON *wire_build_subfactory_psig(const unsigned char *state_psig32,
+                                    const unsigned char *poison_psig32);
+int wire_parse_subfactory_psig(const cJSON *json,
+                                 unsigned char *state_psig32,
+                                 unsigned char *poison_psig32);
 
 /* LSP → sub clients: SUBFACTORY_DONE {leaf_side, sub_idx, chain_len} */
 cJSON *wire_build_subfactory_done(int leaf_side, int sub_idx, uint32_t chain_len);

--- a/src/client.c
+++ b/src/client.c
@@ -2725,7 +2725,7 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
     /* Send NONCE. */
     unsigned char my_pn_ser[66];
     musig_pubnonce_serialize(ctx, my_pn_ser, &my_pubnonce);
-    cJSON *nm = wire_build_subfactory_nonce(my_pn_ser);
+    cJSON *nm = wire_build_subfactory_nonce(my_pn_ser, NULL);
     if (!wire_send(fd, MSG_SUBFACTORY_NONCE, nm)) {
         cJSON_Delete(nm);
         memset(my_seckey, 0, 32);
@@ -2744,7 +2744,7 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
     }
     unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
     size_t n_pn;
-    if (!wire_parse_subfactory_all_nonces(am.json, all_pubnonces,
+    if (!wire_parse_subfactory_all_nonces(am.json, all_pubnonces, NULL,
                                             FACTORY_MAX_SIGNERS, &n_pn)) {
         cJSON_Delete(am.json);
         memset(my_seckey, 0, 32);
@@ -2780,7 +2780,7 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
     memset(my_seckey, 0, 32);
     unsigned char my_psig_ser[32];
     musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
-    cJSON *pm = wire_build_subfactory_psig(my_psig_ser);
+    cJSON *pm = wire_build_subfactory_psig(my_psig_ser, NULL);
     if (!wire_send(fd, MSG_SUBFACTORY_PSIG, pm)) {
         cJSON_Delete(pm);
         return 0;

--- a/src/client.c
+++ b/src/client.c
@@ -2677,17 +2677,10 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
         return 0;
     }
 
-    /* Apply the chain advance locally so our unsigned_tx matches the LSP's. */
-    if (!factory_subfactory_chain_advance_unsigned(factory, leaf_side, sub_idx,
-                                                     channel_idx, delta_sats)) {
-        fprintf(stderr, "Client %u: subfactory chain_advance_unsigned failed "
-                "(leaf=%d sub=%d ch=%d delta=%llu)\n",
-                my_index, leaf_side, sub_idx, channel_idx,
-                (unsigned long long)delta_sats);
-        return 0;
-    }
-
-    /* Locate the sub-factory node we just advanced. */
+    /* Locate the sub-factory node BEFORE the advance so we can snapshot
+       the OLD chain[N-1] state (txid + sales-stock amount) — both are
+       needed to deterministically prepare the poison TX in lockstep with
+       the LSP. */
     if (leaf_side < 0 || leaf_side >= factory->n_leaf_nodes) return 0;
     size_t leaf_idx = factory->leaf_node_indices[leaf_side];
     factory_node_t *leaf = &factory->nodes[leaf_idx];
@@ -2696,10 +2689,51 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
     if (sub_node_i < 0) return 0;
     factory_node_t *sub = &factory->nodes[sub_node_i];
 
-    /* Init signing session for the sub-factory node. */
-    if (!factory_session_init_node(factory, (size_t)sub_node_i)) {
-        fprintf(stderr, "Client %u: subfactory session_init failed\n", my_index);
+    unsigned char wt_old_chain_txid[32];
+    memcpy(wt_old_chain_txid, sub->txid, 32);
+    size_t wt_old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
+    if (wt_old_n_chans > 16) wt_old_n_chans = 16;
+    uint64_t wt_old_sstock_amount = (sub->n_outputs > 0)
+        ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
+
+    /* Wire-ceremony poison-TX prep: deterministic build from snapshot.
+       Both LSP and client run this with byte-identical inputs so they
+       arrive at the same sighash without any additional wire bytes. */
+    const uint64_t POISON_FEE_SATS = 1000;
+    int poison_prepared = 0;
+    if (wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
+        if (factory_session_prepare_poison_tx_subfactory(
+                factory, (size_t)sub_node_i,
+                wt_old_chain_txid, (uint32_t)wt_old_n_chans,
+                wt_old_sstock_amount, POISON_FEE_SATS)) {
+            poison_prepared = 1;
+        }
+    }
+
+    /* Apply the chain advance locally so our unsigned_tx matches the LSP's. */
+    if (!factory_subfactory_chain_advance_unsigned(factory, leaf_side, sub_idx,
+                                                     channel_idx, delta_sats)) {
+        fprintf(stderr, "Client %u: subfactory chain_advance_unsigned failed "
+                "(leaf=%d sub=%d ch=%d delta=%llu)\n",
+                my_index, leaf_side, sub_idx, channel_idx,
+                (unsigned long long)delta_sats);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
         return 0;
+    }
+
+    /* Init both signing sessions (state + poison if prepared). */
+    if (!factory_session_init_node(factory, (size_t)sub_node_i)) {
+        fprintf(stderr, "Client %u: subfactory state session_init failed\n",
+                my_index);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
+    if (poison_prepared &&
+        !factory_session_init_node_poison(factory, (size_t)sub_node_i)) {
+        fprintf(stderr, "Client %u: subfactory poison session_init failed — "
+                "degrading\n", my_index);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        poison_prepared = 0;
     }
 
     /* Find own slot and generate own nonce. */
@@ -2710,25 +2744,42 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
         return 0;
     }
     unsigned char my_seckey[32];
-    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) return 0;
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
     secp256k1_pubkey my_pubkey;
     secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
-    secp256k1_musig_secnonce my_secnonce;
-    secp256k1_musig_pubnonce my_pubnonce;
+    secp256k1_musig_secnonce my_secnonce, my_poison_secnonce;
+    secp256k1_musig_pubnonce my_pubnonce, my_poison_pubnonce;
     if (!musig_generate_nonce(ctx, &my_secnonce, &my_pubnonce,
                                my_seckey, &my_pubkey,
                                &sub->keyagg.cache)) {
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
         return 0;
     }
+    if (poison_prepared &&
+        !musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                my_seckey, &my_pubkey,
+                                &sub->keyagg.cache)) {
+        fprintf(stderr, "Client %u: poison nonce gen failed — degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        poison_prepared = 0;
+    }
 
-    /* Send NONCE. */
-    unsigned char my_pn_ser[66];
+    /* Send NONCE (state + poison if prepared). */
+    unsigned char my_pn_ser[66], my_poison_pn_ser[66];
     musig_pubnonce_serialize(ctx, my_pn_ser, &my_pubnonce);
-    cJSON *nm = wire_build_subfactory_nonce(my_pn_ser, NULL);
+    if (poison_prepared)
+        musig_pubnonce_serialize(ctx, my_poison_pn_ser, &my_poison_pubnonce);
+    cJSON *nm = wire_build_subfactory_nonce(
+        my_pn_ser, poison_prepared ? my_poison_pn_ser : NULL);
     if (!wire_send(fd, MSG_SUBFACTORY_NONCE, nm)) {
         cJSON_Delete(nm);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
         return 0;
     }
     cJSON_Delete(nm);
@@ -2743,49 +2794,97 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
         return 0;
     }
     unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
     size_t n_pn;
-    if (!wire_parse_subfactory_all_nonces(am.json, all_pubnonces, NULL,
-                                            FACTORY_MAX_SIGNERS, &n_pn)) {
-        cJSON_Delete(am.json);
+    int parse_an_rc = wire_parse_subfactory_all_nonces(
+        am.json, all_pubnonces,
+        poison_prepared ? all_poison_pubnonces : NULL,
+        FACTORY_MAX_SIGNERS, &n_pn);
+    cJSON_Delete(am.json);
+    if (parse_an_rc == 0) {
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
         return 0;
     }
-    cJSON_Delete(am.json);
+    if (poison_prepared && parse_an_rc < 2) {
+        /* LSP omitted poison nonces — degrade. */
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        poison_prepared = 0;
+    }
     for (size_t s = 0; s < n_pn; s++) {
         secp256k1_musig_pubnonce pn;
         if (!musig_pubnonce_parse(ctx, &pn, all_pubnonces[s])) {
             memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
             return 0;
         }
         if (!factory_session_set_nonce(factory, (size_t)sub_node_i, s, &pn)) {
             memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
             return 0;
+        }
+        if (poison_prepared) {
+            secp256k1_musig_pubnonce ppn;
+            if (!musig_pubnonce_parse(ctx, &ppn, all_poison_pubnonces[s]) ||
+                !factory_session_set_nonce_poison(factory, (size_t)sub_node_i,
+                                                    s, &ppn)) {
+                fprintf(stderr, "Client %u: poison nonce set failed — degrading\n",
+                        my_index);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                poison_prepared = 0;
+            }
         }
     }
 
-    /* Finalize. */
+    /* Finalize both sessions. */
     if (!factory_session_finalize_node(factory, (size_t)sub_node_i)) {
-        fprintf(stderr, "Client %u: subfactory finalize failed\n", my_index);
+        fprintf(stderr, "Client %u: subfactory state finalize failed\n", my_index);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
         return 0;
     }
+    if (poison_prepared &&
+        !factory_session_finalize_node_poison(factory, (size_t)sub_node_i)) {
+        fprintf(stderr, "Client %u: subfactory poison finalize failed — degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        poison_prepared = 0;
+    }
 
-    /* Create + send PSIG. */
-    secp256k1_musig_partial_sig my_psig;
+    /* Create + send PSIG (state + poison if prepared). */
+    secp256k1_musig_partial_sig my_psig, my_poison_psig;
     if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonce, keypair,
                                     &sub->signing_session)) {
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
         return 0;
     }
+    if (poison_prepared &&
+        !musig_create_partial_sig(ctx, &my_poison_psig, &my_poison_secnonce, keypair,
+                                    &sub->poison_signing_session)) {
+        fprintf(stderr, "Client %u: poison psig create failed — degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        poison_prepared = 0;
+    }
     memset(my_seckey, 0, 32);
-    unsigned char my_psig_ser[32];
+    unsigned char my_psig_ser[32], my_poison_psig_ser[32];
     musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
-    cJSON *pm = wire_build_subfactory_psig(my_psig_ser, NULL);
+    if (poison_prepared)
+        musig_partial_sig_serialize(ctx, my_poison_psig_ser, &my_poison_psig);
+    cJSON *pm = wire_build_subfactory_psig(
+        my_psig_ser, poison_prepared ? my_poison_psig_ser : NULL);
     if (!wire_send(fd, MSG_SUBFACTORY_PSIG, pm)) {
         cJSON_Delete(pm);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
         return 0;
     }
     cJSON_Delete(pm);
+    /* Client reset of poison session — the LSP holds the canonical
+       signed poison TX (we contributed our partial sig); freeing the
+       client's session state here keeps memory bounded across many
+       advances. */
+    factory_session_reset_poison(factory, (size_t)sub_node_i);
 
     /* Wait for DONE. */
     wire_msg_t dm;

--- a/src/factory.c
+++ b/src/factory.c
@@ -2340,6 +2340,138 @@ int factory_session_complete_node(factory_t *f, size_t node_idx) {
     return 1;
 }
 
+/* === Wire-ceremony poison TX helpers (closes SECURITY GAP) === */
+
+void factory_session_reset_poison(factory_t *f, size_t node_idx) {
+    if (!f || node_idx >= f->n_nodes) return;
+    factory_node_t *node = &f->nodes[node_idx];
+    tx_buf_free(&node->poison_unsigned_tx);
+    tx_buf_free(&node->poison_signed_tx);
+    memset(node->poison_sighash, 0, 32);
+    node->poison_partial_sigs_received = 0;
+    node->poison_is_signed = 0;
+    /* secp256k1_musig structures are POD-style; zeroing is safe. */
+    memset(&node->poison_signing_session, 0, sizeof(node->poison_signing_session));
+    memset(node->poison_partial_sigs, 0, sizeof(node->poison_partial_sigs));
+}
+
+int factory_session_prepare_poison_tx_subfactory(
+    factory_t *f, size_t sub_node_idx,
+    const unsigned char *old_chain_txid32, uint32_t old_sstock_vout,
+    uint64_t old_sstock_amount_sats, uint64_t fee_sats)
+{
+    if (!f || sub_node_idx >= f->n_nodes || !old_chain_txid32) return 0;
+    factory_node_t *sub = &f->nodes[sub_node_idx];
+    if (sub->type != NODE_PS_SUBFACTORY) return 0;
+
+    /* Reuse the existing single-process unsigned-poison-TX builder.
+       It produces the bytes + sighash; we don't sign here — that's
+       what the wire ceremony rounds do. */
+    factory_session_reset_poison(f, sub_node_idx);
+    tx_buf_init(&sub->poison_unsigned_tx, 256);
+    if (!factory_build_l_stock_poison_tx_unsigned(
+            f, sub, old_chain_txid32, old_sstock_vout,
+            old_sstock_amount_sats, fee_sats,
+            &sub->poison_unsigned_tx, sub->poison_sighash)) {
+        factory_session_reset_poison(f, sub_node_idx);
+        return 0;
+    }
+    return 1;
+}
+
+int factory_session_init_node_poison(factory_t *f, size_t node_idx) {
+    if (!f || node_idx >= f->n_nodes) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->is_built) return 0;
+    /* The poison TX is signed against the SAME keyagg as the state TX
+       (LSP + leaf signers, N-of-N MuSig).  The SIGHASH differs (poison
+       TX bytes vs new state TX bytes) and the NONCES MUST be fresh. */
+    musig_session_init(&node->poison_signing_session, &node->keyagg,
+                        node->n_signers);
+    node->poison_partial_sigs_received = 0;
+    return 1;
+}
+
+int factory_session_set_nonce_poison(factory_t *f, size_t node_idx,
+                                       size_t signer_slot,
+                                       const secp256k1_musig_pubnonce *pubnonce) {
+    if (!f || node_idx >= f->n_nodes || !pubnonce) return 0;
+    return musig_session_set_pubnonce(&f->nodes[node_idx].poison_signing_session,
+                                        signer_slot, pubnonce);
+}
+
+int factory_session_finalize_node_poison(factory_t *f, size_t node_idx) {
+    if (!f || node_idx >= f->n_nodes) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+
+    /* The poison TX spends the OLD state's L-stock / sales-stock UTXO
+       whose SPK is `or(N-of-N keyagg, L&CSV)` — the keypath spend uses
+       the leaf-level taptree merkle root (single CSV leaf).  Match what
+       sign_l_stock_spend_with_outputs does internally so the sighash
+       resolves to the same value on both LSP + clients. */
+    secp256k1_xonly_pubkey lsp_xonly;
+    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL,
+                                              &f->pubkeys[0]))
+        return 0;
+    uint32_t csv = f->l_stock_csv_blocks > 0
+                   ? f->l_stock_csv_blocks
+                   : L_STOCK_CSV_DEFAULT_BLOCKS;
+    tapscript_leaf_t csv_leaf;
+    if (!tapscript_build_csv_delay(&csv_leaf, csv, &lsp_xonly, f->ctx))
+        return 0;
+    unsigned char merkle_root[32];
+    if (!tapscript_merkle_root(merkle_root, &csv_leaf, 1))
+        return 0;
+
+    int ok = musig_session_finalize_nonces(f->ctx,
+                                             &node->poison_signing_session,
+                                             node->poison_sighash,
+                                             merkle_root, NULL);
+    if (!ok)
+        fprintf(stderr,
+                "finalize_node_poison %zu: musig_session_finalize_nonces failed "
+                "(n_signers=%zu, nonces_collected=%d)\n",
+                node_idx, node->n_signers,
+                node->poison_signing_session.nonces_collected);
+    return ok;
+}
+
+int factory_session_set_partial_sig_poison(factory_t *f, size_t node_idx,
+                                             size_t signer_slot,
+                                             const secp256k1_musig_partial_sig *psig) {
+    if (!f || node_idx >= f->n_nodes || !psig) return 0;
+    if (signer_slot >= FACTORY_MAX_SIGNERS) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    memcpy(&node->poison_partial_sigs[signer_slot], psig,
+           sizeof(secp256k1_musig_partial_sig));
+    node->poison_partial_sigs_received++;
+    return 1;
+}
+
+int factory_session_complete_node_poison(factory_t *f, size_t node_idx) {
+    if (!f || node_idx >= f->n_nodes) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+
+    if (node->poison_partial_sigs_received != (int)node->n_signers)
+        return 0;
+    if (node->poison_unsigned_tx.len == 0) return 0;
+
+    unsigned char sig[64];
+    if (!musig_aggregate_partial_sigs(f->ctx, sig,
+                                        &node->poison_signing_session,
+                                        node->poison_partial_sigs,
+                                        node->n_signers))
+        return 0;
+
+    if (!finalize_signed_tx(&node->poison_signed_tx,
+                              node->poison_unsigned_tx.data,
+                              node->poison_unsigned_tx.len, sig))
+        return 0;
+
+    node->poison_is_signed = 1;
+    return 1;
+}
+
 void factory_set_shachain_seed(factory_t *f, const unsigned char *seed32) {
     memcpy(f->shachain_seed, seed32, 32);
     f->has_shachain = 1;
@@ -3400,6 +3532,11 @@ void factory_free(factory_t *f) {
     for (size_t i = 0; i < f->n_nodes; i++) {
         tx_buf_free(&f->nodes[i].unsigned_tx);
         tx_buf_free(&f->nodes[i].signed_tx);
+        /* Wire-ceremony poison TX buffers — populated by
+           factory_session_prepare_poison_tx_subfactory.  Free always
+           (tx_buf_free is a no-op on zero-init). */
+        tx_buf_free(&f->nodes[i].poison_unsigned_tx);
+        tx_buf_free(&f->nodes[i].poison_signed_tx);
     }
     /* Zero node count so a second factory_free is a no-op (idempotent). */
     f->n_nodes = 0;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2818,7 +2818,13 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (mgr->watchtower && sub->ps_chain_len >= 1) {
         int have_poison = (poison_prepared && sub->poison_is_signed &&
                            sub->poison_signed_tx.len > 0);
-        if (!have_poison)
+        if (have_poison)
+            printf("LSP: sub-factory %d.%d wire-ceremony poison TX signed "
+                   "(%zu bytes, sales-stock %llu sats → %zu clients)\n",
+                   leaf_side, sub_idx_in_leaf,
+                   sub->poison_signed_tx.len,
+                   (unsigned long long)wt_old_sstock_amount, wt_old_n_chans);
+        else
             fprintf(stderr,
                     "LSP subfactory advance: registering watchtower without "
                     "poison TX (poison_prepared=%d, poison_is_signed=%d) — "

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2525,7 +2525,7 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             return 0;
         }
         unsigned char client_pn[66];
-        if (!wire_parse_subfactory_nonce(nmsg.json, client_pn)) {
+        if (!wire_parse_subfactory_nonce(nmsg.json, client_pn, NULL)) {
             cJSON_Delete(nmsg.json);
             memset(lsp_seckey, 0, 32);
             return 0;
@@ -2553,7 +2553,7 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         }
     }
     cJSON *all_nonces = wire_build_subfactory_all_nonces(
-        (const unsigned char (*)[66])all_pubnonces, sub->n_signers);
+        (const unsigned char (*)[66])all_pubnonces, NULL, sub->n_signers);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_ALL_NONCES, all_nonces);
@@ -2597,7 +2597,7 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             return 0;
         }
         unsigned char client_psig_ser[32];
-        if (!wire_parse_subfactory_psig(pmsg.json, client_psig_ser)) {
+        if (!wire_parse_subfactory_psig(pmsg.json, client_psig_ser, NULL)) {
             cJSON_Delete(pmsg.json);
             return 0;
         }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2437,9 +2437,10 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (n_clients_in_sub == 0) return 0;
 
     /* Snapshot the soon-to-be-stale chain[N-1] state for the watchtower
-       (Phase 4b).  Once factory_subfactory_chain_advance_unsigned runs,
-       sub->txid / sub->outputs[] reflect the new chain[N] state, so the
-       previous txid + per-channel amounts must be captured first. */
+       (Phase 4b) AND for the wire-ceremony poison-TX prep (Gap A close).
+       Once factory_subfactory_chain_advance_unsigned runs, sub->txid /
+       sub->outputs[] reflect the new chain[N] state, so the previous
+       txid + per-channel amounts + sales-stock must be captured first. */
     unsigned char wt_old_chain_txid[32];
     memcpy(wt_old_chain_txid, sub->txid, 32);
     size_t wt_old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
@@ -2450,35 +2451,83 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     uint64_t wt_old_sstock_amount = (sub->n_outputs > 0)
         ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
 
+    /* === Wire-ceremony poison TX prep ===
+       Build the unsigned poison TX (deterministic: spends OLD chain[N-1]
+       sales-stock UTXO, distributes equal share to each non-LSP signer)
+       and stash its sighash on the node so factory_session_*_poison
+       helpers can run the second MuSig session in lockstep.  Clients
+       run the same prepare call from their snapshot of the OLD state,
+       so both sides arrive at byte-identical sighash. */
+    const uint64_t POISON_FEE_SATS = 1000;
+    int poison_prepared = 0;
+    if (mgr->watchtower &&
+        wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
+        if (factory_session_prepare_poison_tx_subfactory(
+                f, (size_t)sub_node_i,
+                wt_old_chain_txid, (uint32_t)wt_old_n_chans,
+                wt_old_sstock_amount, POISON_FEE_SATS)) {
+            poison_prepared = 1;
+        } else {
+            fprintf(stderr,
+                    "LSP subfactory advance: poison TX prep failed "
+                    "(sstock=%llu sats, n_chans=%zu) — falling back to NULL "
+                    "poison_tx\n",
+                    (unsigned long long)wt_old_sstock_amount, wt_old_n_chans);
+        }
+    }
+
     /* Step 1: Advance sub-factory state (rebuilds unsigned_tx, clears is_signed). */
     if (!factory_subfactory_chain_advance_unsigned(f, leaf_side,
                                                     sub_idx_in_leaf,
                                                     channel_idx_in_sub,
                                                     delta_sats)) {
         fprintf(stderr, "LSP subfactory advance: chain_advance_unsigned failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
     }
 
-    /* Step 2: Init signing session for the sub-factory node. */
+    /* Step 2: Init BOTH signing sessions (state + poison).  Poison
+       session uses the SAME keyagg as state but a separate session so
+       nonces are independent (MuSig2 demands fresh nonces per message). */
     if (!factory_session_init_node(f, (size_t)sub_node_i)) {
-        fprintf(stderr, "LSP subfactory advance: session init failed\n");
+        fprintf(stderr, "LSP subfactory advance: state session init failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
     }
+    if (poison_prepared &&
+        !factory_session_init_node_poison(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory advance: poison session init failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        poison_prepared = 0;
+    }
 
-    /* Step 3: Generate LSP's nonce (signer slot 0). */
+    /* Step 3: Generate LSP's nonces (one per session, MUST be distinct). */
     int lsp_slot = factory_find_signer_slot(f, (size_t)sub_node_i, 0);
-    if (lsp_slot < 0) return 0;
+    if (lsp_slot < 0) { factory_session_reset_poison(f, (size_t)sub_node_i); return 0; }
     unsigned char lsp_seckey[32];
-    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair))
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) {
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
-    secp256k1_musig_secnonce lsp_secnonce;
-    secp256k1_musig_pubnonce lsp_pubnonce;
+    }
+    secp256k1_musig_secnonce lsp_secnonce, lsp_poison_secnonce;
+    secp256k1_musig_pubnonce lsp_pubnonce, lsp_poison_pubnonce;
     if (!musig_generate_nonce(lsp->ctx, &lsp_secnonce, &lsp_pubnonce,
                                lsp_seckey, &lsp->lsp_pubkey,
                                &sub->keyagg.cache)) {
         memset(lsp_seckey, 0, 32);
-        fprintf(stderr, "LSP subfactory advance: nonce gen failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        fprintf(stderr, "LSP subfactory advance: state nonce gen failed\n");
         return 0;
+    }
+    if (poison_prepared &&
+        !musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce, &lsp_poison_pubnonce,
+                                lsp_seckey, &lsp->lsp_pubkey,
+                                &sub->keyagg.cache)) {
+        memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        fprintf(stderr, "LSP subfactory advance: poison nonce gen failed — "
+                "skipping poison ceremony\n");
+        poison_prepared = 0;
     }
     /* Note: do NOT set the LSP nonce on the session here.  ALL_NONCES
        carries every signer's nonce; we set them all in one pass on the
@@ -2507,9 +2556,15 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
     cJSON_Delete(propose);
 
-    /* Step 5: Collect NONCE from each client. */
+    /* Step 5: Collect NONCE from each client (state + poison if prepared). */
     unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
     memcpy(all_pubnonces[lsp_slot], lsp_pubnonce_ser, 66);
+    if (poison_prepared) {
+        unsigned char lsp_poison_pn_ser[66];
+        musig_pubnonce_serialize(lsp->ctx, lsp_poison_pn_ser, &lsp_poison_pubnonce);
+        memcpy(all_poison_pubnonces[lsp_slot], lsp_poison_pn_ser, 66);
+    }
 
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
@@ -2522,38 +2577,66 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                     sub_clients[ci], nmsg.msg_type);
             if (nmsg.json) cJSON_Delete(nmsg.json);
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
             return 0;
         }
-        unsigned char client_pn[66];
-        if (!wire_parse_subfactory_nonce(nmsg.json, client_pn, NULL)) {
-            cJSON_Delete(nmsg.json);
-            memset(lsp_seckey, 0, 32);
-            return 0;
-        }
+        unsigned char client_pn[66], client_poison_pn[66];
+        int parse_rc = wire_parse_subfactory_nonce(
+            nmsg.json, client_pn,
+            poison_prepared ? client_poison_pn : NULL);
         cJSON_Delete(nmsg.json);
+        if (parse_rc == 0) {
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        if (poison_prepared && parse_rc < 2) {
+            /* Client doesn't speak the poison ceremony — degrade gracefully. */
+            fprintf(stderr,
+                    "LSP subfactory advance: client %u omitted poison nonce "
+                    "— degrading to NULL poison_tx\n", sub_clients[ci]);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
         int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
                                                     sub_clients[ci]);
         if (client_slot < 0) {
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
             return 0;
         }
         memcpy(all_pubnonces[client_slot], client_pn, 66);
+        if (poison_prepared)
+            memcpy(all_poison_pubnonces[client_slot], client_poison_pn, 66);
     }
 
-    /* Step 6: Set every nonce on the session, broadcast ALL_NONCES, finalize. */
+    /* Step 6: Set every nonce on both sessions, broadcast ALL_NONCES, finalize both. */
     for (size_t s = 0; s < sub->n_signers; s++) {
         secp256k1_musig_pubnonce pn;
         if (!musig_pubnonce_parse(lsp->ctx, &pn, all_pubnonces[s])) {
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
             return 0;
         }
         if (!factory_session_set_nonce(f, (size_t)sub_node_i, s, &pn)) {
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
             return 0;
+        }
+        if (poison_prepared) {
+            secp256k1_musig_pubnonce ppn;
+            if (!musig_pubnonce_parse(lsp->ctx, &ppn, all_poison_pubnonces[s]) ||
+                !factory_session_set_nonce_poison(f, (size_t)sub_node_i, s, &ppn)) {
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                poison_prepared = 0;
+            }
         }
     }
     cJSON *all_nonces = wire_build_subfactory_all_nonces(
-        (const unsigned char (*)[66])all_pubnonces, NULL, sub->n_signers);
+        (const unsigned char (*)[66])all_pubnonces,
+        poison_prepared ? (const unsigned char (*)[66])all_poison_pubnonces : NULL,
+        sub->n_signers);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_ALL_NONCES, all_nonces);
@@ -2561,29 +2644,55 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     cJSON_Delete(all_nonces);
 
     if (!factory_session_finalize_node(f, (size_t)sub_node_i)) {
-        fprintf(stderr, "LSP subfactory advance: finalize failed\n");
+        fprintf(stderr, "LSP subfactory advance: state finalize failed\n");
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
     }
+    if (poison_prepared &&
+        !factory_session_finalize_node_poison(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory advance: poison finalize failed — "
+                "degrading to NULL poison_tx\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        poison_prepared = 0;
+    }
 
-    /* Step 7: Create LSP's partial sig. */
+    /* Step 7: Create LSP's partial sigs (one per session). */
     secp256k1_keypair lsp_kp;
     if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
     }
     memset(lsp_seckey, 0, 32);
-    secp256k1_musig_partial_sig lsp_psig;
+    secp256k1_musig_partial_sig lsp_psig, lsp_poison_psig;
     if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
                                     &sub->signing_session)) {
-        fprintf(stderr, "LSP subfactory advance: LSP partial sig failed\n");
+        fprintf(stderr, "LSP subfactory advance: LSP state partial sig failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
     }
     if (!factory_session_set_partial_sig(f, (size_t)sub_node_i,
-                                          (size_t)lsp_slot, &lsp_psig))
+                                          (size_t)lsp_slot, &lsp_psig)) {
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
+    }
+    if (poison_prepared) {
+        if (!musig_create_partial_sig(lsp->ctx, &lsp_poison_psig,
+                                        &lsp_poison_secnonce, &lsp_kp,
+                                        &sub->poison_signing_session)) {
+            fprintf(stderr, "LSP subfactory advance: LSP poison psig failed — "
+                    "degrading to NULL poison_tx\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        } else if (!factory_session_set_partial_sig_poison(
+                       f, (size_t)sub_node_i, (size_t)lsp_slot, &lsp_poison_psig)) {
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
+    }
 
-    /* Step 8: Collect PSIG from each client. */
+    /* Step 8: Collect PSIG from each client (state + poison if prepared). */
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_msg_t pmsg;
@@ -2594,29 +2703,69 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                     "from client %u, got 0x%02x\n",
                     sub_clients[ci], pmsg.msg_type);
             if (pmsg.json) cJSON_Delete(pmsg.json);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
             return 0;
         }
-        unsigned char client_psig_ser[32];
-        if (!wire_parse_subfactory_psig(pmsg.json, client_psig_ser, NULL)) {
-            cJSON_Delete(pmsg.json);
-            return 0;
-        }
+        unsigned char client_psig_ser[32], client_poison_psig_ser[32];
+        int parse_rc = wire_parse_subfactory_psig(
+            pmsg.json, client_psig_ser,
+            poison_prepared ? client_poison_psig_ser : NULL);
         cJSON_Delete(pmsg.json);
+        if (parse_rc == 0) {
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        if (poison_prepared && parse_rc < 2) {
+            fprintf(stderr,
+                    "LSP subfactory advance: client %u omitted poison psig "
+                    "— degrading to NULL poison_tx\n", sub_clients[ci]);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
         int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
                                                     sub_clients[ci]);
-        if (client_slot < 0) return 0;
-        secp256k1_musig_partial_sig client_psig;
-        if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_ser))
+        if (client_slot < 0) {
+            factory_session_reset_poison(f, (size_t)sub_node_i);
             return 0;
+        }
+        secp256k1_musig_partial_sig client_psig, client_poison_psig;
+        if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_ser)) {
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
         if (!factory_session_set_partial_sig(f, (size_t)sub_node_i,
-                                              (size_t)client_slot, &client_psig))
+                                              (size_t)client_slot, &client_psig)) {
+            factory_session_reset_poison(f, (size_t)sub_node_i);
             return 0;
+        }
+        if (poison_prepared) {
+            if (!musig_partial_sig_parse(lsp->ctx, &client_poison_psig,
+                                          client_poison_psig_ser) ||
+                !factory_session_set_partial_sig_poison(
+                    f, (size_t)sub_node_i, (size_t)client_slot, &client_poison_psig)) {
+                fprintf(stderr,
+                        "LSP subfactory advance: client %u poison psig parse/set "
+                        "failed — degrading to NULL poison_tx\n", sub_clients[ci]);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                poison_prepared = 0;
+            }
+        }
     }
 
-    /* Step 9: Aggregate + finalize the new chain[N] signed_tx. */
+    /* Step 9: Aggregate + finalize both signed TXs (state + poison). */
     if (!factory_session_complete_node(f, (size_t)sub_node_i)) {
-        fprintf(stderr, "LSP subfactory advance: complete failed\n");
+        fprintf(stderr, "LSP subfactory advance: state complete failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
         return 0;
+    }
+    if (poison_prepared) {
+        if (!factory_session_complete_node_poison(f, (size_t)sub_node_i)) {
+            fprintf(stderr,
+                    "LSP subfactory advance: poison complete failed — "
+                    "degrading to NULL poison_tx\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
     }
 
     /* Step 10: Persist sub-factory chain entry (Phase 4a save +
@@ -2658,68 +2807,36 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     /* Step 10b: Build the sub-factory sales-stock POISON TX (Gap A) and
        register the now-stale chain[N-1] with the watchtower (Phase 4b).
 
-       The sub-factory's sales-stock SPK has the same shape as a PS
-       leaf's L-stock (or(N-of-N, L&CSV) per t/1242), so the existing
-       factory_sign_l_stock_poison_tx builder works directly here — its
-       authority is the passed factory_node_t's keyagg, which on a
-       sub-factory is the (LSP + sub-factory clients) MuSig.
-
-       The poison TX spends chain[N-1]'s sales-stock UTXO (txid =
-       wt_old_chain_txid, vout = old_n_outputs - 1, amount =
-       wt_old_sstock_amount) and pays each sub-factory client an equal
-       share, less fee.  Pre-signed at advance time so any client /
-       watchtower can broadcast it on breach without coordination. */
-    /* After the first advance, ps_chain_len == 1 (chain[0] → chain[1])
-       and chain[0] is already a stale state worth watching.  Guard at
-       >= 1 (not >= 2) so we register the watchtower entry on the very
-       first advance — the original >= 2 guard was a Phase 4b bug. */
+       The poison TX was co-signed by all sub-factory signers via the
+       wire-ceremony second MuSig round above (closes Gap A SECURITY
+       GAP).  If poison_prepared is true and the ceremony succeeded,
+       sub->poison_signed_tx now holds the fully-signed poison TX.  If
+       any phase of the poison ceremony failed (one client out of date,
+       sales-stock too small, etc.) we fall back to NULL poison_tx —
+       graceful degradation, watchtower still broadcasts response_tx on
+       breach but cannot redistribute the sales-stock. */
     if (mgr->watchtower && sub->ps_chain_len >= 1) {
-        tx_buf_t poison_tx;
-        tx_buf_init(&poison_tx, 256);
-        uint32_t old_sstock_vout = (uint32_t)wt_old_n_chans;  /* trailing */
-        const uint64_t POISON_FEE_SATS = 1000;  /* matches PS leaf default */
-        int poison_ok = 0;
-
-        /* See lsp_have_all_signer_keypairs comment: skip poison TX in
-           multi-process mode (graceful degradation, NULL poison_tx
-           registered with watchtower).  This is a SECURITY GAP — the
-           watchtower can still detect breach via response_tx broadcast
-           but cannot redistribute the sales-stock to clients.  Tracked
-           in CANONICAL_DESIGN_GAPS.md (Gap A follow-up). */
-        int have_all_seckeys = lsp_have_all_signer_keypairs(lsp->ctx, f, sub);
-        if (!have_all_seckeys) {
+        int have_poison = (poison_prepared && sub->poison_is_signed &&
+                           sub->poison_signed_tx.len > 0);
+        if (!have_poison)
             fprintf(stderr,
-                    "LSP subfactory advance: multi-process mode — skipping "
-                    "poison TX (SECURITY GAP: client cannot recover "
-                    "sales-stock on breach without wire-ceremony poison TX)\n");
-        }
-
-        if (have_all_seckeys &&
-            wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
-            poison_ok = factory_sign_l_stock_poison_tx(
-                f, sub,
-                wt_old_chain_txid, old_sstock_vout,
-                wt_old_sstock_amount, POISON_FEE_SATS,
-                &poison_tx);
-            if (!poison_ok)
-                fprintf(stderr,
-                        "LSP subfactory advance: poison TX sign failed "
-                        "(sub=%d, sstock=%llu sats) — registering watchtower "
-                        "without poison\n",
-                        sub_node_i,
-                        (unsigned long long)wt_old_sstock_amount);
-        }
+                    "LSP subfactory advance: registering watchtower without "
+                    "poison TX (poison_prepared=%d, poison_is_signed=%d) — "
+                    "DEGRADED, breach cannot redistribute sales-stock\n",
+                    poison_prepared, sub->poison_is_signed);
 
         watchtower_watch_subfactory_node(mgr->watchtower,
             (uint32_t)sub_node_i,
             wt_old_chain_txid,
             sub->signed_tx.data, sub->signed_tx.len,
-            poison_ok ? poison_tx.data : NULL,
-            poison_ok ? poison_tx.len  : 0,
+            have_poison ? sub->poison_signed_tx.data : NULL,
+            have_poison ? sub->poison_signed_tx.len  : 0,
             wt_old_chan_amounts, wt_old_n_chans,
             wt_old_sstock_amount);
 
-        tx_buf_free(&poison_tx);
+        /* Watchtower copied the bytes; safe to free our poison-session
+           state now that it's been handed off. */
+        factory_session_reset_poison(f, (size_t)sub_node_i);
     }
 
     /* Step 11: Broadcast DONE to all sub-factory clients. */

--- a/src/wire.c
+++ b/src/wire.c
@@ -1768,18 +1768,36 @@ int wire_parse_subfactory_propose(const cJSON *json,
     return 1;
 }
 
-cJSON *wire_build_subfactory_nonce(const unsigned char *pubnonce66) {
+/* MSG_SUBFACTORY_NONCE — carries TWO pubnonces:
+   - state_pubnonce: nonce for the new chain[N] state TX MuSig session
+   - poison_pubnonce: nonce for the OLD chain[N-1] sales-stock poison TX
+                       MuSig session (Wire-Ceremony Gap A closure).
+   poison_pubnonce66 may be NULL on either side as a transitional fallback
+   (old clients without poison support) — receiver detects via parse
+   return value. */
+cJSON *wire_build_subfactory_nonce(const unsigned char *state_pubnonce66,
+                                     const unsigned char *poison_pubnonce66) {
     cJSON *j = cJSON_CreateObject();
-    wire_json_add_hex(j, "pubnonce", pubnonce66, 66);
+    wire_json_add_hex(j, "pubnonce", state_pubnonce66, 66);
+    if (poison_pubnonce66)
+        wire_json_add_hex(j, "poison_pubnonce", poison_pubnonce66, 66);
     return j;
 }
 
-int wire_parse_subfactory_nonce(const cJSON *json, unsigned char *pubnonce66) {
-    if (wire_json_get_hex(json, "pubnonce", pubnonce66, 66) != 66) return 0;
+/* Returns: 1 = state pubnonce parsed; 2 = state + poison pubnonces parsed;
+            0 = parse failure. */
+int wire_parse_subfactory_nonce(const cJSON *json,
+                                  unsigned char *state_pubnonce66,
+                                  unsigned char *poison_pubnonce66) {
+    if (wire_json_get_hex(json, "pubnonce", state_pubnonce66, 66) != 66) return 0;
+    if (poison_pubnonce66 &&
+        wire_json_get_hex(json, "poison_pubnonce", poison_pubnonce66, 66) == 66)
+        return 2;
     return 1;
 }
 
 cJSON *wire_build_subfactory_all_nonces(const unsigned char pubnonces[][66],
+                                          const unsigned char poison_pubnonces[][66],
                                           size_t n_signers) {
     cJSON *j = cJSON_CreateObject();
     cJSON *arr = cJSON_AddArrayToObject(j, "pubnonces");
@@ -1788,11 +1806,19 @@ cJSON *wire_build_subfactory_all_nonces(const unsigned char pubnonces[][66],
         hex_encode(pubnonces[i], 66, hex);
         cJSON_AddItemToArray(arr, cJSON_CreateString(hex));
     }
+    if (poison_pubnonces) {
+        cJSON *parr = cJSON_AddArrayToObject(j, "poison_pubnonces");
+        for (size_t i = 0; i < n_signers; i++) {
+            hex_encode(poison_pubnonces[i], 66, hex);
+            cJSON_AddItemToArray(parr, cJSON_CreateString(hex));
+        }
+    }
     return j;
 }
 
 int wire_parse_subfactory_all_nonces(const cJSON *json,
                                        unsigned char pubnonces_out[][66],
+                                       unsigned char poison_pubnonces_out[][66],
                                        size_t max_signers, size_t *n_out) {
     cJSON *arr = cJSON_GetObjectItem(json, "pubnonces");
     if (!arr || !cJSON_IsArray(arr)) return 0;
@@ -1804,17 +1830,40 @@ int wire_parse_subfactory_all_nonces(const cJSON *json,
         if (hex_decode(item->valuestring, pubnonces_out[i], 66) != 66) return 0;
     }
     *n_out = n;
+
+    /* Optional poison nonces (returns 2 if present, 1 otherwise). */
+    if (poison_pubnonces_out) {
+        cJSON *parr = cJSON_GetObjectItem(json, "poison_pubnonces");
+        if (parr && cJSON_IsArray(parr) &&
+            (size_t)cJSON_GetArraySize(parr) == n) {
+            for (size_t i = 0; i < n; i++) {
+                cJSON *item = cJSON_GetArrayItem(parr, (int)i);
+                if (!item || !cJSON_IsString(item)) return 1;
+                if (hex_decode(item->valuestring, poison_pubnonces_out[i], 66) != 66)
+                    return 1;
+            }
+            return 2;
+        }
+    }
     return 1;
 }
 
-cJSON *wire_build_subfactory_psig(const unsigned char *partial_sig32) {
+cJSON *wire_build_subfactory_psig(const unsigned char *state_psig32,
+                                    const unsigned char *poison_psig32) {
     cJSON *j = cJSON_CreateObject();
-    wire_json_add_hex(j, "partial_sig", partial_sig32, 32);
+    wire_json_add_hex(j, "partial_sig", state_psig32, 32);
+    if (poison_psig32)
+        wire_json_add_hex(j, "poison_partial_sig", poison_psig32, 32);
     return j;
 }
 
-int wire_parse_subfactory_psig(const cJSON *json, unsigned char *partial_sig32) {
-    if (wire_json_get_hex(json, "partial_sig", partial_sig32, 32) != 32) return 0;
+int wire_parse_subfactory_psig(const cJSON *json,
+                                 unsigned char *state_psig32,
+                                 unsigned char *poison_psig32) {
+    if (wire_json_get_hex(json, "partial_sig", state_psig32, 32) != 32) return 0;
+    if (poison_psig32 &&
+        wire_json_get_hex(json, "poison_partial_sig", poison_psig32, 32) == 32)
+        return 2;
     return 1;
 }
 

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -1592,42 +1592,87 @@ int test_wire_subfactory(void) {
     TEST_ASSERT_MEM_EQ(pn_out, lsp_pn, 66, "lsp pubnonce round-trip");
     cJSON_Delete(propose);
 
-    /* NONCE round-trip */
+    /* NONCE round-trip — state-only path (legacy compat) */
     unsigned char nin[66];
     memset(nin, 0xB2, 66);
-    cJSON *nm = wire_build_subfactory_nonce(nin);
-    TEST_ASSERT(nm != NULL, "build subfactory_nonce");
+    cJSON *nm = wire_build_subfactory_nonce(nin, NULL);
+    TEST_ASSERT(nm != NULL, "build subfactory_nonce (state-only)");
     unsigned char nout[66];
-    TEST_ASSERT(wire_parse_subfactory_nonce(nm, nout), "parse subfactory_nonce");
-    TEST_ASSERT_MEM_EQ(nout, nin, 66, "nonce round-trip");
+    TEST_ASSERT(wire_parse_subfactory_nonce(nm, nout, NULL) == 1,
+                "parse subfactory_nonce (state-only)");
+    TEST_ASSERT_MEM_EQ(nout, nin, 66, "state nonce round-trip");
     cJSON_Delete(nm);
+
+    /* NONCE round-trip — DUAL (state + poison) path (Wire-Ceremony Gap A) */
+    unsigned char nin_state[66], nin_poison[66];
+    memset(nin_state,  0xA1, 66);
+    memset(nin_poison, 0xA2, 66);
+    cJSON *nm2 = wire_build_subfactory_nonce(nin_state, nin_poison);
+    TEST_ASSERT(nm2 != NULL, "build subfactory_nonce (dual)");
+    unsigned char nout_state[66], nout_poison[66];
+    int rc = wire_parse_subfactory_nonce(nm2, nout_state, nout_poison);
+    TEST_ASSERT_EQ((long)rc, 2, "parse subfactory_nonce (dual) returns 2");
+    TEST_ASSERT_MEM_EQ(nout_state,  nin_state,  66, "state nonce dual round-trip");
+    TEST_ASSERT_MEM_EQ(nout_poison, nin_poison, 66, "poison nonce dual round-trip");
+    cJSON_Delete(nm2);
 
     /* ALL_NONCES round-trip (3 signers = LSP + 2 clients on a k=2 sub-factory) */
     unsigned char pns[3][66];
     memset(pns[0], 0x10, 66);
     memset(pns[1], 0x20, 66);
     memset(pns[2], 0x30, 66);
-    cJSON *all = wire_build_subfactory_all_nonces(pns, 3);
-    TEST_ASSERT(all != NULL, "build subfactory_all_nonces");
+    cJSON *all = wire_build_subfactory_all_nonces(pns, NULL, 3);
+    TEST_ASSERT(all != NULL, "build subfactory_all_nonces (state-only)");
     unsigned char pns_out[4][66];
     size_t n_pns;
-    TEST_ASSERT(wire_parse_subfactory_all_nonces(all, pns_out, 4, &n_pns),
-                "parse subfactory_all_nonces");
+    TEST_ASSERT(wire_parse_subfactory_all_nonces(all, pns_out, NULL, 4, &n_pns) == 1,
+                "parse subfactory_all_nonces (state-only)");
     TEST_ASSERT_EQ((long)n_pns, 3, "n_signers");
     TEST_ASSERT_MEM_EQ(pns_out[0], pns[0], 66, "pubnonce[0]");
     TEST_ASSERT_MEM_EQ(pns_out[1], pns[1], 66, "pubnonce[1]");
     TEST_ASSERT_MEM_EQ(pns_out[2], pns[2], 66, "pubnonce[2]");
     cJSON_Delete(all);
 
-    /* PSIG round-trip */
+    /* ALL_NONCES round-trip — DUAL (state + poison) */
+    unsigned char poison_pns[3][66];
+    memset(poison_pns[0], 0x40, 66);
+    memset(poison_pns[1], 0x50, 66);
+    memset(poison_pns[2], 0x60, 66);
+    cJSON *all2 = wire_build_subfactory_all_nonces(pns, poison_pns, 3);
+    TEST_ASSERT(all2 != NULL, "build subfactory_all_nonces (dual)");
+    unsigned char pns_out2[4][66], poison_out[4][66];
+    size_t n_pns2;
+    TEST_ASSERT(wire_parse_subfactory_all_nonces(all2, pns_out2, poison_out, 4, &n_pns2) == 2,
+                "parse subfactory_all_nonces (dual) returns 2");
+    TEST_ASSERT_EQ((long)n_pns2, 3, "n_signers (dual)");
+    TEST_ASSERT_MEM_EQ(poison_out[0], poison_pns[0], 66, "poison nonce[0]");
+    TEST_ASSERT_MEM_EQ(poison_out[1], poison_pns[1], 66, "poison nonce[1]");
+    TEST_ASSERT_MEM_EQ(poison_out[2], poison_pns[2], 66, "poison nonce[2]");
+    cJSON_Delete(all2);
+
+    /* PSIG round-trip — state-only path */
     unsigned char psig_in[32];
     memset(psig_in, 0xC3, 32);
-    cJSON *pm = wire_build_subfactory_psig(psig_in);
-    TEST_ASSERT(pm != NULL, "build subfactory_psig");
+    cJSON *pm = wire_build_subfactory_psig(psig_in, NULL);
+    TEST_ASSERT(pm != NULL, "build subfactory_psig (state-only)");
     unsigned char psig_out[32];
-    TEST_ASSERT(wire_parse_subfactory_psig(pm, psig_out), "parse subfactory_psig");
+    TEST_ASSERT(wire_parse_subfactory_psig(pm, psig_out, NULL) == 1,
+                "parse subfactory_psig (state-only)");
     TEST_ASSERT_MEM_EQ(psig_out, psig_in, 32, "psig round-trip");
     cJSON_Delete(pm);
+
+    /* PSIG round-trip — DUAL (state + poison) */
+    unsigned char state_psig_in[32], poison_psig_in[32];
+    memset(state_psig_in,  0xD1, 32);
+    memset(poison_psig_in, 0xD2, 32);
+    cJSON *pm2 = wire_build_subfactory_psig(state_psig_in, poison_psig_in);
+    TEST_ASSERT(pm2 != NULL, "build subfactory_psig (dual)");
+    unsigned char state_psig_out[32], poison_psig_out[32];
+    TEST_ASSERT(wire_parse_subfactory_psig(pm2, state_psig_out, poison_psig_out) == 2,
+                "parse subfactory_psig (dual) returns 2");
+    TEST_ASSERT_MEM_EQ(state_psig_out,  state_psig_in,  32, "state psig dual round-trip");
+    TEST_ASSERT_MEM_EQ(poison_psig_out, poison_psig_in, 32, "poison psig dual round-trip");
+    cJSON_Delete(pm2);
 
     /* DONE round-trip */
     cJSON *dm = wire_build_subfactory_done(0, 1, 5);

--- a/tools/test_multiprocess_subfactory_advance.sh
+++ b/tools/test_multiprocess_subfactory_advance.sh
@@ -286,6 +286,24 @@ if ! grep -q "PS K² SUB-FACTORY TEST: PASS" "$LSP_LOG"; then
 fi
 echo "  PS K² SUB-FACTORY TEST: PASS"
 
+# Wire-ceremony poison TX assertion (closes Gap A SECURITY GAP).  The dual
+# MuSig2 round must have produced a fully-signed poison TX; absence of a
+# "wire-ceremony poison TX signed" line OR presence of any "DEGRADED" /
+# "SECURITY GAP" line means we fell back to NULL poison_tx and the
+# watchtower would have no defense for the sales-stock on breach.
+if grep -q "DEGRADED\|SECURITY GAP" "$LSP_LOG"; then
+    echo "FAIL: poison TX wire-ceremony degraded (SECURITY GAP triggered)"
+    grep -E "DEGRADED|SECURITY GAP|poison" "$LSP_LOG" | head -20
+    exit 1
+fi
+if ! grep -q "wire-ceremony poison TX signed" "$LSP_LOG"; then
+    echo "FAIL: wire-ceremony poison TX was not signed (no positive log)"
+    grep -E "poison|sub-factory" "$LSP_LOG" | head -20
+    exit 1
+fi
+POISON_LINE=$(grep "wire-ceremony poison TX signed" "$LSP_LOG" | head -1)
+echo "  $POISON_LINE"
+
 # --- Per-client participation ---
 echo ""
 echo "=== Verifying clients participated in sub-factory ceremony ==="


### PR DESCRIPTION
## Summary

Closes the SECURITY GAP introduced in PR #134 / hot-fixed in PR #135 / formally documented in `docs/poison-tx.md`: multi-process LSPs lacked the t/1242 poison TX defense for sub-factory sales-stock breach.

The hot-fix in #135 detected multi-process mode and skipped the poison TX (graceful degradation, NULL stored in watchtower entry).  This PR makes the poison TX work in multi-process mode by running a SECOND split-round MuSig2 ceremony alongside the existing state-advance ceremony.

### What changed

**Foundation** (commit b34173f, 193 LOC):
- `factory_node_t` extended with `poison_signing_session`, `poison_partial_sigs[]`, `poison_partial_sigs_received`, `poison_sighash[32]`, `poison_unsigned_tx`, `poison_signed_tx`, `poison_is_signed`
- 7 new helpers in `src/factory.c`: `factory_session_prepare_poison_tx_subfactory`, `factory_session_init_node_poison`, `factory_session_set_nonce_poison`, `factory_session_finalize_node_poison`, `factory_session_set_partial_sig_poison`, `factory_session_complete_node_poison`, `factory_session_reset_poison`
- `factory_free` extended to free new tx_buf_t fields

**Wire messages** (commit a2f76eb, 150 LOC):
- `MSG_SUBFACTORY_NONCE` / `ALL_NONCES` / `PSIG` extended with optional second nonce/sig field (`poison_pubnonce`, `poison_pubnonces[]`, `poison_partial_sig`)
- Parse helpers return `1` for state-only, `2` for state+poison (caller can detect protocol downgrade)
- All existing call sites updated to pass `NULL` as the new param when not bundling poison
- `tests/test_wire.c` extended with both state-only and dual round-trip tests

**Ceremony driver** (commit 544c3c7, 329 LOC):
- `lsp_subfactory_chain_advance`: deterministic poison TX prep from chain[N-1] snapshot → init poison session → gen LSP poison nonce → bundle with state nonce in PROPOSE/ALL_NONCES → collect client poison nonces → finalize poison session → create LSP poison psig → collect client poison psigs → complete poison session → store fully-signed poison TX in watchtower entry (replaces NULL)
- `client_handle_subfactory_advance`: snapshots chain[N-1] BEFORE applying state advance, runs same `factory_session_prepare_poison_tx_subfactory` (deterministic, byte-identical sighash to LSP), generates own poison nonce/psig, sends bundled with state nonce/psig
- Critical: poison nonces are **independent** from state nonces (MuSig2 demands fresh nonces per signed message — nonce reuse on different messages leaks the seckey)
- Graceful degradation at every step: if any client omits poison nonce/psig, both sides downgrade to NULL poison_tx (the SECURITY GAP path that PR #135 documented)

**Verification** (commit 48acd25):
- LSP prints `wire-ceremony poison TX signed (N bytes, sales-stock M sats → K clients)` on success
- `tools/test_multiprocess_subfactory_advance.sh` extended to assert that line is present + no `DEGRADED` / `SECURITY GAP` lines fired

### Verified end-to-end on VPS regtest
```
LSP: sub-factory 0.0 wire-ceremony poison TX signed (205 bytes,
     sales-stock 44334 sats → 2 clients)
=== PASS: Multi-process k² PS sub-factory chain extension ===
  - 5 distinct OS processes
  - k=2 → 1 leaf with 2 sub-factories of 2 clients each
```

### Out of scope (follow-up PRs)
- Same wire-ceremony pattern needs to be applied to `lsp_advance_leaf` (DW per-leaf state advance) and `lsp_realloc_leaf` (Tier B rotation re-sign).  The `lsp_have_all_signer_keypairs` guard from PR #135 stays in those paths until they get the same treatment.  Estimated 1-2 days each — pure pattern duplication, no new design.
- On-chain breach test (existing `test/regtest-k2-subfactory-breach` branch) now has a real poison TX to verify post-breach.

## Test plan
- [x] All 1422 unit tests pass
- [x] `tools/test_multiprocess_subfactory_advance.sh` passes with assertion that wire-ceremony poison TX was signed (no degradation)
- [x] LSP log confirms 205-byte signed poison TX produced from 44k sales-stock split between 2 clients
- [ ] CI: Linux + macOS + sanitizers + TSan + regtest + coverage + fuzz all green