### PR TITLE
feat(factory): multi-input PS sub-factory chain advance signing (#207 phase 2b)

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -174,7 +174,31 @@ typedef struct {
     int is_ps_leaf;              /* 1 if this leaf uses PS chaining instead of DW nSequence */
     int ps_chain_len;            /* number of state advances (0 = initial state) */
     unsigned char ps_prev_txid[32];    /* txid (internal byte order) of the prior chain TX */
-    uint64_t ps_prev_chan_amount;      /* amount_sats of the channel output spent by current TX */
+    uint64_t ps_prev_chan_amount;      /* amount_sats of the channel output spent by current TX
+                                          (legacy 1-input shape; for multi-input PS sub-factory
+                                          chain advances see ps_prev_amounts[] below) */
+
+    /* Multi-input PS sub-factory chain advance state (#207).
+       When a NODE_PS_SUBFACTORY chain extends, the new TX consumes ALL
+       k+1 outputs of the previous chain TX (not just sales-stock).  These
+       arrays cache the per-input prev_amount + prev_scriptpubkey captured
+       before factory_subfactory_chain_advance_unsigned mutates outputs[].
+       Each index i in [0, ps_n_prev_outputs) corresponds to chain[N-1]'s
+       output i (vout i becomes input i of chain[N]).
+       Only populated when ps_chain_len > 0 && type == NODE_PS_SUBFACTORY. */
+    size_t ps_n_prev_outputs;                                     /* 0 = single-input */
+    uint64_t ps_prev_amounts[FACTORY_MAX_OUTPUTS];
+    unsigned char ps_prev_spks[FACTORY_MAX_OUTPUTS][34];
+    size_t ps_prev_spk_lens[FACTORY_MAX_OUTPUTS];
+
+    /* Per-input MuSig sessions for multi-input nodes.  Heap-allocated on
+       first factory_session_init_node_input call; freed in factory_free.
+       Length equals ps_n_prev_outputs (= n_inputs).  Only used by
+       advanced PS sub-factory nodes per #207. */
+    musig_signing_session_t *input_signing_sessions;        /* length n_input_sessions */
+    secp256k1_musig_partial_sig *input_partial_sigs;        /* length n_input_sessions * FACTORY_MAX_SIGNERS */
+    int input_partial_sigs_received[FACTORY_MAX_OUTPUTS];   /* per-input count */
+    size_t n_input_sessions;
 
     /* PS sub-factory wiring (only used when ps_subfactory_arity > 1, the
        canonical k² shape from t/1242).
@@ -537,6 +561,40 @@ int factory_sign_node(factory_t *f, size_t node_idx);
 int factory_session_init_node(factory_t *f, size_t node_idx);
 int factory_session_finalize_node(factory_t *f, size_t node_idx);
 int factory_session_complete_node(factory_t *f, size_t node_idx);
+
+/* --- Multi-input per-input split-round signing helpers (#207) ---
+   Used for advanced PS sub-factory chain extensions where the new TX
+   has k+1 inputs (one per chain[N-1] vout).  Each input gets its own
+   MuSig session because BIP-341 sighashes differ per input.  All k+1
+   sigs are then assembled into a single segwit signed_tx via
+   factory_session_assemble_signed_tx_multi.
+
+   Lifecycle for each input_idx in [0, n_inputs):
+     1. factory_session_init_node_input  — fresh session for this input
+     2. factory_session_set_nonce_input  — per-signer pubnonce
+     3. factory_session_finalize_node_input — compute per-input sighash
+        + run musig_session_finalize_nonces
+     4. factory_session_set_partial_sig_input — per-signer partial sig
+     5. factory_session_complete_node_input — aggregate to 64-byte sig
+        + store internally
+   Then once per node:
+     6. factory_session_assemble_signed_tx_multi — emit segwit signed_tx
+        with all k+1 witnesses */
+int factory_session_init_node_input(factory_t *f, size_t node_idx, size_t input_idx);
+int factory_session_set_nonce_input(factory_t *f, size_t node_idx, size_t input_idx,
+                                      size_t signer_slot,
+                                      const secp256k1_musig_pubnonce *pubnonce);
+int factory_session_finalize_node_input(factory_t *f, size_t node_idx, size_t input_idx);
+int factory_session_set_partial_sig_input(factory_t *f, size_t node_idx, size_t input_idx,
+                                            size_t signer_slot,
+                                            const secp256k1_musig_partial_sig *psig);
+int factory_session_complete_node_input(factory_t *f, size_t node_idx, size_t input_idx);
+int factory_session_assemble_signed_tx_multi(factory_t *f, size_t node_idx);
+
+/* Helper: returns 1 if node_idx is an advanced PS sub-factory node that
+   uses the multi-input chain advance path (i.e. n_inputs > 1).  Used by
+   callers to dispatch between single-input and multi-input session APIs. */
+int factory_node_uses_multi_input(const factory_t *f, size_t node_idx);
 
 /* --- Wire-ceremony poison TX dual-signing helpers (closes SECURITY GAP) ---
    These mirror the per-node session helpers above but operate on the

--- a/src/factory.c
+++ b/src/factory.c
@@ -447,6 +447,35 @@ static int compute_node_sighash(const factory_t *f, const factory_node_t *node,
                                     prev_amount, node->nsequence);
 }
 
+/* Per-input sighash for advanced PS sub-factory chain advance nodes (#207).
+   For ordinary single-input nodes (input_idx == 0), delegates to
+   compute_node_sighash so the existing single-input path is unchanged.
+   For multi-input nodes, builds the BIP-341 preimage from the per-input
+   prev_amounts/prev_spks captured in factory_subfactory_chain_advance_unsigned. */
+static int compute_node_sighash_input(const factory_t *f,
+                                        const factory_node_t *node,
+                                        size_t input_idx,
+                                        unsigned char *sighash_out) {
+    if (node->is_ps_leaf && node->ps_chain_len > 0 &&
+        node->type == NODE_PS_SUBFACTORY && node->ps_n_prev_outputs > 1) {
+        if (input_idx >= node->ps_n_prev_outputs) return 0;
+        const unsigned char *spks[FACTORY_MAX_OUTPUTS];
+        uint32_t seqs[FACTORY_MAX_OUTPUTS];
+        for (size_t i = 0; i < node->ps_n_prev_outputs; i++) {
+            spks[i] = node->ps_prev_spks[i];
+            seqs[i] = node->nsequence;  /* every input shares nsequence in our wire layout */
+        }
+        return compute_taproot_sighash_multi(sighash_out,
+            node->unsigned_tx.data, node->unsigned_tx.len,
+            (uint32_t)input_idx,
+            node->ps_n_prev_outputs,
+            spks, node->ps_prev_spk_lens,
+            node->ps_prev_amounts, seqs);
+    }
+    if (input_idx != 0) return 0;
+    return compute_node_sighash(f, node, sighash_out);
+}
+
 /* Forward declarations for helpers used in init/set_arity */
 static int compute_tree_depth(size_t n_clients, factory_arity_t arity);
 static int compute_leaf_count(size_t n_clients, factory_arity_t arity);
@@ -1944,11 +1973,38 @@ int factory_advance(factory_t *f) {
 
 /* Rebuild unsigned tx for a single node.
    PS leaf chain advances (ps_chain_len > 0) spend the channel output of the
-   previous chain TX (ps_prev_txid:0) rather than the parent KO's output. */
+   previous chain TX (ps_prev_txid:0) rather than the parent KO's output.
+   Advanced PS sub-factory chains (NODE_PS_SUBFACTORY + ps_n_prev_outputs > 1)
+   spend ALL k+1 outputs of the previous chain TX (#207 fix). */
 static int rebuild_node_tx(factory_t *f, size_t node_idx) {
     if (node_idx >= f->n_nodes) return 0;
     factory_node_t *node = &f->nodes[node_idx];
     unsigned char display_txid[32];
+
+    node->nsequence = node_nsequence(f, node);
+
+    /* Multi-input PS sub-factory chain advance (#207).
+       chain[N+1] consumes every chain[N] output, preserving conservation:
+       sum(prev_amounts) ≈ sum(outputs) + fee_per_tx. */
+    if (node->is_ps_leaf && node->ps_chain_len > 0 &&
+        node->type == NODE_PS_SUBFACTORY && node->ps_n_prev_outputs > 1) {
+        tx_input_t inputs[FACTORY_MAX_OUTPUTS];
+        for (size_t i = 0; i < node->ps_n_prev_outputs; i++) {
+            memcpy(inputs[i].prev_txid, node->ps_prev_txid, 32);
+            inputs[i].prev_vout  = (uint32_t)i;
+            inputs[i].nsequence  = node->nsequence;
+        }
+        if (!build_unsigned_tx_multi(&node->unsigned_tx, display_txid,
+                                       inputs, node->ps_n_prev_outputs,
+                                       node->outputs, node->n_outputs,
+                                       /*nVersion=*/2, /*nlocktime=*/0))
+            return 0;
+        memcpy(node->txid, display_txid, 32);
+        reverse_bytes(node->txid, 32);
+        node->is_built = 1;
+        node->is_signed = 0;
+        return 1;
+    }
 
     const unsigned char *input_txid;
     uint32_t input_vout;
@@ -1970,8 +2026,6 @@ static int rebuild_node_tx(factory_t *f, size_t node_idx) {
         input_txid = parent->txid;
         input_vout = node->parent_vout;
     }
-
-    node->nsequence = node_nsequence(f, node);
 
     if (!build_unsigned_tx(&node->unsigned_tx, display_txid,
                            input_txid, input_vout,
@@ -2271,6 +2325,19 @@ int factory_subfactory_chain_advance_unsigned(
     sub->ps_prev_chan_amount = sstock_amount;  /* spending the sales-stock vout */
     sub->ps_chain_len++;
 
+    /* Capture per-input prev state for the multi-input chain advance (#207).
+       chain[N+1] consumes ALL k+1 outputs of chain[N], not just sales-stock,
+       so each prev output's (amount, scriptpubkey) is needed for the BIP-341
+       sighash computation per input.  Capture BEFORE we mutate sub->outputs[]. */
+    sub->ps_n_prev_outputs = sub->n_outputs;
+    for (size_t i = 0; i < sub->n_outputs; i++) {
+        sub->ps_prev_amounts[i] = sub->outputs[i].amount_sats;
+        size_t spk_len = sub->outputs[i].script_pubkey_len;
+        if (spk_len > sizeof(sub->ps_prev_spks[i])) spk_len = sizeof(sub->ps_prev_spks[i]);
+        memcpy(sub->ps_prev_spks[i], sub->outputs[i].script_pubkey, spk_len);
+        sub->ps_prev_spk_lens[i] = spk_len;
+    }
+
     /* New state amounts: channel grows by delta, sales-stock shrinks by
        delta + fee.  Other channels untouched. */
     sub->outputs[channel_idx_in_sub].amount_sats += delta_sats;
@@ -2336,6 +2403,163 @@ int factory_session_complete_node(factory_t *f, size_t node_idx) {
                              sig))
         return 0;
 
+    node->is_signed = 1;
+    return 1;
+}
+
+/* === Per-input split-round signing helpers (#207 multi-input chain advance) === */
+
+int factory_node_uses_multi_input(const factory_t *f, size_t node_idx) {
+    if (!f || node_idx >= f->n_nodes) return 0;
+    const factory_node_t *node = &f->nodes[node_idx];
+    return (node->is_ps_leaf && node->ps_chain_len > 0 &&
+            node->type == NODE_PS_SUBFACTORY && node->ps_n_prev_outputs > 1);
+}
+
+/* Lazily allocate the per-input session arrays on a node.  Idempotent —
+   safe to call once per chain advance even if the previous advance left
+   stale arrays around (we free + realloc to match the new n_inputs). */
+static int ensure_input_sessions_alloc(factory_node_t *node) {
+    if (node->ps_n_prev_outputs == 0) return 0;
+    if (node->input_signing_sessions &&
+        node->n_input_sessions == node->ps_n_prev_outputs) return 1;
+
+    free(node->input_signing_sessions);
+    free(node->input_partial_sigs);
+    node->input_signing_sessions = NULL;
+    node->input_partial_sigs = NULL;
+    node->n_input_sessions = 0;
+
+    node->input_signing_sessions =
+        (musig_signing_session_t *)calloc(node->ps_n_prev_outputs,
+                                            sizeof(musig_signing_session_t));
+    if (!node->input_signing_sessions) return 0;
+
+    node->input_partial_sigs =
+        (secp256k1_musig_partial_sig *)calloc(
+            node->ps_n_prev_outputs * (size_t)FACTORY_MAX_SIGNERS,
+            sizeof(secp256k1_musig_partial_sig));
+    if (!node->input_partial_sigs) {
+        free(node->input_signing_sessions);
+        node->input_signing_sessions = NULL;
+        return 0;
+    }
+    memset(node->input_partial_sigs_received, 0,
+           sizeof(node->input_partial_sigs_received));
+    node->n_input_sessions = node->ps_n_prev_outputs;
+    return 1;
+}
+
+int factory_session_init_node_input(factory_t *f, size_t node_idx, size_t input_idx) {
+    if (!f || node_idx >= f->n_nodes) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->is_built) return 0;
+    if (!factory_node_uses_multi_input(f, node_idx)) return 0;
+    if (input_idx >= node->ps_n_prev_outputs) return 0;
+    if (!ensure_input_sessions_alloc(node)) return 0;
+
+    musig_session_init(&node->input_signing_sessions[input_idx],
+                        &node->keyagg, node->n_signers);
+    node->input_partial_sigs_received[input_idx] = 0;
+    return 1;
+}
+
+int factory_session_set_nonce_input(factory_t *f, size_t node_idx, size_t input_idx,
+                                      size_t signer_slot,
+                                      const secp256k1_musig_pubnonce *pubnonce) {
+    if (!f || node_idx >= f->n_nodes || !pubnonce) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->input_signing_sessions) return 0;
+    if (input_idx >= node->n_input_sessions) return 0;
+    if (signer_slot >= node->n_signers) return 0;
+    return musig_session_set_pubnonce(&node->input_signing_sessions[input_idx],
+                                        signer_slot, pubnonce);
+}
+
+int factory_session_finalize_node_input(factory_t *f, size_t node_idx, size_t input_idx) {
+    if (!f || node_idx >= f->n_nodes) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->input_signing_sessions) return 0;
+    if (input_idx >= node->n_input_sessions) return 0;
+
+    unsigned char sighash[32];
+    if (!compute_node_sighash_input(f, node, input_idx, sighash)) {
+        fprintf(stderr, "finalize_node_input %zu/%zu: compute_node_sighash_input failed\n",
+                node_idx, input_idx);
+        return 0;
+    }
+    const unsigned char *mr = node->has_taptree ? node->merkle_root : NULL;
+    int ok = musig_session_finalize_nonces(f->ctx,
+                                            &node->input_signing_sessions[input_idx],
+                                            sighash, mr, NULL);
+    if (!ok)
+        fprintf(stderr, "finalize_node_input %zu/%zu: finalize_nonces failed\n",
+                node_idx, input_idx);
+    return ok;
+}
+
+int factory_session_set_partial_sig_input(factory_t *f, size_t node_idx, size_t input_idx,
+                                            size_t signer_slot,
+                                            const secp256k1_musig_partial_sig *psig) {
+    if (!f || node_idx >= f->n_nodes || !psig) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->input_signing_sessions) return 0;
+    if (input_idx >= node->n_input_sessions) return 0;
+    if (signer_slot >= (size_t)FACTORY_MAX_SIGNERS) return 0;
+    if (signer_slot >= node->n_signers) return 0;
+    secp256k1_musig_partial_sig *slot =
+        &node->input_partial_sigs[input_idx * (size_t)FACTORY_MAX_SIGNERS + signer_slot];
+    *slot = *psig;
+    node->input_partial_sigs_received[input_idx]++;
+    return 1;
+}
+
+int factory_session_complete_node_input(factory_t *f, size_t node_idx, size_t input_idx) {
+    /* Synchronization point — confirm enough partial sigs are in for this
+       input.  Per-input aggregation happens in
+       factory_session_assemble_signed_tx_multi to keep the segwit
+       finalization atomic over all inputs. */
+    if (!f || node_idx >= f->n_nodes) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->input_signing_sessions) return 0;
+    if (input_idx >= node->n_input_sessions) return 0;
+    if (node->input_partial_sigs_received[input_idx] != (int)node->n_signers) return 0;
+    return 1;
+}
+
+int factory_session_assemble_signed_tx_multi(factory_t *f, size_t node_idx) {
+    if (!f || node_idx >= f->n_nodes) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->input_signing_sessions) return 0;
+    if (node->n_input_sessions == 0) return 0;
+    /* All inputs must have full partial sigs collected. */
+    for (size_t i = 0; i < node->n_input_sessions; i++) {
+        if (node->input_partial_sigs_received[i] != (int)node->n_signers) {
+            fprintf(stderr, "assemble_signed_tx_multi node=%zu input=%zu has %d/%zu sigs\n",
+                    node_idx, i, node->input_partial_sigs_received[i], node->n_signers);
+            return 0;
+        }
+    }
+
+    unsigned char *sigs64 = (unsigned char *)calloc(node->n_input_sessions, 64);
+    if (!sigs64) return 0;
+    for (size_t i = 0; i < node->n_input_sessions; i++) {
+        secp256k1_musig_partial_sig *psigs =
+            &node->input_partial_sigs[i * (size_t)FACTORY_MAX_SIGNERS];
+        if (!musig_aggregate_partial_sigs(f->ctx, sigs64 + 64 * i,
+                                            &node->input_signing_sessions[i],
+                                            psigs, node->n_signers)) {
+            free(sigs64);
+            return 0;
+        }
+    }
+    if (!finalize_signed_tx_multi(&node->signed_tx,
+                                    node->unsigned_tx.data, node->unsigned_tx.len,
+                                    node->n_input_sessions, sigs64)) {
+        free(sigs64);
+        return 0;
+    }
+    free(sigs64);
     node->is_signed = 1;
     return 1;
 }
