### PR TITLE
feat(persist): v22 — persist + rehydrate wire-signed poison TX across LSP restart (PR-B)

### DIFF
--- a/include/superscalar/lsp_channels.h
+++ b/include/superscalar/lsp_channels.h
@@ -234,6 +234,28 @@ int lsp_channels_init_from_db(lsp_channel_mgr_t *mgr,
                                size_t n_clients,
                                void *db);
 
+/* Re-register every PS leaf chain entry and PS sub-factory chain entry
+   with the watchtower after recovery (PR-B / v22).
+
+   persist_load_factory restores in-memory factory state plus, for the
+   LATEST chain entry of each PS leaf and sub-factory, the wire-signed
+   poison TX bytes (now living in node->poison_signed_tx /
+   sub->poison_signed_tx with poison_is_signed=1).  This helper walks
+   every restored leaf + sub-factory, looks up the prior chain entry's
+   txid (the "stale" state to watch for), and calls
+   watchtower_watch_factory_node_with_channels /
+   watchtower_watch_subfactory_node so a post-restart breach still
+   triggers the response_tx + poison_tx broadcast.
+
+   Without this rehydrate step, the wire-ceremony work from PRs
+   #136-#138 is silently undone by the first LSP crash — watchtower
+   has no entries beyond DW commitments.
+
+   Pre-condition: mgr->watchtower set, mgr->persist set,
+   factory_recovery already loaded chains into the in-memory factory.
+   Returns 1 on success (even if 0 entries to register), 0 on bad args. */
+int lsp_channels_rehydrate_watchtower_from_chains(lsp_channel_mgr_t *mgr);
+
 /* Exchange MSG_CHANNEL_BASEPOINTS with all clients.
    Must be called after lsp_channels_init() and before lsp_channels_send_ready().
    Sends LSP's basepoint pubkeys and receives client's basepoint pubkeys.

--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 21
+#define PERSIST_SCHEMA_VERSION 22
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -64,34 +64,50 @@ int persist_has_factory(persist_t *p, uint32_t factory_id);
 
 /* Save one PS chain entry (call after each PS leaf advance).
    chain_pos: index of this entry (0 = initial state, equals old ps_chain_len).
-   txid_display: 32-byte display-order txid.  chan_amount_sats: channel vout amount. */
+   txid_display: 32-byte display-order txid.  chan_amount_sats: channel vout amount.
+   poison_tx / poison_tx_len (v22): the L-stock poison TX co-signed by all
+   leaf signers when this advance was made.  Pass NULL/0 if no poison TX
+   was signed for this advance (e.g. the initial chain[0] entry, which has
+   no preceding stale state to poison). */
 int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
                                  uint32_t leaf_node_idx, int chain_pos,
                                  const unsigned char *txid_display,
                                  const unsigned char *signed_tx, size_t signed_tx_len,
-                                 uint64_t chan_amount_sats);
+                                 uint64_t chan_amount_sats,
+                                 const unsigned char *poison_tx,
+                                 size_t poison_tx_len);
 
 /* Load all PS chain entries for a leaf in chain_pos order.
    chain_txs_out: caller-allocated tx_buf_t[max_chain] (caller must free each on success).
    txids_out: caller-allocated [max_chain][32] internal-order txids.
    amounts_out: caller-allocated uint64_t[max_chain] channel amounts; may be NULL.
+   poison_txs_out: caller-allocated tx_buf_t[max_chain] for per-entry poison
+                   TX bytes (v22). Entries with no persisted poison TX are
+                   left zero-initialized (data=NULL, len=0). May be NULL.
+                   Caller must tx_buf_free() each non-empty entry.
    Returns number of entries loaded, 0 on error or no PS chain. */
 int persist_load_ps_chain(persist_t *p, uint32_t factory_id, uint32_t leaf_node_idx,
                            tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
-                           uint64_t *amounts_out, int max_chain);
+                           uint64_t *amounts_out,
+                           tx_buf_t *poison_txs_out, int max_chain);
 
 /* --- Pseudo-Spilman SUB-FACTORY chain persistence (k² shape) --- */
 
 /* Save one sub-factory chain entry. Each entry has per-channel amounts plus
    the trailing sales-stock amount (the sub-factory analogue of the L-stock
    on the parent leaf). channel_amounts[]: amount per child channel,
-   length = n_channels. The sales_stock vout is the last output. */
+   length = n_channels. The sales_stock vout is the last output.
+   poison_tx / poison_tx_len (v22): the sales-stock poison TX co-signed by
+   all sub-factory signers when this advance was made.  Pass NULL/0 if no
+   poison TX was signed for this advance. */
 int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
                                           uint32_t sub_node_idx, int chain_pos,
                                           const unsigned char *txid_display,
                                           const unsigned char *signed_tx, size_t signed_tx_len,
                                           uint64_t sales_stock_amount_sats,
-                                          const uint64_t *channel_amounts, int n_channels);
+                                          const uint64_t *channel_amounts, int n_channels,
+                                          const unsigned char *poison_tx,
+                                          size_t poison_tx_len);
 
 /* Load all sub-factory chain entries for a sub-factory node in chain_pos order.
    chain_txs_out: caller-allocated tx_buf_t[max_chain].
@@ -99,12 +115,17 @@ int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
    sales_stock_out: caller-allocated uint64_t[max_chain] sales-stock amounts.
    channel_amounts_out: caller-allocated uint64_t[max_chain][max_channels].
    n_channels_out: caller-allocated int[max_chain] number of channels per entry.
+   poison_txs_out: caller-allocated tx_buf_t[max_chain] for per-entry poison
+                   TX bytes (v22). Entries with no persisted poison TX are
+                   left zero-initialized.  May be NULL.  Caller must
+                   tx_buf_free() each non-empty entry.
    Returns number of entries loaded, 0 on no entries or error. */
 int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t sub_node_idx,
                                     tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
                                     uint64_t *sales_stock_out,
                                     uint64_t (*channel_amounts_out)[16],
