### PR TITLE
wire-ceremony poison TX for leaf advance — extends Gap A closure to DW/PS leaves

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -561,6 +561,14 @@ int factory_session_prepare_poison_tx_subfactory(
     factory_t *f, size_t sub_node_idx,
     const unsigned char *old_chain_txid32, uint32_t old_sstock_vout,
     uint64_t old_sstock_amount_sats, uint64_t fee_sats);
+
+/* Same as the subfactory variant but for a DW / PS LEAF node — used by
+   the lsp_advance_leaf wire ceremony to bundle a poison TX over the
+   OLD state's L-stock UTXO alongside the new state TX advance. */
+int factory_session_prepare_poison_tx_leaf(
+    factory_t *f, size_t leaf_node_idx,
+    const unsigned char *old_leaf_txid32, uint32_t old_l_stock_vout,
+    uint64_t old_l_stock_amount_sats, uint64_t fee_sats);
 int factory_session_init_node_poison(factory_t *f, size_t node_idx);
 int factory_session_set_nonce_poison(factory_t *f, size_t node_idx,
                                        size_t signer_slot,

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -554,20 +554,35 @@ int wire_parse_jit_migrate(const cJSON *json, uint32_t *jit_channel_id,
 
 /* --- Per-Leaf Advance message builders (Upgrade 2) --- */
 
-/* LSP -> Client: LEAF_ADVANCE_PROPOSE {leaf_side, pubnonce} */
+/* LSP -> Client: LEAF_ADVANCE_PROPOSE {leaf_side, pubnonce, [poison_pubnonce]}.
+   poison_pubnonce is OPTIONAL on the wire — when present it accompanies
+   the state pubnonce so the client can run two MuSig2 ceremonies in
+   lockstep (closes Wire-Ceremony Gap A for leaf advance: poison TX
+   defense in multi-process LSPs).  Pass `poison_pubnonce66 = NULL` to
+   either build or parse to skip the second nonce.  Parse return value:
+   0 = failure, 1 = state only, 2 = state + poison both parsed. */
 cJSON *wire_build_leaf_advance_propose(int leaf_side,
-                                        const unsigned char *pubnonce66);
+                                        const unsigned char *state_pubnonce66,
+                                        const unsigned char *poison_pubnonce66);
 
 int wire_parse_leaf_advance_propose(const cJSON *json, int *leaf_side,
-                                      unsigned char *pubnonce66);
+                                      unsigned char *state_pubnonce66,
+                                      unsigned char *poison_pubnonce66);
 
-/* Client -> LSP: LEAF_ADVANCE_PSIG {pubnonce, partial_sig} */
-cJSON *wire_build_leaf_advance_psig(const unsigned char *pubnonce66,
-                                      const unsigned char *partial_sig32);
+/* Client -> LSP: LEAF_ADVANCE_PSIG {pubnonce, partial_sig,
+                                       [poison_pubnonce, poison_partial_sig]}.
+   Same dual-sig semantics as PROPOSE — second pair is the client's
+   MuSig2 nonce + partial sig over the OLD state's poison TX sighash. */
+cJSON *wire_build_leaf_advance_psig(const unsigned char *state_pubnonce66,
+                                      const unsigned char *state_partial_sig32,
+                                      const unsigned char *poison_pubnonce66,
+                                      const unsigned char *poison_partial_sig32);
 
 int wire_parse_leaf_advance_psig(const cJSON *json,
-                                    unsigned char *pubnonce66,
-                                    unsigned char *partial_sig32);
+                                    unsigned char *state_pubnonce66,
+                                    unsigned char *state_partial_sig32,
+                                    unsigned char *poison_pubnonce66,
+                                    unsigned char *poison_partial_sig32);
 
 /* LSP -> All: LEAF_ADVANCE_DONE {leaf_side} */
 cJSON *wire_build_leaf_advance_done(int leaf_side);