@@ -3557,6 +3781,14 @@ void factory_free(factory_t *f) {
            (tx_buf_free is a no-op on zero-init). */
         tx_buf_free(&f->nodes[i].poison_unsigned_tx);
         tx_buf_free(&f->nodes[i].poison_signed_tx);
+        /* Multi-input chain advance per-input session arrays (#207).
+           free() is a no-op on NULL, so safe even when the multi-input
+           path was never exercised on this node. */
+        free(f->nodes[i].input_signing_sessions);
+        f->nodes[i].input_signing_sessions = NULL;
+        free(f->nodes[i].input_partial_sigs);
+        f->nodes[i].input_partial_sigs = NULL;
+        f->nodes[i].n_input_sessions = 0;
     }
     /* Zero node count so a second factory_free is a no-op (idempotent). */
     f->n_nodes = 0;

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5491,41 +5491,59 @@ int test_factory_ps_subfactory_chain_extension(void) {
     TEST_ASSERT_EQ((long)total_after, (long)(total_before - f->fee_per_tx),
                     "conservation: total - fee");
 
-    /* Re-sign sub-factory 0 via in-process per-node MuSig (LSP + A + B = 3 signers).
-       Mirrors what the wire ceremony would do but in-process for the unit test. */
-    TEST_ASSERT(factory_session_init_node(f, (size_t)sub0_node_idx),
-                "session init for chain[1]");
-    secp256k1_musig_secnonce secnonces[3];
-    for (size_t j = 0; j < sub->n_signers; j++) {
-        uint32_t participant = sub->signer_indices[j];
-        unsigned char seckey[32];
-        secp256k1_pubkey pk;
-        TEST_ASSERT(secp256k1_keypair_sec(ctx, seckey, &kps[participant]),
-                    "get seckey");
-        TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[participant]),
-                    "get pubkey");
-        secp256k1_musig_pubnonce pubnonce;
-        TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[j], &pubnonce,
-                                           seckey, &pk, &sub->keyagg.cache),
-                    "gen nonce");
-        TEST_ASSERT(factory_session_set_nonce(f, (size_t)sub0_node_idx, j, &pubnonce),
-                    "set nonce");
-        memset(seckey, 0, 32);
+    /* Re-sign sub-factory 0 via the new multi-input per-node MuSig.
+       chain[N+1] consumes ALL k+1 outputs of chain[N], so signing runs k+1
+       independent MuSig sessions (one per input).  Mirrors what the
+       multi-input wire ceremony will do; here we drive it in-process. */
+    TEST_ASSERT(factory_node_uses_multi_input(f, (size_t)sub0_node_idx),
+                "advanced sub-factory uses multi-input");
+    {
+        size_t n_inp = sub->ps_n_prev_outputs;
+        TEST_ASSERT_EQ((long)n_inp, 3, "chain[1] n_inputs = k+1 = 3");
+        secp256k1_musig_secnonce secnonces[3][3];
+        for (size_t i = 0; i < n_inp; i++) {
+            TEST_ASSERT(factory_session_init_node_input(f, (size_t)sub0_node_idx, i),
+                        "init per-input session");
+            for (size_t j = 0; j < sub->n_signers; j++) {
+                uint32_t participant = sub->signer_indices[j];
+                unsigned char seckey[32];
+                secp256k1_pubkey pk;
+                TEST_ASSERT(secp256k1_keypair_sec(ctx, seckey, &kps[participant]),
+                            "get seckey");
+                TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[participant]),
+                            "get pubkey");
+                secp256k1_musig_pubnonce pubnonce;
+                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i][j], &pubnonce,
+                                                   seckey, &pk, &sub->keyagg.cache),
+                            "gen nonce");
+                TEST_ASSERT(factory_session_set_nonce_input(f, (size_t)sub0_node_idx,
+                                                              i, j, &pubnonce),
+                            "set nonce per-input");
+                memset(seckey, 0, 32);
+            }
+            TEST_ASSERT(factory_session_finalize_node_input(f, (size_t)sub0_node_idx, i),
+                        "finalize per-input");
+        }
+        for (size_t i = 0; i < n_inp; i++) {
+            for (size_t j = 0; j < sub->n_signers; j++) {
+                uint32_t participant = sub->signer_indices[j];
+                secp256k1_musig_partial_sig psig;
+                TEST_ASSERT(musig_create_partial_sig(
+                                ctx, &psig, &secnonces[i][j], &kps[participant],
+                                &sub->input_signing_sessions[i]),
+                            "create per-input psig");
+                TEST_ASSERT(factory_session_set_partial_sig_input(
+                                f, (size_t)sub0_node_idx, i, j, &psig),
+                            "set per-input psig");
+            }
+            TEST_ASSERT(factory_session_complete_node_input(
+                            f, (size_t)sub0_node_idx, i),
+                        "complete per-input");
+        }
+        TEST_ASSERT(factory_session_assemble_signed_tx_multi(
+                        f, (size_t)sub0_node_idx),
+                    "assemble multi-witness chain[1] signed_tx");
     }