-                                    int *n_channels_out, int max_chain);
+                                    int *n_channels_out,
+                                    tx_buf_t *poison_txs_out, int max_chain);
 
 /* --- Client-side PS double-spend defense --- */
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1750,6 +1750,13 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     if (mgr->persist)
         persist_clear_signing_progress((persist_t *)mgr->persist, 0);
 
+    /* PR-B: snapshot of the wire-signed poison TX bytes that the watchtower
+       receives below.  Survives `factory_session_reset_poison()` so the
+       Step 11 persist call can save them to ps_leaf_chains.poison_tx_hex.
+       Allocated in the watchtower block, freed at end of function. */
+    unsigned char *poison_snapshot = NULL;
+    size_t poison_snapshot_len = 0;
+
     /* Register old leaf state with watchtower for breach detection.
        If the old state is broadcast, the watchtower responds with the
        new (latest) signed state tx and burns the old L-stock output.
@@ -1820,6 +1827,18 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
             leaf_node->signed_tx.data, leaf_node->signed_tx.len,
             poison_data, poison_len,
             leaf_ch_ids, n_leaf_ch);
+
+        /* PR-B: snapshot for Step 11 persist (must happen before reset/free
+           clear poison_data's underlying storage).  malloc-failure here is
+           non-fatal — degrades to NULL persisted poison, same as pre-#136. */
+        if (poison_data && poison_len > 0) {
+            poison_snapshot = malloc(poison_len);
+            if (poison_snapshot) {
+                memcpy(poison_snapshot, poison_data, poison_len);
+                poison_snapshot_len = poison_len;
+            }
+        }
+
         tx_buf_free(&burn_tx);
         factory_session_reset_poison(f, node_idx);
     }
@@ -1835,7 +1854,11 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     if (mgr->persist) {
         factory_node_t *leaf_node = &f->nodes[node_idx];
         if (leaf_node->is_ps_leaf) {
-            /* PS: save this chain entry; chain_pos = ps_chain_len-1 (0-based) */
+            /* PS: save this chain entry; chain_pos = ps_chain_len-1 (0-based).
+               PR-B (v22): include the wire-signed poison TX bytes (from the
+               snapshot above) so the watchtower can re-register them on
+               restart.  poison_snapshot may be NULL on degraded ceremonies
+               or when no poison TX was signed for this advance. */
             extern void reverse_bytes(unsigned char *, size_t);
             unsigned char txid_display[32];
             memcpy(txid_display, leaf_node->txid, 32);
@@ -1846,7 +1869,8 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
                 leaf_node->ps_chain_len - 1,
                 txid_display,
                 leaf_node->signed_tx.data, leaf_node->signed_tx.len,
-                leaf_node->outputs[0].amount_sats);
+                leaf_node->outputs[0].amount_sats,
+                poison_snapshot, poison_snapshot_len);
         } else {
             /* DW: save counter state */
             uint32_t leaf_states[8];
@@ -1869,6 +1893,7 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     else
         printf("LSP: DW leaf %d advanced (node %zu), DW state %u\n",
                leaf_side, node_idx, f->leaf_layers[leaf_side].current_state);
+    free(poison_snapshot);
     return 1;
 }
 
@@ -3075,6 +3100,19 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         if (n_chans > 16) n_chans = 16;
         for (int ci = 0; ci < n_chans; ci++)
             chan_amounts[ci] = sub->outputs[ci].amount_sats;
