### PR TITLE
feat: multi-input MuSig sub-factory chain advance ceremony (#207 phase 2c.b)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -19,6 +19,19 @@ extern void reverse_bytes(unsigned char *data, size_t len);
 
 /* Optional NK server authentication pubkey (set via client_set_lsp_pubkey) */
 static secp256k1_pubkey g_nk_server_pubkey;
+/* #207 phase 2c.b — multi-input MuSig client-side ceremony for advanced PS
+   sub-factory chain advances.  Called by client_handle_subfactory_advance
+   when factory_node_uses_multi_input(factory, sub_node_i) returns 1
+   after the local chain advance.  Coordinates k+1 per-input state-TX
+   MuSig sessions over the wire alongside the single poison-TX session. */
+static int run_client_subfactory_multi_input_ceremony(
+    int fd, secp256k1_context *ctx,
+    const secp256k1_keypair *keypair,
+    factory_t *factory, uint32_t my_index,
+    int sub_node_i, int leaf_side, int sub_idx,
+    const cJSON *propose_json,
+    int *poison_prepared);
+
 static int g_nk_server_pubkey_set = 0;
 
 /* Optional persistence handle for PS double-spend defense (set via
@@ -2825,6 +2838,21 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
         return 0;
     }
 
+    /* Multi-input dispatch (#207 phase 2c.b — mirrors the LSP-side check
+       in lsp_subfactory_chain_advance).  After phase 2b the advanced
+       sub-factory chain TX has k+1 inputs; the wire ceremony coordinates
+       k+1 per-input MuSig sessions over the existing MSG_SUBFACTORY_*
+       round trips by attaching the array-form fields from PR #150. */
+    if (factory_node_uses_multi_input(factory, (size_t)sub_node_i)) {
+        if (!run_client_subfactory_multi_input_ceremony(
+                fd, ctx, keypair, factory, my_index,
+                sub_node_i, leaf_side, sub_idx,
+                propose_msg->json, &poison_prepared)) {
+            return 0;
+        }
+        goto post_signing;
+    }
+
     /* Init both signing sessions (state + poison if prepared). */
     if (!factory_session_init_node(factory, (size_t)sub_node_i)) {
         fprintf(stderr, "Client %u: subfactory state session_init failed\n",
@@ -2984,6 +3012,8 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
         return 0;
     }
     cJSON_Delete(pm);
+
+post_signing:
     /* Client reset of poison session — the LSP holds the canonical
        signed poison TX (we contributed our partial sig); freeing the
        client's session state here keeps memory bounded across many
@@ -3009,6 +3039,279 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
            "(channel[%d]+=%llu sats)\n",
            my_index, leaf_side, sub_idx, dn_chain_len,
            channel_idx, (unsigned long long)delta_sats);
+    return 1;
+}
+
+/* === Client-side multi-input sub-factory chain advance ceremony
+   (#207 phase 2c.b) ===
+
+   Mirrors run_subfactory_multi_input_ceremony in src/lsp_channels.c
+   from the client's perspective.  Generates per-input pubnonces, sends
+   them in MSG_SUBFACTORY_NONCE via the new pubnonces array field,
+   parses per-input pubnonces from MSG_SUBFACTORY_ALL_NONCES, finalizes
+   per-input sessions, generates per-input partial sigs, sends them in
+   MSG_SUBFACTORY_PSIG via the new partial_sigs array field.  The
+   poison TX path (single-input always) runs in lockstep using the
+   existing legacy poison_pubnonce + poison_partial_sig fields. */
+static int run_client_subfactory_multi_input_ceremony(
+    int fd, secp256k1_context *ctx,
+    const secp256k1_keypair *keypair,
+    factory_t *factory, uint32_t my_index,
+    int sub_node_i, int leaf_side, int sub_idx,
+    const cJSON *propose_json,
+    int *poison_prepared)
+{
+    factory_node_t *sub = &factory->nodes[sub_node_i];
+    size_t n_inputs = sub->ps_n_prev_outputs;
+    size_t n_signers = sub->n_signers;
+    (void)leaf_side; (void)sub_idx;
+
+    if (n_inputs == 0 || n_inputs > FACTORY_MAX_OUTPUTS) {
+        fprintf(stderr, "Client %u: subfactory multi: bad n_inputs=%zu\n",
+                my_index, n_inputs);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
+    /* Sanity: PROPOSE must agree with our local n_inputs. */
+    size_t propose_n_inp = wire_subfactory_propose_get_n_inputs(propose_json);
+    if (propose_n_inp != n_inputs) {
+        fprintf(stderr,
+                "Client %u: subfactory multi: PROPOSE n_inputs=%zu, local=%zu\n",
+                my_index, propose_n_inp, n_inputs);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
+
+    int my_slot = factory_find_signer_slot(factory, (size_t)sub_node_i, my_index);
+    if (my_slot < 0) {
+        fprintf(stderr, "Client %u: not a signer on sub-factory\n", my_index);
+        return 0;
+    }
+
+    /* --- Step CM1: per-input state sessions + poison session init. --- */
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        if (!factory_session_init_node_input(factory, (size_t)sub_node_i, ii)) {
+            fprintf(stderr, "Client %u: subfactory multi: init input %zu failed\n",
+                    my_index, ii);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+    }
+    if (*poison_prepared &&
+        !factory_session_init_node_poison(factory, (size_t)sub_node_i)) {
+        fprintf(stderr, "Client %u: subfactory multi: poison init failed — degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        *poison_prepared = 0;
+    }
+
+    /* --- Step CM2: generate own per-input nonces + (single) poison nonce. --- */
+    unsigned char my_seckey[32];
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
+    secp256k1_pubkey my_pubkey;
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+    secp256k1_musig_secnonce my_state_secnonces[FACTORY_MAX_OUTPUTS];
+    secp256k1_musig_pubnonce my_state_pubnonces[FACTORY_MAX_OUTPUTS];
+    unsigned char my_state_pn_ser[FACTORY_MAX_OUTPUTS][66];
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        if (!musig_generate_nonce(ctx, &my_state_secnonces[ii],
+                                    &my_state_pubnonces[ii],
+                                    my_seckey, &my_pubkey,
+                                    &sub->keyagg.cache)) {
+            fprintf(stderr, "Client %u: nonce gen input %zu failed\n", my_index, ii);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        if (!factory_session_set_nonce_input(factory, (size_t)sub_node_i, ii,
+                                              (size_t)my_slot,
+                                              &my_state_pubnonces[ii])) {
+            fprintf(stderr, "Client %u: set_nonce_input %zu failed\n", my_index, ii);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        musig_pubnonce_serialize(ctx, my_state_pn_ser[ii], &my_state_pubnonces[ii]);
+    }
+
+    secp256k1_musig_secnonce my_poison_secnonce;
+    secp256k1_musig_pubnonce my_poison_pubnonce;
+    unsigned char my_poison_pn_ser[66];
+    if (*poison_prepared) {
+        if (!musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                    my_seckey, &my_pubkey,
+                                    &sub->keyagg.cache)) {
+            fprintf(stderr,
+                    "Client %u: poison nonce gen failed — degrading\n", my_index);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            *poison_prepared = 0;
+        } else {
+            musig_pubnonce_serialize(ctx, my_poison_pn_ser, &my_poison_pubnonce);
+            if (!factory_session_set_nonce_poison(factory, (size_t)sub_node_i,
+                                                    (size_t)my_slot,
+                                                    &my_poison_pubnonce)) {
+                fprintf(stderr,
+                        "Client %u: set_nonce_poison failed — degrading\n", my_index);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                *poison_prepared = 0;
+            }
+        }
+    }
+
+    /* --- Step CM3: send NONCE with per-input pubnonces array (+ optional poison). --- */
+    cJSON *nm = wire_build_subfactory_nonce(my_state_pn_ser[0],
+        *poison_prepared ? my_poison_pn_ser : NULL);
+    wire_subfactory_nonce_set_pubnonces(nm, n_inputs, my_state_pn_ser);
+    if (!wire_send(fd, MSG_SUBFACTORY_NONCE, nm)) {
+        cJSON_Delete(nm);
+        memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
+    cJSON_Delete(nm);
+
+    /* --- Step CM4: receive ALL_NONCES, parse per-input + optional poison. --- */
+    wire_msg_t am;
+    if (!wire_recv(fd, &am) || am.msg_type != MSG_SUBFACTORY_ALL_NONCES) {
+        fprintf(stderr, "Client %u: expected SUBFACTORY_ALL_NONCES, got 0x%02x\n",
+                my_index, am.json ? am.msg_type : 0);
+        if (am.json) cJSON_Delete(am.json);
+        memset(my_seckey, 0, 32);
+        return 0;
+    }
+    unsigned char per_input_pn[FACTORY_MAX_SIGNERS * FACTORY_MAX_OUTPUTS * 66];
+    size_t got_n_inputs = 0;
+    size_t got_n_signers = wire_subfactory_all_nonces_get_per_input(
+        am.json, per_input_pn,
+        FACTORY_MAX_SIGNERS, FACTORY_MAX_OUTPUTS, &got_n_inputs);
+    if (got_n_signers != n_signers || got_n_inputs != n_inputs) {
+        fprintf(stderr,
+                "Client %u: ALL_NONCES bad shape (signers=%zu/%zu inputs=%zu/%zu)\n",
+                my_index, got_n_signers, n_signers, got_n_inputs, n_inputs);
+        cJSON_Delete(am.json);
+        memset(my_seckey, 0, 32);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
+    for (size_t s = 0; s < n_signers; s++) {
+        if (s == (size_t)my_slot) continue;  /* my own nonces already set */
+        for (size_t ii = 0; ii < n_inputs; ii++) {
+            secp256k1_musig_pubnonce pn;
+            if (!musig_pubnonce_parse(ctx, &pn,
+                                        per_input_pn + (s * n_inputs + ii) * 66) ||
+                !factory_session_set_nonce_input(factory, (size_t)sub_node_i, ii,
+                                                  s, &pn)) {
+                fprintf(stderr,
+                        "Client %u: ALL_NONCES set_nonce_input s=%zu i=%zu failed\n",
+                        my_index, s, ii);
+                cJSON_Delete(am.json);
+                memset(my_seckey, 0, 32);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                return 0;
+            }
+        }
+    }
+    /* Optional poison_pubnonces (legacy format — single per signer). */
+    if (*poison_prepared) {
+        unsigned char all_poison_pn[FACTORY_MAX_SIGNERS][66];
+        size_t n_pn = 0;
+        int parse_an_rc = wire_parse_subfactory_all_nonces(
+            am.json, NULL, all_poison_pn, FACTORY_MAX_SIGNERS, &n_pn);
+        (void)parse_an_rc;
+        cJSON *parr = cJSON_GetObjectItem(am.json, "poison_pubnonces");
+        if (parr && cJSON_IsArray(parr) &&
+            (size_t)cJSON_GetArraySize(parr) == n_signers) {
+            for (size_t s = 0; s < n_signers; s++) {
+                if (s == (size_t)my_slot) continue;
+                cJSON *item = cJSON_GetArrayItem(parr, (int)s);
+                unsigned char pn_buf[66];
+                if (!item || !cJSON_IsString(item) ||
+                    hex_decode(item->valuestring, pn_buf, 66) != 66) {
+                    factory_session_reset_poison(factory, (size_t)sub_node_i);
+                    *poison_prepared = 0;
+                    break;
+                }
+                secp256k1_musig_pubnonce pn;
+                if (!musig_pubnonce_parse(ctx, &pn, pn_buf) ||
+                    !factory_session_set_nonce_poison(factory,
+                        (size_t)sub_node_i, s, &pn)) {
+                    fprintf(stderr,
+                            "Client %u: ALL_NONCES poison set_nonce s=%zu failed — degrading\n",
+                            my_index, s);
+                    factory_session_reset_poison(factory, (size_t)sub_node_i);
+                    *poison_prepared = 0;
+                    break;
+                }
+            }
+        } else {
+            fprintf(stderr,
+                    "Client %u: ALL_NONCES missing poison_pubnonces — degrading\n",
+                    my_index);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            *poison_prepared = 0;
+        }
+    }
+    cJSON_Delete(am.json);
+
+    /* --- Step CM5: finalize per-input + poison sessions. --- */
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        if (!factory_session_finalize_node_input(factory, (size_t)sub_node_i, ii)) {
+            fprintf(stderr, "Client %u: finalize input %zu failed\n", my_index, ii);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+    }
+    if (*poison_prepared &&
+        !factory_session_finalize_node_poison(factory, (size_t)sub_node_i)) {
+        fprintf(stderr, "Client %u: poison finalize failed — degrading\n", my_index);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        *poison_prepared = 0;
+    }
+
+    /* --- Step CM6: per-input partial sigs + poison partial sig. --- */
+    memset(my_seckey, 0, 32);
+    unsigned char my_psig_ser[FACTORY_MAX_OUTPUTS][32];
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        secp256k1_musig_partial_sig psig;
+        if (!musig_create_partial_sig(ctx, &psig, &my_state_secnonces[ii],
+                                        keypair,
+                                        &sub->input_signing_sessions[ii])) {
+            fprintf(stderr, "Client %u: create_partial_sig input %zu failed\n",
+                    my_index, ii);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        musig_partial_sig_serialize(ctx, my_psig_ser[ii], &psig);
+    }
+    unsigned char my_poison_psig_ser[32];
+    if (*poison_prepared) {
+        secp256k1_musig_partial_sig ppsig;
+        if (!musig_create_partial_sig(ctx, &ppsig, &my_poison_secnonce, keypair,
+                                        &sub->poison_signing_session)) {
+            fprintf(stderr, "Client %u: poison psig create failed — degrading\n",
+                    my_index);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            *poison_prepared = 0;
+        } else {
+            musig_partial_sig_serialize(ctx, my_poison_psig_ser, &ppsig);
+        }
+    }
+
+    /* --- Step CM7: send PSIG with per-input partial_sigs array (+ optional poison). --- */
+    cJSON *pm = wire_build_subfactory_psig(my_psig_ser[0],
+        *poison_prepared ? my_poison_psig_ser : NULL);
+    wire_subfactory_psig_set_partial_sigs(pm, n_inputs, my_psig_ser);
+    if (!wire_send(fd, MSG_SUBFACTORY_PSIG, pm)) {
+        cJSON_Delete(pm);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+        return 0;
+    }
+    cJSON_Delete(pm);
     return 1;
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -3215,13 +3215,11 @@ static int run_client_subfactory_multi_input_ceremony(
             }
         }
     }
-    /* Optional poison_pubnonces (legacy format — single per signer). */
+    /* Optional poison_pubnonces (legacy format — single per signer).
+       Read directly via cJSON; wire_parse_subfactory_all_nonces would
+       crash on the NULL state-pubnonces arg (it dereferences it
+       unconditionally). */
     if (*poison_prepared) {
-        unsigned char all_poison_pn[FACTORY_MAX_SIGNERS][66];
-        size_t n_pn = 0;
-        int parse_an_rc = wire_parse_subfactory_all_nonces(
-            am.json, NULL, all_poison_pn, FACTORY_MAX_SIGNERS, &n_pn);
-        (void)parse_an_rc;
         cJSON *parr = cJSON_GetObjectItem(am.json, "poison_pubnonces");
         if (parr && cJSON_IsArray(parr) &&
             (size_t)cJSON_GetArraySize(parr) == n_signers) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3743,15 +3743,14 @@ static int run_subfactory_multi_input_ceremony(
             memcpy(per_input_pubnonces + ((size_t)client_slot * n_inputs + ii) * 66,
                    client_state_pn[ii], 66);
         }
-        /* Optional poison nonce — uses the legacy single-poison_pubnonce field */
+        /* Optional poison nonce — uses the legacy single-poison_pubnonce field.
+           We deliberately do NOT call wire_parse_subfactory_nonce here:
+           that helper dereferences its state_pubnonce66 arg unconditionally,
+           and we already pulled per-input state nonces via
+           wire_subfactory_nonce_get_pubnonces above.  Read the optional
+           poison_pubnonce field directly. */
         if (*poison_prepared) {
             unsigned char client_poison_pn[66];
-            int prc = wire_parse_subfactory_nonce(nmsg.json, NULL, client_poison_pn);
-            /* prc==2 means poison present; we don't care about state here
-               since we already pulled it via _get_pubnonces.  Fall back to
-               legacy single-state parse just to determine prc (1=state-only,
-               2=state+poison).  The bytes we'll use are client_poison_pn. */
-            (void)prc;
             cJSON *pp = cJSON_GetObjectItem(nmsg.json, "poison_pubnonce");
             if (pp && cJSON_IsString(pp) &&
                 wire_json_get_hex(nmsg.json, "poison_pubnonce",

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -511,6 +511,19 @@ int lsp_channels_init_from_db(lsp_channel_mgr_t *mgr,
 
 /* Forward declarations for daemon_loop_once */
 static int handle_reconnect_with_msg(lsp_channel_mgr_t *mgr, lsp_t *lsp, int fd, const wire_msg_t *msg);
+
+/* #207 phase 2c.b — multi-input MuSig ceremony for advanced PS sub-factory
+   chain TXs.  Called by lsp_subfactory_chain_advance when the sub-factory
+   has been advanced past chain[0] and chain[N+1] now spans k+1 inputs.
+   Coordinates k+1 independent state-TX MuSig sessions (one per input)
+   alongside the single poison-TX session, populating sub->signed_tx with
+   k+1 witnesses and sub->poison_signed_tx with the redistribution TX. */
+static int run_subfactory_multi_input_ceremony(
+    lsp_channel_mgr_t *mgr, lsp_t *lsp,
+    int leaf_side, int sub_idx_in_leaf, int sub_node_i,
+    const uint32_t *sub_clients, size_t n_clients_in_sub,
+    int channel_idx_in_sub, uint64_t delta_sats,
+    int *poison_prepared);
 int lsp_accept_and_queue_connection(void *mgr_ptr, void *lsp_ptr);
 
 /* Single iteration: drain queue, poll for 1 second, return. */
@@ -3131,6 +3144,31 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
+    /* Build the client list now (signer_indices[1..n] are clients; signer 0
+       is LSP).  Hoisted out of Step 4 so both single-input and multi-input
+       (#207 phase 2c.b) ceremony paths can use it for PROPOSE/ALL_NONCES/DONE. */
+    uint32_t sub_clients[FACTORY_MAX_SIGNERS];
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++)
+        sub_clients[ci] = sub->signer_indices[ci + 1];
+
+    /* Multi-input dispatch (#207 phase 2c.b).  After phase 2b, advanced
+       sub-factory chain TXs have k+1 inputs (one per chain[N-1] vout)
+       to satisfy conservation.  Each input needs its own MuSig session
+       because BIP-341 sighashes differ per input.  Run a separate
+       per-input wire ceremony when factory_node_uses_multi_input is true;
+       fall through to the existing single-input flow otherwise (e.g., a
+       k=1 PS leaf chain advance still uses single-input). */
+    int multi_input = factory_node_uses_multi_input(f, (size_t)sub_node_i);
+    if (multi_input) {
+        if (!run_subfactory_multi_input_ceremony(mgr, lsp,
+                leaf_side, sub_idx_in_leaf, sub_node_i,
+                sub_clients, n_clients_in_sub,
+                channel_idx_in_sub, delta_sats,
+                &poison_prepared))
+            return 0;
+        goto post_signing;
+    }
+
     /* Step 2: Init BOTH signing sessions (state + poison).  Poison
        session uses the SAME keyagg as state but a separate session so
        nonces are independent (MuSig2 demands fresh nonces per message). */
@@ -3178,14 +3216,10 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        carries every signer's nonce; we set them all in one pass on the
        LSP side too (mirrors the leaf-realloc pattern). */
 
-    /* Step 4: Send PROPOSE to each client on the sub-factory. */
+    /* Step 4: Send PROPOSE to each client on the sub-factory.
+       sub_clients[] was hoisted earlier (above the multi-input dispatch). */
     unsigned char lsp_pubnonce_ser[66];
     musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
-
-    /* Build the client list (signer_indices[1..n] are clients; signer 0 is LSP). */
-    uint32_t sub_clients[FACTORY_MAX_SIGNERS];
-    for (size_t ci = 0; ci < n_clients_in_sub; ci++)
-        sub_clients[ci] = sub->signer_indices[ci + 1];
 
     cJSON *propose = wire_build_subfactory_propose(leaf_side, sub_idx_in_leaf,
                                                      channel_idx_in_sub,
@@ -3413,6 +3447,7 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         }
     }
 
+post_signing:
     /* Step 10: Persist sub-factory chain entry (Phase 4a save +
        Phase 4c per-channel amounts) into the dedicated v21
        `ps_subfactory_chains` table.
@@ -3516,6 +3551,400 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     printf("LSP: sub-factory %d.%d chain extended to len %d (client[%d]+=%llu sats)\n",
            leaf_side, sub_idx_in_leaf, sub->ps_chain_len,
            channel_idx_in_sub, (unsigned long long)delta_sats);
+    return 1;
+}
+
+/* === Multi-input sub-factory chain advance ceremony (#207 phase 2c.b) ===
+
+   Drives the per-input MuSig wire ceremony for an advanced PS sub-factory.
+   Called from lsp_subfactory_chain_advance after the chain has been
+   advanced (factory_subfactory_chain_advance_unsigned succeeded) and
+   factory_node_uses_multi_input(f, sub_node_i) returned true.
+
+   On success: sub->signed_tx contains the multi-witness signed TX
+   (factory_session_assemble_signed_tx_multi), and sub->poison_signed_tx
+   contains the wire-coordinated poison TX (when *poison_prepared was
+   passed in true and the ceremony succeeded).  *poison_prepared may be
+   downgraded to 0 by the helper if the poison ceremony failed mid-way.
+
+   On failure: returns 0 with sessions reset; caller should also
+   factory_session_reset_poison if it cares.  Failure reasons logged to
+   stderr. */
+static int run_subfactory_multi_input_ceremony(
+    lsp_channel_mgr_t *mgr, lsp_t *lsp,
+    int leaf_side, int sub_idx_in_leaf, int sub_node_i,
+    const uint32_t *sub_clients, size_t n_clients_in_sub,
+    int channel_idx_in_sub, uint64_t delta_sats,
+    int *poison_prepared)
+{
+    factory_t *f = &lsp->factory;
+    factory_node_t *sub = &f->nodes[sub_node_i];
+    size_t n_inputs = sub->ps_n_prev_outputs;
+    size_t n_signers = sub->n_signers;
+
+    if (n_inputs == 0 || n_inputs > FACTORY_MAX_OUTPUTS) {
+        fprintf(stderr, "LSP subfactory multi: bad n_inputs=%zu\n", n_inputs);
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        return 0;
+    }
+
+    int lsp_slot = factory_find_signer_slot(f, (size_t)sub_node_i, 0);
+    if (lsp_slot < 0) {
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        return 0;
+    }
+
+    /* --- Step M1: per-input state sessions + poison session init. --- */
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        if (!factory_session_init_node_input(f, (size_t)sub_node_i, ii)) {
+            fprintf(stderr, "LSP subfactory multi: init input %zu failed\n", ii);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+    }
+    if (*poison_prepared &&
+        !factory_session_init_node_poison(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory multi: poison session init failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        *poison_prepared = 0;
+    }
+
+    /* --- Step M2: generate LSP nonces (one per input + one for poison). --- */
+    unsigned char lsp_seckey[32];
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) {
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        return 0;
+    }
+    secp256k1_musig_secnonce lsp_state_secnonces[FACTORY_MAX_OUTPUTS];
+    secp256k1_musig_pubnonce lsp_state_pubnonces[FACTORY_MAX_OUTPUTS];
+    unsigned char lsp_state_pn_ser[FACTORY_MAX_OUTPUTS][66];
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        if (!musig_generate_nonce(lsp->ctx, &lsp_state_secnonces[ii],
+                                    &lsp_state_pubnonces[ii],
+                                    lsp_seckey, &lsp->lsp_pubkey,
+                                    &sub->keyagg.cache)) {
+            fprintf(stderr, "LSP subfactory multi: nonce gen input %zu failed\n", ii);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        if (!factory_session_set_nonce_input(f, (size_t)sub_node_i, ii,
+                                              (size_t)lsp_slot,
+                                              &lsp_state_pubnonces[ii])) {
+            fprintf(stderr, "LSP subfactory multi: set_nonce_input %zu failed\n", ii);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        musig_pubnonce_serialize(lsp->ctx, lsp_state_pn_ser[ii],
+                                  &lsp_state_pubnonces[ii]);
+    }
+    secp256k1_musig_secnonce lsp_poison_secnonce;
+    secp256k1_musig_pubnonce lsp_poison_pubnonce;
+    unsigned char lsp_poison_pn_ser[66];
+    if (*poison_prepared) {
+        if (!musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce,
+                                    &lsp_poison_pubnonce,
+                                    lsp_seckey, &lsp->lsp_pubkey,
+                                    &sub->keyagg.cache)) {
+            fprintf(stderr,
+                    "LSP subfactory multi: poison nonce gen failed — degrading\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            *poison_prepared = 0;
+        } else {
+            musig_pubnonce_serialize(lsp->ctx, lsp_poison_pn_ser, &lsp_poison_pubnonce);
+            if (!factory_session_set_nonce_poison(f, (size_t)sub_node_i,
+                                                    (size_t)lsp_slot,
+                                                    &lsp_poison_pubnonce)) {
+                fprintf(stderr,
+                        "LSP subfactory multi: set_nonce_poison LSP failed — degrading\n");
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                *poison_prepared = 0;
+            }
+        }
+    }
+
+    /* --- Step M3: send PROPOSE with multi-input pubnonces array. --- */
+    cJSON *propose = wire_build_subfactory_propose(leaf_side, sub_idx_in_leaf,
+                                                     channel_idx_in_sub,
+                                                     delta_sats,
+                                                     lsp_state_pn_ser[0]);
+    wire_subfactory_propose_set_inputs(propose, n_inputs, lsp_state_pn_ser);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_PROPOSE, propose)) {
+            cJSON_Delete(propose);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+    }
+    cJSON_Delete(propose);
+
+    /* --- Step M4: collect NONCE from each client (per-input array + poison). --- */
+    /* per_input_pubnonces[signer][input] flat layout */
+    unsigned char per_input_pubnonces[FACTORY_MAX_SIGNERS * FACTORY_MAX_OUTPUTS * 66];
+    /* seed LSP's contributions */
+    for (size_t ii = 0; ii < n_inputs; ii++)
+        memcpy(per_input_pubnonces + ((size_t)lsp_slot * n_inputs + ii) * 66,
+               lsp_state_pn_ser[ii], 66);
+    unsigned char poison_pubnonces_per_signer[FACTORY_MAX_SIGNERS][66];
+    if (*poison_prepared)
+        memcpy(poison_pubnonces_per_signer[lsp_slot], lsp_poison_pn_ser, 66);
+
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t nmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &nmsg, 30) ||
+            nmsg.msg_type != MSG_SUBFACTORY_NONCE) {
+            fprintf(stderr,
+                    "LSP subfactory multi: expected SUBFACTORY_NONCE from client %u\n",
+                    sub_clients[ci]);
+            if (nmsg.json) cJSON_Delete(nmsg.json);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        unsigned char client_state_pn[FACTORY_MAX_OUTPUTS][66];
+        size_t got = wire_subfactory_nonce_get_pubnonces(nmsg.json,
+                                                          client_state_pn,
+                                                          FACTORY_MAX_OUTPUTS);
+        if (got != n_inputs) {
+            fprintf(stderr,
+                    "LSP subfactory multi: client %u sent %zu pubnonces, want %zu\n",
+                    sub_clients[ci], got, n_inputs);
+            cJSON_Delete(nmsg.json);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
+                                                    sub_clients[ci]);
+        if (client_slot < 0) {
+            cJSON_Delete(nmsg.json);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        for (size_t ii = 0; ii < n_inputs; ii++) {
+            secp256k1_musig_pubnonce pn;
+            if (!musig_pubnonce_parse(lsp->ctx, &pn, client_state_pn[ii]) ||
+                !factory_session_set_nonce_input(f, (size_t)sub_node_i, ii,
+                                                  (size_t)client_slot, &pn)) {
+                fprintf(stderr,
+                        "LSP subfactory multi: set_nonce_input client %u input %zu failed\n",
+                        sub_clients[ci], ii);
+                cJSON_Delete(nmsg.json);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            memcpy(per_input_pubnonces + ((size_t)client_slot * n_inputs + ii) * 66,
+                   client_state_pn[ii], 66);
+        }
+        /* Optional poison nonce — uses the legacy single-poison_pubnonce field */
+        if (*poison_prepared) {
+            unsigned char client_poison_pn[66];
+            int prc = wire_parse_subfactory_nonce(nmsg.json, NULL, client_poison_pn);
+            /* prc==2 means poison present; we don't care about state here
+               since we already pulled it via _get_pubnonces.  Fall back to
+               legacy single-state parse just to determine prc (1=state-only,
+               2=state+poison).  The bytes we'll use are client_poison_pn. */
+            (void)prc;
+            cJSON *pp = cJSON_GetObjectItem(nmsg.json, "poison_pubnonce");
+            if (pp && cJSON_IsString(pp) &&
+                wire_json_get_hex(nmsg.json, "poison_pubnonce",
+                                   client_poison_pn, 66) == 66) {
+                secp256k1_musig_pubnonce ppn;
+                if (!musig_pubnonce_parse(lsp->ctx, &ppn, client_poison_pn) ||
+                    !factory_session_set_nonce_poison(f, (size_t)sub_node_i,
+                                                        (size_t)client_slot, &ppn)) {
+                    fprintf(stderr,
+                            "LSP subfactory multi: client %u poison nonce set failed — degrading\n",
+                            sub_clients[ci]);
+                    factory_session_reset_poison(f, (size_t)sub_node_i);
+                    *poison_prepared = 0;
+                }
+                if (*poison_prepared)
+                    memcpy(poison_pubnonces_per_signer[client_slot], client_poison_pn, 66);
+            } else {
+                fprintf(stderr,
+                        "LSP subfactory multi: client %u omitted poison nonce — degrading\n",
+                        sub_clients[ci]);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                *poison_prepared = 0;
+            }
+        }
+        cJSON_Delete(nmsg.json);
+    }
+
+    /* --- Step M5: build ALL_NONCES with per-input + optional poison arrays. --- */
+    {
+        /* Use legacy single-input form's first nonce per signer to populate
+           the "pubnonces" field for parser compat (clients in multi-input
+           mode read pubnonces_per_input instead). */
+        unsigned char legacy_pn[FACTORY_MAX_SIGNERS][66];
+        for (size_t s = 0; s < n_signers; s++)
+            memcpy(legacy_pn[s], per_input_pubnonces + (s * n_inputs + 0) * 66, 66);
+        cJSON *all_msg = wire_build_subfactory_all_nonces(
+            (const unsigned char (*)[66])legacy_pn,
+            *poison_prepared ? (const unsigned char (*)[66])poison_pubnonces_per_signer
+                              : NULL,
+            n_signers);
+        wire_subfactory_all_nonces_set_per_input(all_msg, n_signers, n_inputs,
+            (const unsigned char (*)[66])per_input_pubnonces);
+        for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+            size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+            wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_ALL_NONCES, all_msg);
+        }
+        cJSON_Delete(all_msg);
+    }
+
+    /* --- Step M6: finalize per-input + poison sessions. --- */
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        if (!factory_session_finalize_node_input(f, (size_t)sub_node_i, ii)) {
+            fprintf(stderr,
+                    "LSP subfactory multi: finalize input %zu failed\n", ii);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+    }
+    if (*poison_prepared &&
+        !factory_session_finalize_node_poison(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory multi: poison finalize failed — degrading\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        *poison_prepared = 0;
+    }
+
+    /* --- Step M7: LSP partial sigs (per-input + poison). --- */
+    secp256k1_keypair lsp_kp;
+    if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
+        memset(lsp_seckey, 0, 32);
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        return 0;
+    }
+    memset(lsp_seckey, 0, 32);
+    for (size_t ii = 0; ii < n_inputs; ii++) {
+        secp256k1_musig_partial_sig psig;
+        if (!musig_create_partial_sig(lsp->ctx, &psig,
+                                        &lsp_state_secnonces[ii], &lsp_kp,
+                                        &sub->input_signing_sessions[ii])) {
+            fprintf(stderr,
+                    "LSP subfactory multi: create_partial_sig input %zu failed\n", ii);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        if (!factory_session_set_partial_sig_input(f, (size_t)sub_node_i, ii,
+                                                     (size_t)lsp_slot, &psig)) {
+            fprintf(stderr,
+                    "LSP subfactory multi: set_partial_sig_input %zu LSP failed\n", ii);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+    }
+    if (*poison_prepared) {
+        secp256k1_musig_partial_sig ppsig;
+        if (!musig_create_partial_sig(lsp->ctx, &ppsig,
+                                        &lsp_poison_secnonce, &lsp_kp,
+                                        &sub->poison_signing_session) ||
+            !factory_session_set_partial_sig_poison(f, (size_t)sub_node_i,
+                                                      (size_t)lsp_slot, &ppsig)) {
+            fprintf(stderr,
+                    "LSP subfactory multi: poison LSP psig failed — degrading\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            *poison_prepared = 0;
+        }
+    }
+
+    /* --- Step M8: collect PSIG from each client (per-input array + poison). --- */
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t pmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &pmsg, 30) ||
+            pmsg.msg_type != MSG_SUBFACTORY_PSIG) {
+            fprintf(stderr,
+                    "LSP subfactory multi: expected SUBFACTORY_PSIG from client %u\n",
+                    sub_clients[ci]);
+            if (pmsg.json) cJSON_Delete(pmsg.json);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        unsigned char client_psigs[FACTORY_MAX_OUTPUTS][32];
+        size_t got = wire_subfactory_psig_get_partial_sigs(pmsg.json,
+                                                             client_psigs,
+                                                             FACTORY_MAX_OUTPUTS);
+        if (got != n_inputs) {
+            fprintf(stderr,
+                    "LSP subfactory multi: client %u sent %zu psigs, want %zu\n",
+                    sub_clients[ci], got, n_inputs);
+            cJSON_Delete(pmsg.json);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
+                                                    sub_clients[ci]);
+        if (client_slot < 0) {
+            cJSON_Delete(pmsg.json);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        for (size_t ii = 0; ii < n_inputs; ii++) {
+            secp256k1_musig_partial_sig psig;
+            if (!musig_partial_sig_parse(lsp->ctx, &psig, client_psigs[ii]) ||
+                !factory_session_set_partial_sig_input(f, (size_t)sub_node_i, ii,
+                                                         (size_t)client_slot, &psig)) {
+                fprintf(stderr,
+                        "LSP subfactory multi: set_partial_sig_input client %u input %zu failed\n",
+                        sub_clients[ci], ii);
+                cJSON_Delete(pmsg.json);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+        }
+        if (*poison_prepared) {
+            unsigned char client_poison_psig_ser[32];
+            cJSON *pp = cJSON_GetObjectItem(pmsg.json, "poison_partial_sig");
+            if (pp && cJSON_IsString(pp) &&
+                wire_json_get_hex(pmsg.json, "poison_partial_sig",
+                                   client_poison_psig_ser, 32) == 32) {
+                secp256k1_musig_partial_sig ppsig;
+                if (!musig_partial_sig_parse(lsp->ctx, &ppsig, client_poison_psig_ser) ||
+                    !factory_session_set_partial_sig_poison(f, (size_t)sub_node_i,
+                                                              (size_t)client_slot, &ppsig)) {
+                    fprintf(stderr,
+                            "LSP subfactory multi: client %u poison psig set failed — degrading\n",
+                            sub_clients[ci]);
+                    factory_session_reset_poison(f, (size_t)sub_node_i);
+                    *poison_prepared = 0;
+                }
+            } else {
+                fprintf(stderr,
+                        "LSP subfactory multi: client %u omitted poison psig — degrading\n",
+                        sub_clients[ci]);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                *poison_prepared = 0;
+            }
+        }
+        cJSON_Delete(pmsg.json);
+    }
+
+    /* --- Step M9: aggregate per-input sigs into multi-witness signed_tx. --- */
+    if (!factory_session_assemble_signed_tx_multi(f, (size_t)sub_node_i)) {
+        fprintf(stderr, "LSP subfactory multi: assemble_signed_tx_multi failed\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        return 0;
+    }
+    if (*poison_prepared &&
+        !factory_session_complete_node_poison(f, (size_t)sub_node_i)) {
+        fprintf(stderr,
+                "LSP subfactory multi: poison complete failed — degrading\n");
+        factory_session_reset_poison(f, (size_t)sub_node_i);
+        *poison_prepared = 0;
+    }
+
     return 1;
 }
 

--- a/tools/test_multiprocess_subfactory_advance.sh
+++ b/tools/test_multiprocess_subfactory_advance.sh
@@ -334,9 +334,37 @@ echo ""
 echo "  $PARTICIPATED clients on sub-factory 0 logged completion (>= $PS_SUB_ARITY required)"
 
 echo ""
+
+# === #207 phase 2c.b end-to-end gate ===
+# After phases 1-2c.b, advancing a sub-factory's chain produces a valid
+# k+1-input TX that broadcasts cleanly.  Verify the LSP successfully
+# broadcast + confirmed chain[1] (the post-advance state) on-chain.
+# Without the fix this hangs indefinitely on bitcoin -25 bad-txns-in-belowout
+# OR -25 bad-txns-inputs-missingorspent, and the LSP eventually exits
+# non-zero — so reaching this assertion at all means the cryptography
+# checks out, but we still want a positive marker in the log.
+echo "=== #207 phase 2c.b: verify chain[1] confirmed on-chain ==="
+if ! grep -qE "tree_node_[0-9]+_chain1 confirmed" "$LSP_LOG"; then
+    echo "FAIL: no 'tree_node_<i>_chain1 confirmed' log line — chain[1]"
+    echo "      either failed to broadcast OR failed to reach 1 conf."
+    grep -E "chain[01]|broadcast|bad-txns" "$LSP_LOG" | head -20
+    exit 1
+fi
+CHAIN1_LINE=$(grep -E "tree_node_[0-9]+_chain1 confirmed" "$LSP_LOG" | head -1)
+echo "  $CHAIN1_LINE"
+# Also assert no broadcast-rejected error fired anywhere in force-close
+if grep -qE "bad-txns-in-belowout|bad-txns-inputs-missingorspent" "$LSP_LOG"; then
+    echo "FAIL: bitcoind rejected a chain TX (regression of #207)"
+    grep -E "bad-txns" "$LSP_LOG" | head -5
+    exit 1
+fi
+echo "  no bitcoind rejection of chain TXs — #207 fix verified end-to-end"
+
+echo ""
 echo "=== PASS: Multi-process k² PS sub-factory chain extension ==="
 echo "  - $((N_CLIENTS + 1)) distinct OS processes"
 echo "  - k=$PS_SUB_ARITY → 1 leaf with $PS_SUB_ARITY sub-factories of $PS_SUB_ARITY clients each"
 echo "  - LSP-driven sub-factory chain extension over MSG_SUBFACTORY_*"
 echo "  - $PARTICIPATED clients confirmed completion"
 echo "  - Post-extension factory tree force-closed on-chain"
+echo "  - chain[1] (post-advance multi-input TX) confirmed on-chain"


### PR DESCRIPTION
## Summary

Closes the end-to-end gap left by phase 2b: \`lsp_subfactory_chain_advance\` + \`client_handle_subfactory_advance\` now dispatch to a per-input MuSig ceremony when \`factory_node_uses_multi_input(f, sub_node_i)\` returns 1. **After this PR + the existing phases 1-2c.a, force-close after a sub-factory chain advance produces broadcast-valid TXs end-to-end on signet.**

## Mechanics

Both \`lsp_channels.c\` and \`client.c\` get:
- Forward declaration of a static helper near the top
- Dispatch right after \`factory_subfactory_chain_advance_unsigned\` succeeds: if multi-input → call helper, then \`goto post_signing\` to skip the existing single-input flow
- Helper implementation after the function body

| Step | LSP-side `run_subfactory_multi_input_ceremony` | Client-side `run_client_subfactory_multi_input_ceremony` |
|---|---|---|
| Init | k+1 `init_node_input` + `init_node_poison` | same |
| Nonces | `musig_generate_nonce` per input + poison; `set_nonce_input/poison` | same |
| Send NONCE | n/a (LSP) | `wire_build_subfactory_nonce` + `set_pubnonces(k+1)` |
| Send PROPOSE | `wire_build_subfactory_propose` + `set_inputs(k+1, lsp_pubnonces)` | n/a |
| Recv NONCE | `wire_subfactory_nonce_get_pubnonces` per client; legacy `poison_pubnonce` parsed via `wire_json_get_hex` | n/a |
| Send/Recv ALL_NONCES | `wire_build_subfactory_all_nonces` (legacy compat) + `set_per_input(n_signers × n_inputs)` | `wire_subfactory_all_nonces_get_per_input` |
| Finalize | k+1 `finalize_node_input` + `finalize_node_poison` | same |
| Partial sigs | `musig_create_partial_sig` per input + poison; `set_partial_sig_input/poison` | same |
| Send PSIG | n/a (LSP collects) | `wire_build_subfactory_psig` + `set_partial_sigs(k+1)` |
| Recv PSIG | `wire_subfactory_psig_get_partial_sigs`; legacy `poison_partial_sig` parsed | n/a |
| Assemble | `factory_session_assemble_signed_tx_multi` → multi-witness signed_tx; `complete_node_poison` → poison_signed_tx | n/a (LSP aggregates) |

## Backward compat

Non-advanced sub-factories (the very first chain[0] sign — pre-advance, no chain history yet) and any k=1 PS leaf path still take the existing single-input flow. \`factory_node_uses_multi_input\` returns true iff \`is_ps_leaf && ps_chain_len > 0 && type == NODE_PS_SUBFACTORY && ps_n_prev_outputs > 1\` — i.e., post-advance k=2+ sub-factories only.

## Test plan

- [ ] All existing 1430+ unit tests still pass (CI). \`test_factory_ps_subfactory_chain_extension\` exercises the in-process per-input flow (PR #148); the wire path runs the same \`factory_session_*_input\` helpers so unit-test confidence transfers.
- [ ] Sanitizers green (CI) — significant heap allocation in the wire bundle parsing helpers
- [ ] \`tools/test_multiprocess_subfactory_advance.sh\` extension (next PR) will wait for force-close + assert chain[1] confirms on bitcoind. That's the **end-to-end gate proving #207 is fully fixed**.