-    TEST_ASSERT(factory_session_finalize_node(f, (size_t)sub0_node_idx),
-                "finalize");
-    for (size_t j = 0; j < sub->n_signers; j++) {
-        uint32_t participant = sub->signer_indices[j];
-        secp256k1_musig_partial_sig psig;
-        TEST_ASSERT(musig_create_partial_sig(ctx, &psig, &secnonces[j],
-                                               &kps[participant],
-                                               &sub->signing_session),
-                    "create psig");
-        TEST_ASSERT(factory_session_set_partial_sig(f, (size_t)sub0_node_idx, j, &psig),
-                    "set psig");
-    }
-    TEST_ASSERT(factory_session_complete_node(f, (size_t)sub0_node_idx),
-                "complete chain[1] sig");
     TEST_ASSERT(sub->is_signed, "chain[1] signed");
     TEST_ASSERT(sub->signed_tx.len > 0, "chain[1] signed_tx populated");
 
@@ -5548,37 +5566,52 @@ int test_factory_ps_subfactory_chain_extension(void) {
                     (long)(sstock_chain1 - delta2 - f->fee_per_tx),
                     "sales-stock = chain[1] - delta2 - fee");
 
-    /* Sign chain[2] same way to confirm multi-extension works */
-    TEST_ASSERT(factory_session_init_node(f, (size_t)sub0_node_idx),
-                "chain[2] session init");
-    for (size_t j = 0; j < sub->n_signers; j++) {
-        uint32_t participant = sub->signer_indices[j];
-        unsigned char seckey[32];
-        secp256k1_pubkey pk;
-        secp256k1_keypair_sec(ctx, seckey, &kps[participant]);
-        secp256k1_keypair_pub(ctx, &pk, &kps[participant]);
-        secp256k1_musig_pubnonce pubnonce;
-        TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[j], &pubnonce,
-                                           seckey, &pk, &sub->keyagg.cache),
-                    "chain[2] gen nonce");
-        TEST_ASSERT(factory_session_set_nonce(f, (size_t)sub0_node_idx, j, &pubnonce),
-                    "chain[2] set nonce");
-        memset(seckey, 0, 32);
+    /* Sign chain[2] via the per-input flow */
+    {
+        size_t n_inp2 = sub->ps_n_prev_outputs;
+        TEST_ASSERT_EQ((long)n_inp2, 3, "chain[2] n_inputs = 3");
+        secp256k1_musig_secnonce secnonces2[3][3];
+        for (size_t i = 0; i < n_inp2; i++) {
+            TEST_ASSERT(factory_session_init_node_input(f, (size_t)sub0_node_idx, i),
+                        "chain[2] init per-input");
+            for (size_t j = 0; j < sub->n_signers; j++) {
+                uint32_t participant = sub->signer_indices[j];
+                unsigned char seckey[32];
+                secp256k1_pubkey pk;
+                secp256k1_keypair_sec(ctx, seckey, &kps[participant]);
+                secp256k1_keypair_pub(ctx, &pk, &kps[participant]);
+                secp256k1_musig_pubnonce pubnonce;
+                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces2[i][j], &pubnonce,
+                                                   seckey, &pk, &sub->keyagg.cache),
+                            "chain[2] gen nonce");
+                TEST_ASSERT(factory_session_set_nonce_input(f, (size_t)sub0_node_idx,
+                                                              i, j, &pubnonce),
+                            "chain[2] set per-input nonce");
+                memset(seckey, 0, 32);
+            }
+            TEST_ASSERT(factory_session_finalize_node_input(f, (size_t)sub0_node_idx, i),
+                        "chain[2] finalize per-input");
+        }
+        for (size_t i = 0; i < n_inp2; i++) {
+            for (size_t j = 0; j < sub->n_signers; j++) {
+                uint32_t participant = sub->signer_indices[j];
+                secp256k1_musig_partial_sig psig;
+                TEST_ASSERT(musig_create_partial_sig(
+                                ctx, &psig, &secnonces2[i][j], &kps[participant],
+                                &sub->input_signing_sessions[i]),
+                            "chain[2] create psig");
+                TEST_ASSERT(factory_session_set_partial_sig_input(
+                                f, (size_t)sub0_node_idx, i, j, &psig),
+                            "chain[2] set per-input psig");
+            }
+            TEST_ASSERT(factory_session_complete_node_input(
+                            f, (size_t)sub0_node_idx, i),
+                        "chain[2] complete per-input");
+        }
+        TEST_ASSERT(factory_session_assemble_signed_tx_multi(
+                        f, (size_t)sub0_node_idx),
+                    "chain[2] assemble multi-witness");
     }