+        /* PR-B (v22): include the wire-signed sales-stock poison TX bytes so
+           the watchtower can redistribute them on a post-restart breach.
+           sub->poison_signed_tx is still populated here (Step 10b's
+           reset_poison runs after this save).  Pass NULL/0 if the poison
+           ceremony degraded — graceful loss of redistribution capability,
+           response_tx broadcast still works. */
+        const unsigned char *poison_bytes = NULL;
+        size_t poison_bytes_len = 0;
+        if (poison_prepared && sub->poison_is_signed &&
+            sub->poison_signed_tx.len > 0) {
+            poison_bytes     = sub->poison_signed_tx.data;
+            poison_bytes_len = sub->poison_signed_tx.len;
+        }
         persist_save_subfactory_chain_entry(
             (persist_t *)mgr->persist, /* factory_id = */ 0,
             (uint32_t)sub_node_i,
@@ -3082,7 +3120,8 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             txid_display,
             sub->signed_tx.data, sub->signed_tx.len,
             sub->outputs[sstock_vout].amount_sats,
-            chan_amounts, n_chans);
+            chan_amounts, n_chans,
+            poison_bytes, poison_bytes_len);
     }
 
     /* Step 10b: Build the sub-factory sales-stock POISON TX (Gap A) and

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -5974,3 +5974,139 @@ int lsp_channels_check_conservation(const lsp_channel_mgr_t *mgr)
 int lsp_channels_advance_ps_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     return lsp_advance_leaf(mgr, lsp, leaf_side);
 }
+
+/* PR-B (v22): post-recovery watchtower rehydration.
+
+   For every PS leaf with chain_len >= 2, look up chain[N-1].txid (the
+   stale-state-to-watch-for) from the persist layer and re-register
+   (chain[N-1].txid → response=chain[N], poison=poison[N]) with the
+   watchtower.  Same for every PS sub-factory chain.
+
+   We only register the LATEST advance (chain[N-1] → chain[N]) — not all
+   prior advances.  The earlier stale entries from before the LSP restart
+   were watched in the live LSP, but those watchtower entries were
+   in-memory only (the watchtower never persisted WATCH_FACTORY_NODE /
+   WATCH_SUBFACTORY_NODE entries — only WATCH_COMMITMENT does, in
+   watchtower_init).  Recovering the full history would require either
+   walking every chain entry and chaining responses, or migrating the
+   watchtower to persist its watch table.  The latter is a separate
+   concern; the former leaves us with M-watch-entries-per-chain
+   redundancy.  For PR-B's scope we restore the just-stale entry's
+   coverage, which is the most-likely cheat target (a malicious LSP
+   broadcasting the immediately-superseded chain state). */
+int lsp_channels_rehydrate_watchtower_from_chains(lsp_channel_mgr_t *mgr) {
+    if (!mgr || !mgr->watchtower || !mgr->persist) return 0;
+
+    factory_t *f = NULL;
+    /* mgr->ladder may not be set in unit-test contexts; fall through to
+       the ladder factory[0] only when present.  The recovery branch
+       in superscalar_lsp.c sets mgr->ladder = &rec_lad after this
+       helper would be called, so we instead key off the lsp_t * the
+       caller passes in via mgr->ladder once it's set.  In practice the
+       recovery code calls this BEFORE mgr->ladder = &rec_lad, when the
+       in-memory factory still lives at lsp_rp->factory — accessible via
+       mgr->factory_for_recovery if set, else not callable.
+
+       Simpler: take the factory pointer from mgr->ladder if available,
+       otherwise expect the caller to have set mgr->factory_for_recovery
+       to lsp_rp->factory before calling.  For now we use ladder. */
+    if (mgr->ladder) {
+        ladder_t *lad = (ladder_t *)mgr->ladder;
+        if (lad->n_factories > 0) f = &lad->factories[0].factory;
+    }
+    if (!f) {
+        fprintf(stderr, "rehydrate_watchtower: no factory available\n");
+        return 0;
+    }
+
+    persist_t *pdb = (persist_t *)mgr->persist;
+    int n_registered = 0;
+
+    /* Walk every PS leaf node.  For each that has chain_len >= 2,
+       look up the previous chain entry's txid as the "old" state. */
+    for (int li = 0; li < f->n_leaf_nodes; li++) {
+        size_t node_idx = f->leaf_node_indices[li];
+        factory_node_t *leaf = &f->nodes[node_idx];
+        if (!leaf->is_ps_leaf) continue;
+        if (leaf->ps_chain_len < 2) continue;
+        if (!leaf->is_signed || leaf->signed_tx.len == 0) continue;
+
+        /* leaf->ps_prev_txid is set by persist_load_factory to the
+           previous chain entry's txid (internal byte order) — exactly
+           what watchtower wants for old_txid32. */
+
+        /* Collect channel ids on this leaf. */
+        uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+        size_t n_leaf_ch = 0;
+        for (size_t c = 0; c < mgr->n_channels; c++) {
+            size_t c_node; uint32_t c_vout;
+            client_to_leaf(c, f, &c_node, &c_vout);
+            if (c_node == node_idx)
+                leaf_ch_ids[n_leaf_ch++] = (uint32_t)c;
+        }
+
+        const unsigned char *poison_data = NULL;
+        size_t poison_len = 0;
+        if (leaf->poison_is_signed && leaf->poison_signed_tx.len > 0) {
+            poison_data = leaf->poison_signed_tx.data;
+            poison_len  = leaf->poison_signed_tx.len;
+        }
+
+        watchtower_watch_factory_node_with_channels(mgr->watchtower,
+            (uint32_t)node_idx, leaf->ps_prev_txid,
+            leaf->signed_tx.data, leaf->signed_tx.len,
+            poison_data, poison_len,
+            leaf_ch_ids, n_leaf_ch);
+        n_registered++;
+        printf("LSP recovery: re-watched PS leaf %d (node %zu) "
+               "chain_pos=%d (poison_tx=%s, %zu channels)\n",
+               li, node_idx, leaf->ps_chain_len - 1,
+               poison_data ? "yes" : "no", n_leaf_ch);
+
+        (void)pdb; /* persist_load_subfactory_chain uses sales-stock /
+                      channel amounts directly from the in-memory
+                      sub-factory state (already restored by
+                      persist_load_factory) — no extra DB round-trip. */
+    }
+
+    /* Walk every sub-factory.  Same shape: chain_len >= 2 → register
+       (sub->ps_prev_txid → response=sub->signed_tx, poison=sub->poison_signed_tx). */
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        factory_node_t *sub = &f->nodes[i];
+        if (sub->type != NODE_PS_SUBFACTORY) continue;
+        if (sub->ps_chain_len < 2) continue;
+        if (!sub->is_signed || sub->signed_tx.len == 0) continue;
+
+        size_t sstock_vout = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
+        uint64_t sstock_amount = sub->outputs[sstock_vout].amount_sats;
+        uint64_t chan_amounts[16] = {0};
+        size_t n_chans = sstock_vout;
+        if (n_chans > 16) n_chans = 16;
+        for (size_t ci = 0; ci < n_chans; ci++)
+            chan_amounts[ci] = sub->outputs[ci].amount_sats;
+
+        const unsigned char *poison_data = NULL;
+        size_t poison_len = 0;
+        if (sub->poison_is_signed && sub->poison_signed_tx.len > 0) {
+            poison_data = sub->poison_signed_tx.data;
+            poison_len  = sub->poison_signed_tx.len;
+        }
+
+        watchtower_watch_subfactory_node(mgr->watchtower,
+            (uint32_t)i, sub->ps_prev_txid,
+            sub->signed_tx.data, sub->signed_tx.len,
+            poison_data, poison_len,
+            chan_amounts, n_chans, sstock_amount);
+        n_registered++;
+        printf("LSP recovery: re-watched sub-factory node %zu "
+               "chain_pos=%d (poison_tx=%s, %zu channels, sstock=%llu)\n",
+               i, sub->ps_chain_len - 1,
+               poison_data ? "yes" : "no", n_chans,
+               (unsigned long long)sstock_amount);
+    }
+
+    if (n_registered > 0)
+        printf("LSP recovery: rehydrated %d watchtower entries from "
+               "persisted PS chains\n", n_registered);
+    return 1;
+}

--- a/src/persist.c
+++ b/src/persist.c
@@ -858,6 +858,24 @@ int persist_open(persist_t *p, const char *path) {
             NULL, NULL, NULL);
     }
 
