### PR TITLE
chore(signet/watchtower): autodetect bitcoin RPC + drop dead response_tx broadcast

### DIFF
--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -570,12 +570,26 @@ int watchtower_check(watchtower_t *wt) {
 
         if (e->type == WATCH_SUBFACTORY_NODE) {
             /* PS sub-factory chain breach (k² shape).
-               Stale chain[N-1] confirmed; we broadcast the latest chain[N]
-               (which spends a UTXO that no longer exists on-chain after
-               the stale state confirms — but this is the same shape as
-               the FACTORY_NODE response, retained for symmetry until the
-               poison TX builder lands).  We then broadcast the poison TX
-               that distributes the stale sales-stock to clients pro-rata.
+               Stale chain[N-1] confirmed.  The recourse mechanism is the
+               poison TX (Gap A): it spends chain[N-1].sales_stock_vout and
+               distributes the sales-stock pro-rata to each non-LSP signer.
+
+               Historical note: an earlier version of this handler ALSO
+               broadcast `response_tx` (the latest chain[N]) for symmetry
+               with WATCH_FACTORY_NODE.  But response_tx and poison_tx
+               compete for the same chain[N-1].sales_stock UTXO — only one
+               can win.  After chain[N-1] confirms, response_tx
+               (chain[N]) is structurally invalid: its parent input is
+               consumed by chain[N-1]'s confirmation and bitcoind correctly
+               rejects with -25 bad-txns-inputs-missingorspent.  Poison
+               TX is the actual recourse; response_tx broadcast was always
+               a no-op when bitcoind validation actually ran (regtest tests
+               passed because they exited before broadcast was attempted).
+
+               This cleanup removes the dead response_tx broadcast.  The
+               watchtower entry's response_tx field is still populated by
+               watchtower_watch_subfactory_node for compatibility with the
+               WATCH_FACTORY_NODE shape, but is no longer broadcast here.
 
                Unlike WATCH_FACTORY_NODE we do NOT auto-settle channels —
                sub-factory clients live inside the sub-factory chain TX,
@@ -590,29 +604,6 @@ int watchtower_check(watchtower_t *wt) {
 
             char sub_resp_txid[65] = {0};
 
-            if (e->response_tx && e->response_tx_len > 0) {
-                char *resp_hex = (char *)malloc(e->response_tx_len * 2 + 1);
-                if (resp_hex) {
-                    hex_encode(e->response_tx, e->response_tx_len, resp_hex);
-                    char resp_txid[65];
-                    if (wt->chain->send_raw_tx(wt->chain, resp_hex, resp_txid)) {
-                        printf("  Sub-factory response tx broadcast: %s\n", resp_txid);
-                        memcpy(sub_resp_txid, resp_txid, 64);
-                        sub_resp_txid[64] = '\0';
-                        penalties_broadcast++;
-                        if (wt->db && wt->db->db)
-                            persist_log_broadcast(wt->db, resp_txid,
-                                                  "subfactory_response", resp_hex, "ok");
-                    } else {
-                        fprintf(stderr, "  Sub-factory response tx broadcast failed\n");
-                        if (wt->db && wt->db->db)
-                            persist_log_broadcast(wt->db, "?",
-                                                  "subfactory_response", resp_hex, "failed");
-                    }
-                    free(resp_hex);
-                }
-            }
-
             if (e->burn_tx && e->burn_tx_len > 0) {
                 char *poison_hex = (char *)malloc(e->burn_tx_len * 2 + 1);
                 if (poison_hex) {
@@ -620,6 +611,9 @@ int watchtower_check(watchtower_t *wt) {
                     char poison_txid[65];
                     if (wt->chain->send_raw_tx(wt->chain, poison_hex, poison_txid)) {
                         printf("  Sub-factory poison tx broadcast: %s\n", poison_txid);
+                        memcpy(sub_resp_txid, poison_txid, 64);
+                        sub_resp_txid[64] = '\0';
+                        penalties_broadcast++;
                         if (wt->db && wt->db->db)
                             persist_log_broadcast(wt->db, poison_txid,
                                                   "subfactory_poison", poison_hex, "ok");
@@ -631,6 +625,11 @@ int watchtower_check(watchtower_t *wt) {
                     }
                     free(poison_hex);
                 }
+            } else {
+                fprintf(stderr,
+                        "  Sub-factory breach detected but no poison TX "
+                        "available — degraded path (Gap A SECURITY GAP).  "
+                        "Stale sales-stock cannot be redistributed.\n");
             }
 
             e->penalty_broadcast = 1;

--- a/tools/signet_k2_campaign.sh
+++ b/tools/signet_k2_campaign.sh
@@ -54,6 +54,32 @@ FUNDING_SATS="${FUNDING_SATS:-400000}"
 # causes false pessimism during signet-faucet windows.
 TREE_CONFIRM_TIMEOUT="${TREE_CONFIRM_TIMEOUT:-14400}"  # 4 hours
 
+# Auto-detect bitcoind RPC creds from the signet conf if env not set.
+# Avoids needing the operator to remember to override RPCUSER/RPCPASS;
+# this was the #1 setup hit in the v0.1.15 first-run signet campaign.
+SIGNET_CONF_DEFAULT=/var/lib/bitcoind-signet/bitcoin.conf
+if [ -z "${RPCUSER:-}" ] && [ -r "$SIGNET_CONF_DEFAULT" ]; then
+    detected=$(awk -F= '/^[[:space:]]*rpcuser[[:space:]]*=/  {gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2); print $2; exit}' \
+                   "$SIGNET_CONF_DEFAULT" 2>/dev/null)
+    [ -n "$detected" ] && export RPCUSER="$detected"
+fi
+if [ -z "${RPCPASS:-}" ] && [ -r "$SIGNET_CONF_DEFAULT" ]; then
+    detected=$(awk -F= '/^[[:space:]]*rpcpassword[[:space:]]*=/ {gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2); print $2; exit}' \
+                   "$SIGNET_CONF_DEFAULT" 2>/dev/null)
+    [ -n "$detected" ] && export RPCPASS="$detected"
+fi
+if [ -z "${RPCPORT:-}" ] && [ -r "$SIGNET_CONF_DEFAULT" ]; then
+    detected=$(awk -F= '/^[[:space:]]*rpcport[[:space:]]*=/    {gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2); print $2; exit}' \
+                   "$SIGNET_CONF_DEFAULT" 2>/dev/null)
+    [ -n "$detected" ] && export RPCPORT="$detected"
+fi
+
+# Auto-pick a non-LN port for the LSP listener.  9735 is the canonical LN
+# port and is held by CLN on most VPS setups; the LSP daemon needs its own.
+# Default 29735 is unlikely to clash; operator can still override via
+# LSP_PORT env.
+export LSP_PORT="${LSP_PORT:-29735}"
+
 # Log everything to transcript so the operator can replay.
 exec > >(tee -a "$TRANSCRIPT") 2>&1
 

--- a/tools/test_regtest_k2_subfactory_breach.sh
+++ b/tools/test_regtest_k2_subfactory_breach.sh
@@ -282,48 +282,36 @@ echo "  $DETECT_LINE"
 
 echo ""
 echo "=== Verifying poison TX broadcast ==="
-# Note: in t/1242 the response_tx (chain[N]) and poison_tx both spend the
-# same chain[N-1].sales-stock UTXO — they race, only one can win.  After
-# chain[N-1] confirms (the cheat), chain[N] is INVALID (its parent input
-# vanished), so response_tx broadcast attempts will fail with sendrawtransaction
-# rejection.  The poison TX is the actual recourse mechanism: it
-# distributes the now-orphaned sales-stock to clients pro-rata.
-#
-# This harness asserts only the poison TX broadcast.  The response_tx
-# attempt is best-effort and its failure is expected (and logged in the
-# LSP daemon as "Sub-factory response tx broadcast failed").  A future PR
-# should remove the response_tx broadcast for WATCH_SUBFACTORY_NODE
-# entries entirely — see watchtower.c:573-577 for the explanatory comment.
+# Per t/1242, after chain[N-1] confirms (the cheat) the recourse is the
+# poison TX which spends chain[N-1].sales_stock and distributes pro-rata to
+# each non-LSP signer.  Earlier versions of the watchtower also tried to
+# broadcast response_tx (chain[N]) for symmetry with WATCH_FACTORY_NODE,
+# but chain[N]'s only input is chain[N-1].sales_stock — the same UTXO the
+# poison TX claims, AND it can't co-exist with the cheat being on-chain.
+# That dead path was removed in the v0.1.15 watchtower cleanup; only
+# poison_tx is broadcast now.
 if ! grep -q "Sub-factory poison tx broadcast:" "$LSP_LOG"; then
     echo "FAIL: poison_tx was not broadcast by watchtower"
-    grep -E "poison|broadcast|FAIL|BREACH|response" "$LSP_LOG" | head -40
+    grep -E "poison|broadcast|FAIL|BREACH" "$LSP_LOG" | head -40
     exit 1
 fi
 POISON_LINE=$(grep "Sub-factory poison tx broadcast:" "$LSP_LOG" | head -1)
 POISON_TXID=$(echo "$POISON_LINE" | awk '{print $NF}')
 echo "  $POISON_LINE"
 
-# response_tx broadcast is informational only (expected to fail because its
-# parent UTXO was just consumed by the cheat broadcast).
-RESP_LINE=$(grep -E "Sub-factory response tx broadcast" "$LSP_LOG" | head -1)
-echo "  response_tx attempt: ${RESP_LINE:-<not logged>}"
-
 # --- Verify broadcast_log entries via SQLite ---
 echo ""
 echo "=== Verifying broadcast_log entries ==="
 if [ -f "$LSP_DB" ]; then
-    NREP=$(sqlite3 "$LSP_DB" \
-        "SELECT COUNT(*) FROM broadcast_log WHERE source='subfactory_response';" \
-        2>/dev/null || echo 0)
     NPOI=$(sqlite3 "$LSP_DB" \
         "SELECT COUNT(*) FROM broadcast_log WHERE source='subfactory_poison';" \
         2>/dev/null || echo 0)
     NCHEAT=$(sqlite3 "$LSP_DB" \
         "SELECT COUNT(*) FROM broadcast_log WHERE source='cheat_subfactory_stale';" \
         2>/dev/null || echo 0)
-    echo "  broadcast_log rows: cheat=$NCHEAT response=$NREP poison=$NPOI"
-    # response_tx may be 0 (broadcast attempt fails post-cheat by design — see
-    # the response_tx-vs-poison comment above); poison + cheat are mandatory.
+    echo "  broadcast_log rows: cheat=$NCHEAT poison=$NPOI"
+    # response_tx broadcast removed in v0.1.15 (was structurally invalid by
+    # design — see watchtower.c WATCH_SUBFACTORY_NODE handler).
     if [ "$NPOI" -lt 1 ] || [ "$NCHEAT" -lt 1 ]; then
         echo "FAIL: missing broadcast_log entries (need cheat>=1 and poison>=1)"
         exit 1


### PR DESCRIPTION
## Summary
Two small QoL fixes from the v0.1.15 first-run signet campaign findings:

### 1. tools/signet_k2_campaign.sh: auto-detect bitcoin RPC creds + non-LN port
Reads RPCUSER/RPCPASS/RPCPORT from `/var/lib/bitcoind-signet/bitcoin.conf` when env vars aren't set; defaults LSP_PORT to 29735 (avoids clashing with CLN on 9735). Operators no longer have to remember to override creds — the script just works on a vanilla VPS layout.

### 2. src/watchtower.c: drop dead WATCH_SUBFACTORY_NODE response_tx broadcast
Original handler broadcast BOTH response_tx (chain[N]) AND poison_tx after a sub-factory breach, for symmetry with WATCH_FACTORY_NODE. But response_tx and poison_tx compete for the same chain[N-1].sales_stock UTXO — only one wins, and after chain[N-1] confirms (the cheat), chain[N]'s parent input is consumed → bitcoind correctly rejects with -25. poison_tx is the actual recourse mechanism per t/1242 Gap A. This cleanup removes the dead code; the harness assertion was already poison-only (per PR #142's investigation).

## Test plan
- [ ] CI: all unit + sanitizer + multi-process harness jobs pass
- [ ] Existing breach harness test_regtest_k2_subfactory_breach.sh still passes (already poison-only assertion)

Both changes are safe/additive — env-overridable defaults; response_tx broadcast was never successful in practice (always -25 post-cheat).