-    TEST_ASSERT(factory_session_finalize_node(f, (size_t)sub0_node_idx),
-                "chain[2] finalize");
-    for (size_t j = 0; j < sub->n_signers; j++) {
-        uint32_t participant = sub->signer_indices[j];
-        secp256k1_musig_partial_sig psig;
-        TEST_ASSERT(musig_create_partial_sig(ctx, &psig, &secnonces[j],
-                                               &kps[participant],
-                                               &sub->signing_session),
-                    "chain[2] create psig");
-        TEST_ASSERT(factory_session_set_partial_sig(f, (size_t)sub0_node_idx, j, &psig),
-                    "chain[2] set psig");
-    }
-    TEST_ASSERT(factory_session_complete_node(f, (size_t)sub0_node_idx),
-                "chain[2] complete");
     TEST_ASSERT(sub->is_signed, "chain[2] signed");
 
     /* Failure cases */
@@ -5596,6 +5629,180 @@ int test_factory_ps_subfactory_chain_extension(void) {
     /* (c) channel_idx out of range (= sales-stock vout) */
     rc = factory_subfactory_chain_advance_unsigned(f, 0, 0, 2, 1000);
     TEST_ASSERT_EQ(rc, 0, "reject: channel_idx == sales-stock vout");
+
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
+/* Decode chain[1]'s signed_tx bytes and assert TX-level conservation
+   (the regression that #207 fixes — pre-fix chain[1] was a 1-vin / 3-vout
+   TX whose outputs exceeded the single input by ~3x).
+
+   Reads the segwit serialization manually:
+     [nVersion(4)][marker(1)=00][flag(1)=01][vin_count varint]
+     [vin × N: txid(32) + vout(4) + scriptSig_varint(0) + nSeq(4)]
+     [vout_count varint]
+     [vout × M: amount(8) + spk_varint + spk]
+     [witness × N (each = stack_count varint + per-item varint+data)]
+     [nLockTime(4)] */
+int test_factory_ps_subfactory_chain_tx_validity(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[5];
+    for (int i = 0; i < 5; i++) {
+        unsigned char sk[32] = {0};
+        sk[31] = (unsigned char)(i + 1);
+        sk[0]  = 0xAB;
+        TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], sk), "keypair");
+    }
+
+    unsigned char fund_spk[34];
+    {
+        secp256k1_pubkey pks[5];
+        for (int i = 0; i < 5; i++)
+            secp256k1_keypair_pub(ctx, &pks[i], &kps[i]);
+        musig_keyagg_t ka;
+        musig_aggregate_keys(ctx, &ka, pks, 5);
+        unsigned char ser[32];
+        secp256k1_xonly_pubkey_serialize(ctx, ser, &ka.agg_pubkey);
+        unsigned char tweak[32];
+        sha256_tagged("TapTweak", ser, 32, tweak);
+        secp256k1_pubkey tweaked_pk;
+        secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tweaked_pk, &ka.cache, tweak);
+        secp256k1_xonly_pubkey fund_tw;
+        secp256k1_xonly_pubkey_from_pubkey(ctx, &fund_tw, NULL, &tweaked_pk);
+        build_p2tr_script_pubkey(fund_spk, &fund_tw);
+    }
+    unsigned char fake_txid[32];
+    memset(fake_txid, 0xFA, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+    factory_init(f, ctx, kps, 5, 6, 10);
+    factory_set_arity(f, FACTORY_ARITY_PS);
+    factory_set_ps_subfactory_arity(f, 2);
+    factory_set_funding(f, fake_txid, 0, 1000000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(f), "build k² PS tree");
+    TEST_ASSERT(factory_sign_all(f), "sign initial state");
+
+    size_t leaf_idx = f->leaf_node_indices[0];
+    factory_node_t *leaf = &f->nodes[leaf_idx];
+    int sub0_node_idx = leaf->subfactory_node_indices[0];
+    factory_node_t *sub = &f->nodes[sub0_node_idx];
+
+    /* Snapshot the 3 chain[0] output amounts (these become chain[1]'s 3 inputs). */
+    uint64_t in_amounts[3];
+    for (size_t i = 0; i < sub->n_outputs; i++)
+        in_amounts[i] = sub->outputs[i].amount_sats;
+    uint64_t in_total = in_amounts[0] + in_amounts[1] + in_amounts[2];
+
+    /* Advance: client A buys 50000 from sales-stock. */
+    uint64_t delta = 50000;
+    TEST_ASSERT_EQ(factory_subfactory_chain_advance_unsigned(f, 0, 0, 0, delta), 1,
+                    "advance ok");
+
+    /* Sign chain[1] via per-input flow. */
+    {
+        size_t n_inp = sub->ps_n_prev_outputs;
+        secp256k1_musig_secnonce secnonces[3][3];
+        for (size_t i = 0; i < n_inp; i++) {
+            TEST_ASSERT(factory_session_init_node_input(f, (size_t)sub0_node_idx, i),
+                        "init input");
+            for (size_t j = 0; j < sub->n_signers; j++) {
+                uint32_t participant = sub->signer_indices[j];
+                unsigned char seckey[32];
+                secp256k1_pubkey pk;
+                secp256k1_keypair_sec(ctx, seckey, &kps[participant]);
+                secp256k1_keypair_pub(ctx, &pk, &kps[participant]);
+                secp256k1_musig_pubnonce pubnonce;
+                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i][j], &pubnonce,
+                                                   seckey, &pk, &sub->keyagg.cache),
+                            "gen nonce");
+                TEST_ASSERT(factory_session_set_nonce_input(f, (size_t)sub0_node_idx,
+                                                              i, j, &pubnonce),
+                            "set nonce");
+                memset(seckey, 0, 32);
+            }
+            TEST_ASSERT(factory_session_finalize_node_input(f, (size_t)sub0_node_idx, i),
+                        "finalize input");
+        }
+        for (size_t i = 0; i < n_inp; i++) {
+            for (size_t j = 0; j < sub->n_signers; j++) {
+                uint32_t participant = sub->signer_indices[j];
+                secp256k1_musig_partial_sig psig;
+                TEST_ASSERT(musig_create_partial_sig(
+                                ctx, &psig, &secnonces[i][j], &kps[participant],
+                                &sub->input_signing_sessions[i]),
+                            "create psig");
+                TEST_ASSERT(factory_session_set_partial_sig_input(
+                                f, (size_t)sub0_node_idx, i, j, &psig),
+                            "set psig");
+            }
+        }
+        TEST_ASSERT(factory_session_assemble_signed_tx_multi(
+                        f, (size_t)sub0_node_idx),
+                    "assemble signed_tx");
+    }
+
+    /* === Decode signed_tx bytes and verify TX-level conservation === */
+    const unsigned char *tx = sub->signed_tx.data;
+    size_t tx_len = sub->signed_tx.len;
+    TEST_ASSERT(tx_len > 100, "signed_tx is non-trivial");
+
+    /* offset 0..3: nVersion = 2 */
+    TEST_ASSERT_EQ(tx[0], 0x02, "nVersion byte 0");
+    /* offset 4: segwit marker = 0x00 */
+    TEST_ASSERT_EQ(tx[4], 0x00, "segwit marker");
+    /* offset 5: segwit flag = 0x01 */
+    TEST_ASSERT_EQ(tx[5], 0x01, "segwit flag");
+
+    /* offset 6: vin_count varint.  We expect 3 inputs (= k+1). */
+    TEST_ASSERT_EQ(tx[6], 0x03, "vin_count = 3 (THIS IS THE #207 FIX)");
+
+    /* Walk the 3 inputs, each 41 bytes (32 txid + 4 vout + 1 scriptSig=0 + 4 nSeq). */
+    size_t pos = 7;
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT(memcmp(tx + pos, sub->ps_prev_txid, 32) == 0,
+                    "input txid matches ps_prev_txid");
+        uint32_t vout = (uint32_t)tx[pos + 32] | ((uint32_t)tx[pos + 33] << 8) |
+                        ((uint32_t)tx[pos + 34] << 16) | ((uint32_t)tx[pos + 35] << 24);
+        TEST_ASSERT_EQ((long)vout, (long)i, "input vout matches index");
+        TEST_ASSERT_EQ(tx[pos + 36], 0x00, "scriptSig length = 0");
+        pos += 41;
+    }
+
+    /* vout_count varint */
+    TEST_ASSERT_EQ(tx[pos], 0x03, "vout_count = 3");
+    pos++;
+
+    /* Walk 3 outputs, sum amounts.  Each output = 8 (amount) + 1 (spk_len varint) + spk_len. */
+    uint64_t out_total = 0;
+    for (int i = 0; i < 3; i++) {
+        uint64_t amount = 0;
+        for (int b = 0; b < 8; b++)
+            amount |= ((uint64_t)tx[pos + b]) << (b * 8);
+        out_total += amount;
+        size_t spk_len = (size_t)tx[pos + 8];
+        pos += 9 + spk_len;
+    }
+
+    /* Conservation: sum(in_amounts) == sum(out_amounts) + fee_per_tx.
+       The advance moves `delta` from sales-stock to channel A — total
+       just decreases by fee. */
+    TEST_ASSERT_EQ((long)out_total, (long)(in_total - f->fee_per_tx),
+                    "input total - fee = output total (conservation)");
+
+    /* 3 witnesses follow, each = 1 + 1 + 64 = 66 bytes (stack_count=1, sig_len=64, sig). */
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT_EQ(tx[pos + 0], 0x01, "witness stack count = 1");
+        TEST_ASSERT_EQ(tx[pos + 1], 0x40, "witness sig len = 64");
+        pos += 66;
+    }
+
+    /* nLockTime at end: 4 bytes */
+    TEST_ASSERT(pos == tx_len - 4, "consumed all bytes except nLockTime");
+    TEST_ASSERT_EQ(tx[tx_len - 4], 0x00, "nLockTime byte 0");
 
     factory_free(f);
     secp256k1_context_destroy(ctx);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1670,6 +1670,7 @@ extern int test_factory_config_default(void);
 extern int test_factory_ps_leaf_build(void);
 extern int test_factory_ps_subfactory_k2_n4(void);
 extern int test_factory_ps_subfactory_chain_extension(void);