+    /* v22 migration: poison TX persistence on PS leaf and sub-factory chain
+       entries.  Without this, the wire-signed poison TXs from the
+       multi-process MuSig ceremonies (PRs #136-#138) live only in memory
+       and are silently lost on the first LSP crash — leaving the watchtower
+       unable to redistribute the L-stock / sales-stock on a post-restart
+       breach.  NULL is tolerated for backward compatibility (degrades to
+       the same behavior as pre-#136: response_tx broadcast on breach,
+       but no poison TX redistribution).  ALTER TABLE ... ADD COLUMN with
+       no default is the standard SQLite approach for nullable additions. */
+    if (db_version < 22) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE ps_leaf_chains ADD COLUMN poison_tx_hex TEXT;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE ps_subfactory_chains ADD COLUMN poison_tx_hex TEXT;",
+            NULL, NULL, NULL);
+    }
+
     /* Record the current version if not already present */
     if (db_version < PERSIST_SCHEMA_VERSION) {
         char vsql[128];
@@ -1045,12 +1063,17 @@ int persist_mark_factory_closed(persist_t *p, uint32_t factory_id) {
    chain_pos: 0-based position in the chain (equal to old ps_chain_len before advance).
    signed_tx / signed_tx_len: the signed TX being stored.
    txid_display: 32-byte display-order txid.
-   chan_amount_sats: channel output amount for this chain position. */
+   chan_amount_sats: channel output amount for this chain position.
+   poison_tx / poison_tx_len: optional L-stock poison TX (v22). Pass NULL/0
+   when no poison TX exists for this advance (chain[0] or a degraded
+   single-process advance). */
 int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
                                  uint32_t leaf_node_idx, int chain_pos,
                                  const unsigned char *txid_display,
                                  const unsigned char *signed_tx, size_t signed_tx_len,
-                                 uint64_t chan_amount_sats) {
+                                 uint64_t chan_amount_sats,
+                                 const unsigned char *poison_tx,
+                                 size_t poison_tx_len) {
     if (!p || !p->db) return 0;
 
     char txid_hex[65];
@@ -1061,13 +1084,21 @@ int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
     if (!tx_hex) return 0;
     hex_encode(signed_tx, signed_tx_len, tx_hex);
 
+    char *poison_hex = NULL;
+    if (poison_tx && poison_tx_len > 0) {
+        poison_hex = malloc(poison_tx_len * 2 + 1);
+        if (!poison_hex) { free(tx_hex); return 0; }
+        hex_encode(poison_tx, poison_tx_len, poison_hex);
+    }
+
     sqlite3_stmt *stmt;
     const char *sql =
         "INSERT OR REPLACE INTO ps_leaf_chains "
-        "(factory_id, leaf_node_idx, chain_pos, txid, signed_tx_hex, chan_amount_sats) "
-        "VALUES (?, ?, ?, ?, ?, ?);";
+        "(factory_id, leaf_node_idx, chain_pos, txid, signed_tx_hex, chan_amount_sats, poison_tx_hex) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?);";
     if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
         free(tx_hex);
+        free(poison_hex);
         return 0;
     }
     sqlite3_bind_int(stmt, 1, (int)factory_id);
@@ -1076,25 +1107,34 @@ int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
     sqlite3_bind_text(stmt, 4, txid_hex, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 5, tx_hex, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int64(stmt, 6, (sqlite3_int64)chan_amount_sats);
+    if (poison_hex)
+        sqlite3_bind_text(stmt, 7, poison_hex, -1, SQLITE_TRANSIENT);
+    else
+        sqlite3_bind_null(stmt, 7);
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
     free(tx_hex);
+    free(poison_hex);
     return ok;
 }
 
 /* Load PS leaf chain for a given leaf node.
    Fills chain_txs_out (caller-allocated array of tx_buf_t, size max_chain).
    txids_out: caller-allocated [max_chain][32] for internal-order txids.
+   poison_txs_out: optional per-entry poison TX bytes (v22).  Entries with
+   no persisted poison are left zeroed (data=NULL, len=0).
    Returns number of chain entries loaded (0 = no PS chain or error). */
 int persist_load_ps_chain(persist_t *p, uint32_t factory_id, uint32_t leaf_node_idx,
                            tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
-                           uint64_t *amounts_out, int max_chain) {
+                           uint64_t *amounts_out,
+                           tx_buf_t *poison_txs_out, int max_chain) {
     if (!p || !p->db || !chain_txs_out || !txids_out || max_chain <= 0) return 0;
 
     sqlite3_stmt *stmt;
     const char *sql =
-        "SELECT chain_pos, txid, signed_tx_hex, chan_amount_sats FROM ps_leaf_chains "
+        "SELECT chain_pos, txid, signed_tx_hex, chan_amount_sats, poison_tx_hex "
+        "FROM ps_leaf_chains "
         "WHERE factory_id=? AND leaf_node_idx=? ORDER BY chain_pos ASC;";
     if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
     sqlite3_bind_int(stmt, 1, (int)factory_id);
@@ -1128,6 +1168,26 @@ int persist_load_ps_chain(persist_t *p, uint32_t factory_id, uint32_t leaf_node_
         if (amounts_out)
             amounts_out[count] = (uint64_t)sqlite3_column_int64(stmt, 3);
 
+        /* Optional v22 poison TX column (NULL on pre-v22 rows or when no
+           poison TX was signed for this advance). */
+        if (poison_txs_out) {
+            memset(&poison_txs_out[count], 0, sizeof(tx_buf_t));
+            const char *poison_hex = (const char *)sqlite3_column_text(stmt, 4);
+            if (poison_hex) {
+                size_t poison_hex_len = strlen(poison_hex);
+                size_t poison_len = poison_hex_len / 2;
+                if (poison_len > 0) {
+                    tx_buf_init(&poison_txs_out[count], (int)poison_len);
+                    if (!hex_decode(poison_hex,
+                                    poison_txs_out[count].data, poison_len)) {
+                        tx_buf_free(&poison_txs_out[count]);
+                    } else {
+                        poison_txs_out[count].len = poison_len;
+                    }
+                }
+            }
+        }
+
         count++;
     }
     sqlite3_finalize(stmt);
@@ -1141,7 +1201,9 @@ int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
                                           const unsigned char *txid_display,
                                           const unsigned char *signed_tx, size_t signed_tx_len,
                                           uint64_t sales_stock_amount_sats,
-                                          const uint64_t *channel_amounts, int n_channels)
+                                          const uint64_t *channel_amounts, int n_channels,
+                                          const unsigned char *poison_tx,
+                                          size_t poison_tx_len)
 {
     if (!p || !p->db || !channel_amounts || n_channels <= 0 || n_channels > 16) return 0;
 
@@ -1153,13 +1215,22 @@ int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
     if (!tx_hex) return 0;
     hex_encode(signed_tx, signed_tx_len, tx_hex);
 
+    char *poison_hex = NULL;
+    if (poison_tx && poison_tx_len > 0) {
+        poison_hex = malloc(poison_tx_len * 2 + 1);
+        if (!poison_hex) { free(tx_hex); return 0; }
+        hex_encode(poison_tx, poison_tx_len, poison_hex);
+    }
+
     /* Build CSV: "amt0,amt1,...,amtN-1" — max 16 entries × 21 chars/u64 + commas + NUL. */
     char csv[16 * 22 + 1];
     int off = 0;
     for (int i = 0; i < n_channels; i++) {
         int n = snprintf(csv + off, sizeof(csv) - off, "%s%llu",
                          i ? "," : "", (unsigned long long)channel_amounts[i]);
-        if (n < 0 || (size_t)(off + n) >= sizeof(csv)) { free(tx_hex); return 0; }
+        if (n < 0 || (size_t)(off + n) >= sizeof(csv)) {
+            free(tx_hex); free(poison_hex); return 0;
+        }
         off += n;
     }
 
@@ -1167,10 +1238,11 @@ int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
     const char *sql =
         "INSERT OR REPLACE INTO ps_subfactory_chains "
         "(factory_id, sub_node_idx, chain_pos, txid, signed_tx_hex, "
-        " sales_stock_amount_sats, channel_amounts_csv) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?);";
+        " sales_stock_amount_sats, channel_amounts_csv, poison_tx_hex) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
     if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
         free(tx_hex);
+        free(poison_hex);
         return 0;
     }
     sqlite3_bind_int(stmt, 1, (int)factory_id);
