### PR TITLE
feat(tx_builder): multi-input sighash + multi-witness primitives (#207 phase 2a)

### DIFF
--- a/include/superscalar/tx_builder.h
+++ b/include/superscalar/tx_builder.h
@@ -91,12 +91,42 @@ int compute_taproot_sighash(
     uint32_t nsequence
 );
 
+/* BIP-341 sighash (key-path, SIGHASH_DEFAULT) for a multi-input tx built by
+   build_unsigned_tx_multi.  Hashes the full prev{outpoints, amounts, scripts,
+   sequences} sets per BIP-341 §4.2 and binds to input_index.  Each per-input
+   array must have n_inputs entries.  prev_scriptpubkeys is an array of
+   pointers (so callers can pass non-contiguous SPKs without copying). */
+int compute_taproot_sighash_multi(
+    unsigned char *sighash_out32,
+    const unsigned char *unsigned_tx,
+    size_t tx_len,
+    uint32_t input_index,
+    size_t n_inputs,
+    const unsigned char * const *prev_scriptpubkeys,
+    const size_t *prev_spk_lens,
+    const uint64_t *prev_amounts,
+    const uint32_t *nsequences
+);
+
 /* Attach 64-byte Schnorr witness to unsigned tx. */
 int finalize_signed_tx(
     tx_buf_t *out,
     const unsigned char *unsigned_tx,
     size_t unsigned_tx_len,
     const unsigned char *sig64
+);
+
+/* Attach N 64-byte Schnorr witnesses (one per input) to a multi-input
+   unsigned tx built by build_unsigned_tx_multi.  Each witness is a single
+   64-byte schnorr key-path signature (SIGHASH_DEFAULT, no annex), serialized
+   in segwit format: per-input { varint(n_items=1) || varint(64) || sig64 }.
+   sig64s is a contiguous buffer of n_inputs * 64 bytes. */
+int finalize_signed_tx_multi(
+    tx_buf_t *out,
+    const unsigned char *unsigned_tx,
+    size_t unsigned_tx_len,
+    size_t n_inputs,
+    const unsigned char *sig64s
 );
 
 #endif /* SUPERSCALAR_TX_BUILDER_H */

--- a/src/tx_builder.c
+++ b/src/tx_builder.c
@@ -300,3 +300,154 @@ int finalize_signed_tx(
     tx_buf_write_bytes(out, unsigned_tx + unsigned_tx_len - 4, 4); /* nLockTime */
     return !out->oom;
 }
+
+/* Compute the byte length of a varint given its value. */
+static size_t varint_size(uint64_t v) {
+    if (v < 0xfd)        return 1;
+    if (v <= 0xffff)     return 3;
+    if (v <= 0xffffffff) return 5;
+    return 9;
+}
+
+int compute_taproot_sighash_multi(
+    unsigned char *sighash_out32,
+    const unsigned char *unsigned_tx,
+    size_t tx_len,
+    uint32_t input_index,
+    size_t n_inputs,
+    const unsigned char * const *prev_scriptpubkeys,
+    const size_t *prev_spk_lens,
+    const uint64_t *prev_amounts,
+    const uint32_t *nsequences
+) {
+    if (!sighash_out32 || !unsigned_tx || !prev_scriptpubkeys ||
+        !prev_spk_lens || !prev_amounts || !nsequences) return 0;
+    if (n_inputs == 0) return 0;
+    if ((size_t)input_index >= n_inputs) return 0;
+    if (tx_len < 8) return 0;
+
+    unsigned char nversion_le[4], nlocktime_le[4];
+    memcpy(nversion_le, unsigned_tx, 4);
+    memcpy(nlocktime_le, unsigned_tx + tx_len - 4, 4);
+
+    /* Locate the inputs section in the serialized tx.
+       Layout: [nVersion(4)][varint(n_inputs)][input × n_inputs][varint(n_outputs)][outputs][nLockTime(4)]
+       Each input: [prev_txid(32)][prev_vout(4)][varint(scriptSig_len)=0][nSequence(4)] = 41 bytes.
+       (scriptSig is empty in unsigned TXs we build, so its varint is a single 0x00 byte.) */
+    size_t n_inputs_varint_len = varint_size((uint64_t)n_inputs);
+    size_t inputs_start = 4 + n_inputs_varint_len;
+    const size_t each_input_len = 32 + 4 + 1 + 4;
+    size_t outputs_start = inputs_start + each_input_len * n_inputs;
+    if (outputs_start + 4 > tx_len) return 0;
+
+    /* sha_prevouts: SHA256 of all (txid + vout) concatenated, in tx order.
+       Read them straight from the tx bytes — that guarantees we hash
+       exactly what bitcoin will hash. */
+    unsigned char *prevouts_concat = (unsigned char *)malloc(36 * n_inputs);
+    if (!prevouts_concat) return 0;
+    for (size_t i = 0; i < n_inputs; i++) {
+        size_t off = inputs_start + each_input_len * i;
+        memcpy(prevouts_concat + 36 * i, unsigned_tx + off, 36);
+    }
+    unsigned char sha_prevouts[32];
+    sha256(prevouts_concat, 36 * n_inputs, sha_prevouts);
+    free(prevouts_concat);
+
+    /* sha_amounts: SHA256 of all 8-byte LE amounts concatenated. */
+    unsigned char *amounts_concat = (unsigned char *)malloc(8 * n_inputs);
+    if (!amounts_concat) return 0;
+    for (size_t i = 0; i < n_inputs; i++)
+        write_u64_le(amounts_concat + 8 * i, prev_amounts[i]);
+    unsigned char sha_amounts[32];
+    sha256(amounts_concat, 8 * n_inputs, sha_amounts);
+    free(amounts_concat);
+
+    /* sha_scriptpubkeys: SHA256 of (varint(spk_len) || spk) per input concatenated. */
+    size_t spk_total = 0;
+    for (size_t i = 0; i < n_inputs; i++) {
+        if (prev_spk_lens[i] >= 0xfd) return 0;  /* SPKs in our usage are <253 bytes */
+        spk_total += 1 + prev_spk_lens[i];
+    }
+    unsigned char *spk_concat = (unsigned char *)malloc(spk_total);
+    if (!spk_concat) return 0;
+    size_t spk_pos = 0;
+    for (size_t i = 0; i < n_inputs; i++) {
+        spk_concat[spk_pos++] = (unsigned char)prev_spk_lens[i];
+        memcpy(spk_concat + spk_pos, prev_scriptpubkeys[i], prev_spk_lens[i]);
+        spk_pos += prev_spk_lens[i];
+    }
+    unsigned char sha_scriptpubkeys[32];
+    sha256(spk_concat, spk_total, sha_scriptpubkeys);
+    free(spk_concat);
+
+    /* sha_sequences: SHA256 of all 4-byte LE sequences concatenated. */
+    unsigned char *seq_concat = (unsigned char *)malloc(4 * n_inputs);
+    if (!seq_concat) return 0;
+    for (size_t i = 0; i < n_inputs; i++)
+        write_u32_le(seq_concat + 4 * i, nsequences[i]);
+    unsigned char sha_sequences[32];
+    sha256(seq_concat, 4 * n_inputs, sha_sequences);
+    free(seq_concat);
+
+    /* sha_outputs: SHA256 of the entire outputs section (excluding the
+       leading varint(n_outputs)).  In single-input compute_taproot_sighash
+       we hardcoded the +1 byte skip; here we read the actual varint length. */
+    size_t out_count_varint_off = outputs_start;
+    /* peek varint len; outputs in our usage always have small varint */
+    uint8_t b0 = unsigned_tx[out_count_varint_off];
+    size_t out_count_varint_len = (b0 < 0xfd) ? 1 : (b0 == 0xfd ? 3 : (b0 == 0xfe ? 5 : 9));
+    size_t outputs_data_start = outputs_start + out_count_varint_len;
+    if (outputs_data_start + 4 > tx_len) return 0;
+    size_t outputs_data_len = tx_len - 4 - outputs_data_start;
+    unsigned char sha_outputs[32];
+    sha256(unsigned_tx + outputs_data_start, outputs_data_len, sha_outputs);
+
+    /* Assemble preimage (BIP-341 §4.2 key-path, SIGHASH_DEFAULT, no annex). */
+    unsigned char msg[175];
+    size_t pos = 0;
+    msg[pos++] = 0x00;                                 /* epoch */
+    msg[pos++] = 0x00;                                 /* SIGHASH_DEFAULT */
+    memcpy(msg + pos, nversion_le,  4);  pos += 4;
+    memcpy(msg + pos, nlocktime_le, 4);  pos += 4;
+    memcpy(msg + pos, sha_prevouts,      32); pos += 32;
+    memcpy(msg + pos, sha_amounts,       32); pos += 32;
+    memcpy(msg + pos, sha_scriptpubkeys, 32); pos += 32;
+    memcpy(msg + pos, sha_sequences,     32); pos += 32;
+    memcpy(msg + pos, sha_outputs,       32); pos += 32;
+    msg[pos++] = 0x00;                                 /* spend_type: key-path, no annex */
+    write_u32_le(msg + pos, input_index); pos += 4;
+
+    sha256_tagged("TapSighash", msg, pos, sighash_out32);
+    return 1;
+}
+
+int finalize_signed_tx_multi(
+    tx_buf_t *out,
+    const unsigned char *unsigned_tx,
+    size_t unsigned_tx_len,
+    size_t n_inputs,
+    const unsigned char *sig64s
+) {
+    if (!out || !unsigned_tx || !sig64s) return 0;
+    if (n_inputs == 0) return 0;
+    if (unsigned_tx_len < 8) return 0;
+
+    tx_buf_reset(out);
+
+    tx_buf_write_bytes(out, unsigned_tx, 4);   /* nVersion */
+    tx_buf_write_u8(out, 0x00);                /* segwit marker */
+    tx_buf_write_u8(out, 0x01);                /* segwit flag */
+
+    /* inputs + outputs (everything between nVersion and nLockTime) */
+    tx_buf_write_bytes(out, unsigned_tx + 4, unsigned_tx_len - 8);
+
+    /* witness data: one stack-of-1 64-byte schnorr sig per input, in input order. */
+    for (size_t i = 0; i < n_inputs; i++) {
+        tx_buf_write_varint(out, 1);
+        tx_buf_write_varint(out, 64);
+        tx_buf_write_bytes(out, sig64s + 64 * i, 64);
+    }
+
+    tx_buf_write_bytes(out, unsigned_tx + unsigned_tx_len - 4, 4); /* nLockTime */
+    return !out->oom;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -78,6 +78,9 @@ extern int test_build_p2tr_script_pubkey(void);
 extern int test_build_unsigned_tx(void);
 extern int test_build_unsigned_tx_multi(void);
 extern int test_finalize_signed_tx(void);
+extern int test_compute_taproot_sighash_multi_matches_single_for_n1(void);
+extern int test_compute_taproot_sighash_multi_n3_input_binding(void);
+extern int test_finalize_signed_tx_multi(void);
 extern int test_varint_encoding(void);
 
 /* Phase C: V3/TRUC CPFP */
@@ -1914,6 +1917,9 @@ static void run_unit_tests(void) {
     RUN_TEST(test_build_unsigned_tx);
     RUN_TEST(test_build_unsigned_tx_multi);
     RUN_TEST(test_finalize_signed_tx);
+    RUN_TEST(test_compute_taproot_sighash_multi_matches_single_for_n1);
+    RUN_TEST(test_compute_taproot_sighash_multi_n3_input_binding);
+    RUN_TEST(test_finalize_signed_tx_multi);
     RUN_TEST(test_varint_encoding);
 
     printf("\n=== Phase C: V3/TRUC CPFP ===\n");

--- a/tests/test_tx_builder.c
+++ b/tests/test_tx_builder.c
@@ -306,6 +306,225 @@ int test_finalize_signed_tx(void) {
     return 1;
 }
 
+/* For n_inputs=1, compute_taproot_sighash_multi must match
+   compute_taproot_sighash byte-for-byte.  Anchors the multi-input variant
+   against the existing single-input implementation. */
+int test_compute_taproot_sighash_multi_matches_single_for_n1(void) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    unsigned char prev_txid[32]; memset(prev_txid, 0xa1, 32);
+    unsigned char seckey[32];   memset(seckey, 0x07, 32);
+    secp256k1_keypair kp;
+    if (!secp256k1_keypair_create(ctx, &kp, seckey)) return 0;
+    secp256k1_xonly_pubkey xpk;
+    if (!secp256k1_keypair_xonly_pub(ctx, &xpk, NULL, &kp)) return 0;
+
+    tx_output_t output = {0};
+    output.amount_sats = 50000;
+    build_p2tr_script_pubkey(output.script_pubkey, &xpk);
+    output.script_pubkey_len = 34;
+
+    unsigned char prev_spk[34];
+    build_p2tr_script_pubkey(prev_spk, &xpk);
+    uint64_t prev_amount = 100000;
+    uint32_t nseq = 0xFFFFFFFE;
+
+    /* Build the same TX two ways: single-input and multi-input(n=1). */
+    tx_buf_t single_buf; tx_buf_init(&single_buf, 256);
+    TEST_ASSERT(build_unsigned_tx(&single_buf, NULL, prev_txid, 0, nseq,
+                                    &output, 1),
+                "build single-input");
+
+    tx_input_t inp = {0};
+    memcpy(inp.prev_txid, prev_txid, 32);
+    inp.prev_vout = 0;
+    inp.nsequence = nseq;
+    tx_buf_t multi_buf; tx_buf_init(&multi_buf, 256);
+    TEST_ASSERT(build_unsigned_tx_multi(&multi_buf, NULL, &inp, 1, &output, 1, 2, 0),
+                "build multi-input n=1");
+
+    /* The two byte streams must be identical. */
+    TEST_ASSERT_EQ(single_buf.len, multi_buf.len, "n=1 lengths match");
+    TEST_ASSERT(memcmp(single_buf.data, multi_buf.data, single_buf.len) == 0,
+                "n=1 bytes match");
+
+    /* Both sighash functions must produce identical 32-byte output. */
+    unsigned char sh_single[32], sh_multi[32];
+    TEST_ASSERT(compute_taproot_sighash(sh_single, single_buf.data, single_buf.len,
+                                          0, prev_spk, 34, prev_amount, nseq),
+                "single-input sighash");
+
+    const unsigned char *spks[1] = { prev_spk };
+    size_t spk_lens[1] = { 34 };
+    uint64_t amounts[1] = { prev_amount };
+    uint32_t seqs[1] = { nseq };
+    TEST_ASSERT(compute_taproot_sighash_multi(sh_multi, multi_buf.data, multi_buf.len,
+                                                0, 1, spks, spk_lens, amounts, seqs),
+                "multi-input sighash n=1");
+
+    TEST_ASSERT(memcmp(sh_single, sh_multi, 32) == 0,
+                "single == multi sighash for n=1");
+
+    tx_buf_free(&single_buf);
+    tx_buf_free(&multi_buf);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
+/* For n_inputs=3, sighashes for input_index=0..2 must all differ from
+   each other (the input_index is mixed into the preimage), and changing
+   any per-input field must change the sighash. */
+int test_compute_taproot_sighash_multi_n3_input_binding(void) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    unsigned char seckey[32]; memset(seckey, 0x09, 32);
+    secp256k1_keypair kp;
+    if (!secp256k1_keypair_create(ctx, &kp, seckey)) return 0;
+    secp256k1_xonly_pubkey xpk;
+    if (!secp256k1_keypair_xonly_pub(ctx, &xpk, NULL, &kp)) return 0;
+
+    tx_input_t inputs[3];
+    memset(inputs[0].prev_txid, 0xa1, 32); inputs[0].prev_vout = 0; inputs[0].nsequence = 0xFFFFFFFE;
+    memset(inputs[1].prev_txid, 0xa1, 32); inputs[1].prev_vout = 1; inputs[1].nsequence = 0xFFFFFFFE;
+    memset(inputs[2].prev_txid, 0xa1, 32); inputs[2].prev_vout = 2; inputs[2].nsequence = 0xFFFFFFFE;
+
+    tx_output_t outs[3];
+    for (int i = 0; i < 3; i++) {
+        outs[i].amount_sats = 30000 + (uint64_t)i * 1000;
+        build_p2tr_script_pubkey(outs[i].script_pubkey, &xpk);
+        outs[i].script_pubkey_len = 34;
+    }
+
+    tx_buf_t buf; tx_buf_init(&buf, 512);
+    TEST_ASSERT(build_unsigned_tx_multi(&buf, NULL, inputs, 3, outs, 3, 2, 0),
+                "build n=3 multi");
+
+    unsigned char prev_spk[34];
+    build_p2tr_script_pubkey(prev_spk, &xpk);
+    const unsigned char *spks[3] = { prev_spk, prev_spk, prev_spk };
+    size_t spk_lens[3] = { 34, 34, 34 };
+    uint64_t amounts[3] = { 50000, 60000, 70000 };
+    uint32_t seqs[3] = { 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFE };
+
+    unsigned char sh[3][32];
+    for (uint32_t i = 0; i < 3; i++) {
+        TEST_ASSERT(compute_taproot_sighash_multi(sh[i], buf.data, buf.len,
+                                                   i, 3, spks, spk_lens, amounts, seqs),
+                    "multi sighash per-input");
+    }
+    /* Each sighash must differ — input_index mixes into the preimage. */
+    TEST_ASSERT(memcmp(sh[0], sh[1], 32) != 0, "sh[0] != sh[1]");
+    TEST_ASSERT(memcmp(sh[1], sh[2], 32) != 0, "sh[1] != sh[2]");
+    TEST_ASSERT(memcmp(sh[0], sh[2], 32) != 0, "sh[0] != sh[2]");
+
+    /* Changing one prev_amount must change the sighash for ALL inputs
+       (sha_amounts is shared across inputs in the BIP-341 preimage). */
+    amounts[1] = 60001;
+    unsigned char sh2[32];
+    TEST_ASSERT(compute_taproot_sighash_multi(sh2, buf.data, buf.len,
+                                                0, 3, spks, spk_lens, amounts, seqs),
+                "sighash with bumped amount");
+    TEST_ASSERT(memcmp(sh[0], sh2, 32) != 0,
+                "amount mutation propagates to sighash");
+
+    tx_buf_free(&buf);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
+/* finalize_signed_tx_multi must:
+   - emit segwit marker/flag
+   - attach exactly N witness records, each {1, 64, sig}
+   - place nLockTime at the end
+   - for n=1, equal finalize_signed_tx byte-for-byte */
+int test_finalize_signed_tx_multi(void) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    unsigned char seckey[32]; memset(seckey, 0x0b, 32);
+    secp256k1_keypair kp;
+    if (!secp256k1_keypair_create(ctx, &kp, seckey)) return 0;
+    secp256k1_xonly_pubkey xpk;
+    if (!secp256k1_keypair_xonly_pub(ctx, &xpk, NULL, &kp)) return 0;
+
+    /* Build n=3 unsigned multi-input tx */
+    tx_input_t inputs[3];
+    memset(inputs[0].prev_txid, 0xa1, 32); inputs[0].prev_vout = 0; inputs[0].nsequence = 0xFFFFFFFE;
+    memset(inputs[1].prev_txid, 0xa1, 32); inputs[1].prev_vout = 1; inputs[1].nsequence = 0xFFFFFFFE;
+    memset(inputs[2].prev_txid, 0xa1, 32); inputs[2].prev_vout = 2; inputs[2].nsequence = 0xFFFFFFFE;
+    tx_output_t outs[3];
+    for (int i = 0; i < 3; i++) {
+        outs[i].amount_sats = 30000;
+        build_p2tr_script_pubkey(outs[i].script_pubkey, &xpk);
+        outs[i].script_pubkey_len = 34;
+    }
+    tx_buf_t unsigned_buf; tx_buf_init(&unsigned_buf, 512);
+    TEST_ASSERT(build_unsigned_tx_multi(&unsigned_buf, NULL, inputs, 3, outs, 3, 2, 0),
+                "build unsigned");
+
+    /* Distinct sigs per input so we can spot-check ordering */
+    unsigned char sigs[3 * 64];
+    memset(sigs + 0  * 64, 0xc1, 64);
+    memset(sigs + 1  * 64, 0xc2, 64);
+    memset(sigs + 2  * 64, 0xc3, 64);
+
+    tx_buf_t signed_buf; tx_buf_init(&signed_buf, 1024);
+    TEST_ASSERT(finalize_signed_tx_multi(&signed_buf, unsigned_buf.data,
+                                          unsigned_buf.len, 3, sigs),
+                "finalize multi");
+
+    /* nVersion + segwit marker + flag */
+    TEST_ASSERT_EQ(signed_buf.data[0], 0x02, "nVersion");
+    TEST_ASSERT_EQ(signed_buf.data[4], 0x00, "segwit marker");
+    TEST_ASSERT_EQ(signed_buf.data[5], 0x01, "segwit flag");
+
+    /* Each witness adds varint(1) + varint(64) + 64 = 66 bytes; 3 witnesses = 198 */
+    TEST_ASSERT(signed_buf.len == unsigned_buf.len + 2 + 3 * 66,
+                "signed length = unsigned + marker/flag + 3 witnesses");
+
+    /* Locate witness section: directly before the trailing 4-byte nLockTime.
+       Each witness is 66 bytes; first witness starts at signed_buf.len - 4 - 198. */
+    size_t wit_start = signed_buf.len - 4 - 3 * 66;
+    /* witness 0 */
+    TEST_ASSERT_EQ(signed_buf.data[wit_start + 0], 0x01, "wit0 stack count");
+    TEST_ASSERT_EQ(signed_buf.data[wit_start + 1], 0x40, "wit0 sig len = 64");
+    TEST_ASSERT_EQ(signed_buf.data[wit_start + 2], 0xc1, "wit0 sig byte");
+    /* witness 1 */
+    TEST_ASSERT_EQ(signed_buf.data[wit_start + 66 + 2], 0xc2, "wit1 sig byte");
+    /* witness 2 */
+    TEST_ASSERT_EQ(signed_buf.data[wit_start + 132 + 2], 0xc3, "wit2 sig byte");
+
+    /* nLockTime at end */
+    TEST_ASSERT_EQ(signed_buf.data[signed_buf.len - 4], 0x00, "nlocktime byte 0");
+
+    /* For n=1, finalize_signed_tx_multi must match finalize_signed_tx. */
+    tx_buf_t u1; tx_buf_init(&u1, 256);
+    TEST_ASSERT(build_unsigned_tx_multi(&u1, NULL, inputs, 1, outs, 3, 2, 0),
+                "build n=1");
+    unsigned char one_sig[64]; memset(one_sig, 0xee, 64);
+    tx_buf_t s_a, s_b;
+    tx_buf_init(&s_a, 512); tx_buf_init(&s_b, 512);
+    TEST_ASSERT(finalize_signed_tx(&s_a, u1.data, u1.len, one_sig),
+                "single finalize");
+    TEST_ASSERT(finalize_signed_tx_multi(&s_b, u1.data, u1.len, 1, one_sig),
+                "multi finalize n=1");
+    TEST_ASSERT_EQ(s_a.len, s_b.len, "n=1 finalize lengths match");
+    TEST_ASSERT(memcmp(s_a.data, s_b.data, s_a.len) == 0,
+                "n=1 finalize bytes match");
+
+    /* Argument validation */
+    TEST_ASSERT(!finalize_signed_tx_multi(&signed_buf, NULL, 100, 3, sigs),
+                "null tx rejected");
+    TEST_ASSERT(!finalize_signed_tx_multi(&signed_buf, unsigned_buf.data, unsigned_buf.len, 0, sigs),
+                "zero inputs rejected");
+
+    tx_buf_free(&unsigned_buf);
+    tx_buf_free(&signed_buf);
+    tx_buf_free(&u1);
+    tx_buf_free(&s_a);
+    tx_buf_free(&s_b);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
 /* Phase C: V3/TRUC CPFP — build_unsigned_tx_v with nVersion=3 */
 int test_v3_cpfp_tx_version(void)
 {


### PR DESCRIPTION
## Summary

Adds the two crypto primitives the chain[1+] sub-factory fix needs:

- **`compute_taproot_sighash_multi`** — BIP-341 key-path sighash for an N-input TX, hashing the full {prevouts, amounts, scripts, sequences} sets and binding to a chosen `input_index`. For `n_inputs=1` it produces byte-identical output to `compute_taproot_sighash` (anchored by test).
- **`finalize_signed_tx_multi`** — wraps an N-input unsigned TX with segwit marker/flag and N stack-of-1 64-byte schnorr witnesses, one per input. For `n_inputs=1` it produces byte-identical output to `finalize_signed_tx`.

These are the foundations for **#207 phase 2b**, which wires multi-input into `rebuild_node_tx` for advanced PS sub-factory chain extensions. **This PR is build-only** — no callers in the production path yet.

## Test plan

- [x] `test_compute_taproot_sighash_multi_matches_single_for_n1` — single-input regression anchor
- [x] `test_compute_taproot_sighash_multi_n3_input_binding` — n=3 sighashes differ by `input_index`, prev_amount mutation propagates
- [x] `test_finalize_signed_tx_multi` — segwit wire format spot-checks + byte-equal to `finalize_signed_tx` for n=1
- [ ] All existing 1426 unit tests still pass (CI)
- [ ] Sanitizers green (CI)
- [ ] Static analysis green (CI)

## Why split from #207 wiring

The wiring step (rebuild_node_tx + per-input MuSig session refactor + updated chain-extension test) is substantially larger and touches signing-path code. Landing the primitives first gives reviewers a small, well-tested foundation and lets phase 2b focus purely on the integration.