+extern int test_factory_ps_subfactory_chain_tx_validity(void);
 extern int test_factory_ps_subfactory_poison_tx_k2_n4(void);
 extern int test_factory_ps_leaf_build_n64(void);
 extern int test_factory_ps_build_n128(void);
@@ -3454,6 +3455,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_ps_leaf_build);
     RUN_TEST(test_factory_ps_subfactory_k2_n4);
     RUN_TEST(test_factory_ps_subfactory_chain_extension);
+    RUN_TEST(test_factory_ps_subfactory_chain_tx_validity);
     RUN_TEST(test_factory_ps_subfactory_poison_tx_k2_n4);
     RUN_TEST(test_factory_ps_leaf_build_n64);
     RUN_TEST(test_factory_ps_build_n128);


### PR DESCRIPTION
## Summary

Wires the multi-input primitives from #147 into the PS sub-factory chain advance path. After this PR, `chain[N+1]` is built and signed correctly as a `k+1`-input TX whose outputs balance the `k+1` input amounts (minus `fee_per_tx`) — closing the structural conservation violation that broke force-close after sub-factory advance on signet (campaign #1, 2026-05-03).

## Mechanics

- `factory_node_t` now caches per-input prev state on chain advance: `ps_n_prev_outputs`, `ps_prev_amounts[]`, `ps_prev_spks[]`, `ps_prev_spk_lens[]`. Captured BEFORE `factory_subfactory_chain_advance_unsigned` mutates `outputs[]`.
- `rebuild_node_tx` detects advanced PS sub-factories and builds the unsigned TX via `build_unsigned_tx_multi` (k+1 inputs, one per chain[N-1] vout).
- `compute_node_sighash_input` — per-input BIP-341 sighash for multi-input nodes; delegates to `compute_node_sighash` for the single-input case (no behavior change for non-chain-advance flows).
- Per-input MuSig session helpers (`factory_session_init_node_input` / `set_nonce_input` / `finalize_node_input` / `set_partial_sig_input` / `complete_node_input` / `assemble_signed_tx_multi`). Each input gets its own session because BIP-341 sighashes differ per input. Per-input session arrays heap-allocated lazily, freed in `factory_free`.