@@ -1180,10 +1252,15 @@ int persist_save_subfactory_chain_entry(persist_t *p, uint32_t factory_id,
     sqlite3_bind_text(stmt, 5, tx_hex, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int64(stmt, 6, (sqlite3_int64)sales_stock_amount_sats);
     sqlite3_bind_text(stmt, 7, csv, -1, SQLITE_TRANSIENT);
+    if (poison_hex)
+        sqlite3_bind_text(stmt, 8, poison_hex, -1, SQLITE_TRANSIENT);
+    else
+        sqlite3_bind_null(stmt, 8);
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
     free(tx_hex);
+    free(poison_hex);
     return ok;
 }
 
@@ -1191,7 +1268,8 @@ int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t su
                                     tx_buf_t *chain_txs_out, unsigned char (*txids_out)[32],
                                     uint64_t *sales_stock_out,
                                     uint64_t (*channel_amounts_out)[16],
-                                    int *n_channels_out, int max_chain)
+                                    int *n_channels_out,
+                                    tx_buf_t *poison_txs_out, int max_chain)
 {
     if (!p || !p->db || !chain_txs_out || !txids_out || !sales_stock_out ||
         !channel_amounts_out || !n_channels_out || max_chain <= 0)
@@ -1199,7 +1277,8 @@ int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t su
 
     sqlite3_stmt *stmt;
     const char *sql =
-        "SELECT chain_pos, txid, signed_tx_hex, sales_stock_amount_sats, channel_amounts_csv "
+        "SELECT chain_pos, txid, signed_tx_hex, sales_stock_amount_sats, "
+        "       channel_amounts_csv, poison_tx_hex "
         "FROM ps_subfactory_chains "
         "WHERE factory_id=? AND sub_node_idx=? ORDER BY chain_pos ASC;";
     if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
@@ -1248,6 +1327,26 @@ int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t su
             if (*q == ',') q++;
         }
         n_channels_out[count] = nc;
+
+        /* Optional v22 poison TX column (NULL on pre-v22 rows or when no
+           poison TX was signed for this advance). */
+        if (poison_txs_out) {
+            memset(&poison_txs_out[count], 0, sizeof(tx_buf_t));
+            const char *poison_hex = (const char *)sqlite3_column_text(stmt, 5);
+            if (poison_hex) {
+                size_t poison_hex_len = strlen(poison_hex);
+                size_t poison_len = poison_hex_len / 2;
+                if (poison_len > 0) {
+                    tx_buf_init(&poison_txs_out[count], (int)poison_len);
+                    if (!hex_decode(poison_hex,
+                                    poison_txs_out[count].data, poison_len)) {
+                        tx_buf_free(&poison_txs_out[count]);
+                    } else {
+                        poison_txs_out[count].len = poison_len;
+                    }
+                }
+            }
+        }
 
         count++;
     }
@@ -1514,17 +1613,29 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
         uint64_t       *sub_sstock  = calloc(PS_RESTORE_MAX, sizeof(uint64_t));
         uint64_t      (*sub_chans)[16] = calloc(PS_RESTORE_MAX, sizeof(uint64_t[16]));
         int            *sub_n_chans = calloc(PS_RESTORE_MAX, sizeof(int));
