### PR TITLE
feat(wire): multi-input sub-factory chain advance helpers (#207 phase 2c.a)

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -801,7 +801,7 @@ int wire_parse_subfactory_done(const cJSON *json,
      if (n_inp > 0)
          wire_subfactory_propose_get_pubnonces(json, lsp_pubnonces_out, max);
      else
-         /* legacy single-input — use existing wire_parse_subfactory_propose */
+         // legacy single-input — use existing wire_parse_subfactory_propose
 */
 
 /* PROPOSE — set/get optional `n_inputs` + `lsp_pubnonces[n_inputs]`. */

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -766,6 +766,75 @@ int wire_parse_subfactory_done(const cJSON *json,
                                  int *leaf_side, int *sub_idx,
                                  uint32_t *chain_len);
 
+/* --- Multi-input sub-factory chain advance helpers (#207 phase 2c) ---
+
+   When the sub-factory has been advanced (ps_chain_len > 0) and is now
+   spending k+1 outputs of the prior chain TX, the wire ceremony needs
+   to coordinate k+1 independent MuSig2 sessions (BIP-341 sighashes
+   differ per input, so nonces and partial sigs are distinct per
+   input).  These helpers attach OPTIONAL array-form fields to the
+   existing MSG_SUBFACTORY_* messages, alongside the existing
+   single-nonce/sig fields:
+
+   - MSG_SUBFACTORY_PROPOSE optionally carries `n_inputs` + `lsp_pubnonces`
+     (array of k+1 hex 66-byte nonces).
+   - MSG_SUBFACTORY_NONCE optionally carries `pubnonces` (array of k+1
+     hex 66-byte nonces from the client) — alongside the existing single
+     `pubnonce` field for backward compat.
+   - MSG_SUBFACTORY_ALL_NONCES optionally carries `pubnonces_per_input`
+     (a 2D array indexed [signer][input] of hex 66-byte nonces).
+   - MSG_SUBFACTORY_PSIG optionally carries `partial_sigs` (array of
+     k+1 hex 32-byte partial sigs).
+
+   When n_inputs == 1, the receiver may use either the legacy single
+   field or the new arrays — they're equivalent.  When n_inputs > 1,
+   the receiver MUST use the array form (single field is undefined).
+
+   These helpers MUTATE the existing PROPOSE/NONCE/ALL_NONCES/PSIG cJSON
+   built by the legacy helpers.  Pattern:
+     cJSON *p = wire_build_subfactory_propose(..., lsp_pubnonces[0]);
+     wire_subfactory_propose_set_inputs(p, 3, lsp_pubnonces);   // adds n_inputs + lsp_pubnonces[]
+     wire_send(... MSG_SUBFACTORY_PROPOSE ...);
+
+   Receivers do:
+     int n_inp = wire_subfactory_propose_get_n_inputs(json);  // 0 if absent
+     if (n_inp > 0)
+         wire_subfactory_propose_get_pubnonces(json, lsp_pubnonces_out, max);
+     else
+         /* legacy single-input — use existing wire_parse_subfactory_propose */
+*/
+
+/* PROPOSE — set/get optional `n_inputs` + `lsp_pubnonces[n_inputs]`. */
+void wire_subfactory_propose_set_inputs(cJSON *propose, size_t n_inputs,
+                                          const unsigned char (*lsp_pubnonces)[66]);
+size_t wire_subfactory_propose_get_n_inputs(const cJSON *json);
+size_t wire_subfactory_propose_get_pubnonces(const cJSON *json,
+                                               unsigned char (*out)[66], size_t max);
+
+/* NONCE — set/get optional `pubnonces[n_inputs]` (client's per-input nonces). */
+void wire_subfactory_nonce_set_pubnonces(cJSON *nonce, size_t n_inputs,
+                                           const unsigned char (*pubnonces)[66]);
+size_t wire_subfactory_nonce_get_pubnonces(const cJSON *json,
+                                             unsigned char (*out)[66], size_t max);
+
+/* ALL_NONCES — set/get optional `pubnonces_per_input[n_signers][n_inputs]`. */
+void wire_subfactory_all_nonces_set_per_input(cJSON *all_nonces, size_t n_signers,
+                                                size_t n_inputs,
+                                                const unsigned char (*pubnonces)[66]);
+/* Reads back the per-input array.  out has shape [n_signers][n_inputs][66].
+   Returns the n_signers count (0 if field absent), and writes n_inputs to *n_inputs_out. */
+size_t wire_subfactory_all_nonces_get_per_input(const cJSON *json,
+                                                  unsigned char *out_flat,
+                                                  size_t max_signers,
+                                                  size_t max_inputs,
+                                                  size_t *n_inputs_out);
+
+/* PSIG — set/get optional `partial_sigs[n_inputs]`. */
+void wire_subfactory_psig_set_partial_sigs(cJSON *psig, size_t n_inputs,
+                                             const unsigned char (*partial_sigs)[32]);
+size_t wire_subfactory_psig_get_partial_sigs(const cJSON *json,
+                                                unsigned char (*out)[32], size_t max);
+
 /* --- SCID assignment for route hints (4B) --- */
 
 /* LSP → Client: SCID_ASSIGN {channel_id, scid, fee_base_msat, fee_ppm, cltv_delta} */

--- a/src/wire.c
+++ b/src/wire.c
@@ -1987,6 +1987,147 @@ cJSON *wire_build_subfactory_done(int leaf_side, int sub_idx, uint32_t chain_len
     return j;
 }
 
+/* --- Multi-input sub-factory chain advance helpers (#207 phase 2c) ---
+   See include/superscalar/wire.h for the design rationale.  All these
+   helpers MUTATE an existing PROPOSE/NONCE/ALL_NONCES/PSIG cJSON by
+   adding optional array fields alongside the legacy single-nonce/sig
+   field.  Receivers detect multi-input mode by reading n_inputs (0 if
+   absent → legacy single-input mode). */
+
+void wire_subfactory_propose_set_inputs(cJSON *propose, size_t n_inputs,
+                                          const unsigned char (*lsp_pubnonces)[66]) {
+    if (!propose || n_inputs == 0 || !lsp_pubnonces) return;
+    cJSON_AddNumberToObject(propose, "n_inputs", (double)n_inputs);
+    cJSON *arr = cJSON_AddArrayToObject(propose, "lsp_pubnonces");
+    char hex[133];
+    for (size_t i = 0; i < n_inputs; i++) {
+        hex_encode(lsp_pubnonces[i], 66, hex);
+        cJSON_AddItemToArray(arr, cJSON_CreateString(hex));
+    }
+}
+
+size_t wire_subfactory_propose_get_n_inputs(const cJSON *json) {
+    if (!json) return 0;
+    cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
+    if (!ni || !cJSON_IsNumber(ni)) return 0;
+    double v = ni->valuedouble;
+    if (v < 1 || v > 1024) return 0;
+    return (size_t)v;
+}
+
+size_t wire_subfactory_propose_get_pubnonces(const cJSON *json,
+                                               unsigned char (*out)[66], size_t max) {
+    if (!json || !out || max == 0) return 0;
+    cJSON *arr = cJSON_GetObjectItem(json, "lsp_pubnonces");
+    if (!arr || !cJSON_IsArray(arr)) return 0;
+    size_t n = (size_t)cJSON_GetArraySize(arr);
+    if (n > max) return 0;
+    for (size_t i = 0; i < n; i++) {
+        cJSON *item = cJSON_GetArrayItem(arr, (int)i);
+        if (!item || !cJSON_IsString(item)) return 0;
+        if (hex_decode(item->valuestring, out[i], 66) != 66) return 0;
+    }
+    return n;
+}
+
+void wire_subfactory_nonce_set_pubnonces(cJSON *nonce, size_t n_inputs,
+                                           const unsigned char (*pubnonces)[66]) {
+    if (!nonce || n_inputs == 0 || !pubnonces) return;
+    cJSON *arr = cJSON_AddArrayToObject(nonce, "pubnonces");
+    char hex[133];
+    for (size_t i = 0; i < n_inputs; i++) {
+        hex_encode(pubnonces[i], 66, hex);
+        cJSON_AddItemToArray(arr, cJSON_CreateString(hex));
+    }
+}
+
+size_t wire_subfactory_nonce_get_pubnonces(const cJSON *json,
+                                             unsigned char (*out)[66], size_t max) {
+    if (!json || !out || max == 0) return 0;
+    cJSON *arr = cJSON_GetObjectItem(json, "pubnonces");
+    if (!arr || !cJSON_IsArray(arr)) return 0;
+    size_t n = (size_t)cJSON_GetArraySize(arr);
+    if (n > max) return 0;
+    for (size_t i = 0; i < n; i++) {
+        cJSON *item = cJSON_GetArrayItem(arr, (int)i);
+        if (!item || !cJSON_IsString(item)) return 0;
+        if (hex_decode(item->valuestring, out[i], 66) != 66) return 0;
+    }
+    return n;
+}
+
+void wire_subfactory_all_nonces_set_per_input(cJSON *all_nonces, size_t n_signers,
+                                                size_t n_inputs,
+                                                const unsigned char (*pubnonces)[66]) {
+    if (!all_nonces || n_signers == 0 || n_inputs == 0 || !pubnonces) return;
+    /* pubnonces is laid out as [signer][input], i.e. pubnonces[s * n_inputs + i]. */
+    cJSON *outer = cJSON_AddArrayToObject(all_nonces, "pubnonces_per_input");
+    char hex[133];
+    for (size_t s = 0; s < n_signers; s++) {
+        cJSON *inner = cJSON_CreateArray();
+        for (size_t i = 0; i < n_inputs; i++) {
+            hex_encode(pubnonces[s * n_inputs + i], 66, hex);
+            cJSON_AddItemToArray(inner, cJSON_CreateString(hex));
+        }
+        cJSON_AddItemToArray(outer, inner);
+    }
+}
+
+size_t wire_subfactory_all_nonces_get_per_input(const cJSON *json,
+                                                  unsigned char *out_flat,
+                                                  size_t max_signers,
+                                                  size_t max_inputs,
+                                                  size_t *n_inputs_out) {
+    if (!json || !out_flat || !n_inputs_out) return 0;
+    cJSON *outer = cJSON_GetObjectItem(json, "pubnonces_per_input");
+    if (!outer || !cJSON_IsArray(outer)) return 0;
+    size_t n_signers = (size_t)cJSON_GetArraySize(outer);
+    if (n_signers == 0 || n_signers > max_signers) return 0;
+    cJSON *first = cJSON_GetArrayItem(outer, 0);
+    if (!first || !cJSON_IsArray(first)) return 0;
+    size_t n_inputs = (size_t)cJSON_GetArraySize(first);
+    if (n_inputs == 0 || n_inputs > max_inputs) return 0;
+    for (size_t s = 0; s < n_signers; s++) {
+        cJSON *inner = cJSON_GetArrayItem(outer, (int)s);
+        if (!inner || !cJSON_IsArray(inner)) return 0;
+        if ((size_t)cJSON_GetArraySize(inner) != n_inputs) return 0;
+        for (size_t i = 0; i < n_inputs; i++) {
+            cJSON *item = cJSON_GetArrayItem(inner, (int)i);
+            if (!item || !cJSON_IsString(item)) return 0;
+            if (hex_decode(item->valuestring,
+                           out_flat + (s * n_inputs + i) * 66, 66) != 66) return 0;
+        }
+    }
+    *n_inputs_out = n_inputs;
+    return n_signers;
+}
+
+void wire_subfactory_psig_set_partial_sigs(cJSON *psig, size_t n_inputs,
+                                             const unsigned char (*partial_sigs)[32]) {
+    if (!psig || n_inputs == 0 || !partial_sigs) return;
+    cJSON *arr = cJSON_AddArrayToObject(psig, "partial_sigs");
+    char hex[65];
+    for (size_t i = 0; i < n_inputs; i++) {
+        hex_encode(partial_sigs[i], 32, hex);
+        cJSON_AddItemToArray(arr, cJSON_CreateString(hex));
+    }
+}
+
+size_t wire_subfactory_psig_get_partial_sigs(const cJSON *json,
+                                                unsigned char (*out)[32], size_t max) {
+    if (!json || !out || max == 0) return 0;
+    cJSON *arr = cJSON_GetObjectItem(json, "partial_sigs");
+    if (!arr || !cJSON_IsArray(arr)) return 0;
+    size_t n = (size_t)cJSON_GetArraySize(arr);
+    if (n > max) return 0;
+    for (size_t i = 0; i < n; i++) {
+        cJSON *item = cJSON_GetArrayItem(arr, (int)i);
+        if (!item || !cJSON_IsString(item)) return 0;
+        if (hex_decode(item->valuestring, out[i], 32) != 32) return 0;
+    }
+    return n;
+}
+
 int wire_parse_subfactory_done(const cJSON *json, int *leaf_side,
                                  int *sub_idx, uint32_t *chain_len) {
     cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1100,6 +1100,7 @@ extern int test_wire_nonce_bundle(void);
 extern int test_wire_psig_bundle(void);
 extern int test_wire_path_bundle_with_poison_round_trip(void);
 extern int test_wire_path_bundle_no_poison_back_compat(void);
+extern int test_wire_subfactory_multi_input_helpers_round_trip(void);
 extern int test_wire_close_unsigned(void);
 extern int test_wire_distributed_signing(void);
 extern int test_regtest_wire_factory(void);
@@ -2959,6 +2960,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_wire_psig_bundle);
     RUN_TEST(test_wire_path_bundle_with_poison_round_trip);
     RUN_TEST(test_wire_path_bundle_no_poison_back_compat);
+    RUN_TEST(test_wire_subfactory_multi_input_helpers_round_trip);
     RUN_TEST(test_wire_close_unsigned);
     RUN_TEST(test_wire_distributed_signing);
 

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -353,6 +353,97 @@ int test_wire_path_bundle_with_poison_round_trip(void) {
     return 1;
 }
 
+/* #207 phase 2c — multi-input sub-factory chain advance helpers.
+   Round-trip the new optional array fields on each of PROPOSE/NONCE/
+   ALL_NONCES/PSIG.  When the array fields are absent, getter functions
+   return 0 (legacy single-input path). */
+int test_wire_subfactory_multi_input_helpers_round_trip(void) {
+    /* PROPOSE: build legacy single-input first, then attach multi-input arrays. */
+    unsigned char single_nonce[66];
+    memset(single_nonce, 0xa0, 66);
+    cJSON *propose = wire_build_subfactory_propose(0, 0, 0, 50000, single_nonce);
+
+    /* No multi-input fields yet. */
+    TEST_ASSERT_EQ(wire_subfactory_propose_get_n_inputs(propose), 0,
+                    "propose w/o n_inputs returns 0");
+
+    unsigned char lsp_nonces[3][66];
+    for (int i = 0; i < 3; i++) memset(lsp_nonces[i], 0xb0 + i, 66);
+    wire_subfactory_propose_set_inputs(propose, 3, lsp_nonces);
+
+    TEST_ASSERT_EQ(wire_subfactory_propose_get_n_inputs(propose), 3,
+                    "propose n_inputs=3 after set");
+    unsigned char out_nonces[3][66] = {{0}};
+    size_t got = wire_subfactory_propose_get_pubnonces(propose, out_nonces, 3);
+    TEST_ASSERT_EQ(got, 3, "propose round-trip count");
+    for (int i = 0; i < 3; i++)
+        TEST_ASSERT_MEM_EQ(out_nonces[i], lsp_nonces[i], 66, "propose nonce data");
+    cJSON_Delete(propose);
+
+    /* NONCE: client per-input nonces. */
+    cJSON *nonce = wire_build_subfactory_nonce(single_nonce, NULL);
+    unsigned char client_nonces[3][66];
+    for (int i = 0; i < 3; i++) memset(client_nonces[i], 0xc0 + i, 66);
+    wire_subfactory_nonce_set_pubnonces(nonce, 3, client_nonces);
+    unsigned char nonce_out[3][66] = {{0}};
+    size_t cn = wire_subfactory_nonce_get_pubnonces(nonce, nonce_out, 3);
+    TEST_ASSERT_EQ(cn, 3, "nonce array count");
+    for (int i = 0; i < 3; i++)
+        TEST_ASSERT_MEM_EQ(nonce_out[i], client_nonces[i], 66, "nonce array data");
+    cJSON_Delete(nonce);
+
+    /* ALL_NONCES: per-input × per-signer 2D array.  3 signers × 3 inputs. */
+    unsigned char single_all[3][66];
+    for (int s = 0; s < 3; s++) memset(single_all[s], 0xd0 + s, 66);
+    cJSON *all = wire_build_subfactory_all_nonces(single_all, NULL, 3);
+    unsigned char per_input_flat[3 * 3 * 66];
+    for (int s = 0; s < 3; s++) {
+        for (int i = 0; i < 3; i++) {
+            memset(per_input_flat + (s * 3 + i) * 66, 0xe0 + s * 3 + i, 66);
+        }
+    }
+    wire_subfactory_all_nonces_set_per_input(all, 3, 3, (const unsigned char (*)[66])per_input_flat);
+
+    unsigned char out_per_input[3 * 3 * 66] = {0};
+    size_t n_inputs_out = 0;
+    size_t n_signers_out = wire_subfactory_all_nonces_get_per_input(
+        all, out_per_input, 3, 3, &n_inputs_out);
+    TEST_ASSERT_EQ(n_signers_out, 3, "all_nonces signers count");
+    TEST_ASSERT_EQ(n_inputs_out, 3, "all_nonces inputs count");
+    TEST_ASSERT(memcmp(out_per_input, per_input_flat, 3 * 3 * 66) == 0,
+                "all_nonces per-input round-trip");
+    cJSON_Delete(all);
+
+    /* PSIG: per-input partial sigs. */
+    unsigned char single_sig[32];
+    memset(single_sig, 0xf0, 32);
+    cJSON *psig = wire_build_subfactory_psig(single_sig, NULL);
+    unsigned char part_sigs[3][32];
+    for (int i = 0; i < 3; i++) memset(part_sigs[i], 0x10 + i, 32);
+    wire_subfactory_psig_set_partial_sigs(psig, 3, part_sigs);
+    unsigned char part_out[3][32] = {{0}};
+    size_t pn = wire_subfactory_psig_get_partial_sigs(psig, part_out, 3);
+    TEST_ASSERT_EQ(pn, 3, "psig partial_sigs count");
+    for (int i = 0; i < 3; i++)
+        TEST_ASSERT_MEM_EQ(part_out[i], part_sigs[i], 32, "psig partial sigs data");
+    cJSON_Delete(psig);
+
+    /* Backward compat: receiver that only checks legacy fields still works. */
+    cJSON *legacy_propose = wire_build_subfactory_propose(0, 0, 0, 50000, single_nonce);
+    /* No multi-input fields set. */
+    int leaf_side, sub_idx, channel_idx;
+    uint64_t delta;
+    unsigned char legacy_nonce_out[66];
+    int parse_rc = wire_parse_subfactory_propose(legacy_propose, &leaf_side, &sub_idx,
+                                                   &channel_idx, &delta, legacy_nonce_out);
+    TEST_ASSERT_EQ(parse_rc, 1, "legacy propose parse");
+    TEST_ASSERT_EQ(wire_subfactory_propose_get_n_inputs(legacy_propose), 0,
+                    "legacy has no n_inputs");
+    cJSON_Delete(legacy_propose);
+
+    return 1;
+}
+
 /* When n_poison=0 (or NULL poison_entries), the with_poison builder must
    produce JSON byte-equal to the plain builder — backward compat receivers
    parse it cleanly with no special handling. */


### PR DESCRIPTION
## Summary

Adds optional array-form fields to `MSG_SUBFACTORY_PROPOSE` / `NONCE` / `ALL_NONCES` / `PSIG` so the sub-factory chain advance ceremony can coordinate `k+1` independent MuSig2 sessions over the wire — one per input on the new multi-input `chain[N+1]` TX produced by #207 phase 2b.

Pattern follows PR #149 (poison_entries on path bundles): legacy single-nonce fields stay unchanged; new array fields attach via mutator helpers; receivers detect multi-input mode by reading `n_inputs` (0 = legacy single-input).

## API

| Message | Setter | Getter |
|---|---|---|
| PROPOSE | `wire_subfactory_propose_set_inputs(n, lsp_pubnonces[])` | `wire_subfactory_propose_get_n_inputs / get_pubnonces` |
| NONCE | `wire_subfactory_nonce_set_pubnonces(n, pubnonces[])` | `wire_subfactory_nonce_get_pubnonces` |
| ALL_NONCES | `wire_subfactory_all_nonces_set_per_input(n_signers, n_inputs, [s × n_inputs + i])` | `wire_subfactory_all_nonces_get_per_input` |
| PSIG | `wire_subfactory_psig_set_partial_sigs(n, sigs[])` | `wire_subfactory_psig_get_partial_sigs` |

## What this PR does NOT yet do

**Phase 2c.a is BUILD-ONLY.** Wire helpers exist + are tested but not yet called by `lsp_subfactory_chain_advance` / `client_handle_subfactory_advance`. **Phase 2c.b** will refactor those handlers to dispatch to the multi-input flow via `factory_node_uses_multi_input` + the new per-input session helpers from #148. Phase 2c.b lands the end-to-end fix that makes force-close after sub-factory advance work on signet.

## Test plan

- [x] `test_wire_subfactory_multi_input_helpers_round_trip` — propose/nonce/all_nonces/psig round-trips with 3 inputs × 3 signers, backward-compat check (legacy parser still works on plain propose without n_inputs set)
- [ ] All existing 1432+ unit tests still pass (CI)
- [ ] Sanitizers green (CI)