### PR TITLE
feat(tx_builder): multi-input builder for sub-factory chain advance (#207 phase 1)

### DIFF
--- a/include/superscalar/tx_builder.h
+++ b/include/superscalar/tx_builder.h
@@ -57,6 +57,28 @@ int build_unsigned_tx_v(
     uint32_t nVersion
 );
 
+/* Multi-input variant. Each tx_input_t describes one (prev_txid, prev_vout,
+   nsequence) triple.  Used by PS sub-factory chain advance (chain[N+1]
+   spends ALL k+1 vouts of chain[N] — see #207 fix for the full design).
+   txids are 32-byte internal-byte-order (little-endian when written to the
+   wire format, matching build_unsigned_tx's `funding_txid` layout). */
+typedef struct {
+    unsigned char prev_txid[32];
+    uint32_t      prev_vout;
+    uint32_t      nsequence;
+} tx_input_t;
+
+int build_unsigned_tx_multi(
+    tx_buf_t *out,
+    unsigned char *txid_out32,     /* can be NULL */
+    const tx_input_t *inputs,
+    size_t n_inputs,
+    const tx_output_t *outputs,
+    size_t n_outputs,
+    uint32_t nVersion,             /* 2 standard, 3 TRUC */
+    uint32_t nlocktime
+);
+
 /* BIP-341 sighash (key-path, SIGHASH_DEFAULT). */
 int compute_taproot_sighash(
     unsigned char *sighash_out32,

--- a/src/tx_builder.c
+++ b/src/tx_builder.c
@@ -113,6 +113,48 @@ int build_unsigned_tx(
                                             nsequence, 0, outputs, n_outputs);
 }
 
+int build_unsigned_tx_multi(
+    tx_buf_t *out,
+    unsigned char *txid_out32,
+    const tx_input_t *inputs,
+    size_t n_inputs,
+    const tx_output_t *outputs,
+    size_t n_outputs,
+    uint32_t nVersion,
+    uint32_t nlocktime
+) {
+    if (!out || !inputs || n_inputs == 0 || (!outputs && n_outputs > 0))
+        return 0;
+    tx_buf_reset(out);
+
+    tx_buf_write_u32_le(out, nVersion);
+    tx_buf_write_varint(out, n_inputs);
+    for (size_t i = 0; i < n_inputs; i++) {
+        tx_buf_write_bytes(out, inputs[i].prev_txid, 32);
+        tx_buf_write_u32_le(out, inputs[i].prev_vout);
+        tx_buf_write_varint(out, 0);           /* empty scriptSig */
+        tx_buf_write_u32_le(out, inputs[i].nsequence);
+    }
+
+    tx_buf_write_varint(out, n_outputs);
+    for (size_t i = 0; i < n_outputs; i++) {
+        tx_buf_write_u64_le(out, outputs[i].amount_sats);
+        tx_buf_write_varint(out, outputs[i].script_pubkey_len);
+        tx_buf_write_bytes(out, outputs[i].script_pubkey,
+                           outputs[i].script_pubkey_len);
+    }
+
+    tx_buf_write_u32_le(out, nlocktime);
+
+    if (out->oom) return 0;
+
+    if (txid_out32) {
+        sha256_double(out->data, out->len, txid_out32);
+        reverse_bytes(txid_out32, 32);
+    }
+    return 1;
+}
+
 int build_unsigned_tx_v(
     tx_buf_t *out,
     unsigned char *txid_out32,

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -76,6 +76,7 @@ extern int test_musig_split_round_5of5(void);
 extern int test_tx_buf_primitives(void);
 extern int test_build_p2tr_script_pubkey(void);
 extern int test_build_unsigned_tx(void);
+extern int test_build_unsigned_tx_multi(void);
 extern int test_finalize_signed_tx(void);
 extern int test_varint_encoding(void);
 
@@ -1911,6 +1912,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_tx_buf_primitives);
     RUN_TEST(test_build_p2tr_script_pubkey);
     RUN_TEST(test_build_unsigned_tx);
+    RUN_TEST(test_build_unsigned_tx_multi);
     RUN_TEST(test_finalize_signed_tx);
     RUN_TEST(test_varint_encoding);
 

--- a/tests/test_tx_builder.c
+++ b/tests/test_tx_builder.c
@@ -175,6 +175,91 @@ int test_build_unsigned_tx(void) {
     return 1;
 }
 
+int test_build_unsigned_tx_multi(void) {
+    /* Multi-input variant for the v0.1.15 #207 fix.  Asserts the wire
+       format encodes N inputs correctly + each input's nsequence is
+       independent + the txid hashes deterministically. */
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    /* 3 distinct inputs (e.g. chain[N-1]'s 2 channel outputs + sales-stock). */
+    tx_input_t inputs[3];
+    memset(inputs[0].prev_txid, 0xa1, 32); inputs[0].prev_vout = 0; inputs[0].nsequence = 0xFFFFFFFE;
+    memset(inputs[1].prev_txid, 0xa1, 32); inputs[1].prev_vout = 1; inputs[1].nsequence = 0xFFFFFFFE;
+    memset(inputs[2].prev_txid, 0xa1, 32); inputs[2].prev_vout = 2; inputs[2].nsequence = 144;
+
+    /* Mock outputs (k+1 = 3). */
+    unsigned char seckey[32]; memset(seckey, 0x05, 32);
+    secp256k1_keypair kp;
+    if (!secp256k1_keypair_create(ctx, &kp, seckey)) return 0;
+    secp256k1_xonly_pubkey xpk;
+    if (!secp256k1_keypair_xonly_pub(ctx, &xpk, NULL, &kp)) return 0;
+
+    tx_output_t outs[3];
+    for (int i = 0; i < 3; i++) {
+        outs[i].amount_sats = 40000 + (uint64_t)i * 1000;
+        build_p2tr_script_pubkey(outs[i].script_pubkey, &xpk);
+        outs[i].script_pubkey_len = 34;
+    }
+
+    tx_buf_t buf; tx_buf_init(&buf, 512);
+    unsigned char txid[32];
+
+    TEST_ASSERT(build_unsigned_tx_multi(&buf, txid, inputs, 3, outs, 3, 2, 0),
+                "multi-input build");
+
+    /* Wire format spot-checks:
+       offset 0..3: nVersion=2 (LE)
+       offset 4: input count varint = 3
+       offset 5..36: input[0].prev_txid
+       offset 37..40: input[0].prev_vout=0
+       offset 41: scriptSig len = 0
+       offset 42..45: input[0].nsequence=0xFFFFFFFE */
+    TEST_ASSERT_EQ(buf.data[0], 0x02, "nVersion byte 0");
+    TEST_ASSERT_EQ(buf.data[4], 0x03, "input count = 3");
+    TEST_ASSERT(memcmp(buf.data + 5, inputs[0].prev_txid, 32) == 0,
+                "input[0] txid");
+    TEST_ASSERT_EQ(buf.data[37], 0x00, "input[0] vout = 0");
+    TEST_ASSERT_EQ(buf.data[42], 0xFE, "input[0] nseq[0] = 0xFE");
+    TEST_ASSERT_EQ(buf.data[43], 0xFF, "input[0] nseq[1] = 0xFF");
+    TEST_ASSERT_EQ(buf.data[44], 0xFF, "input[0] nseq[2] = 0xFF");
+    TEST_ASSERT_EQ(buf.data[45], 0xFF, "input[0] nseq[3] = 0xFF");
+
+    /* input[1]: at offset 46, txid (32) + vout (4) + scriptsig_len(1) + nseq(4) = 41 bytes */
+    TEST_ASSERT(memcmp(buf.data + 46, inputs[1].prev_txid, 32) == 0,
+                "input[1] txid");
+    TEST_ASSERT_EQ(buf.data[78], 0x01, "input[1] vout = 1");
+
+    /* input[2]: at offset 87, with nseq = 144 = 0x90 */
+    TEST_ASSERT_EQ(buf.data[87 + 32], 0x02, "input[2] vout = 2");
+    TEST_ASSERT_EQ(buf.data[87 + 32 + 4 + 1], 0x90, "input[2] nseq = 144");
+
+    /* txid is non-zero */
+    int all_zero = 1;
+    for (int i = 0; i < 32; i++) if (txid[i]) { all_zero = 0; break; }
+    TEST_ASSERT(!all_zero, "multi-input txid is non-zero");
+
+    /* Determinism — re-build with same inputs, expect identical bytes */
+    tx_buf_t buf2; tx_buf_init(&buf2, 512);
+    unsigned char txid2[32];
+    TEST_ASSERT(build_unsigned_tx_multi(&buf2, txid2, inputs, 3, outs, 3, 2, 0),
+                "multi-input rebuild");
+    TEST_ASSERT(buf.len == buf2.len, "deterministic length");
+    TEST_ASSERT(memcmp(buf.data, buf2.data, buf.len) == 0,
+                "deterministic bytes");
+    TEST_ASSERT(memcmp(txid, txid2, 32) == 0, "deterministic txid");
+
+    /* Argument validation */
+    TEST_ASSERT(!build_unsigned_tx_multi(&buf, NULL, NULL, 3, outs, 3, 2, 0),
+                "null inputs rejected");
+    TEST_ASSERT(!build_unsigned_tx_multi(&buf, NULL, inputs, 0, outs, 3, 2, 0),
+                "zero inputs rejected");
+
+    tx_buf_free(&buf);
+    tx_buf_free(&buf2);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
 int test_finalize_signed_tx(void) {
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
 


### PR DESCRIPTION
## Summary
Phase 1 of the v0.1.15 #207 chain[1+] sub-factory construction fix. Adds the foundational \`build_unsigned_tx_multi\` helper. No behavior change — purely additive.

## Why
PS sub-factory chain[N+1] currently builds with 1 vin (chain[N-1].sales_stock) but k+1 vouts (full state) → outputs > inputs by ~3x → bitcoin -25 \`bad-txns-in-belowout\`. The signet campaign surfaced this; existing \`test_factory_ps_subfactory_chain_extension\` only asserts on in-memory \`sub->outputs[]\`, never on TX-level conservation, so the bug was hidden.

Per t/1242 design (\`docs/ps-subfactories.md\`): chain[N+1] must spend ALL k+1 vouts of chain[N]. This PR adds the multi-input wire-format helper that subsequent phases will wire into \`rebuild_node_tx\`.

## Subsequent phases
Per \`.claude/PR207_DESIGN.md\` (local doc, not shipped):
- Phase 2: wire \`build_unsigned_tx_multi\` into \`rebuild_node_tx\` for advanced PS sub-factories
- Phase 3: multi-input MuSig signing (k+1 sighashes per node)
- Phase 4: TX-level conservation test (would have caught the bug)
- Phase 5: verify same fix covers PS leaves with k>1

## Test plan
- [ ] \`./test_superscalar --unit\` includes new \`test_build_unsigned_tx_multi\` (round-trip, determinism, arg validation)
- [ ] All existing tests still pass (no caller migrated yet)