+        /* PR-B (v22): per-entry poison TX bytes for both leaf chains and
+           sub-factory chains.  Heap-allocated to keep ~100KB off the
+           stack — same rationale as chain_txs above. */
+        tx_buf_t       *leaf_poisons = calloc(PS_RESTORE_MAX, sizeof(tx_buf_t));
+        tx_buf_t       *sub_poisons  = calloc(PS_RESTORE_MAX, sizeof(tx_buf_t));
 
         if (chain_txs && chain_ids && chain_amts &&
-            sub_sstock && sub_chans && sub_n_chans) {
+            sub_sstock && sub_chans && sub_n_chans &&
+            leaf_poisons && sub_poisons) {
             for (int li = 0; li < f->n_leaf_nodes; li++) {
                 size_t node_idx = f->leaf_node_indices[li];
                 factory_node_t *node = &f->nodes[node_idx];
                 if (!node->is_ps_leaf) continue;
 
+                /* PR-B: load per-entry poison TX bytes alongside the chain
+                   so the recovery code can attach the latest poison TX to
+                   the in-memory leaf node — superscalar_lsp.c reads this
+                   from node->poison_signed_tx when re-registering with the
+                   watchtower after restart. */
+                memset(leaf_poisons, 0, PS_RESTORE_MAX * sizeof(tx_buf_t));
                 int count = persist_load_ps_chain(p, factory_id,
                     (uint32_t)node_idx, chain_txs, chain_ids, chain_amts,
-                    PS_RESTORE_MAX);
+                    leaf_poisons, PS_RESTORE_MAX);
 
                 if (count > 0) {
                     /* chain[0] txid is node->txid as set by factory_build_tree
@@ -1555,11 +1666,32 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
                     node->signed_tx.len = last->len;
                     node->is_signed = 1;
 
+                    /* PR-B: restore the latest entry's poison TX so that
+                       superscalar_lsp.c's recovery branch can re-register
+                       (chain[N-1].txid → response=chain[N], poison) with
+                       the watchtower.  Older entries' poisons are dropped
+                       — this PR only recovers the most-recent advance to
+                       avoid the M-watch-entries-per-chain blow-up. */
+                    tx_buf_free(&node->poison_signed_tx);
+                    node->poison_is_signed = 0;
+                    if (leaf_poisons[count - 1].len > 0) {
+                        tx_buf_init(&node->poison_signed_tx,
+                                    (int)leaf_poisons[count - 1].len);
+                        memcpy(node->poison_signed_tx.data,
+                               leaf_poisons[count - 1].data,
+                               leaf_poisons[count - 1].len);
+                        node->poison_signed_tx.len = leaf_poisons[count - 1].len;
+                        node->poison_is_signed = 1;
+                    }
+
                     for (int j = 0; j < count; j++) tx_buf_free(&chain_txs[j]);
+                    for (int j = 0; j < count; j++) tx_buf_free(&leaf_poisons[j]);
 
                     printf("persist: PS leaf %d restored to chain_len=%d "
-                           "(%lu sats)\n", li, count,
-                           (unsigned long)node->outputs[0].amount_sats);
+                           "(%lu sats, poison_tx=%s)\n",
+                           li, count,
+                           (unsigned long)node->outputs[0].amount_sats,
+                           node->poison_is_signed ? "yes" : "no");
                 }
 
                 /* Sub-factory recovery (k² shape, v21).
@@ -1573,10 +1705,11 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
                     if (sub_node_i < 0 || (size_t)sub_node_i >= f->n_nodes) continue;
                     factory_node_t *sub = &f->nodes[sub_node_i];
 
+                    memset(sub_poisons, 0, PS_RESTORE_MAX * sizeof(tx_buf_t));
                     int sub_count = persist_load_subfactory_chain(p, factory_id,
                         (uint32_t)sub_node_i,
                         chain_txs, chain_ids, sub_sstock, sub_chans, sub_n_chans,
-                        PS_RESTORE_MAX);
+                        sub_poisons, PS_RESTORE_MAX);
                     if (sub_count <= 0) continue;
 
                     /* Linkage parents (chain[0] is the sub's existing
@@ -1615,12 +1748,30 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
                     sub->signed_tx.len = latest->len;
                     sub->is_signed = 1;
 
+                    /* PR-B: restore the latest sub-factory entry's poison TX
+                       so superscalar_lsp.c's recovery branch can re-register
+                       with the watchtower via watchtower_watch_subfactory_node. */
+                    tx_buf_free(&sub->poison_signed_tx);
+                    sub->poison_is_signed = 0;
+                    if (sub_poisons[last].len > 0) {
+                        tx_buf_init(&sub->poison_signed_tx,
+                                    (int)sub_poisons[last].len);
+                        memcpy(sub->poison_signed_tx.data,
+                               sub_poisons[last].data,
+                               sub_poisons[last].len);
+                        sub->poison_signed_tx.len = sub_poisons[last].len;
+                        sub->poison_is_signed = 1;
+                    }
+
                     for (int j = 0; j < sub_count; j++) tx_buf_free(&chain_txs[j]);
+                    for (int j = 0; j < sub_count; j++) tx_buf_free(&sub_poisons[j]);
 
                     printf("persist: PS sub-factory leaf=%d sub=%d restored to "
-                           "chain_len=%d (sales-stock %lu sats, %d channels)\n",
+                           "chain_len=%d (sales-stock %lu sats, %d channels, "
+                           "poison_tx=%s)\n",
                            li, si, sub_count,
-                           (unsigned long)sub->outputs[nc].amount_sats, nc);
+                           (unsigned long)sub->outputs[nc].amount_sats, nc,
+                           sub->poison_is_signed ? "yes" : "no");
                 }
             }
         }
@@ -1630,6 +1781,8 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
         free(sub_sstock);
         free(sub_chans);
         free(sub_n_chans);
+        free(leaf_poisons);
+        free(sub_poisons);
         #undef PS_RESTORE_MAX
     }
 

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -244,13 +244,14 @@ int test_offer_decode_bad_checksum(void)
 
 /* Schema version smoke test (v2=HD wallet, v3=BOLT 12 offers, v4=pending_cs,
  * v5=hd_utxos.reserved, ..., v20=client_ps_signed_inputs,
- * v21=ps_subfactory_chains with per-channel amounts) */
+ * v21=ps_subfactory_chains with per-channel amounts,
+ * v22=poison_tx_hex on ps_leaf_chains + ps_subfactory_chains) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 21, "schema version is 21 (v21 adds ps_subfactory_chains)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 22, "schema version is 22 (v22 persists wire-signed poison TX)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1164,6 +1164,8 @@ extern int test_regtest_lsp_restart_recovery(void);
 extern int test_persist_open_close(void);
 extern int test_persist_ps_subfactory_chain_round_trip(void);
 extern int test_persist_ps_subfactory_chain_v21_round_trip(void);
+extern int test_persist_ps_leaf_chain_v22_poison_round_trip(void);
+extern int test_persist_ps_subfactory_chain_v22_poison_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -2956,6 +2958,8 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_open_close);
     RUN_TEST(test_persist_ps_subfactory_chain_round_trip);
     RUN_TEST(test_persist_ps_subfactory_chain_v21_round_trip);
