### PR TITLE
feat(wire): bundle builders with optional poison_entries (PR-D phase 2)

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -233,6 +233,40 @@ cJSON *wire_build_all_nonces(const wire_bundle_entry_t *entries, size_t n);
 /* Client → LSP: PSIG_BUNDLE {entries: [{node_idx, slot, psig_hex}...]} */
 cJSON *wire_build_psig_bundle(const wire_bundle_entry_t *entries, size_t n);
 
+/* --- Bundle variants with optional poison TX entries (PR-D / Tier B
+   rotation poison wire ceremony, closes the SECURITY GAP at
+   lsp_channels.c::lsp_run_state_advance multi-process path).
+
+   Same JSON shape as the plain bundle builders, with an optional
+   second "poison_entries" array.  Receivers parsing a plain bundle
+   simply ignore the new field — backward compatible.  When n_poison is
+   0 OR poison_entries is NULL, the field is omitted entirely so the
+   wire bytes are byte-equal to the plain builder.
+
+   Use wire_parse_poison_bundle to read the second array out of any
+   incoming bundle message; returns 0 entries when the field is
+   absent.  */
+cJSON *wire_build_nonce_bundle_with_poison(const wire_bundle_entry_t *entries, size_t n,
+                                             const wire_bundle_entry_t *poison_entries,
+                                             size_t n_poison);
+
+cJSON *wire_build_all_nonces_with_poison(const wire_bundle_entry_t *entries, size_t n,
+                                           const wire_bundle_entry_t *poison_entries,
+                                           size_t n_poison);
+
+cJSON *wire_build_psig_bundle_with_poison(const wire_bundle_entry_t *entries, size_t n,
+                                            const wire_bundle_entry_t *poison_entries,
+                                            size_t n_poison);
+
+/* Look up the optional "poison_entries" array on a bundle message and parse
+   it into the caller-provided buffer.  Returns the number of parsed entries
+   (0 when the field is missing — that's a valid backward-compat case, not
+   an error).  data_size is 66 for pubnonce bundles, 32 for psig bundles. */
+size_t wire_parse_poison_bundle(const cJSON *json,
+                                  wire_bundle_entry_t *poison_entries,
+                                  size_t max_poison,
+                                  size_t data_size);
+
 /* LSP → Client: FACTORY_READY {signed_txs: [{node_idx, tx_hex}...]} */
 cJSON *wire_build_factory_ready(const factory_t *f);
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -682,6 +682,50 @@ cJSON *wire_build_psig_bundle(const wire_bundle_entry_t *entries, size_t n) {
     return j;
 }
 
