### PR TITLE
wire-ceremony poison TX for lsp_realloc_leaf — Tier B per-leaf rotation

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -622,33 +622,48 @@ int wire_parse_path_sign_done(const cJSON *json, uint32_t *epoch_out);
 
 /* --- Leaf-Level Fund Reallocation message builders (Upgrade 3) --- */
 
-/* LSP → Clients: LEAF_REALLOC_PROPOSE {leaf_side, amounts[], pubnonce} */
+/* LSP → Clients: LEAF_REALLOC_PROPOSE {leaf_side, amounts[], pubnonce, [poison_pubnonce]}.
+   Optional poison_pubnonce closes Wire-Ceremony Gap A for Tier B
+   rotation — when present it accompanies the state pubnonce so a
+   second MuSig2 round runs in lockstep over the OLD leaf state's
+   L-stock poison TX sighash.  Pass NULL to skip.  Parse return value:
+   0 = failure, 1 = state-only parsed, 2 = state + poison parsed. */
 cJSON *wire_build_leaf_realloc_propose(int leaf_side,
                                         const uint64_t *amounts, size_t n_amounts,
-                                        const unsigned char *pubnonce66);
+                                        const unsigned char *state_pubnonce66,
+                                        const unsigned char *poison_pubnonce66);
 
 int wire_parse_leaf_realloc_propose(const cJSON *json, int *leaf_side,
                                       uint64_t *amounts, size_t max_amounts,
                                       size_t *n_amounts_out,
-                                      unsigned char *pubnonce66);
+                                      unsigned char *state_pubnonce66,
+                                      unsigned char *poison_pubnonce66);
 
-/* Client → LSP: LEAF_REALLOC_NONCE {pubnonce} */
-cJSON *wire_build_leaf_realloc_nonce(const unsigned char *pubnonce66);
+/* Client → LSP: LEAF_REALLOC_NONCE {pubnonce, [poison_pubnonce]} */
+cJSON *wire_build_leaf_realloc_nonce(const unsigned char *state_pubnonce66,
+                                       const unsigned char *poison_pubnonce66);
 
-int wire_parse_leaf_realloc_nonce(const cJSON *json, unsigned char *pubnonce66);
+int wire_parse_leaf_realloc_nonce(const cJSON *json,
+                                    unsigned char *state_pubnonce66,
+                                    unsigned char *poison_pubnonce66);
 
-/* LSP → Clients: LEAF_REALLOC_ALL_NONCES {pubnonces[3]} */
+/* LSP → Clients: LEAF_REALLOC_ALL_NONCES {pubnonces[], [poison_pubnonces[]]} */
 cJSON *wire_build_leaf_realloc_all_nonces(const unsigned char pubnonces[][66],
+                                            const unsigned char poison_pubnonces[][66],
                                             size_t n_signers);
 
 int wire_parse_leaf_realloc_all_nonces(const cJSON *json,
                                          unsigned char pubnonces_out[][66],
+                                         unsigned char poison_pubnonces_out[][66],
                                          size_t max_signers, size_t *n_out);
 
-/* Client → LSP: LEAF_REALLOC_PSIG {partial_sig} */
-cJSON *wire_build_leaf_realloc_psig(const unsigned char *partial_sig32);
+/* Client → LSP: LEAF_REALLOC_PSIG {partial_sig, [poison_partial_sig]} */
+cJSON *wire_build_leaf_realloc_psig(const unsigned char *state_psig32,
+                                      const unsigned char *poison_psig32);
 