+    RUN_TEST(test_persist_ps_leaf_chain_v22_poison_round_trip);
+    RUN_TEST(test_persist_ps_subfactory_chain_v22_poison_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -85,13 +85,15 @@ int test_persist_ps_subfactory_chain_round_trip(void) {
         memset(signed_txs[i], 0xB0 + i, signed_tx_lens[i]);
     }
 
-    /* Save chain[0..2] */
+    /* Save chain[0..2] (no poison TX in this older test — that case is
+       covered by the dedicated v22 round-trip below). */
     for (int i = 0; i < 3; i++) {
         TEST_ASSERT(persist_save_ps_chain_entry(
                         &db, factory_id, sub_node_idx, i,
                         txids[i],
                         signed_txs[i], signed_tx_lens[i],
-                        sstock_amounts[i]),
+                        sstock_amounts[i],
+                        /* poison_tx */ NULL, 0),
                     "save sub-factory chain entry");
     }
 
@@ -105,7 +107,8 @@ int test_persist_ps_subfactory_chain_round_trip(void) {
     uint64_t loaded_amounts[3];
     int n_loaded = persist_load_ps_chain(&db, factory_id, sub_node_idx,
                                             loaded_txs, loaded_txids,
-                                            loaded_amounts, 3);
+                                            loaded_amounts,
+                                            /* poison_txs_out */ NULL, 3);
 
     int ok = 1;
     if (n_loaded != 3) {
@@ -188,7 +191,8 @@ int test_persist_ps_subfactory_chain_v21_round_trip(void) {
                         txids[i],
                         signed_txs[i], signed_tx_lens[i],
                         sstock_amounts[i],
-                        channel_amounts[i], n_channels[i]),
+                        channel_amounts[i], n_channels[i],
+                        /* poison_tx */ NULL, 0),
                     "save v21 sub-factory entry");
     }
 