+/* Helper: build a bundle JSON with primary + optional poison_entries arrays.
+   When n_poison is 0 OR poison_entries is NULL, the poison_entries field is
+   omitted entirely so the wire bytes match the plain builder exactly
+   (backward-compat receivers parse cleanly). */
+static cJSON *build_bundle_with_poison(const wire_bundle_entry_t *entries, size_t n,
+                                         const wire_bundle_entry_t *poison_entries,
+                                         size_t n_poison,
+                                         const char *primary_key) {
+    cJSON *j = cJSON_CreateObject();
+    cJSON_AddItemToObject(j, primary_key, build_bundle_array(entries, n));
+    if (poison_entries && n_poison > 0)
+        cJSON_AddItemToObject(j, "poison_entries",
+                              build_bundle_array(poison_entries, n_poison));
+    return j;
+}
+
+cJSON *wire_build_nonce_bundle_with_poison(const wire_bundle_entry_t *entries, size_t n,
+                                             const wire_bundle_entry_t *poison_entries,
+                                             size_t n_poison) {
+    return build_bundle_with_poison(entries, n, poison_entries, n_poison, "entries");
+}
+
+cJSON *wire_build_all_nonces_with_poison(const wire_bundle_entry_t *entries, size_t n,
+                                           const wire_bundle_entry_t *poison_entries,
+                                           size_t n_poison) {
+    return build_bundle_with_poison(entries, n, poison_entries, n_poison, "nonces");
+}
+
+cJSON *wire_build_psig_bundle_with_poison(const wire_bundle_entry_t *entries, size_t n,
+                                            const wire_bundle_entry_t *poison_entries,
+                                            size_t n_poison) {
+    return build_bundle_with_poison(entries, n, poison_entries, n_poison, "entries");
+}
+
+size_t wire_parse_poison_bundle(const cJSON *json,
+                                  wire_bundle_entry_t *poison_entries,
+                                  size_t max_poison,
+                                  size_t data_size) {
+    if (!json || !poison_entries || max_poison == 0) return 0;
+    cJSON *arr = cJSON_GetObjectItem(json, "poison_entries");
+    if (!arr) return 0;
+    return wire_parse_bundle(arr, poison_entries, max_poison, data_size);
+}
+
 cJSON *wire_build_factory_ready(const factory_t *f) {
     cJSON *j = cJSON_CreateObject();
     cJSON *arr = cJSON_CreateArray();

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1098,6 +1098,8 @@ extern int test_wire_framing(void);
 extern int test_wire_crypto_serialization(void);
 extern int test_wire_nonce_bundle(void);
 extern int test_wire_psig_bundle(void);
+extern int test_wire_path_bundle_with_poison_round_trip(void);
+extern int test_wire_path_bundle_no_poison_back_compat(void);
 extern int test_wire_close_unsigned(void);
 extern int test_wire_distributed_signing(void);
 extern int test_regtest_wire_factory(void);
@@ -2954,6 +2956,8 @@ static void run_unit_tests(void) {
     RUN_TEST(test_wire_crypto_serialization);
     RUN_TEST(test_wire_nonce_bundle);
     RUN_TEST(test_wire_psig_bundle);
+    RUN_TEST(test_wire_path_bundle_with_poison_round_trip);
+    RUN_TEST(test_wire_path_bundle_no_poison_back_compat);
     RUN_TEST(test_wire_close_unsigned);
     RUN_TEST(test_wire_distributed_signing);
 

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -271,6 +271,135 @@ int test_wire_psig_bundle(void) {
     return 1;
 }
 
+/* PR-D — Tier B rotation poison wire ceremony.  The new
+   *_with_poison bundle builders attach an optional second array of
+   poison entries.  Receivers that don't recognize the field ignore
+   it (backward compat — proven by parsing the with-poison bundle
+   with the plain wire_parse_bundle parser). */
+int test_wire_path_bundle_with_poison_round_trip(void) {
+    /* state entries (3 nodes × 1 slot) */
+    wire_bundle_entry_t state_entries[3];
+    for (int i = 0; i < 3; i++) {
+        state_entries[i].node_idx = (uint32_t)i;
+        state_entries[i].signer_slot = 1;
+        memset(state_entries[i].data, 0xa0 + i, 66);
+        state_entries[i].data_len = 66;
+    }
+    /* poison entries (2 leaves × 1 slot) — fewer than state because
+       only leaf nodes get poison TXs */
+    wire_bundle_entry_t poison_entries[2];
+    for (int i = 0; i < 2; i++) {
+        poison_entries[i].node_idx = (uint32_t)(i + 7);
+        poison_entries[i].signer_slot = 1;
+        memset(poison_entries[i].data, 0xb0 + i, 66);
+        poison_entries[i].data_len = 66;
+    }
+
+    cJSON *bundle = wire_build_nonce_bundle_with_poison(
+        state_entries, 3, poison_entries, 2);
+    TEST_ASSERT(cJSON_GetObjectItem(bundle, "entries"), "state entries present");
+    TEST_ASSERT(cJSON_GetObjectItem(bundle, "poison_entries"), "poison entries present");
+
+    /* parse state side via existing parser */
+    cJSON *st_arr = cJSON_GetObjectItem(bundle, "entries");
+    wire_bundle_entry_t parsed_state[3];
+    size_t n_state = wire_parse_bundle(st_arr, parsed_state, 3, 66);
+    TEST_ASSERT_EQ(n_state, 3, "state parsed count");
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT_EQ(parsed_state[i].node_idx, state_entries[i].node_idx, "state node_idx");
+        TEST_ASSERT_MEM_EQ(parsed_state[i].data, state_entries[i].data, 66, "state data");
+    }
+
+    /* parse poison side via the new helper */
+    wire_bundle_entry_t parsed_poison[2];
+    size_t n_poison = wire_parse_poison_bundle(bundle, parsed_poison, 2, 66);
+    TEST_ASSERT_EQ(n_poison, 2, "poison parsed count");
+    for (int i = 0; i < 2; i++) {
+        TEST_ASSERT_EQ(parsed_poison[i].node_idx, poison_entries[i].node_idx, "poison node_idx");
+        TEST_ASSERT_MEM_EQ(parsed_poison[i].data, poison_entries[i].data, 66, "poison data");
+    }
+
+    cJSON_Delete(bundle);
+
+    /* Same flow for psig (32-byte data), and use the all_nonces builder
+       to verify the primary key changes ("nonces" instead of "entries"). */
+    wire_bundle_entry_t psig_state[2];
+    for (int i = 0; i < 2; i++) {
+        psig_state[i].node_idx = (uint32_t)i;
+        psig_state[i].signer_slot = 0;
+        memset(psig_state[i].data, 0xc0 + i, 32);
+        psig_state[i].data_len = 32;
+    }
+    wire_bundle_entry_t psig_poison[1];
+    psig_poison[0].node_idx = 9;
+    psig_poison[0].signer_slot = 1;
+    memset(psig_poison[0].data, 0xd0, 32);
+    psig_poison[0].data_len = 32;
+
+    cJSON *psig_bundle = wire_build_psig_bundle_with_poison(psig_state, 2,
+                                                              psig_poison, 1);
+    wire_bundle_entry_t parsed_psig_poison[1];
+    size_t np = wire_parse_poison_bundle(psig_bundle, parsed_psig_poison, 1, 32);
+    TEST_ASSERT_EQ(np, 1, "psig poison parsed count");
+    TEST_ASSERT_MEM_EQ(parsed_psig_poison[0].data, psig_poison[0].data, 32, "psig poison data");
+    cJSON_Delete(psig_bundle);
+
+    cJSON *all_bundle = wire_build_all_nonces_with_poison(state_entries, 3,
+                                                            poison_entries, 2);
+    TEST_ASSERT(cJSON_GetObjectItem(all_bundle, "nonces"), "all_nonces uses 'nonces' key");
+    TEST_ASSERT(cJSON_GetObjectItem(all_bundle, "poison_entries"), "all_nonces poison present");
+    cJSON_Delete(all_bundle);
+
+    return 1;
+}
+
+/* When n_poison=0 (or NULL poison_entries), the with_poison builder must
+   produce JSON byte-equal to the plain builder — backward compat receivers
+   parse it cleanly with no special handling. */
+int test_wire_path_bundle_no_poison_back_compat(void) {
+    wire_bundle_entry_t entries[2];
+    for (int i = 0; i < 2; i++) {
+        entries[i].node_idx = (uint32_t)i;
+        entries[i].signer_slot = 0;
+        memset(entries[i].data, 0xee, 66);
+        entries[i].data_len = 66;
+    }
+
+    cJSON *plain = wire_build_nonce_bundle(entries, 2);
+    cJSON *no_poison = wire_build_nonce_bundle_with_poison(entries, 2, NULL, 0);
+    cJSON *zero_poison = wire_build_nonce_bundle_with_poison(entries, 2, entries, 0);
+
+    char *plain_s = cJSON_PrintUnformatted(plain);
+    char *no_poison_s = cJSON_PrintUnformatted(no_poison);
+    char *zero_poison_s = cJSON_PrintUnformatted(zero_poison);
+
+    TEST_ASSERT(plain_s && no_poison_s && zero_poison_s, "render JSON");
+    TEST_ASSERT(strcmp(plain_s, no_poison_s) == 0,
+                "with_poison(NULL,0) == plain build");
+    TEST_ASSERT(strcmp(plain_s, zero_poison_s) == 0,
+                "with_poison(non-null,0) == plain build (n_poison=0 wins)");
+
+    /* Old parser handles new builder output (additive field ignored). */
+    cJSON *parsed_root = cJSON_Parse(no_poison_s);
+    cJSON *arr = cJSON_GetObjectItem(parsed_root, "entries");
+    wire_bundle_entry_t out[2];
+    size_t n = wire_parse_bundle(arr, out, 2, 66);
+    TEST_ASSERT_EQ(n, 2, "old parser still works on new builder");
+
+    /* And the new poison parser cleanly returns 0 when the field is absent. */
+    size_t np = wire_parse_poison_bundle(parsed_root, out, 2, 66);
+    TEST_ASSERT_EQ(np, 0, "missing poison_entries returns 0 entries (not error)");
+
+    free(plain_s);
+    free(no_poison_s);
+    free(zero_poison_s);
+    cJSON_Delete(plain);
+    cJSON_Delete(no_poison);
+    cJSON_Delete(zero_poison);
+    cJSON_Delete(parsed_root);
+    return 1;
+}
+
 /* ---- Test 6: cooperative close unsigned ---- */
 
 int test_wire_close_unsigned(void) {


### PR DESCRIPTION
## Summary

Adds `*_with_poison` variants of the three Tier B rotation bundle builders (`MSG_PATH_NONCE_BUNDLE`, `MSG_PATH_ALL_NONCES`, `MSG_PATH_PSIG_BUNDLE`) that accept a second array of poison-TX entries.

This is the wire-format scaffolding for closing the SECURITY GAP at `src/lsp_channels.c::lsp_run_state_advance` multi-process path. The LSP-side and client-side state-machine integration (PR-D phase 3 + 4) will follow as separate PRs.

## Backward compatibility

When `n_poison=0` OR `poison_entries=NULL`, the JSON is **byte-equal** to the plain builders' output (verified by test). Receivers that don't recognize the `poison_entries` field ignore it.

## API

```c
cJSON *wire_build_nonce_bundle_with_poison(state[], n_state,
                                              poison[], n_poison);
// + analogous _all_nonces / _psig_bundle variants
size_t wire_parse_poison_bundle(json, out[], max, data_size);
// returns 0 if no poison_entries field — that's a valid backcompat case
```

## Test plan

- [x] `test_wire_path_bundle_with_poison_round_trip` — build + parse 3-state + 2-poison entries through all three bundle variants; verify per-key layout (`entries` / `nonces` / `poison_entries`).
- [x] `test_wire_path_bundle_no_poison_back_compat` — confirms `with_poison(NULL,0)` and `with_poison(non-null,0)` both equal plain output; old parser handles new builder; new poison parser returns 0 cleanly when field absent.
- [ ] All existing 1430+ unit tests still pass (CI)
- [ ] Sanitizers green (CI)

## Files touched

- `include/superscalar/wire.h` — 4 new declarations
- `src/wire.c` — 3 new builders + 1 parse helper + `build_bundle_with_poison` static helper
- `tests/test_wire.c` — 2 new round-trip tests
- `tests/test_main.c` — register new tests