-int wire_parse_leaf_realloc_psig(const cJSON *json, unsigned char *partial_sig32);
+int wire_parse_leaf_realloc_psig(const cJSON *json,
+                                   unsigned char *state_psig32,
+                                   unsigned char *poison_psig32);
 
 /* LSP → Clients: LEAF_REALLOC_DONE {leaf_side, amounts[]} */
 cJSON *wire_build_leaf_realloc_done(int leaf_side,

--- a/src/client.c
+++ b/src/client.c
@@ -2501,36 +2501,75 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
                                 factory_t *factory,
                                 uint32_t my_index,
                                 const wire_msg_t *propose_msg) {
-    /* Parse REALLOC_PROPOSE */
+    /* Parse REALLOC_PROPOSE (state + optional poison nonce) */
     int leaf_side;
     uint64_t amounts[FACTORY_MAX_OUTPUTS];
     size_t n_amounts;
-    unsigned char lsp_pubnonce_ser[66];
+    unsigned char lsp_pubnonce_ser[66], lsp_poison_pn_ser[66];
 
-    if (!wire_parse_leaf_realloc_propose(propose_msg->json, &leaf_side,
-                                          amounts, FACTORY_MAX_OUTPUTS,
-                                          &n_amounts, lsp_pubnonce_ser)) {
+    int propose_rc = wire_parse_leaf_realloc_propose(propose_msg->json, &leaf_side,
+                                                       amounts, FACTORY_MAX_OUTPUTS,
+                                                       &n_amounts, lsp_pubnonce_ser,
+                                                       lsp_poison_pn_ser);
+    if (propose_rc == 0) {
         fprintf(stderr, "Client %u: failed to parse REALLOC_PROPOSE\n", my_index);
         return 0;
+    }
+    int wire_poison_offered = (propose_rc == 2);
+
+    /* Snapshot OLD leaf state BEFORE the realloc — needed to deterministically
+       prep the wire-ceremony poison TX in lockstep with the LSP. */
+    if (leaf_side < 0 || leaf_side >= factory->n_leaf_nodes) return 0;
+    size_t pre_node_idx_r = factory->leaf_node_indices[leaf_side];
+    factory_node_t *pre_leaf_r = &factory->nodes[pre_node_idx_r];
+    unsigned char pre_old_leaf_txid_r[32];
+    memcpy(pre_old_leaf_txid_r, pre_leaf_r->txid, 32);
+    int pre_old_n_outputs_r = pre_leaf_r->n_outputs;
+    uint64_t pre_old_l_amount_r = (pre_old_n_outputs_r >= 2)
+                                  ? pre_leaf_r->outputs[pre_old_n_outputs_r - 1].amount_sats
+                                  : 0;
+    int pre_had_signed_r = (pre_leaf_r->is_signed && pre_leaf_r->signed_tx.len > 0);
+
+    const uint64_t REALLOC_POISON_FEE_SATS = 1000;
+    int realloc_poison_prepared = 0;
+    if (wire_poison_offered && pre_had_signed_r && pre_old_n_outputs_r >= 2 &&
+        pre_old_l_amount_r > REALLOC_POISON_FEE_SATS +
+                             (uint64_t)(pre_leaf_r->n_signers - 1) * 330u) {
+        if (factory_session_prepare_poison_tx_leaf(
+                factory, pre_node_idx_r,
+                pre_old_leaf_txid_r, (uint32_t)(pre_old_n_outputs_r - 1),
+                pre_old_l_amount_r, REALLOC_POISON_FEE_SATS)) {
+            realloc_poison_prepared = 1;
+        }
     }
 
     /* Advance local DW + set amounts */
     int rc = factory_advance_leaf_unsigned(factory, leaf_side);
     if (rc <= 0) {
         fprintf(stderr, "Client %u: leaf advance for realloc failed\n", my_index);
+        factory_session_reset_poison(factory, pre_node_idx_r);
         return 0;
     }
     if (!factory_set_leaf_amounts(factory, leaf_side, amounts, n_amounts)) {
         fprintf(stderr, "Client %u: set_leaf_amounts failed\n", my_index);
+        factory_session_reset_poison(factory, pre_node_idx_r);
         return 0;
     }
 
     size_t node_idx = factory->leaf_node_indices[leaf_side];
 
-    /* Init signing session for this node */
+    /* Init both signing sessions */
     if (!factory_session_init_node(factory, node_idx)) {
-        fprintf(stderr, "Client %u: realloc session_init_node failed (node %zu)\n", my_index, node_idx);
+        fprintf(stderr, "Client %u: realloc state session_init_node failed (node %zu)\n",
+                my_index, node_idx);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (realloc_poison_prepared &&
+        !factory_session_init_node_poison(factory, node_idx)) {
+        fprintf(stderr, "Client %u: realloc poison session_init failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        realloc_poison_prepared = 0;
     }
 
     /* NOTE: Do NOT set the LSP nonce here.  The ALL_NONCES message
@@ -2553,94 +2592,159 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
         return 0;
     }
 
+    /* Set LSP nonces (state + poison if offered) */
+    int lsp_slot_r = factory_find_signer_slot(factory, node_idx, 0);
+    if (lsp_slot_r < 0) {
+        memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
+        return 0;
+    }
+    /* (LSP nonce will be set via ALL_NONCES below — same as before) */
+
     secp256k1_pubkey my_pubkey;
     secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
 
-    secp256k1_musig_secnonce my_secnonce;
-    secp256k1_musig_pubnonce my_pubnonce;
+    secp256k1_musig_secnonce my_secnonce, my_poison_secnonce;
+    secp256k1_musig_pubnonce my_pubnonce, my_poison_pubnonce;
     if (!musig_generate_nonce(ctx, &my_secnonce, &my_pubnonce,
                                my_seckey, &my_pubkey,
                                &factory->nodes[node_idx].keyagg.cache)) {
-        fprintf(stderr, "Client %u: realloc nonce_gen failed\n", my_index);
+        fprintf(stderr, "Client %u: realloc state nonce_gen failed\n", my_index);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (realloc_poison_prepared &&
+        !musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                my_seckey, &my_pubkey,
+                                &factory->nodes[node_idx].keyagg.cache)) {
+        fprintf(stderr, "Client %u: realloc poison nonce_gen failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        realloc_poison_prepared = 0;
+    }
 
-    /* Send REALLOC_NONCE */
-    unsigned char my_pubnonce_ser[66];
+    /* Send REALLOC_NONCE (state + optional poison) */
+    unsigned char my_pubnonce_ser[66], my_poison_pn_ser[66];
     musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
-    cJSON *nonce_msg = wire_build_leaf_realloc_nonce(my_pubnonce_ser);
+    if (realloc_poison_prepared)
+        musig_pubnonce_serialize(ctx, my_poison_pn_ser, &my_poison_pubnonce);
+    cJSON *nonce_msg = wire_build_leaf_realloc_nonce(
+        my_pubnonce_ser, realloc_poison_prepared ? my_poison_pn_ser : NULL);
     if (!wire_send(fd, MSG_LEAF_REALLOC_NONCE, nonce_msg)) {
         fprintf(stderr, "Client %u: realloc send NONCE failed\n", my_index);
         cJSON_Delete(nonce_msg);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
     cJSON_Delete(nonce_msg);
 
-    /* Receive REALLOC_ALL_NONCES */
+    /* Receive REALLOC_ALL_NONCES (state + optional poison) */
     wire_msg_t all_msg;
     if (!wire_recv(fd, &all_msg) || all_msg.msg_type != MSG_LEAF_REALLOC_ALL_NONCES) {
         fprintf(stderr, "Client %u: expected REALLOC_ALL_NONCES, got 0x%02x\n",
                 my_index, all_msg.msg_type);
         if (all_msg.json) cJSON_Delete(all_msg.json);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
 
     unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
     size_t n_signers;
-    if (!wire_parse_leaf_realloc_all_nonces(all_msg.json, all_pubnonces,
-                                              FACTORY_MAX_SIGNERS, &n_signers)) {
+    int an_parse_rc = wire_parse_leaf_realloc_all_nonces(
+        all_msg.json, all_pubnonces,
+        realloc_poison_prepared ? all_poison_pubnonces : NULL,
+        FACTORY_MAX_SIGNERS, &n_signers);
+    cJSON_Delete(all_msg.json);
+    if (an_parse_rc == 0) {
         fprintf(stderr, "Client %u: realloc parse all_nonces failed\n", my_index);
-        cJSON_Delete(all_msg.json);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
-    cJSON_Delete(all_msg.json);
+    if (realloc_poison_prepared && an_parse_rc < 2) {
+        factory_session_reset_poison(factory, node_idx);
+        realloc_poison_prepared = 0;
+    }
 
-    /* Set all nonces */
+    /* Set all nonces (state + poison if prepared) */
     for (size_t i = 0; i < n_signers; i++) {
         secp256k1_musig_pubnonce pn;
         if (!musig_pubnonce_parse(ctx, &pn, all_pubnonces[i])) {
             fprintf(stderr, "Client %u: realloc parse nonce[%zu] failed\n", my_index, i);
             memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, node_idx);
             return 0;
         }
         if (!factory_session_set_nonce(factory, node_idx, i, &pn)) {
             fprintf(stderr, "Client %u: realloc set_nonce[%zu] failed\n", my_index, i);
             memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, node_idx);
             return 0;
+        }
+        if (realloc_poison_prepared) {
+            secp256k1_musig_pubnonce ppn;
+            if (!musig_pubnonce_parse(ctx, &ppn, all_poison_pubnonces[i]) ||
+                !factory_session_set_nonce_poison(factory, node_idx, i, &ppn)) {
+                fprintf(stderr, "Client %u: realloc poison set_nonce[%zu] failed — degrading\n",
+                        my_index, i);
+                factory_session_reset_poison(factory, node_idx);
+                realloc_poison_prepared = 0;
+            }
         }
     }
 
-    /* Finalize */
+    /* Finalize both sessions */
     if (!factory_session_finalize_node(factory, node_idx)) {
-        fprintf(stderr, "Client %u: realloc session_finalize failed (node %zu)\n", my_index, node_idx);
+        fprintf(stderr, "Client %u: realloc state session_finalize failed (node %zu)\n",
+                my_index, node_idx);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (realloc_poison_prepared &&
+        !factory_session_finalize_node_poison(factory, node_idx)) {
+        fprintf(stderr, "Client %u: realloc poison session_finalize failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
+        realloc_poison_prepared = 0;
+    }
 
-    /* Create partial sig */
-    secp256k1_musig_partial_sig my_psig;
+    /* Create partial sigs (state + poison if prepared) */
+    secp256k1_musig_partial_sig my_psig, my_poison_psig;
     if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonce, keypair,
                                     &factory->nodes[node_idx].signing_session)) {
-        fprintf(stderr, "Client %u: realloc partial_sig creation failed\n", my_index);
+        fprintf(stderr, "Client %u: realloc state partial_sig creation failed\n", my_index);
         memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (realloc_poison_prepared &&
+        !musig_create_partial_sig(ctx, &my_poison_psig, &my_poison_secnonce, keypair,
+                                    &factory->nodes[node_idx].poison_signing_session)) {
+        fprintf(stderr, "Client %u: realloc poison partial_sig creation failed — degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        realloc_poison_prepared = 0;
     }
     memset(my_seckey, 0, 32);
 
-    /* Send REALLOC_PSIG */
-    unsigned char my_psig_ser[32];
+    /* Send REALLOC_PSIG (state + poison if prepared) */
+    unsigned char my_psig_ser[32], my_poison_psig_ser[32];
     musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
-    cJSON *psig_json = wire_build_leaf_realloc_psig(my_psig_ser);
+    if (realloc_poison_prepared)
+        musig_partial_sig_serialize(ctx, my_poison_psig_ser, &my_poison_psig);
+    cJSON *psig_json = wire_build_leaf_realloc_psig(
+        my_psig_ser, realloc_poison_prepared ? my_poison_psig_ser : NULL);
     if (!wire_send(fd, MSG_LEAF_REALLOC_PSIG, psig_json)) {
         fprintf(stderr, "Client %u: realloc wire_send PSIG failed\n", my_index);
         cJSON_Delete(psig_json);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
     cJSON_Delete(psig_json);
+    factory_session_reset_poison(factory, node_idx);
 
     /* Receive REALLOC_DONE */
     wire_msg_t done_msg;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2295,6 +2295,29 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
+    /* Snapshot OLD leaf state BEFORE the realloc — needed to deterministically
+       prep the wire-ceremony poison TX (closes Wire-Ceremony Gap A for Tier B
+       rotation). */
+    unsigned char realloc_old_leaf_txid[32];
+    memcpy(realloc_old_leaf_txid, node->txid, 32);
+    int realloc_old_n_outputs = node->n_outputs;
+    uint64_t realloc_old_l_amount = (realloc_old_n_outputs >= 2)
+        ? node->outputs[realloc_old_n_outputs - 1].amount_sats : 0;
+    int realloc_had_signed = (node->is_signed && node->signed_tx.len > 0);
+
+    const uint64_t REALLOC_POISON_FEE_SATS = 1000;
+    int realloc_poison_prepared = 0;
+    if (mgr->watchtower && realloc_had_signed && realloc_old_n_outputs >= 2 &&
+        realloc_old_l_amount > REALLOC_POISON_FEE_SATS +
+                               (uint64_t)(node->n_signers - 1) * 330u) {
+        if (factory_session_prepare_poison_tx_leaf(
+                f, node_idx,
+                realloc_old_leaf_txid, (uint32_t)(realloc_old_n_outputs - 1),
+                realloc_old_l_amount, REALLOC_POISON_FEE_SATS)) {
+            realloc_poison_prepared = 1;
+        }
+    }
+
     /* Step 1: Advance DW counter + rebuild unsigned tx */
     int rc = factory_advance_leaf_unsigned(f, leaf_side);
     if (rc == 0) {
@@ -2313,57 +2336,91 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
-    /* Step 3: Init signing session for the leaf node */
+    /* Step 3: Init BOTH signing sessions (state + poison if prepared). */
     if (!factory_session_init_node(f, node_idx)) {
-        fprintf(stderr, "LSP realloc: session init failed for node %zu\n", node_idx);
+        fprintf(stderr, "LSP realloc: state session init failed for node %zu\n", node_idx);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (realloc_poison_prepared &&
+        !factory_session_init_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP realloc: poison session init failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        realloc_poison_prepared = 0;
+    }
 
-    /* Step 4: Generate LSP's nonce (participant 0) */
+    /* Step 4: Generate LSP's nonces (state + poison — MUST be distinct) */
     int lsp_slot = factory_find_signer_slot(f, node_idx, 0);
     if (lsp_slot < 0) {
         fprintf(stderr, "LSP realloc: LSP not signer on node %zu\n", node_idx);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
 
     unsigned char lsp_seckey[32];
-    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair))
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) {
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
 
-    secp256k1_musig_secnonce lsp_secnonce;
-    secp256k1_musig_pubnonce lsp_pubnonce;
+    secp256k1_musig_secnonce lsp_secnonce, lsp_poison_secnonce;
+    secp256k1_musig_pubnonce lsp_pubnonce, lsp_poison_pubnonce;
     if (!musig_generate_nonce(lsp->ctx, &lsp_secnonce, &lsp_pubnonce,
                                lsp_seckey, &lsp->lsp_pubkey,
                                &node->keyagg.cache)) {
         memset(lsp_seckey, 0, 32);
-        fprintf(stderr, "LSP realloc: nonce gen failed\n");
+        factory_session_reset_poison(f, node_idx);
+        fprintf(stderr, "LSP realloc: state nonce gen failed\n");
         return 0;
+    }
+    if (realloc_poison_prepared &&
+        !musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce, &lsp_poison_pubnonce,
+                                lsp_seckey, &lsp->lsp_pubkey,
+                                &node->keyagg.cache)) {
+        fprintf(stderr, "LSP realloc: poison nonce gen failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        realloc_poison_prepared = 0;
     }
 
     if (!factory_session_set_nonce(f, node_idx, (size_t)lsp_slot, &lsp_pubnonce)) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (realloc_poison_prepared &&
+        !factory_session_set_nonce_poison(f, node_idx, (size_t)lsp_slot,
+                                            &lsp_poison_pubnonce)) {
+        fprintf(stderr, "LSP realloc: set LSP poison nonce failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        realloc_poison_prepared = 0;
+    }
 
-    /* Step 5: Send REALLOC_PROPOSE to all clients on this leaf */
-    unsigned char lsp_pubnonce_ser[66];
+    /* Step 5: Send REALLOC_PROPOSE (state + optional poison nonce). */
+    unsigned char lsp_pubnonce_ser[66], lsp_poison_pn_ser[66];
     musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
-    cJSON *propose = wire_build_leaf_realloc_propose(leaf_side, amounts, n_amounts,
-                                                      lsp_pubnonce_ser);
+    if (realloc_poison_prepared)
+        musig_pubnonce_serialize(lsp->ctx, lsp_poison_pn_ser, &lsp_poison_pubnonce);
+    cJSON *propose = wire_build_leaf_realloc_propose(
+        leaf_side, amounts, n_amounts, lsp_pubnonce_ser,
+        realloc_poison_prepared ? lsp_poison_pn_ser : NULL);
     for (size_t ci = 0; ci < n_clients; ci++) {
         /* client_fds indexed by client_idx - 1 (participant_idx 1-based) */
         size_t fd_idx = (size_t)(clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_LEAF_REALLOC_PROPOSE, propose)) {
             cJSON_Delete(propose);
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
     }
     cJSON_Delete(propose);
 
-    /* Step 6: Recv REALLOC_NONCE from each client, set their nonces */
+    /* Step 6: Recv REALLOC_NONCE from each client, set their nonces (state + poison). */
     unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
     memcpy(all_pubnonces[lsp_slot], lsp_pubnonce_ser, 66);
+    if (realloc_poison_prepared)
+        memcpy(all_poison_pubnonces[lsp_slot], lsp_poison_pn_ser, 66);
 
     for (size_t ci = 0; ci < n_clients; ci++) {
         size_t fd_idx = (size_t)(clients[ci] - 1);
@@ -2374,74 +2431,125 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                     clients[ci], nonce_msg.msg_type);
             if (nonce_msg.json) cJSON_Delete(nonce_msg.json);
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
 
-        unsigned char client_pn_ser[66];
-        if (!wire_parse_leaf_realloc_nonce(nonce_msg.json, client_pn_ser)) {
+        unsigned char client_pn_ser[66], client_poison_pn_ser[66];
+        int n_parse_rc = wire_parse_leaf_realloc_nonce(
+            nonce_msg.json, client_pn_ser,
+            realloc_poison_prepared ? client_poison_pn_ser : NULL);
+        cJSON_Delete(nonce_msg.json);
+        if (n_parse_rc == 0) {
             fprintf(stderr, "LSP realloc: failed to parse REALLOC_NONCE\n");
-            cJSON_Delete(nonce_msg.json);
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
-        cJSON_Delete(nonce_msg.json);
+        if (realloc_poison_prepared && n_parse_rc < 2) {
+            fprintf(stderr, "LSP realloc: client %u omitted poison nonce — degrading\n",
+                    clients[ci]);
+            factory_session_reset_poison(f, node_idx);
+            realloc_poison_prepared = 0;
+        }
 
         int client_slot = factory_find_signer_slot(f, node_idx, clients[ci]);
         if (client_slot < 0) {
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
 
         secp256k1_musig_pubnonce client_pubnonce;
         if (!musig_pubnonce_parse(lsp->ctx, &client_pubnonce, client_pn_ser)) {
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
         if (!factory_session_set_nonce(f, node_idx, (size_t)client_slot, &client_pubnonce)) {
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
         memcpy(all_pubnonces[client_slot], client_pn_ser, 66);
+
+        if (realloc_poison_prepared) {
+            secp256k1_musig_pubnonce client_poison_pn;
+            if (!musig_pubnonce_parse(lsp->ctx, &client_poison_pn, client_poison_pn_ser) ||
+                !factory_session_set_nonce_poison(f, node_idx, (size_t)client_slot,
+                                                    &client_poison_pn)) {
+                fprintf(stderr, "LSP realloc: parse/set client %u poison nonce failed — degrading\n",
+                        clients[ci]);
+                factory_session_reset_poison(f, node_idx);
+                realloc_poison_prepared = 0;
+            } else {
+                memcpy(all_poison_pubnonces[client_slot], client_poison_pn_ser, 66);
+            }
+        }
     }
 
-    /* Step 7: Send REALLOC_ALL_NONCES to all clients on this leaf */
+    /* Step 7: Send REALLOC_ALL_NONCES (state + optional poison). */
     cJSON *all_nonces = wire_build_leaf_realloc_all_nonces(
-        (const unsigned char (*)[66])all_pubnonces, node->n_signers);
+        (const unsigned char (*)[66])all_pubnonces,
+        realloc_poison_prepared ? (const unsigned char (*)[66])all_poison_pubnonces : NULL,
+        node->n_signers);
     for (size_t ci = 0; ci < n_clients; ci++) {
         size_t fd_idx = (size_t)(clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_LEAF_REALLOC_ALL_NONCES, all_nonces)) {
             cJSON_Delete(all_nonces);
             memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
     }
     cJSON_Delete(all_nonces);
 
-    /* Step 8: Finalize nonces */
+    /* Step 8: Finalize both sessions. */
     if (!factory_session_finalize_node(f, node_idx)) {
-        fprintf(stderr, "LSP realloc: session finalize failed for node %zu\n", node_idx);
+        fprintf(stderr, "LSP realloc: state session finalize failed for node %zu\n", node_idx);
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (realloc_poison_prepared &&
+        !factory_session_finalize_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP realloc: poison finalize failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        realloc_poison_prepared = 0;
+    }
 
-    /* Step 9: Create LSP's partial sig */
+    /* Step 9: Create LSP's partial sigs (state + poison if prepared). */
     secp256k1_keypair lsp_kp;
     if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
         memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
     memset(lsp_seckey, 0, 32);
 
-    secp256k1_musig_partial_sig lsp_psig;
+    secp256k1_musig_partial_sig lsp_psig, lsp_poison_psig;
     if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
                                     &node->signing_session)) {
-        fprintf(stderr, "LSP realloc: partial sig failed\n");
+        fprintf(stderr, "LSP realloc: state partial sig failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
-    if (!factory_session_set_partial_sig(f, node_idx, (size_t)lsp_slot, &lsp_psig))
+    if (!factory_session_set_partial_sig(f, node_idx, (size_t)lsp_slot, &lsp_psig)) {
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (realloc_poison_prepared) {
+        if (!musig_create_partial_sig(lsp->ctx, &lsp_poison_psig, &lsp_poison_secnonce, &lsp_kp,
+                                        &node->poison_signing_session) ||
+            !factory_session_set_partial_sig_poison(f, node_idx, (size_t)lsp_slot,
+                                                     &lsp_poison_psig)) {
+            fprintf(stderr, "LSP realloc: poison psig create/set failed — degrading\n");
+            factory_session_reset_poison(f, node_idx);
+            realloc_poison_prepared = 0;
+        }
+    }
 
-    /* Step 10: Recv REALLOC_PSIG from each client */
+    /* Step 10: Recv REALLOC_PSIG from each client (state + poison). */
     for (size_t ci = 0; ci < n_clients; ci++) {
         size_t fd_idx = (size_t)(clients[ci] - 1);
         wire_msg_t psig_msg;
@@ -2450,30 +2558,65 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             fprintf(stderr, "LSP realloc: expected REALLOC_PSIG from client %u, got 0x%02x\n",
                     clients[ci], psig_msg.msg_type);
             if (psig_msg.json) cJSON_Delete(psig_msg.json);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
 
-        unsigned char client_psig_ser[32];
-        if (!wire_parse_leaf_realloc_psig(psig_msg.json, client_psig_ser)) {
+        unsigned char client_psig_ser[32], client_poison_psig_ser[32];
+        int p_parse_rc = wire_parse_leaf_realloc_psig(
+            psig_msg.json, client_psig_ser,
+            realloc_poison_prepared ? client_poison_psig_ser : NULL);
+        cJSON_Delete(psig_msg.json);
+        if (p_parse_rc == 0) {
             fprintf(stderr, "LSP realloc: failed to parse REALLOC_PSIG\n");
-            cJSON_Delete(psig_msg.json);
+            factory_session_reset_poison(f, node_idx);
             return 0;
         }
-        cJSON_Delete(psig_msg.json);
+        if (realloc_poison_prepared && p_parse_rc < 2) {
+            fprintf(stderr, "LSP realloc: client %u omitted poison psig — degrading\n",
+                    clients[ci]);
+            factory_session_reset_poison(f, node_idx);
+            realloc_poison_prepared = 0;
+        }
 
         int client_slot = factory_find_signer_slot(f, node_idx, clients[ci]);
-        if (client_slot < 0) return 0;
+        if (client_slot < 0) {
+            factory_session_reset_poison(f, node_idx);
+            return 0;
+        }
 
         secp256k1_musig_partial_sig client_psig;
-        if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_ser))
+        if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_ser)) {
+            factory_session_reset_poison(f, node_idx);
             return 0;
-        if (!factory_session_set_partial_sig(f, node_idx, (size_t)client_slot, &client_psig))
+        }
+        if (!factory_session_set_partial_sig(f, node_idx, (size_t)client_slot, &client_psig)) {
+            factory_session_reset_poison(f, node_idx);
             return 0;
+        }
+        if (realloc_poison_prepared) {
+            secp256k1_musig_partial_sig client_poison_psig;
+            if (!musig_partial_sig_parse(lsp->ctx, &client_poison_psig, client_poison_psig_ser) ||
+                !factory_session_set_partial_sig_poison(f, node_idx, (size_t)client_slot,
+                                                         &client_poison_psig)) {
+                fprintf(stderr, "LSP realloc: parse/set client %u poison psig failed — degrading\n",
+                        clients[ci]);
+                factory_session_reset_poison(f, node_idx);
+                realloc_poison_prepared = 0;
+            }
+        }
     }
 
-    /* Step 11: Aggregate + finalize */
+    /* Step 11: Aggregate + finalize both signed TXs. */
+    if (realloc_poison_prepared &&
+        !factory_session_complete_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP realloc: poison complete failed — degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        realloc_poison_prepared = 0;
+    }
     if (!factory_session_complete_node(f, node_idx)) {
-        fprintf(stderr, "LSP realloc: session complete failed for node %zu\n", node_idx);
+        fprintf(stderr, "LSP realloc: state session complete failed for node %zu\n", node_idx);
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -1642,20 +1642,25 @@ int wire_parse_leaf_advance_done(const cJSON *json, int *leaf_side) {
 
 cJSON *wire_build_leaf_realloc_propose(int leaf_side,
                                         const uint64_t *amounts, size_t n_amounts,
-                                        const unsigned char *pubnonce66) {
+                                        const unsigned char *state_pubnonce66,
+                                        const unsigned char *poison_pubnonce66) {
     cJSON *j = cJSON_CreateObject();
     cJSON_AddNumberToObject(j, "leaf_side", leaf_side);
     cJSON *arr = cJSON_AddArrayToObject(j, "amounts");
     for (size_t i = 0; i < n_amounts; i++)
         cJSON_AddItemToArray(arr, cJSON_CreateNumber((double)amounts[i]));
-    wire_json_add_hex(j, "pubnonce", pubnonce66, 66);
+    wire_json_add_hex(j, "pubnonce", state_pubnonce66, 66);
+    if (poison_pubnonce66)
+        wire_json_add_hex(j, "poison_pubnonce", poison_pubnonce66, 66);
     return j;
 }
 
+/* Returns: 0 = failure, 1 = state-only parsed, 2 = state + poison parsed. */
 int wire_parse_leaf_realloc_propose(const cJSON *json, int *leaf_side,
                                       uint64_t *amounts, size_t max_amounts,
                                       size_t *n_amounts_out,
-                                      unsigned char *pubnonce66) {
+                                      unsigned char *state_pubnonce66,
+                                      unsigned char *poison_pubnonce66) {
     cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");
     if (!ls || !cJSON_IsNumber(ls)) return 0;
     *leaf_side = (int)ls->valuedouble;
@@ -1671,22 +1676,34 @@ int wire_parse_leaf_realloc_propose(const cJSON *json, int *leaf_side,
     }
     *n_amounts_out = n;
 
-    if (wire_json_get_hex(json, "pubnonce", pubnonce66, 66) != 66) return 0;
+    if (wire_json_get_hex(json, "pubnonce", state_pubnonce66, 66) != 66) return 0;
+    if (poison_pubnonce66 &&
+        wire_json_get_hex(json, "poison_pubnonce", poison_pubnonce66, 66) == 66)
+        return 2;
     return 1;
 }
 
-cJSON *wire_build_leaf_realloc_nonce(const unsigned char *pubnonce66) {
+cJSON *wire_build_leaf_realloc_nonce(const unsigned char *state_pubnonce66,
+                                       const unsigned char *poison_pubnonce66) {
     cJSON *j = cJSON_CreateObject();
-    wire_json_add_hex(j, "pubnonce", pubnonce66, 66);
+    wire_json_add_hex(j, "pubnonce", state_pubnonce66, 66);
+    if (poison_pubnonce66)
+        wire_json_add_hex(j, "poison_pubnonce", poison_pubnonce66, 66);
     return j;
 }
 
-int wire_parse_leaf_realloc_nonce(const cJSON *json, unsigned char *pubnonce66) {
-    if (wire_json_get_hex(json, "pubnonce", pubnonce66, 66) != 66) return 0;
+int wire_parse_leaf_realloc_nonce(const cJSON *json,
+                                    unsigned char *state_pubnonce66,
+                                    unsigned char *poison_pubnonce66) {
+    if (wire_json_get_hex(json, "pubnonce", state_pubnonce66, 66) != 66) return 0;
+    if (poison_pubnonce66 &&
+        wire_json_get_hex(json, "poison_pubnonce", poison_pubnonce66, 66) == 66)
+        return 2;
     return 1;
 }
 
 cJSON *wire_build_leaf_realloc_all_nonces(const unsigned char pubnonces[][66],
+                                            const unsigned char poison_pubnonces[][66],
                                             size_t n_signers) {
     cJSON *j = cJSON_CreateObject();
     cJSON *arr = cJSON_AddArrayToObject(j, "pubnonces");
@@ -1695,11 +1712,19 @@ cJSON *wire_build_leaf_realloc_all_nonces(const unsigned char pubnonces[][66],
         hex_encode(pubnonces[i], 66, hex);
         cJSON_AddItemToArray(arr, cJSON_CreateString(hex));
     }
+    if (poison_pubnonces) {
+        cJSON *parr = cJSON_AddArrayToObject(j, "poison_pubnonces");
+        for (size_t i = 0; i < n_signers; i++) {
+            hex_encode(poison_pubnonces[i], 66, hex);
+            cJSON_AddItemToArray(parr, cJSON_CreateString(hex));
+        }
+    }
     return j;
 }
 
 int wire_parse_leaf_realloc_all_nonces(const cJSON *json,
                                          unsigned char pubnonces_out[][66],
+                                         unsigned char poison_pubnonces_out[][66],
                                          size_t max_signers, size_t *n_out) {
     cJSON *arr = cJSON_GetObjectItem(json, "pubnonces");
     if (!arr || !cJSON_IsArray(arr)) return 0;
@@ -1711,17 +1736,39 @@ int wire_parse_leaf_realloc_all_nonces(const cJSON *json,
         if (hex_decode(item->valuestring, pubnonces_out[i], 66) != 66) return 0;
     }
     *n_out = n;
+
+    if (poison_pubnonces_out) {
+        cJSON *parr = cJSON_GetObjectItem(json, "poison_pubnonces");
+        if (parr && cJSON_IsArray(parr) &&
+            (size_t)cJSON_GetArraySize(parr) == n) {
+            for (size_t i = 0; i < n; i++) {
+                cJSON *item = cJSON_GetArrayItem(parr, (int)i);
+                if (!item || !cJSON_IsString(item)) return 1;
+                if (hex_decode(item->valuestring, poison_pubnonces_out[i], 66) != 66)
+                    return 1;
+            }
+            return 2;
+        }
+    }
     return 1;
 }
 
-cJSON *wire_build_leaf_realloc_psig(const unsigned char *partial_sig32) {
+cJSON *wire_build_leaf_realloc_psig(const unsigned char *state_psig32,
+                                      const unsigned char *poison_psig32) {
     cJSON *j = cJSON_CreateObject();
-    wire_json_add_hex(j, "partial_sig", partial_sig32, 32);
+    wire_json_add_hex(j, "partial_sig", state_psig32, 32);
+    if (poison_psig32)
+        wire_json_add_hex(j, "poison_partial_sig", poison_psig32, 32);
     return j;
 }
 
-int wire_parse_leaf_realloc_psig(const cJSON *json, unsigned char *partial_sig32) {
-    if (wire_json_get_hex(json, "partial_sig", partial_sig32, 32) != 32) return 0;
+int wire_parse_leaf_realloc_psig(const cJSON *json,
+                                   unsigned char *state_psig32,
+                                   unsigned char *poison_psig32) {
+    if (wire_json_get_hex(json, "partial_sig", state_psig32, 32) != 32) return 0;
+    if (poison_psig32 &&
+        wire_json_get_hex(json, "poison_partial_sig", poison_psig32, 32) == 32)
+        return 2;
     return 1;
 }
 

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -1497,7 +1497,7 @@ int test_wire_leaf_realloc(void) {
     unsigned char pubnonce[66];
     memset(pubnonce, 0xAB, 66);
 
-    cJSON *propose = wire_build_leaf_realloc_propose(1, amounts, 3, pubnonce);
+    cJSON *propose = wire_build_leaf_realloc_propose(1, amounts, 3, pubnonce, NULL);
     TEST_ASSERT(propose != NULL, "build realloc_propose");
 
     int ls_out;
@@ -1505,7 +1505,7 @@ int test_wire_leaf_realloc(void) {
     size_t n_out;
     unsigned char pn_out[66];
     TEST_ASSERT(wire_parse_leaf_realloc_propose(propose, &ls_out,
-                amounts_out, 8, &n_out, pn_out), "parse realloc_propose");
+                amounts_out, 8, &n_out, pn_out, NULL), "parse realloc_propose");
     TEST_ASSERT_EQ(ls_out, 1, "leaf_side");
     TEST_ASSERT_EQ((long)n_out, 3, "n_amounts");
     TEST_ASSERT_EQ((long)amounts_out[0], 20000, "amount[0]");
@@ -1517,10 +1517,11 @@ int test_wire_leaf_realloc(void) {
     /* NONCE round-trip */
     unsigned char nonce_in[66];
     memset(nonce_in, 0xCD, 66);
-    cJSON *nonce = wire_build_leaf_realloc_nonce(nonce_in);
+    cJSON *nonce = wire_build_leaf_realloc_nonce(nonce_in, NULL);
     TEST_ASSERT(nonce != NULL, "build realloc_nonce");
     unsigned char nonce_out[66];
-    TEST_ASSERT(wire_parse_leaf_realloc_nonce(nonce, nonce_out), "parse realloc_nonce");
+    TEST_ASSERT(wire_parse_leaf_realloc_nonce(nonce, nonce_out, NULL),
+                "parse realloc_nonce");
     TEST_ASSERT_MEM_EQ(nonce_out, nonce_in, 66, "nonce round-trip");
     cJSON_Delete(nonce);
 
@@ -1529,11 +1530,11 @@ int test_wire_leaf_realloc(void) {
     memset(pns[0], 0x11, 66);
     memset(pns[1], 0x22, 66);
     memset(pns[2], 0x33, 66);
-    cJSON *all = wire_build_leaf_realloc_all_nonces(pns, 3);
+    cJSON *all = wire_build_leaf_realloc_all_nonces(pns, NULL, 3);
     TEST_ASSERT(all != NULL, "build realloc_all_nonces");
     unsigned char pns_out[4][66];
     size_t n_pns;
-    TEST_ASSERT(wire_parse_leaf_realloc_all_nonces(all, pns_out, 4, &n_pns),
+    TEST_ASSERT(wire_parse_leaf_realloc_all_nonces(all, pns_out, NULL, 4, &n_pns),
                 "parse realloc_all_nonces");
     TEST_ASSERT_EQ((long)n_pns, 3, "n_signers");
     TEST_ASSERT_MEM_EQ(pns_out[0], pns[0], 66, "pubnonce[0]");
@@ -1544,10 +1545,11 @@ int test_wire_leaf_realloc(void) {
     /* PSIG round-trip */
     unsigned char psig_in[32];
     memset(psig_in, 0xEE, 32);
-    cJSON *psig = wire_build_leaf_realloc_psig(psig_in);
+    cJSON *psig = wire_build_leaf_realloc_psig(psig_in, NULL);
     TEST_ASSERT(psig != NULL, "build realloc_psig");
     unsigned char psig_out[32];
-    TEST_ASSERT(wire_parse_leaf_realloc_psig(psig, psig_out), "parse realloc_psig");
+    TEST_ASSERT(wire_parse_leaf_realloc_psig(psig, psig_out, NULL),
+                "parse realloc_psig");
     TEST_ASSERT_MEM_EQ(psig_out, psig_in, 32, "psig round-trip");
     cJSON_Delete(psig);
 


### PR DESCRIPTION
## Summary

Extends the wire-ceremony poison TX pattern from PR #136 (sub-factory) and PR #137 (leaf advance) to `lsp_realloc_leaf` (per-leaf fund reallocation, used by Tier B at the per-leaf granularity).

After this PR, **all per-leaf wire ceremonies** (sub-factory advance, leaf advance, and leaf realloc) produce a fully-signed L-stock / sales-stock poison TX in multi-process mode.  The remaining SECURITY GAP site is the multi-leaf rotation re-sign in `lsp_run_state_advance` (Tier B root rollover) — that uses the MSG_PATH_* ceremony with nonce pools and is more complex; tracked as a separate follow-up.

### What changed

**Wire** (`include/superscalar/wire.h`, `src/wire.c`):
- `MSG_LEAF_REALLOC_PROPOSE / NONCE / ALL_NONCES / PSIG` extended with optional `poison_*` fields
- Parse helpers return `0`/`1`/`2` so callers can detect protocol downgrade

**LSP** (`src/lsp_channels.c::lsp_realloc_leaf`):
- Snapshots OLD leaf state BEFORE realloc
- If watchtower configured + L-stock present + sufficient: prepares poison TX, runs second MuSig2 round in lockstep with state realloc
- LSP gen 2 nonces, bundles with PROPOSE
- Receives client's dual nonce + dual psig in NONCE/PSIG
- Finalizes both sessions → completes both
- (Note: `lsp_realloc_leaf` doesn't currently register with watchtower — that's where the wire-ceremony output would land.  The plumbing is in place; if/when realloc adds a watchtower hook it will use the pre-signed poison TX automatically.)

**Client** (`src/client.c::client_handle_leaf_realloc`):
- Snapshots OLD leaf state BEFORE realloc
- Wire offers poison nonce → prepare poison TX deterministically (byte-identical to LSP), run dual MuSig
- Sends bundled state + poison nonce/psig

**Tests**:
- `tests/test_wire.c` updated for new realloc wire signatures (pass NULL for poison fields)
- All 1422 unit tests pass
- Multi-process subfactory + N=8 MuSig tests still pass

### Out of scope (final follow-up)
- `lsp_run_state_advance` (Tier B root rollover, MSG_PATH_* ceremony, ~lsp_channels.c:2195 watchtower hook).  This is the LAST remaining SECURITY GAP site — it's complex because the rotation re-signs N nodes simultaneously with nonce pools.  Once that lands, the `lsp_have_all_signer_keypairs` guard + all SECURITY GAP stderr warnings + the README warning can be removed (final cleanup PR).

## Test plan
- [x] All 1422 unit tests pass on VPS
- [x] `tools/test_multiprocess_subfactory_advance.sh` still passes
- [x] `tools/test_multiprocess_musig_n8.sh` still passes
- [ ] CI: Linux + macOS + sanitizers + TSan + regtest + coverage + fuzz all green