@@ -202,7 +206,8 @@ int test_persist_ps_subfactory_chain_v21_round_trip(void) {
     int n_loaded = persist_load_subfactory_chain(&db, factory_id, sub_node_idx,
                                                     loaded_txs, loaded_txids,
                                                     loaded_sstock, loaded_channels,
-                                                    loaded_n_channels, 3);
+                                                    loaded_n_channels,
+                                                    /* poison_txs_out */ NULL, 3);
 
     int ok = 1;
     if (n_loaded != 3) {
@@ -249,6 +254,151 @@ int test_persist_ps_subfactory_chain_v21_round_trip(void) {
 
     for (int i = 0; i < n_loaded && i < 3; i++)
         tx_buf_free(&loaded_txs[i]);
+
+    persist_close(&db);
+    return ok;
+}
+
+/* ---- v22: PS leaf + sub-factory chain entry round-trip with poison TX ----
+
+   Verifies the poison_tx_hex column added in PR-B persists end-to-end.
+   Mixes presence/absence of poison TX across entries to confirm NULL
+   handling works (chain[0] typically has no poison; degraded ceremonies
+   may also produce NULL poison even on later entries). */
+int test_persist_ps_leaf_chain_v22_poison_round_trip(void) {
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, NULL), "open in-memory");
+
+    const uint32_t factory_id = 0;
+    const uint32_t leaf_node_idx = 7;
+
+    /* 3 entries: entry 0 has no poison (initial state), entries 1+2 have
+       poison TXs of distinct lengths to catch off-by-one decode bugs. */
+    unsigned char txids[3][32];
+    unsigned char signed_txs[3][32];
+    unsigned char poison_txs[3][96];
+    size_t poison_lens[3] = { 0, 50, 80 };
+    for (int i = 0; i < 3; i++) {
+        memset(txids[i], 0xE0 + i, 32);
+        memset(signed_txs[i], 0xF0 + i, 32);
+        if (poison_lens[i] > 0)
+            memset(poison_txs[i], 0x70 + i, poison_lens[i]);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT(persist_save_ps_chain_entry(
+                        &db, factory_id, leaf_node_idx, i,
+                        txids[i],
+                        signed_txs[i], 32,
+                        100000 - (uint64_t)i * 1000,
+                        poison_lens[i] > 0 ? poison_txs[i] : NULL,
+                        poison_lens[i]),
+                    "save v22 ps leaf entry with poison");
+    }
+
+    tx_buf_t loaded_txs[3]     = {0};
+    tx_buf_t loaded_poisons[3] = {0};
+    unsigned char loaded_txids[3][32];
+    uint64_t loaded_amounts[3];
+    int n_loaded = persist_load_ps_chain(&db, factory_id, leaf_node_idx,
+                                            loaded_txs, loaded_txids,
+                                            loaded_amounts,
+                                            loaded_poisons, 3);
+
+    int ok = (n_loaded == 3);
+    if (!ok) printf("  FAIL: v22 leaf n_loaded=%d expected 3\n", n_loaded);
+    for (int i = 0; ok && i < 3; i++) {
+        if (loaded_poisons[i].len != poison_lens[i]) {
+            printf("  FAIL: v22 leaf chain[%d] poison_len %zu != %zu\n",
+                   i, loaded_poisons[i].len, poison_lens[i]);
+            ok = 0;
+        } else if (poison_lens[i] > 0 &&
+                   memcmp(loaded_poisons[i].data, poison_txs[i],
+                          poison_lens[i]) != 0) {
+            printf("  FAIL: v22 leaf chain[%d] poison bytes mismatch\n", i);
+            ok = 0;
+        }
+    }
+
+    for (int i = 0; i < n_loaded && i < 3; i++) {
+        tx_buf_free(&loaded_txs[i]);
+        tx_buf_free(&loaded_poisons[i]);
+    }
+
+    persist_close(&db);
+    return ok;
+}
+
+int test_persist_ps_subfactory_chain_v22_poison_round_trip(void) {
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, NULL), "open in-memory");
+
+    const uint32_t factory_id = 0;
+    const uint32_t sub_node_idx = 41;
+
+    /* 3 entries: mix of poison_tx presence + sizes. */
+    unsigned char txids[3][32];
+    unsigned char signed_txs[3][64];
+    unsigned char poison_txs[3][120];
+    size_t signed_tx_lens[3] = { 32, 48, 64 };
+    size_t poison_lens[3] = { 60, 0, 100 };
+    uint64_t sstock_amounts[3] = { 80000, 70000, 60000 };
+    int n_channels[3] = { 2, 3, 4 };
+    uint64_t channel_amounts[3][16] = {
+        { 30000, 20000 },
+        { 25000, 25000, 20000 },
+        { 15000, 15000, 15000, 15000 },
+    };
+    for (int i = 0; i < 3; i++) {
+        memset(txids[i], 0x10 + i, 32);
+        memset(signed_txs[i], 0x20 + i, signed_tx_lens[i]);
+        if (poison_lens[i] > 0)
+            memset(poison_txs[i], 0x80 + i, poison_lens[i]);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT(persist_save_subfactory_chain_entry(
+                        &db, factory_id, sub_node_idx, i,
+                        txids[i],
+                        signed_txs[i], signed_tx_lens[i],
+                        sstock_amounts[i],
+                        channel_amounts[i], n_channels[i],
+                        poison_lens[i] > 0 ? poison_txs[i] : NULL,
+                        poison_lens[i]),
+                    "save v22 sub-factory entry with poison");
+    }
+
+    tx_buf_t loaded_txs[3]     = {0};
+    tx_buf_t loaded_poisons[3] = {0};
+    unsigned char loaded_txids[3][32];
+    uint64_t loaded_sstock[3];
+    uint64_t loaded_channels[3][16];
+    int loaded_n_channels[3];
+    int n_loaded = persist_load_subfactory_chain(&db, factory_id, sub_node_idx,
+                                                    loaded_txs, loaded_txids,
+                                                    loaded_sstock, loaded_channels,
+                                                    loaded_n_channels,
+                                                    loaded_poisons, 3);
+
+    int ok = (n_loaded == 3);
+    if (!ok) printf("  FAIL: v22 sub n_loaded=%d expected 3\n", n_loaded);
+    for (int i = 0; ok && i < 3; i++) {
+        if (loaded_poisons[i].len != poison_lens[i]) {
+            printf("  FAIL: v22 sub chain[%d] poison_len %zu != %zu\n",
+                   i, loaded_poisons[i].len, poison_lens[i]);
+            ok = 0;
+        } else if (poison_lens[i] > 0 &&
+                   memcmp(loaded_poisons[i].data, poison_txs[i],
+                          poison_lens[i]) != 0) {
+            printf("  FAIL: v22 sub chain[%d] poison bytes mismatch\n", i);
+            ok = 0;
+        }
+    }
+
+    for (int i = 0; i < n_loaded && i < 3; i++) {
+        tx_buf_free(&loaded_txs[i]);
+        tx_buf_free(&loaded_poisons[i]);
+    }
 
     persist_close(&db);
     return ok;

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2334,6 +2334,16 @@ int main(int argc, char *argv[]) {
             mgr->ladder = &rec_lad;
             #undef rec_lad
 
+            /* PR-B (v22): re-register PS leaf + sub-factory chains with
+               the watchtower from the persisted poison TX bytes.
+               persist_load_factory above already restored the latest chain
+               entry's poison TX into node->poison_signed_tx; this helper
+               walks the factory and calls watchtower_watch_*_node so
+               post-restart breaches still trigger the response_tx +
+               poison_tx broadcast.  Without this, the wire-ceremony work
+               from PRs #136-#138 is silently undone on every restart. */
+            lsp_channels_rehydrate_watchtower_from_chains(mgr);
+
             /* Wire rotation parameters */
             memcpy(mgr->rot_lsp_seckey, lsp_seckey, 32);
             mgr->rot_fee_est = fee_est;


### PR DESCRIPTION
## Summary
- Schema v22: add poison_tx_hex TEXT column to ps_leaf_chains and ps_subfactory_chains. Pre-v22 rows just see NULL (degrades like pre-#136).
- persist_save_ps_chain_entry + persist_save_subfactory_chain_entry gain trailing (poison_tx, poison_tx_len) args.
- persist_load_* gain optional poison_txs_out array; persist_load_factory's PS chain restore stuffs the LATEST entry's poison TX into node->poison_signed_tx (with poison_is_signed = 1) so the recovery branch can read it back.
- New lsp_channels_rehydrate_watchtower_from_chains(mgr) walks PS leaves + NODE_PS_SUBFACTORY nodes with chain_len >= 2 and re-registers (old_txid → response_tx, poison_tx) with the watchtower. Wired into superscalar_lsp.c's recovery branch right after ladder setup.
- Two new round-trip tests exercise both empty and non-empty poison columns.

## Why
Without this, the wire-ceremony work from PRs #136-#138 is silently undone by the first LSP crash. The watchtower's only persistence today is WATCH_COMMITMENT (in watchtower_init); WATCH_FACTORY_NODE and WATCH_SUBFACTORY_NODE entries live in memory only. Once the LSP exits, every poison TX it just got from the multi-process MuSig ceremony is gone — even though a malicious LSP could now broadcast a stale chain entry with no fear of redistribution.

This PR is item 2 of the v0.1.15 production-readiness master plan in .claude/V0_1_15_PRODUCTION_READINESS_TODO.md (local doc, not pushed).

## Scope limit (intentional)
Only the LATEST advance per chain is re-watched. Older stale entries from before the restart are not. Recovering full history requires either persisting the watchtower's WATCH_FACTORY_NODE table or chaining per-entry responses through every prior chain[i] — both out of scope for PR-B. PR-D's Tier B work is the right place to revisit.

## Test plan
- [ ] ./test_superscalar --unit — new tests pass; existing v21/v20 round-trips updated to pass NULL/0 for new params (still pass).
- [ ] ./test_superscalar --regtest — no behavior regressions.
- [ ] tools/test_multiprocess_subfactory_advance.sh — sub-factory advance ceremony writes poison TX to DB; harness verifies via the Regtest Multi-Process (sanitizers) CI job (PR #140).
- [ ] Sanitizers (ASan/LSan) — clean (extra malloc/free paths in lsp_advance_leaf snapshot + persist_load_* poison_txs_out arrays).