### PR TITLE
fix(force-close): persist chain[0] + broadcast PS chain history (CRITICAL)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 22
+#define PERSIST_SCHEMA_VERSION 23
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -126,6 +126,35 @@ int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t su
                                     uint64_t (*channel_amounts_out)[16],
                                     int *n_channels_out,
                                     tx_buf_t *poison_txs_out, int max_chain);
+
+/* --- Initial-state signed TX persistence (v23) ---
+   The factory tree is signed once at build time (factory_sign_all in
+   single-process, or wire ceremony in multi-process).  Each PS leaf and
+   PS sub-factory node's signed_tx at this point is "chain[0]" — the
+   initial state.  On the first PS chain advance, signed_tx is overwritten
+   with chain[1] and the original chain[0] bytes are lost (except for its
+   txid, which is preserved in node->ps_prev_txid).
+   For force-close after advance to broadcast the chain history correctly,
+   we need chain[0]'s signed bytes on disk.  This table stores them once,
+   keyed (factory_id, node_idx).  The save is idempotent (INSERT OR
+   REPLACE) so callers can save unconditionally.
+   Saved by lsp_subfactory_chain_advance + lsp_advance_leaf right before
+   the first advance overwrites node->signed_tx.  Loaded by
+   tools/superscalar_lsp.c's force-close broadcaster.  Closes the bug
+   discovered by the v0.1.15 signet campaign (force-close after sub-
+   factory advance hung indefinitely on -25 errors). */
+int persist_save_ps_initial_signed_state(persist_t *p, uint32_t factory_id,
+                                          uint32_t node_idx,
+                                          const unsigned char *txid_display,
+                                          const unsigned char *signed_tx,
+                                          size_t signed_tx_len);
+
+/* Returns 1 on success and fills out_buf via tx_buf_init + memcpy
+   (caller must tx_buf_free), 0 if no row or error. */
+int persist_load_ps_initial_signed_state(persist_t *p, uint32_t factory_id,
+                                          uint32_t node_idx,
+                                          tx_buf_t *out_tx,
+                                          unsigned char *out_txid_internal_be);
 
 /* --- Client-side PS double-spend defense --- */
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1480,6 +1480,27 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
                             ? f->nodes[pre_node_idx].outputs[old_n_outputs - 1].amount_sats
                             : 0;
 
+    /* v23 fix: on FIRST PS advance only, persist chain[0] (the initial
+       signed leaf state) so force-close after advance can broadcast the
+       full chain history.  See ps_initial_signed_states in persist.h.
+       Discovered by the v0.1.15 signet campaign.  Only applies to PS
+       leaves (DW leaves don't have a chain that needs replay). */
+    if (f->leaf_arity == FACTORY_ARITY_PS &&
+        f->nodes[pre_node_idx].is_ps_leaf &&
+        f->nodes[pre_node_idx].ps_chain_len == 0 &&
+        mgr->persist && had_old_signed) {
+        extern void reverse_bytes(unsigned char *, size_t);
+        unsigned char chain0_txid_display[32];
+        memcpy(chain0_txid_display, f->nodes[pre_node_idx].txid, 32);
+        reverse_bytes(chain0_txid_display, 32);
+        persist_save_ps_initial_signed_state(
+            (persist_t *)mgr->persist, /* factory_id = */ 0,
+            (uint32_t)pre_node_idx,
+            chain0_txid_display,
+            f->nodes[pre_node_idx].signed_tx.data,
+            f->nodes[pre_node_idx].signed_tx.len);
+    }
+
     /* Wire-ceremony poison-TX prep (closes SECURITY GAP for leaf advance).
        Both LSP and client run the same prepare call from their snapshot
        of the OLD state — deterministic, byte-identical sighash on both
@@ -2741,6 +2762,25 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     /* k clients on this sub-factory (LSP is signer 0). */
     size_t n_clients_in_sub = sub->n_signers - 1;
     if (n_clients_in_sub == 0) return 0;