--- a/src/client.c
+++ b/src/client.c
@@ -2914,16 +2914,48 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
                                  const wire_msg_t *propose_msg) {
     persist_t *persist = g_client_persist;
     int leaf_side;
-    unsigned char lsp_pubnonce_ser[66];
-    if (!wire_parse_leaf_advance_propose(propose_msg->json, &leaf_side, lsp_pubnonce_ser)) {
+    unsigned char lsp_pubnonce_ser[66], lsp_poison_pn_ser[66];
+    int propose_rc = wire_parse_leaf_advance_propose(propose_msg->json, &leaf_side,
+                                                       lsp_pubnonce_ser,
+                                                       lsp_poison_pn_ser);
+    if (propose_rc == 0) {
         fprintf(stderr, "Client %u: failed to parse LEAF_ADVANCE_PROPOSE\n", my_index);
         return 0;
+    }
+    int wire_poison_offered = (propose_rc == 2);
+
+    /* Snapshot OLD leaf state BEFORE applying the advance — needed to
+       deterministically prep the poison TX in lockstep with the LSP
+       (closes Wire-Ceremony Gap A for leaf advance). */
+    if (leaf_side < 0 || leaf_side >= factory->n_leaf_nodes) return 0;
+    size_t pre_node_idx_c = factory->leaf_node_indices[leaf_side];
+    factory_node_t *pre_leaf = &factory->nodes[pre_node_idx_c];
+    unsigned char pre_old_leaf_txid[32];
+    memcpy(pre_old_leaf_txid, pre_leaf->txid, 32);
+    int pre_old_n_outputs = pre_leaf->n_outputs;
+    uint64_t pre_old_l_amount = (pre_old_n_outputs >= 2)
+                                ? pre_leaf->outputs[pre_old_n_outputs - 1].amount_sats
+                                : 0;
+    int pre_had_signed = (pre_leaf->is_signed && pre_leaf->signed_tx.len > 0);
+
+    const uint64_t LEAF_POISON_FEE_SATS = 1000;
+    int leaf_poison_prepared = 0;
+    if (wire_poison_offered && pre_had_signed && pre_old_n_outputs >= 2 &&
+        pre_old_l_amount > LEAF_POISON_FEE_SATS +
+                           (uint64_t)(pre_leaf->n_signers - 1) * 330u) {
+        if (factory_session_prepare_poison_tx_leaf(
+                factory, pre_node_idx_c,
+                pre_old_leaf_txid, (uint32_t)(pre_old_n_outputs - 1),
+                pre_old_l_amount, LEAF_POISON_FEE_SATS)) {
+            leaf_poison_prepared = 1;
+        }
     }
 
     int rc = factory_advance_leaf_unsigned(factory, leaf_side);
     if (rc <= 0) {
         fprintf(stderr, "Client %u: leaf %d advance_unsigned failed (rc=%d)\n",
                 my_index, leaf_side, rc);
+        factory_session_reset_poison(factory, pre_node_idx_c);
         return 0;
     }
 
@@ -2960,29 +2992,51 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
 
     if (!factory_session_init_node(factory, node_idx)) {
         fprintf(stderr, "Client %u: leaf %d session_init failed\n", my_index, leaf_side);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared &&
+        !factory_session_init_node_poison(factory, node_idx)) {
+        fprintf(stderr, "Client %u: leaf poison session init failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Set LSP nonce (participant 0) — received in PROPOSE */
+    /* Set LSP nonces (state + poison if prepared) — received in PROPOSE */
     int lsp_slot = factory_find_signer_slot(factory, node_idx, 0);
     if (lsp_slot < 0) {
         fprintf(stderr, "Client %u: LSP not signer on leaf node %zu\n", my_index, node_idx);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
     secp256k1_musig_pubnonce lsp_pubnonce;
     if (!musig_pubnonce_parse(ctx, &lsp_pubnonce, lsp_pubnonce_ser)) {
         fprintf(stderr, "Client %u: parse LSP pubnonce failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
     if (!factory_session_set_nonce(factory, node_idx, (size_t)lsp_slot, &lsp_pubnonce)) {
         fprintf(stderr, "Client %u: set LSP nonce failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared) {
+        secp256k1_musig_pubnonce lsp_poison_pn;
+        if (!musig_pubnonce_parse(ctx, &lsp_poison_pn, lsp_poison_pn_ser) ||
+            !factory_session_set_nonce_poison(factory, node_idx, (size_t)lsp_slot,
+                                                &lsp_poison_pn)) {
+            fprintf(stderr, "Client %u: parse/set LSP poison nonce failed — degrading\n",
+                    my_index);
+            factory_session_reset_poison(factory, node_idx);
+            leaf_poison_prepared = 0;
+        }
+    }
 
-    /* Generate own nonce */
+    /* Generate own nonces (state + poison if prepared). */
     int my_slot = factory_find_signer_slot(factory, node_idx, my_index);
     if (my_slot < 0) {
         fprintf(stderr, "Client %u: self not signer on leaf node %zu\n", my_index, node_idx);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
 
@@ -2990,45 +3044,83 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
     secp256k1_pubkey my_pubkey;
     if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
         fprintf(stderr, "Client %u: keypair_sec failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
     secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
 
-    secp256k1_musig_secnonce my_secnonce;
-    secp256k1_musig_pubnonce my_pubnonce;
+    secp256k1_musig_secnonce my_secnonce, my_poison_secnonce;
+    secp256k1_musig_pubnonce my_pubnonce, my_poison_pubnonce;
     if (!musig_generate_nonce(ctx, &my_secnonce, &my_pubnonce,
                                my_seckey, &my_pubkey,
                                &factory->nodes[node_idx].keyagg.cache)) {
-        fprintf(stderr, "Client %u: nonce gen failed\n", my_index);
+        fprintf(stderr, "Client %u: state nonce gen failed\n", my_index);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared &&
+        !musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                my_seckey, &my_pubkey,
+                                &factory->nodes[node_idx].keyagg.cache)) {
+        fprintf(stderr, "Client %u: poison nonce gen failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared = 0;
     }
 
     if (!factory_session_set_nonce(factory, node_idx, (size_t)my_slot, &my_pubnonce)) {
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared &&
+        !factory_session_set_nonce_poison(factory, node_idx, (size_t)my_slot,
+                                            &my_poison_pubnonce)) {
+        fprintf(stderr, "Client %u: set own poison nonce failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared = 0;
     }
 
     if (!factory_session_finalize_node(factory, node_idx)) {
-        fprintf(stderr, "Client %u: session finalize failed\n", my_index);
+        fprintf(stderr, "Client %u: state session finalize failed\n", my_index);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared &&
+        !factory_session_finalize_node_poison(factory, node_idx)) {
+        fprintf(stderr, "Client %u: poison session finalize failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Create partial sig */
-    secp256k1_musig_partial_sig my_psig;
+    /* Create partial sigs (state + poison if prepared). */
+    secp256k1_musig_partial_sig my_psig, my_poison_psig;
     if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonce, keypair,
                                     &factory->nodes[node_idx].signing_session)) {
-        fprintf(stderr, "Client %u: partial sig failed\n", my_index);
+        fprintf(stderr, "Client %u: state partial sig failed\n", my_index);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared &&
+        !musig_create_partial_sig(ctx, &my_poison_psig, &my_poison_secnonce, keypair,
+                                    &factory->nodes[node_idx].poison_signing_session)) {
+        fprintf(stderr, "Client %u: poison partial sig failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared = 0;
     }
     memset(my_seckey, 0, 32);
 
     /* Serialize now so we can record + send. */
     unsigned char my_pubnonce_ser[66], my_psig_ser[32];
+    unsigned char my_poison_pn_ser[66], my_poison_psig_ser[32];
     musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
     musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
+    if (leaf_poison_prepared) {
+        musig_pubnonce_serialize(ctx, my_poison_pn_ser, &my_poison_pubnonce);
+        musig_partial_sig_serialize(ctx, my_poison_psig_ser, &my_poison_psig);
+    }
 
     /* PS defense: record what we just signed BEFORE releasing the partial
        sig over the wire. A crash after record + before send is safe —
@@ -3054,13 +3146,20 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
         }
     }
 
-    cJSON *psig_json = wire_build_leaf_advance_psig(my_pubnonce_ser, my_psig_ser);
+    cJSON *psig_json = wire_build_leaf_advance_psig(
+        my_pubnonce_ser, my_psig_ser,
+        leaf_poison_prepared ? my_poison_pn_ser : NULL,
+        leaf_poison_prepared ? my_poison_psig_ser : NULL);
     if (!wire_send(fd, MSG_LEAF_ADVANCE_PSIG, psig_json)) {
         fprintf(stderr, "Client %u: send LEAF_ADVANCE_PSIG failed\n", my_index);
         cJSON_Delete(psig_json);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
     cJSON_Delete(psig_json);
+    /* Free client poison-session memory now that we've contributed our
+       partial sig (LSP holds the canonical signed poison TX). */
+    factory_session_reset_poison(factory, node_idx);
 
     /* Wait for LEAF_ADVANCE_DONE */
     wire_msg_t done_msg;

--- a/src/factory.c
+++ b/src/factory.c
@@ -2379,6 +2379,26 @@ int factory_session_prepare_poison_tx_subfactory(
     return 1;
 }
 
+int factory_session_prepare_poison_tx_leaf(
+    factory_t *f, size_t leaf_node_idx,
+    const unsigned char *old_leaf_txid32, uint32_t old_l_stock_vout,
+    uint64_t old_l_stock_amount_sats, uint64_t fee_sats)
+{
+    if (!f || leaf_node_idx >= f->n_nodes || !old_leaf_txid32) return 0;
+    factory_node_t *leaf = &f->nodes[leaf_node_idx];
+
+    factory_session_reset_poison(f, leaf_node_idx);
+    tx_buf_init(&leaf->poison_unsigned_tx, 256);
+    if (!factory_build_l_stock_poison_tx_unsigned(
+            f, leaf, old_leaf_txid32, old_l_stock_vout,
+            old_l_stock_amount_sats, fee_sats,
+            &leaf->poison_unsigned_tx, leaf->poison_sighash)) {
+        factory_session_reset_poison(f, leaf_node_idx);
+        return 0;
+    }
+    return 1;
+}
+
 int factory_session_init_node_poison(factory_t *f, size_t node_idx) {
     if (!f || node_idx >= f->n_nodes) return 0;
     factory_node_t *node = &f->nodes[node_idx];

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1480,6 +1480,24 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
                             ? f->nodes[pre_node_idx].outputs[old_n_outputs - 1].amount_sats
                             : 0;
 
+    /* Wire-ceremony poison-TX prep (closes SECURITY GAP for leaf advance).
+       Both LSP and client run the same prepare call from their snapshot
+       of the OLD state — deterministic, byte-identical sighash on both
+       sides, no extra wire fields needed beyond the dual nonce/sig pair
+       carried by MSG_LEAF_ADVANCE_PROPOSE / PSIG. */
+    const uint64_t LEAF_POISON_FEE_SATS = 1000;
+    int leaf_poison_prepared = 0;
+    if (mgr->watchtower && had_old_signed && old_n_outputs >= 2 &&
+        old_l_amount > LEAF_POISON_FEE_SATS +
+                       (uint64_t)(f->nodes[pre_node_idx].n_signers - 1) * 330u) {
+        if (factory_session_prepare_poison_tx_leaf(
+                f, pre_node_idx,
+                old_leaf_txid, (uint32_t)(old_n_outputs - 1),
+                old_l_amount, LEAF_POISON_FEE_SATS)) {
+            leaf_poison_prepared = 1;
+        }
+    }
+
     /* Step 1: Advance leaf state + rebuild unsigned tx */
     int rc = factory_advance_leaf_unsigned(f, leaf_side);
     if (rc == 0) {
@@ -1501,45 +1519,77 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     size_t node_idx = f->leaf_node_indices[leaf_side];
     uint32_t client_participant = (uint32_t)(leaf_side + 1);
 
-    /* Step 2: Init signing session for the leaf node */
+    /* Step 2: Init BOTH signing sessions (state + poison if prepared). */
     if (!factory_session_init_node(f, node_idx)) {
-        fprintf(stderr, "LSP: session init failed for leaf node %zu\n", node_idx);
+        fprintf(stderr, "LSP: state session init failed for leaf node %zu\n", node_idx);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared &&
+        !factory_session_init_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP: leaf poison session init failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Step 3: Generate LSP's nonce (participant 0) */
+    /* Step 3: Generate LSP's nonces (one per session — MUST be distinct). */
     int lsp_slot = factory_find_signer_slot(f, node_idx, 0);
     if (lsp_slot < 0) {
         fprintf(stderr, "LSP: LSP not signer on leaf node %zu\n", node_idx);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
 
     unsigned char lsp_seckey[32];
-    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair))
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) {
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
 
-    secp256k1_musig_secnonce lsp_secnonce;
-    secp256k1_musig_pubnonce lsp_pubnonce;
+    secp256k1_musig_secnonce lsp_secnonce, lsp_poison_secnonce;
+    secp256k1_musig_pubnonce lsp_pubnonce, lsp_poison_pubnonce;
     if (!musig_generate_nonce(lsp->ctx, &lsp_secnonce, &lsp_pubnonce,
                                lsp_seckey, &lsp->lsp_pubkey,
                                &f->nodes[node_idx].keyagg.cache)) {
         memset(lsp_seckey, 0, 32);
-        fprintf(stderr, "LSP: nonce gen failed for leaf advance\n");
+        factory_session_reset_poison(f, node_idx);
+        fprintf(stderr, "LSP: state nonce gen failed for leaf advance\n");
         return 0;
+    }
+    if (leaf_poison_prepared &&
+        !musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce, &lsp_poison_pubnonce,
+                                lsp_seckey, &lsp->lsp_pubkey,
+                                &f->nodes[node_idx].keyagg.cache)) {
+        fprintf(stderr, "LSP: leaf poison nonce gen failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
     }
 
     if (!factory_session_set_nonce(f, node_idx, (size_t)lsp_slot, &lsp_pubnonce)) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared &&
+        !factory_session_set_nonce_poison(f, node_idx, (size_t)lsp_slot,
+                                            &lsp_poison_pubnonce)) {
+        fprintf(stderr, "LSP: leaf poison set_nonce failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Step 4: Send LEAF_ADVANCE_PROPOSE to the affected client */
-    unsigned char lsp_pubnonce_ser[66];
+    /* Step 4: Send LEAF_ADVANCE_PROPOSE to the affected client (state + poison). */
+    unsigned char lsp_pubnonce_ser[66], lsp_poison_pn_ser[66];
     musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
-    cJSON *propose = wire_build_leaf_advance_propose(leaf_side, lsp_pubnonce_ser);
+    if (leaf_poison_prepared)
+        musig_pubnonce_serialize(lsp->ctx, lsp_poison_pn_ser, &lsp_poison_pubnonce);
+    cJSON *propose = wire_build_leaf_advance_propose(
+        leaf_side, lsp_pubnonce_ser,
+        leaf_poison_prepared ? lsp_poison_pn_ser : NULL);
     if (!wire_send(lsp->client_fds[leaf_side], MSG_LEAF_ADVANCE_PROPOSE, propose)) {
         cJSON_Delete(propose);
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
     cJSON_Delete(propose);
@@ -1556,78 +1606,143 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     }
 
     unsigned char client_pubnonce_ser[66], client_psig_ser[32];
-    if (!wire_parse_leaf_advance_psig(psig_msg.json,
-                                        client_pubnonce_ser, client_psig_ser)) {
+    unsigned char client_poison_pubnonce_ser[66], client_poison_psig_ser[32];
+    int psig_parse_rc = wire_parse_leaf_advance_psig(
+        psig_msg.json,
+        client_pubnonce_ser, client_psig_ser,
+        leaf_poison_prepared ? client_poison_pubnonce_ser : NULL,
+        leaf_poison_prepared ? client_poison_psig_ser : NULL);
+    cJSON_Delete(psig_msg.json);
+    if (psig_parse_rc == 0) {
         fprintf(stderr, "LSP: failed to parse LEAF_ADVANCE_PSIG\n");
-        cJSON_Delete(psig_msg.json);
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
-    cJSON_Delete(psig_msg.json);
+    if (leaf_poison_prepared && psig_parse_rc < 2) {
+        fprintf(stderr, "LSP: client omitted poison sig in LEAF_ADVANCE_PSIG — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Step 6: Set client's nonce + finalize */
+    /* Step 6: Set client's nonces (state + poison) + finalize both. */
     int client_slot = factory_find_signer_slot(f, node_idx, client_participant);
     if (client_slot < 0) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
 
     secp256k1_musig_pubnonce client_pubnonce;
     if (!musig_pubnonce_parse(lsp->ctx, &client_pubnonce, client_pubnonce_ser)) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
-
     if (!factory_session_set_nonce(f, node_idx, (size_t)client_slot, &client_pubnonce)) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared) {
+        secp256k1_musig_pubnonce client_poison_pn;
+        if (!musig_pubnonce_parse(lsp->ctx, &client_poison_pn, client_poison_pubnonce_ser) ||
+            !factory_session_set_nonce_poison(f, node_idx, (size_t)client_slot,
+                                                &client_poison_pn)) {
+            fprintf(stderr, "LSP: client poison nonce parse/set failed — degrading\n");
+            factory_session_reset_poison(f, node_idx);
+            leaf_poison_prepared = 0;
+        }
     }
 
     if (!factory_session_finalize_node(f, node_idx)) {
-        fprintf(stderr, "LSP: session finalize failed for leaf node %zu\n", node_idx);
+        fprintf(stderr, "LSP: state session finalize failed for leaf node %zu\n", node_idx);
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared &&
+        !factory_session_finalize_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP: leaf poison finalize failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Step 7: Create LSP's partial sig */
+    /* Step 7: Create LSP's partial sigs (state + poison if prepared). */
     secp256k1_keypair lsp_kp;
     if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
     memset(lsp_seckey, 0, 32);
 
-    secp256k1_musig_partial_sig lsp_psig;
+    secp256k1_musig_partial_sig lsp_psig, lsp_poison_psig;
     if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
                                     &f->nodes[node_idx].signing_session)) {
-        fprintf(stderr, "LSP: partial sig failed for leaf advance\n");
+        fprintf(stderr, "LSP: state partial sig failed for leaf advance\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
 
-    if (!factory_session_set_partial_sig(f, node_idx, (size_t)lsp_slot, &lsp_psig))
+    if (!factory_session_set_partial_sig(f, node_idx, (size_t)lsp_slot, &lsp_psig)) {
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared) {
+        if (!musig_create_partial_sig(lsp->ctx, &lsp_poison_psig,
+                                        &lsp_poison_secnonce, &lsp_kp,
+                                        &f->nodes[node_idx].poison_signing_session) ||
+            !factory_session_set_partial_sig_poison(f, node_idx,
+                                                     (size_t)lsp_slot, &lsp_poison_psig)) {
+            fprintf(stderr, "LSP: leaf poison psig create/set failed — degrading\n");
+            factory_session_reset_poison(f, node_idx);
+            leaf_poison_prepared = 0;
+        }
+    }
 
     /* Track LSP signing progress */
     if (mgr->persist)
         persist_save_signing_progress((persist_t *)mgr->persist, 0,
                                        (uint32_t)node_idx, (uint32_t)lsp_slot, 1, 1);
 
-    /* Step 8: Set client's partial sig */
+    /* Step 8: Set client's partial sigs (state + poison). */
     secp256k1_musig_partial_sig client_psig;
-    if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_ser))
+    if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_ser)) {
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
 
-    if (!factory_session_set_partial_sig(f, node_idx, (size_t)client_slot, &client_psig))
+    if (!factory_session_set_partial_sig(f, node_idx, (size_t)client_slot, &client_psig)) {
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared) {
+        secp256k1_musig_partial_sig client_poison_psig;
+        if (!musig_partial_sig_parse(lsp->ctx, &client_poison_psig, client_poison_psig_ser) ||
+            !factory_session_set_partial_sig_poison(f, node_idx, (size_t)client_slot,
+                                                     &client_poison_psig)) {
+            fprintf(stderr, "LSP: client poison psig parse/set failed — degrading\n");
+            factory_session_reset_poison(f, node_idx);
+            leaf_poison_prepared = 0;
+        }
+    }
 
     /* Track client signing progress */
     if (mgr->persist)
         persist_save_signing_progress((persist_t *)mgr->persist, 0,
                                        (uint32_t)node_idx, (uint32_t)client_slot, 1, 1);
 
-    /* Step 9: Aggregate + finalize */
+    /* Step 9: Aggregate + finalize both signed TXs. */
+    if (leaf_poison_prepared &&
+        !factory_session_complete_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP: leaf poison complete failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
     if (!factory_session_complete_node(f, node_idx)) {
-        fprintf(stderr, "LSP: session complete failed for leaf node %zu\n", node_idx);
+        fprintf(stderr, "LSP: state session complete failed for leaf node %zu\n", node_idx);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
 
@@ -1644,28 +1759,51 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     if (had_old_signed && mgr->watchtower) {
         factory_node_t *leaf_node = &f->nodes[node_idx];
 
+        /* Closes the SECURITY GAP that PR #135 documented: in
+           multi-process mode the wire-ceremony poison TX above already
+           ran a second MuSig2 round in lockstep with the state advance.
+           If poison_is_signed, we now have a real per-client-distribution
+           poison TX (no longer NULL).  If the ceremony degraded for any
+           reason, fall back to the old single-process builder when
+           keypairs are available (single-process unit tests / --demo). */
+        int have_poison_wire = (leaf_poison_prepared &&
+                                leaf_node->poison_is_signed &&
+                                leaf_node->poison_signed_tx.len > 0);
+        if (have_poison_wire)
+            printf("LSP: leaf %d wire-ceremony L-stock poison TX signed "
+                   "(%zu bytes, L-stock %llu sats → %zu clients)\n",
+                   leaf_side, leaf_node->poison_signed_tx.len,
+                   (unsigned long long)old_l_amount,
+                   leaf_node->n_signers - 1);
+
         tx_buf_t burn_tx;
         tx_buf_init(&burn_tx, 256);
-        uint32_t old_epoch = f->counter.current_epoch > 0
-                           ? f->counter.current_epoch - 1 : 0;
-        int burn_ok = 0;
-        /* Multi-process guard: factory_build_burn_tx wraps
-           factory_sign_l_stock_poison_tx which crashes in libsecp256k1
-           if any leaf signer's seckey is missing.  Same SECURITY GAP
-           as the sub-factory poison TX path. */
-        int have_leaf_seckeys =
-            lsp_have_all_signer_keypairs(lsp->ctx, f, leaf_node);
-        if (!have_leaf_seckeys)
-            fprintf(stderr,
-                    "LSP advance leaf: multi-process mode — skipping "
-                    "L-stock poison TX (SECURITY GAP: clients cannot "
-                    "recover L-stock on breach without wire-ceremony "
-                    "poison TX)\n");
-        if (have_leaf_seckeys && old_n_outputs >= 2) {
+        const unsigned char *poison_data = NULL;
+        size_t poison_len = 0;
+        if (have_poison_wire) {
+            poison_data = leaf_node->poison_signed_tx.data;
+            poison_len  = leaf_node->poison_signed_tx.len;
+        } else if (old_n_outputs >= 2 &&
+                   lsp_have_all_signer_keypairs(lsp->ctx, f, leaf_node)) {
+            /* Single-process fallback (unit tests / --demo): use the
+               in-process poison TX builder.  Multi-process LSPs hit
+               have_poison_wire above; if that failed they get NULL
+               with a SECURITY GAP warning. */
+            uint32_t old_epoch = f->counter.current_epoch > 0
+                                 ? f->counter.current_epoch - 1 : 0;
             size_t l_vout = (size_t)(old_n_outputs - 1);
-            burn_ok = factory_build_burn_tx(f, &burn_tx, leaf_node,
-                old_leaf_txid, (uint32_t)l_vout,
-                old_l_amount, old_epoch);
+            if (factory_build_burn_tx(f, &burn_tx, leaf_node,
+                    old_leaf_txid, (uint32_t)l_vout,
+                    old_l_amount, old_epoch)) {
+                poison_data = burn_tx.data;
+                poison_len  = burn_tx.len;
+            }
+        } else if (!have_poison_wire && old_n_outputs >= 2) {
+            fprintf(stderr,
+                    "LSP advance leaf: registering watchtower without poison "
+                    "TX (poison_prepared=%d, poison_is_signed=%d) — "
+                    "DEGRADED, breach cannot redistribute L-stock\n",
+                    leaf_poison_prepared, leaf_node->poison_is_signed);
         }
 
         /* Collect channel indices that live on this leaf node */
@@ -1680,10 +1818,10 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
         watchtower_watch_factory_node_with_channels(mgr->watchtower,
             (uint32_t)node_idx, old_leaf_txid,
             leaf_node->signed_tx.data, leaf_node->signed_tx.len,
-            burn_ok ? burn_tx.data : NULL,
-            burn_ok ? burn_tx.len : 0,
+            poison_data, poison_len,
             leaf_ch_ids, n_leaf_ch);
         tx_buf_free(&burn_tx);
+        factory_session_reset_poison(f, node_idx);
     }
 
     /* Step 10: Send LEAF_ADVANCE_DONE to all clients */

--- a/src/wire.c
+++ b/src/wire.c
@@ -1572,35 +1572,56 @@ int wire_parse_jit_migrate(const cJSON *json, uint32_t *jit_channel_id,
 /* --- Per-Leaf Advance messages (Upgrade 2) --- */
 
 cJSON *wire_build_leaf_advance_propose(int leaf_side,
-                                        const unsigned char *pubnonce66) {
+                                        const unsigned char *state_pubnonce66,
+                                        const unsigned char *poison_pubnonce66) {
     cJSON *j = cJSON_CreateObject();
     cJSON_AddNumberToObject(j, "leaf_side", leaf_side);
-    wire_json_add_hex(j, "pubnonce", pubnonce66, 66);
+    wire_json_add_hex(j, "pubnonce", state_pubnonce66, 66);
+    if (poison_pubnonce66)
+        wire_json_add_hex(j, "poison_pubnonce", poison_pubnonce66, 66);
     return j;
 }
 
+/* Returns: 0 on failure, 1 = state pubnonce parsed, 2 = state + poison parsed. */
 int wire_parse_leaf_advance_propose(const cJSON *json, int *leaf_side,
-                                      unsigned char *pubnonce66) {
+                                      unsigned char *state_pubnonce66,
+                                      unsigned char *poison_pubnonce66) {
     cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");
     if (!ls || !cJSON_IsNumber(ls)) return 0;
     *leaf_side = (int)ls->valuedouble;
-    if (wire_json_get_hex(json, "pubnonce", pubnonce66, 66) != 66) return 0;
+    if (wire_json_get_hex(json, "pubnonce", state_pubnonce66, 66) != 66) return 0;
+    if (poison_pubnonce66 &&
+        wire_json_get_hex(json, "poison_pubnonce", poison_pubnonce66, 66) == 66)
+        return 2;
     return 1;
 }
 
-cJSON *wire_build_leaf_advance_psig(const unsigned char *pubnonce66,
-                                      const unsigned char *partial_sig32) {
+cJSON *wire_build_leaf_advance_psig(const unsigned char *state_pubnonce66,
+                                      const unsigned char *state_partial_sig32,
+                                      const unsigned char *poison_pubnonce66,
+                                      const unsigned char *poison_partial_sig32) {
     cJSON *j = cJSON_CreateObject();
-    wire_json_add_hex(j, "pubnonce", pubnonce66, 66);
-    wire_json_add_hex(j, "partial_sig", partial_sig32, 32);
+    wire_json_add_hex(j, "pubnonce", state_pubnonce66, 66);
+    wire_json_add_hex(j, "partial_sig", state_partial_sig32, 32);
+    if (poison_pubnonce66 && poison_partial_sig32) {
+        wire_json_add_hex(j, "poison_pubnonce", poison_pubnonce66, 66);
+        wire_json_add_hex(j, "poison_partial_sig", poison_partial_sig32, 32);
+    }
     return j;
 }
 
+/* Returns: 0 on failure, 1 = state-only parsed, 2 = state + poison parsed. */
 int wire_parse_leaf_advance_psig(const cJSON *json,
-                                    unsigned char *pubnonce66,
-                                    unsigned char *partial_sig32) {
-    if (wire_json_get_hex(json, "pubnonce", pubnonce66, 66) != 66) return 0;
-    if (wire_json_get_hex(json, "partial_sig", partial_sig32, 32) != 32) return 0;
+                                    unsigned char *state_pubnonce66,
+                                    unsigned char *state_partial_sig32,
+                                    unsigned char *poison_pubnonce66,
+                                    unsigned char *poison_partial_sig32) {
+    if (wire_json_get_hex(json, "pubnonce", state_pubnonce66, 66) != 66) return 0;
+    if (wire_json_get_hex(json, "partial_sig", state_partial_sig32, 32) != 32) return 0;
+    if (poison_pubnonce66 && poison_partial_sig32 &&
+        wire_json_get_hex(json, "poison_pubnonce", poison_pubnonce66, 66) == 66 &&
+        wire_json_get_hex(json, "poison_partial_sig", poison_partial_sig32, 32) == 32)
+        return 2;
     return 1;
 }
 

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -4127,7 +4127,7 @@ int test_client_ps_double_spend_defense_refuses(void) {
     memset(lsp_seckey, 0, 32);
     unsigned char lsp_pubnonce_ser[66];
     musig_pubnonce_serialize(ctx, lsp_pubnonce_ser, &lsp_pubnonce);
-    cJSON *propose_json = wire_build_leaf_advance_propose(0, lsp_pubnonce_ser);
+    cJSON *propose_json = wire_build_leaf_advance_propose(0, lsp_pubnonce_ser, NULL);
     TEST_ASSERT(propose_json != NULL, "build PROPOSE json");
     wire_msg_t propose = {0};
     propose.msg_type = 0x58;  /* MSG_LEAF_ADVANCE_PROPOSE — unused after

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1727,7 +1727,7 @@ handle_message:
             int leaf_side;
             unsigned char lsp_pubnonce_ser[66];
             if (!wire_parse_leaf_advance_propose(msg.json, &leaf_side,
-                                                    lsp_pubnonce_ser)) {
+                                                    lsp_pubnonce_ser, NULL)) {
                 fprintf(stderr, "Client %u: bad LEAF_ADVANCE_PROPOSE\n", my_index);
                 cJSON_Delete(msg.json);
                 break;
@@ -1822,7 +1822,7 @@ handle_message:
             musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
 
             cJSON *psig_json = wire_build_leaf_advance_psig(
-                my_pubnonce_ser, my_psig_ser);
+                my_pubnonce_ser, my_psig_ser, NULL, NULL);
             wire_send(fd, MSG_LEAF_ADVANCE_PSIG, psig_json);
             cJSON_Delete(psig_json);
 


### PR DESCRIPTION
## Summary

Extends the wire-ceremony poison TX pattern from PR #136 (sub-factory advance) to `lsp_advance_leaf` (DW per-leaf and PS-leaf state advance).  This is the **default deployment shape** — every multi-process LSP that does any per-payment state update hits `lsp_advance_leaf`, which previously had the SECURITY GAP from PR #135 (factory_build_burn_tx returns NULL in multi-process mode).

After this PR:
- Multi-process LSPs running arity-1 (DW) or arity-PS (k=1) factories now produce a fully-signed L-stock poison TX via the second MuSig2 round bundled with each leaf advance ceremony
- Single-process LSPs (unit tests, `--demo`) keep the existing `factory_build_burn_tx` fallback for backward compatibility
- The watchtower receives a real signed poison TX (not NULL) on every advance — closes the SECURITY GAP for the leaf path

`lsp_realloc_leaf` (Tier B rotation re-sign) is the only remaining call site with the SECURITY GAP guard; that's the next follow-up PR.

### What changed
**Wire** (`include/superscalar/wire.h`, `src/wire.c`):
- `MSG_LEAF_ADVANCE_PROPOSE` extended with optional `poison_pubnonce` (LSP→client)
- `MSG_LEAF_ADVANCE_PSIG` extended with optional `poison_pubnonce` + `poison_partial_sig` (client→LSP)
- Parse helpers return `0`/`1`/`2` (failure / state-only / state+poison) so callers can detect protocol downgrade

**Factory** (`include/superscalar/factory.h`, `src/factory.c`):
- New helper `factory_session_prepare_poison_tx_leaf` (mirrors the subfactory variant, builds unsigned poison TX + sighash for the leaf node from the OLD L-stock UTXO snapshot)

**LSP** (`src/lsp_channels.c::lsp_advance_leaf`):
- Snapshots OLD leaf state (txid, n_outputs, l_stock amount) BEFORE the advance
- If sufficient L-stock + watchtower configured: prepares poison TX, runs second MuSig2 round in lockstep with state advance
- LSP gen 2 nonces (state + poison), bundles with PROPOSE
- Receives client's dual psig in PSIG
- Finalizes both sessions → completes both → poison_signed_tx populated
- Watchtower hook prefers wire-ceremony poison TX; falls back to single-process `factory_build_burn_tx` if all keypairs available; logs DEGRADED otherwise

**Client** (`src/client.c::client_handle_leaf_advance`):
- Snapshots OLD leaf state BEFORE the advance (same fields as LSP)
- If wire offers poison nonce: prepares poison TX deterministically (byte-identical to LSP), runs dual MuSig
- Sends bundled `state_pubnonce + state_psig + poison_pubnonce + poison_psig`

**Tests**:
- `tests/test_channels.c` and `tools/superscalar_client.c` updated for new wire signatures (pass NULL for poison fields where not exercised)
- All 1422 unit tests pass
- `tools/test_multiprocess_subfactory_advance.sh` (leaves use updated wire helpers) still passes

### Out of scope
- `lsp_realloc_leaf` (Tier B rotation) — same pattern, separate PR (`feat/wire-ceremony-poison-rotation`).  Estimated ~150 LOC.
- After all three call sites have wire-ceremony poison TX, the `lsp_have_all_signer_keypairs` helper can be deleted entirely along with the SECURITY GAP warnings — it'll be a cleanup PR.

## Test plan
- [x] All 1422 unit tests pass on VPS
- [x] `tools/test_multiprocess_subfactory_advance.sh` passes (uses extended wire helpers)
- [x] `tools/test_multiprocess_musig_n8.sh` passes (factory creation + force-close, uses arity-3 PS)
- [ ] CI: Linux + macOS + sanitizers + TSan + regtest + coverage + fuzz all green