## What this PR does NOT yet fix

The wire-ceremony version of chain advance (`lsp_subfactory_chain_advance` in `lsp_channels.c` + matching client handler in `client.c`) still uses single-input session helpers. The multi-process flow will produce signed bytes whose witness fails verification — same broken state as today. **Phase 2c** will refactor that ceremony to coordinate per-input MuSig over the wire. At that point force-close after sub-factory advance works end-to-end on signet.

## Test plan

- [x] `test_factory_ps_subfactory_chain_extension` — rewritten to use the per-input flow. Asserts both `chain[1]` and `chain[2]` sign cleanly.
- [x] `test_factory_ps_subfactory_chain_tx_validity` (NEW) — decodes `chain[1]`'s wire bytes and asserts:
  - segwit marker/flag present
  - `vin_count == 3` (k+1 inputs — **THE #207 FIX**)
  - each input txid == `ps_prev_txid`, vout matches index
  - `sum(input.amount) == sum(output.amount) + fee_per_tx` (conservation, the regression #207 fixes)
  - 3 64-byte schnorr witnesses, one per input
- [ ] All existing 1428 unit tests still pass (CI)
- [ ] Sanitizers green (CI)
- [ ] Static analysis green (CI)

## Memory cost

`factory_node_t` grows by ~896 bytes (per-input arrays). At `FACTORY_MAX_NODES=512`, factory_t grows by ~458KB — already heap-allocated by callers. Per-input MuSig session arrays (~136KB at max k=15) are heap-allocated lazily only on nodes that actually exercise the multi-input path.