+
+    /* v23 fix: on FIRST advance only, persist chain[0] (the initial
+       signed state) so force-close after advance can broadcast the full
+       chain history.  Without this, chain[1+]'s parent input
+       (chain[0].sales_stock) is never on-chain → bitcoin -25.
+       Discovered by the v0.1.15 signet campaign.  Idempotent (INSERT OR
+       REPLACE) so safe if called twice somehow. */
+    if (sub->ps_chain_len == 0 && mgr->persist &&
+        sub->is_signed && sub->signed_tx.len > 0) {
+        extern void reverse_bytes(unsigned char *, size_t);
+        unsigned char chain0_txid_display[32];
+        memcpy(chain0_txid_display, sub->txid, 32);
+        reverse_bytes(chain0_txid_display, 32);
+        persist_save_ps_initial_signed_state(
+            (persist_t *)mgr->persist, /* factory_id = */ 0,
+            (uint32_t)sub_node_i,
+            chain0_txid_display,
+            sub->signed_tx.data, sub->signed_tx.len);
+    }
 
     /* Snapshot the soon-to-be-stale chain[N-1] state for the watchtower
        (Phase 4b) AND for the wire-ceremony poison-TX prep (Gap A close).

--- a/src/persist.c
+++ b/src/persist.c
@@ -876,6 +876,29 @@ int persist_open(persist_t *p, const char *path) {
             NULL, NULL, NULL);
     }
 
+    /* v23 migration: persist chain[0] (initial signed state) for PS leaves
+       and PS sub-factories so force-close after advance can broadcast the
+       full chain history.  Discovered by the v0.1.15 signet campaign:
+       after advance, node->signed_tx is overwritten with chain[1+] and
+       chain[0]'s signed bytes are lost.  Force-close trying to broadcast
+       chain[1] without chain[0] on-chain produces -25
+       bad-txns-inputs-missingorspent indefinitely.
+       Additive — keeps PR-B's ps_subfactory_chains and ps_leaf_chains
+       semantics unchanged (chain_pos=0..N-1 = chain[1..N]).  This new
+       table fills the missing chain[0] entry separately, keyed by
+       (factory_id, node_idx) since each node has at most one chain[0]. */
+    if (db_version < 23) {
+        sqlite3_exec(p->db,
+            "CREATE TABLE IF NOT EXISTS ps_initial_signed_states ("
+            "  factory_id INTEGER NOT NULL,"
+            "  node_idx INTEGER NOT NULL,"
+            "  txid TEXT NOT NULL,"
+            "  signed_tx_hex TEXT NOT NULL,"
+            "  PRIMARY KEY (factory_id, node_idx)"
+            ");",
+            NULL, NULL, NULL);
+    }
+
     /* Record the current version if not already present */
     if (db_version < PERSIST_SCHEMA_VERSION) {
         char vsql[128];
@@ -1352,6 +1375,88 @@ int persist_load_subfactory_chain(persist_t *p, uint32_t factory_id, uint32_t su
     }
     sqlite3_finalize(stmt);
     return count;
+}
+
+/* --- Initial-state signed TX persistence (v23) ---
+   See header for design notes.  Closes the v0.1.15 force-close-after-
+   advance bug discovered by the signet campaign. */
+
+int persist_save_ps_initial_signed_state(persist_t *p, uint32_t factory_id,
+                                          uint32_t node_idx,
+                                          const unsigned char *txid_display,
+                                          const unsigned char *signed_tx,
+                                          size_t signed_tx_len) {
+    if (!p || !p->db || !txid_display || !signed_tx || signed_tx_len == 0)
+        return 0;
+
+    char txid_hex[65];
+    hex_encode(txid_display, 32, txid_hex);
+
+    char *tx_hex = malloc(signed_tx_len * 2 + 1);
+    if (!tx_hex) return 0;
+    hex_encode(signed_tx, signed_tx_len, tx_hex);
+
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "INSERT OR REPLACE INTO ps_initial_signed_states "
+        "(factory_id, node_idx, txid, signed_tx_hex) "
+        "VALUES (?, ?, ?, ?);";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        free(tx_hex);
+        return 0;
+    }
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_int(stmt, 2, (int)node_idx);
+    sqlite3_bind_text(stmt, 3, txid_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 4, tx_hex, -1, SQLITE_TRANSIENT);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    free(tx_hex);
+    return ok;
+}
+
+int persist_load_ps_initial_signed_state(persist_t *p, uint32_t factory_id,
+                                          uint32_t node_idx,
+                                          tx_buf_t *out_tx,
+                                          unsigned char *out_txid_internal_be) {
+    if (!p || !p->db || !out_tx) return 0;
+
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "SELECT txid, signed_tx_hex FROM ps_initial_signed_states "
+        "WHERE factory_id=? AND node_idx=? LIMIT 1;";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_int(stmt, 2, (int)node_idx);
+
+    int ok = 0;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *txid_hex = (const char *)sqlite3_column_text(stmt, 0);
+        const char *tx_hex   = (const char *)sqlite3_column_text(stmt, 1);
+        if (txid_hex && tx_hex) {
+            size_t tx_hex_len = strlen(tx_hex);
+            size_t tx_len = tx_hex_len / 2;
+            if (tx_len > 0) {
+                tx_buf_init(out_tx, (int)tx_len);
+                if (hex_decode(tx_hex, out_tx->data, tx_len)) {
+                    out_tx->len = tx_len;
+                    if (out_txid_internal_be) {
+                        unsigned char txid_display[32];
+                        if (hex_decode(txid_hex, txid_display, 32)) {
+                            memcpy(out_txid_internal_be, txid_display, 32);
+                            reverse_bytes(out_txid_internal_be, 32);
+                        }
+                    }
+                    ok = 1;
+                } else {
+                    tx_buf_free(out_tx);
+                }
+            }
+        }
+    }
+    sqlite3_finalize(stmt);
+    return ok;
 }
 
 /* --- Client-side PS double-spend defense (v20) --- */

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -245,13 +245,14 @@ int test_offer_decode_bad_checksum(void)
 /* Schema version smoke test (v2=HD wallet, v3=BOLT 12 offers, v4=pending_cs,
  * v5=hd_utxos.reserved, ..., v20=client_ps_signed_inputs,
  * v21=ps_subfactory_chains with per-channel amounts,
- * v22=poison_tx_hex on ps_leaf_chains + ps_subfactory_chains) */
+ * v22=poison_tx_hex on ps_leaf_chains + ps_subfactory_chains,
+ * v23=ps_initial_signed_states for force-close-after-advance chain history) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 22, "schema version is 22 (v22 persists wire-signed poison TX)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 23, "schema version is 23 (v23 persists chain[0] for force-close history)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1166,6 +1166,7 @@ extern int test_persist_ps_subfactory_chain_round_trip(void);
 extern int test_persist_ps_subfactory_chain_v21_round_trip(void);
 extern int test_persist_ps_leaf_chain_v22_poison_round_trip(void);
 extern int test_persist_ps_subfactory_chain_v22_poison_round_trip(void);
+extern int test_persist_ps_initial_signed_state_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -2960,6 +2961,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_ps_subfactory_chain_v21_round_trip);
     RUN_TEST(test_persist_ps_leaf_chain_v22_poison_round_trip);
     RUN_TEST(test_persist_ps_subfactory_chain_v22_poison_round_trip);
+    RUN_TEST(test_persist_ps_initial_signed_state_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -404,6 +404,91 @@ int test_persist_ps_subfactory_chain_v22_poison_round_trip(void) {
     return ok;
 }
 
+/* ---- v23: ps_initial_signed_states round-trip ----
+
+   Verifies persist_save/load_ps_initial_signed_state correctly stores and
+   retrieves chain[0] signed bytes + display-order txid keyed on
+   (factory_id, node_idx).  Closes the v0.1.15 force-close-after-advance
+   bug discovered by the signet campaign. */
+int test_persist_ps_initial_signed_state_round_trip(void) {
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, NULL), "open in-memory");
+
+    const uint32_t factory_id = 0;
+    const uint32_t node_idx_a = 5;
+    const uint32_t node_idx_b = 11;
+
+    /* Two distinct (node, txid, signed_tx) tuples to verify keying. */
+    unsigned char txid_a[32];
+    unsigned char txid_b[32];
+    memset(txid_a, 0xAA, 32);
+    memset(txid_b, 0xBB, 32);
+
+    unsigned char tx_a[64];
+    unsigned char tx_b[96];
+    memset(tx_a, 0x10, sizeof(tx_a));
+    memset(tx_b, 0x20, sizeof(tx_b));
+
+    TEST_ASSERT(persist_save_ps_initial_signed_state(
+                    &db, factory_id, node_idx_a, txid_a, tx_a, sizeof(tx_a)),
+                "save A");
+    TEST_ASSERT(persist_save_ps_initial_signed_state(
+                    &db, factory_id, node_idx_b, txid_b, tx_b, sizeof(tx_b)),
+                "save B");
+
+    /* Reload A and verify */
+    tx_buf_t out_a = {0};
+    unsigned char out_a_txid_be[32];
+    TEST_ASSERT(persist_load_ps_initial_signed_state(
+                    &db, factory_id, node_idx_a, &out_a, out_a_txid_be),
+                "load A");
+    TEST_ASSERT(out_a.len == sizeof(tx_a), "A tx_len round-trips");
+    TEST_ASSERT(memcmp(out_a.data, tx_a, sizeof(tx_a)) == 0,
+                "A tx bytes round-trip");
+    /* save passes display-order txid; load returns internal-byte-order
+       (display reversed) — so out_a_txid_be should equal reversed(txid_a).
+       For txid_a = 0xAA repeated, reversed is still 0xAA repeated. */
+    TEST_ASSERT(memcmp(out_a_txid_be, txid_a, 32) == 0,
+                "A txid round-trips (palindrome)");
+
+    /* Reload B and verify */
+    tx_buf_t out_b = {0};
+    TEST_ASSERT(persist_load_ps_initial_signed_state(
+                    &db, factory_id, node_idx_b, &out_b, NULL /*txid optional*/),
+                "load B");
+    TEST_ASSERT(out_b.len == sizeof(tx_b), "B tx_len round-trips");
+    TEST_ASSERT(memcmp(out_b.data, tx_b, sizeof(tx_b)) == 0,
+                "B tx bytes round-trip");
+
+    /* Idempotent save (INSERT OR REPLACE) — same row updates */
+    unsigned char tx_a2[80];
+    memset(tx_a2, 0x42, sizeof(tx_a2));
+    TEST_ASSERT(persist_save_ps_initial_signed_state(
+                    &db, factory_id, node_idx_a, txid_a, tx_a2, sizeof(tx_a2)),
+                "re-save A overwrites");
+    tx_buf_t out_a2 = {0};
+    TEST_ASSERT(persist_load_ps_initial_signed_state(
+                    &db, factory_id, node_idx_a, &out_a2, NULL),
+                "reload A after overwrite");
+    TEST_ASSERT(out_a2.len == sizeof(tx_a2), "A overwritten tx_len matches");
+    TEST_ASSERT(memcmp(out_a2.data, tx_a2, sizeof(tx_a2)) == 0,
+                "A overwritten tx bytes match");
+
+    /* Missing key returns 0 */
+    tx_buf_t out_missing = {0};
+    int loaded_missing = persist_load_ps_initial_signed_state(
+        &db, factory_id, /*node_idx=*/999, &out_missing, NULL);
+    TEST_ASSERT(loaded_missing == 0, "missing key returns 0");
+    TEST_ASSERT(out_missing.len == 0, "missing key leaves out_tx empty");
+
+    tx_buf_free(&out_a);
+    tx_buf_free(&out_b);
+    tx_buf_free(&out_a2);
+
+    persist_close(&db);
+    return 1;
+}
+
 /* ---- Test 1: Open/close in-memory database ---- */
 
 int test_persist_open_close(void) {

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -700,9 +700,127 @@ static int broadcast_factory_tree(factory_t *f, regtest_t *rt,
     return 1;
 }
 
+/* Broadcast a single signed TX with BIP68 wait + retry logic.
+   Returns 1 on success, 0 on failure.  Logs to broadcast_log via g_db.
+   `display_txid_internal_be` is for the diagnostic print at the end. */
+static int broadcast_one_signed_tx(regtest_t *rt, const char *mine_addr,
+                                     int is_regtest, int confirm_timeout,
+                                     const unsigned char *signed_tx,
+                                     size_t signed_tx_len,
+                                     uint32_t nsequence,
+                                     const char *log_source,
+                                     const unsigned char *display_txid_internal_be) {
+    char *tx_hex = malloc(signed_tx_len * 2 + 1);
+    if (!tx_hex) return 0;
+    hex_encode(signed_tx, signed_tx_len, tx_hex);
+
+    char txid_out[65];
+
+    /* For nodes with nSequence > 0, we may need to wait for the parent
+       to reach sufficient depth before this tx is valid */
+    if (!(nsequence & 0x80000000u) && nsequence > 0) {  /* BIP68 enabled only when bit 31 clear */
+        uint32_t required_depth = (nsequence & 0xFFFF);
+        int est_mins = (int)required_depth * 10; /* ~10 min/block */
+        printf("  %s requires %u-block relative timelock "
+               "(~%dh%02dm), waiting...\n",
+               log_source, required_depth,
+               est_mins / 60, est_mins % 60);
+
+        if (is_regtest) {
+            regtest_mine_blocks(rt, (int)required_depth, mine_addr);
+        } else {
+            int start_height = regtest_get_block_height(rt);
+            int target_height = start_height + (int)required_depth;
+            int waited = 0;
+            while (regtest_get_block_height(rt) < target_height) {
+                if (waited >= confirm_timeout) {
+                    fprintf(stderr, "force-close: %s BIP68 wait "
+                            "timed out after %ds (height %d / %d)\n",
+                            log_source, waited, regtest_get_block_height(rt),
+                            target_height);
+                    free(tx_hex);
+                    return 0;
+                }
+                sleep(10);
+                waited += 10;
+                int cur_h = regtest_get_block_height(rt);
+                int blocks_left = target_height - cur_h;
+                int em = blocks_left * 10;
+                printf("    height: %d / %d (%ds elapsed, ~%dh%02dm remaining)\n",
+                       cur_h, target_height, waited, em / 60, em % 60);
+                fflush(stdout);
+            }
+        }
+    }
+
+    /* Try to broadcast — may need retries if BIP68 not yet satisfied */
+    int ok = 0;
+    int bcast_waited = 0;
+    int bcast_limit = is_regtest ? 60 : confirm_timeout;
+    for (int attempt = 0; bcast_waited < bcast_limit; attempt++) {
+        ok = regtest_send_raw_tx(rt, tx_hex, txid_out);
+        if (ok) break;
+        if (attempt == 0)
+            printf("  %s broadcast pending (waiting for BIP68)...\n", log_source);
+        if (is_regtest) {
+            regtest_mine_blocks(rt, 1, mine_addr);
+            bcast_waited++;
+        } else {
+            sleep(15);
+            bcast_waited += 15;
+        }
+    }
+
+    if (g_db) {
+        persist_log_broadcast(g_db, ok ? txid_out : "?", log_source, tx_hex,
+                              ok ? "ok" : "failed");
+    }
+    free(tx_hex);
+
+    if (!ok) {
+        fprintf(stderr, "force-close: %s broadcast failed after retries\n", log_source);
+        return 0;
+    }
+
+    /* Confirm it */
+    if (is_regtest) {
+        regtest_mine_blocks(rt, 1, mine_addr);
+    } else {
+        printf("  %s broadcast OK (txid=%.16s...), waiting for confirmation...\n",
+               log_source, txid_out);
+        fflush(stdout);
+        regtest_wait_for_confirmation(rt, txid_out, confirm_timeout);
+    }
+
+    if (display_txid_internal_be) {
+        unsigned char disp[32];
+        memcpy(disp, display_txid_internal_be, 32);
+        reverse_bytes(disp, 32);
+        char disp_hex[65];
+        hex_encode(disp, 32, disp_hex);
+        int conf = regtest_get_confirmations(rt, txid_out);
+        printf("  %s confirmed: %s (%d confs)\n", log_source, disp_hex, conf);
+    }
+    return 1;
+}
+
 /* Broadcast all signed factory tree nodes, waiting for real block confirmations.
    On regtest: mines blocks. On signet/testnet: polls getblockcount.
    Handles nSequence relative timelocks by waiting for the required depth.
+
+   v23 fix: for PS leaf and PS sub-factory nodes that have advanced
+   (ps_chain_len > 0), broadcasts the FULL chain history in order:
+     chain[0]  ← from ps_initial_signed_states (saved on first advance)
+     chain[1]  ← from ps_{leaf,subfactory}_chains chain_pos=0
+     chain[2]  ← from ps_{leaf,subfactory}_chains chain_pos=1
+     ...
+     chain[N]  ← from ps_{leaf,subfactory}_chains chain_pos=N-1
+                 (== node->signed_tx in memory)
+   Each chain[i+1] spends chain[i].sales_stock_vout, so they MUST go on-chain
+   sequentially.  Without this, force-close after any advance hangs forever
+   on bitcoin -25 bad-txns-inputs-missingorspent (the bug discovered by
+   the v0.1.15 signet campaign).
+
    Returns 1 on success. */
 static int broadcast_factory_tree_any_network(factory_t *f, regtest_t *rt,
                                                 const char *mine_addr,
@@ -715,103 +833,107 @@ static int broadcast_factory_tree_any_network(factory_t *f, regtest_t *rt,
             return 0;
         }
 
-        char *tx_hex = malloc(node->signed_tx.len * 2 + 1);
-        if (!tx_hex) return 0;
-        hex_encode(node->signed_tx.data, node->signed_tx.len, tx_hex);
+        int is_ps_chain_node = (node->is_ps_leaf ||
+                                node->type == NODE_PS_SUBFACTORY);
+        int has_advanced = (node->ps_chain_len > 0);
 
-        char txid_out[65];
+        if (is_ps_chain_node && has_advanced && g_db) {
+            /* === PS chain history broadcast === */
+            printf("  node[%zu] is PS-advanced (chain_len=%d) — broadcasting "
+                   "chain history\n", i, node->ps_chain_len);
 
-        /* For nodes with nSequence > 0, we may need to wait for the parent
-           to reach sufficient depth before this tx is valid */
-        if (!(node->nsequence & 0x80000000u) && node->nsequence > 0) {  /* BIP68 enabled only when bit 31 clear */
-            uint32_t required_depth = (node->nsequence & 0xFFFF);
-            int est_mins = (int)required_depth * 10; /* ~10 min/block */
-            printf("  node[%zu/%zu] requires %u-block relative timelock "
-                   "(~%dh%02dm), waiting...\n",
-                   i, f->n_nodes, required_depth,
-                   est_mins / 60, est_mins % 60);
+            /* Step 1: chain[0] from ps_initial_signed_states */
+            tx_buf_t init_tx;
+            memset(&init_tx, 0, sizeof(init_tx));
+            unsigned char init_txid_be[32] = {0};
+            if (!persist_load_ps_initial_signed_state(g_db, /*factory_id=*/0,
+                    (uint32_t)i, &init_tx, init_txid_be)) {
+                fprintf(stderr,
+                    "force-close: node %zu has %d PS advances but "
+                    "ps_initial_signed_states is missing chain[0] — cannot "
+                    "reconstruct broadcast history.  This factory advanced "
+                    "before v23 schema; force-close is unrecoverable.\n",
+                    i, node->ps_chain_len);
+                return 0;
+            }
+            char label0[64];
+            snprintf(label0, sizeof(label0), "tree_node_%zu_chain0", i);
+            /* chain[0]'s nSequence: PS chain[0] (the initial state) inherits
+               the node's CURRENT nsequence — but actually for chain history
+               we use 0 (no relative timelock on chain[0] itself; its parent
+               is the leaf above which has its own nsequence).  Actually safest:
+               use whatever the unsigned_tx had encoded.  For now use the same
+               nsequence as the node, which is correct for the topology. */
+            int ok0 = broadcast_one_signed_tx(rt, mine_addr, is_regtest,
+                confirm_timeout, init_tx.data, init_tx.len, node->nsequence,
+                label0, init_txid_be);
+            tx_buf_free(&init_tx);
+            if (!ok0) return 0;
 
-            if (is_regtest) {
-                /* Mine the required blocks */
-                regtest_mine_blocks(rt, (int)required_depth, mine_addr);
-            } else {
-                /* Poll for blocks on signet/testnet with timeout */
-                int start_height = regtest_get_block_height(rt);
-                int target_height = start_height + (int)required_depth;
-                int waited = 0;
-                while (regtest_get_block_height(rt) < target_height) {
-                    if (waited >= confirm_timeout) {
-                        fprintf(stderr, "force-close: node %zu BIP68 wait "
-                                "timed out after %ds (height %d / %d)\n",
-                                i, waited, regtest_get_block_height(rt),
-                                target_height);
-                        free(tx_hex);
-                        return 0;
-                    }
-                    sleep(10);
-                    waited += 10;
-                    int cur_h = regtest_get_block_height(rt);
-                    int blocks_left = target_height - cur_h;
-                    int est_mins = blocks_left * 10;
-                    printf("    height: %d / %d (%ds elapsed, ~%dh%02dm remaining)\n",
-                           cur_h, target_height, waited,
-                           est_mins / 60, est_mins % 60);
-                    fflush(stdout);
+            /* Step 2: load chain[1..ps_chain_len] from
+               ps_subfactory_chains (or ps_leaf_chains) and broadcast each.
+               PR-B's chain_pos=K-1 == chain[K] in semantic terms. */
+            #define CHAIN_HIST_MAX 256
+            tx_buf_t hist_txs[CHAIN_HIST_MAX];
+            unsigned char hist_txids[CHAIN_HIST_MAX][32];
+            memset(hist_txs, 0, sizeof(hist_txs));
+            int n_hist = 0;
+            if (node->type == NODE_PS_SUBFACTORY) {
+                uint64_t hist_sstock[CHAIN_HIST_MAX];
+                uint64_t hist_chans[CHAIN_HIST_MAX][16];
+                int hist_n_chans[CHAIN_HIST_MAX];
+                tx_buf_t hist_poison[CHAIN_HIST_MAX];
+                memset(hist_poison, 0, sizeof(hist_poison));
+                n_hist = persist_load_subfactory_chain(g_db, /*factory_id=*/0,
+                    (uint32_t)i, hist_txs, hist_txids,
+                    hist_sstock, hist_chans, hist_n_chans,
+                    hist_poison, CHAIN_HIST_MAX);
+                /* poison_txs and per-channel amounts not needed here —
+                   broadcast just needs signed_tx. */
+                for (int k = 0; k < n_hist; k++) tx_buf_free(&hist_poison[k]);
+            } else if (node->is_ps_leaf) {
+                uint64_t hist_amts[CHAIN_HIST_MAX];
+                tx_buf_t hist_poison[CHAIN_HIST_MAX];
+                memset(hist_poison, 0, sizeof(hist_poison));
+                n_hist = persist_load_ps_chain(g_db, /*factory_id=*/0,
+                    (uint32_t)i, hist_txs, hist_txids, hist_amts,
+                    hist_poison, CHAIN_HIST_MAX);
+                for (int k = 0; k < n_hist; k++) tx_buf_free(&hist_poison[k]);
+            }
+            if (n_hist != node->ps_chain_len) {
+                fprintf(stderr,
+                    "force-close: node %zu PS chain history mismatch — "
+                    "node->ps_chain_len=%d but loaded %d entries.  Aborting.\n",
+                    i, node->ps_chain_len, n_hist);
+                for (int k = 0; k < n_hist; k++) tx_buf_free(&hist_txs[k]);
+                return 0;
+            }
+            int chain_ok = 1;
+            for (int k = 0; k < n_hist && chain_ok; k++) {
+                char labelK[64];
+                snprintf(labelK, sizeof(labelK), "tree_node_%zu_chain%d", i, k + 1);
+                if (!broadcast_one_signed_tx(rt, mine_addr, is_regtest,
+                        confirm_timeout, hist_txs[k].data, hist_txs[k].len,
+                        node->nsequence,
+                        labelK, hist_txids[k])) {
+                    chain_ok = 0;
                 }
             }
+            for (int k = 0; k < n_hist; k++) tx_buf_free(&hist_txs[k]);
+            if (!chain_ok) return 0;
+            #undef CHAIN_HIST_MAX
+            /* Already broadcast node->signed_tx as the last chain entry. */
+            continue;
         }
 
-        /* Try to broadcast — may need retries if BIP68 not yet satisfied */
-        int ok = 0;
-        int bcast_waited = 0;
-        int bcast_limit = is_regtest ? 60 : confirm_timeout;
-        for (int attempt = 0; bcast_waited < bcast_limit; attempt++) {
-            ok = regtest_send_raw_tx(rt, tx_hex, txid_out);
-            if (ok) break;
-            if (attempt == 0)
-                printf("  node[%zu] broadcast pending (waiting for BIP68)...\n", i);
-            if (is_regtest) {
-                regtest_mine_blocks(rt, 1, mine_addr);
-                bcast_waited++;
-            } else {
-                sleep(15);
-                bcast_waited += 15;
-            }
-        }
-
-        /* Audit log */
-        if (g_db) {
-            char src[32];
-            snprintf(src, sizeof(src), "tree_node_%zu", i);
-            persist_log_broadcast(g_db, ok ? txid_out : "?", src, tx_hex,
-                                  ok ? "ok" : "failed");
-        }
-        free(tx_hex);
-
-        if (!ok) {
-            fprintf(stderr, "force-close: node %zu broadcast failed after retries\n", i);
+        /* === Default: broadcast node->signed_tx === */
+        char label[32];
+        snprintf(label, sizeof(label), "tree_node_%zu", i);
+        if (!broadcast_one_signed_tx(rt, mine_addr, is_regtest, confirm_timeout,
+                node->signed_tx.data, node->signed_tx.len, node->nsequence,
+                label, node->txid)) {
             return 0;
         }
-
-        /* Confirm it: mine 1 block on regtest, wait on signet */
-        if (is_regtest) {
-            regtest_mine_blocks(rt, 1, mine_addr);
-        } else {
-            printf("  node[%zu/%zu] broadcast OK (txid=%.16s...), "
-                   "waiting for confirmation...\n",
-                   i, f->n_nodes, txid_out);
-            fflush(stdout);
-            regtest_wait_for_confirmation(rt, txid_out, confirm_timeout);
-        }
-
-        unsigned char display_txid[32];
-        memcpy(display_txid, node->txid, 32);
-        reverse_bytes(display_txid, 32);
-        char display_hex[65];
-        hex_encode(display_txid, 32, display_hex);
-
-        int conf = regtest_get_confirmations(rt, txid_out);
-        printf("  node[%zu] confirmed: %s (%d confs)\n", i, display_hex, conf);
     }
     return 1;
 }


### PR DESCRIPTION
## Summary
Fixes a CRITICAL bug discovered by the v0.1.15 signet campaign: force-close after a sub-factory chain advance hangs indefinitely on bitcoin -25 bad-txns-inputs-missingorspent.

## Root cause
lsp_subfactory_chain_advance overwrites sub->signed_tx with chain[N] (the latest advance result). Force-close iterates f->nodes[i].signed_tx and broadcasts each — for sub-factories that have advanced, that's chain[N], which spends chain[N-1].sales_stock. But chain[0..N-1] were never broadcast on-chain, so chain[N]'s parent input doesn't exist.

The regtest harness exits after the ceremony fires (its grep markers are satisfied) BEFORE force-close completes — so this was hidden until signet's longer wait surfaced it.

## Fix (additive, no breaking schema change)
- **New schema v23**: `ps_initial_signed_states` (factory_id, node_idx) → txid + signed_tx_hex. Stores chain[0]'s signed bytes once, before the first advance overwrites them.
- **lsp_subfactory_chain_advance + lsp_advance_leaf** detect ps_chain_len==0 on entry and persist chain[0] before proceeding. Idempotent.
- **broadcast_factory_tree_any_network** detects PS chain nodes with ps_chain_len > 0 and broadcasts the FULL chain history in order: chain[0] from ps_initial_signed_states, then chain[1..N] from ps_{leaf,subfactory}_chains. Each broadcast waits for confirmation before the next.
- **broadcast_one_signed_tx** helper extracted to deduplicate the BIP68-wait + retry + log + confirm logic across chain[0] and chain[1..N] paths.

## Tests
- test_persist_ps_initial_signed_state_round_trip: save/load/overwrite/missing-key paths on the new table.
- v23 schema-version smoke test bumped.
- The existing test_multiprocess_subfactory_advance.sh harness will exercise the full path on the next CI run.

## Backward compat
Factories that advanced before v23 won't have chain[0] in ps_initial_signed_states. Force-close on those returns 0 with a clear error. v23 is pre-release so no production migration concerns.

## Test plan
- [ ] CI: unit + sanitizer + multi-process harnesses pass
- [ ] Re-run signet k² campaign on VPS — should now confirm node[0..N] in sequence and reach the conservation check