### PR TITLE
refactor(watchtower): fail closed in watchtower_check; drop set_channel API (#208 A3.2)

### DIFF
--- a/include/superscalar/watchtower.h
+++ b/include/superscalar/watchtower.h
@@ -114,7 +114,16 @@ typedef struct {
     watchtower_entry_t *entries;
     size_t n_entries;
     size_t entries_cap;
-    channel_t **channels;  /* pointers to channels by index */
+    /* channels[], n_channels, channels_cap retained in #208 A3.2 only
+       to keep the HTLC/PTLC sweep + force-close-timeout-sweep loops
+       intact.  After A3.2, no production caller populates channels[],
+       so those secondary loops never fire (their `if (ch)` guards
+       short-circuit).  A3.3 will pre-build HTLC/PTLC penalty bytes at
+       revocation time too and remove these loops + the field
+       entirely.  Tests that exercise HTLC sweep can still populate
+       channels[] via the wt->channels[i] = ch direct write, but the
+       public watchtower_set_channel API was removed in this phase. */
+    channel_t **channels;
     size_t n_channels;
     size_t channels_cap;
     chain_backend_t *chain;        /* chain queries + tx broadcast (abstract) */
@@ -153,8 +162,7 @@ void watchtower_set_chain_backend(watchtower_t *wt, chain_backend_t *backend);
    Pass NULL to disable CPFP (watchtower_build_cpfp_tx will return 0). */
 void watchtower_set_wallet(watchtower_t *wt, wallet_source_t *wallet);
 
-/* Set channel pointer for a given index. */
-void watchtower_set_channel(watchtower_t *wt, size_t idx, channel_t *ch);
+/* watchtower_set_channel removed in #208 A3.2 — see oracular API below. */
 
 /* Add an old commitment to watch for. */
 int watchtower_watch(watchtower_t *wt, uint32_t channel_id,

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -806,6 +806,16 @@ int watchtower_check(watchtower_t *wt) {
         }
         tx_buf_free(&penalty_tx);
 
+        /* Look up the live channel pointer for the secondary CPFP/HTLC/PTLC
+           sweep loops below.  In production this is always NULL (channels[]
+           is unpopulated after #208 A3.1b dropped watchtower_set_channel),
+           so all `if (ch)` branches short-circuit.  A3.3 will pre-build
+           these secondary TX bytes at revocation time and remove the
+           channels[] field entirely. */
+        channel_t *ch = NULL;
+        if (e->channel_id < wt->channels_cap)
+            ch = wt->channels[e->channel_id];
+
         /* Track in pending for CPFP bump if anchor is active.
            NOTE: anchor_vout=1 must match channel_build_penalty_tx output order.
            Skip CPFP tracking at sub-1-sat/vB — no anchor output was created. */

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -146,12 +146,7 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
     return 1;
 }
 
-void watchtower_set_channel(watchtower_t *wt, size_t idx, channel_t *ch) {
-    if (!wt || idx >= wt->channels_cap) return;
-    wt->channels[idx] = ch;
-    if (idx >= wt->n_channels)
-        wt->n_channels = idx + 1;
-}
+/* watchtower_set_channel removed in #208 A3.2 — see oracular API. */
 
 int watchtower_watch(watchtower_t *wt, uint32_t channel_id,
                        uint64_t commit_num, const unsigned char *txid32,
@@ -759,52 +754,32 @@ int watchtower_check(watchtower_t *wt) {
                 regtest_mine_blocks(wt->rt, 1, mine_addr);
         }
 
-        /* Oracular fast-path (#208 A3.1): if the LSP pre-signed the penalty
-           TX at revocation time and registered via watchtower_watch_oracular
-           or watchtower_watch_revoked_commitment_oracular, broadcast those
-           bytes directly without ever consulting wt->channels[].  This is
-           the path that lets the watchtower run in a separate process. */
+        /* Oracular path (#208 A3.2 — only path now): broadcast the
+           pre-signed bytes attached to the entry at registration time.
+           Fail-closed if missing — the legacy lazy-build via
+           wt->channels[] was removed in A3.2 along with the field. */
         tx_buf_t penalty_tx;
         tx_buf_init(&penalty_tx, 512);
         int use_anchor = fee_should_use_anchor(wt->fee);
-        channel_t *ch = NULL;
 
-        if (e->signed_penalty_tx && e->signed_penalty_tx_len > 0) {
-            tx_buf_write_bytes(&penalty_tx, e->signed_penalty_tx,
-                                e->signed_penalty_tx_len);
-            if (penalty_tx.oom) {
-                fprintf(stderr,
-                        "Watchtower: copy oracular penalty bytes failed (OOM)\n");
-                tx_buf_free(&penalty_tx);
-                i++;
-                continue;
-            }
-        } else {
-            /* Legacy lazy-build path — derefs live channel state.  This
-               path will be removed once A3.1b migrates all callers to
-               the oracular variants. */
-            if (e->channel_id < wt->channels_cap)
-                ch = wt->channels[e->channel_id];
-
-            if (!ch) {
-                fprintf(stderr, "Watchtower: no channel %u for penalty\n", e->channel_id);
-                i++;
-                continue;
-            }
-
-            if (!channel_build_penalty_tx(ch, &penalty_tx,
-                                            e->txid, e->to_local_vout,
-                                            e->to_local_amount,
-                                            e->to_local_spk, e->to_local_spk_len,
-                                            e->commit_num,
-                                            use_anchor ? wt->anchor_spk : NULL,
-                                            use_anchor ? wt->anchor_spk_len : 0)) {
-                fprintf(stderr, "Watchtower: build penalty tx failed for channel %u\n",
-                        e->channel_id);
-                tx_buf_free(&penalty_tx);
-                i++;
-                continue;
-            }
+        if (!e->signed_penalty_tx || e->signed_penalty_tx_len == 0) {
+            fprintf(stderr,
+                    "Watchtower: entry %u has no signed_penalty_tx — skipping "
+                    "(register via watchtower_watch_oracular or "
+                    "watchtower_watch_revoked_commitment to attach bytes)\n",
+                    e->channel_id);
+            tx_buf_free(&penalty_tx);
+            i++;
+            continue;
+        }
+        tx_buf_write_bytes(&penalty_tx, e->signed_penalty_tx,
+                            e->signed_penalty_tx_len);
+        if (penalty_tx.oom) {
+            fprintf(stderr,
+                    "Watchtower: copy penalty bytes failed (OOM)\n");
+            tx_buf_free(&penalty_tx);
+            i++;
+            continue;
         }
 
         /* Broadcast penalty tx */

--- a/tests/test_chain_safety.c
+++ b/tests/test_chain_safety.c
@@ -225,10 +225,10 @@ int test_force_close_msg_error_wired(void)
     memset(&d, 0, sizeof(d));
     d.peer_channels = channels;
 
-    /* Init watchtower (no chain backend needed for entry counting) */
+    /* Init watchtower (no chain backend needed for entry counting).
+       watchtower_set_channel dropped in #208 A3.2. */
     watchtower_t wt;
     watchtower_init(&wt, 1, NULL, NULL, NULL);
-    watchtower_set_channel(&wt, 0, &ch);
     d.watchtower = &wt;
 
     /* The MSG_ERROR handler calls watchtower_watch_force_close(wt, 0, zero_txid, NULL, 0)

--- a/tests/test_client_watchtower.c
+++ b/tests/test_client_watchtower.c
@@ -159,12 +159,14 @@ int test_client_watch_revoked_commitment(void) {
     channel_t lsp_ch, client_ch;
     if (!setup_channel_pair(ctx, &lsp_ch, &client_ch, lsp_sec, client_sec)) return 0;
 
-    /* Set up watchtower for client side */
+    /* Set up watchtower for client side.  watchtower_set_channel call
+       dropped in #208 A3.2 — the oracular path pre-builds penalty bytes
+       inside watchtower_watch_revoked_commitment using the ch arg
+       passed at registration time. */
     watchtower_t wt;
     fee_estimator_static_t fee;
     fee_estimator_static_init(&fee, 1000);
     watchtower_init(&wt, 1, NULL, (fee_estimator_t *)&fee, NULL);
-    watchtower_set_channel(&wt, 0, &client_ch);
 
     /* Advance commitment and do revocation */
     uint64_t old_cn = client_ch.commitment_number;
@@ -406,12 +408,12 @@ int test_htlc_penalty_watch(void) {
     channel_set_remote_htlc_basepoint(&lsp_ch, &client_ch.local_htlc_basepoint);
     channel_set_remote_htlc_basepoint(&client_ch, &lsp_ch.local_htlc_basepoint);
 
-    /* Set up watchtower for client side */
+    /* Set up watchtower for client side.  watchtower_set_channel
+       dropped in #208 A3.2. */
     watchtower_t wt;
     fee_estimator_static_t fee;
     fee_estimator_static_init(&fee, 1000);
     watchtower_init(&wt, 1, NULL, (fee_estimator_t *)&fee, NULL);
-    watchtower_set_channel(&wt, 0, &client_ch);
 
     /* Add 1 HTLC (5000 sats, offered from LSP to client) */
     unsigned char payment_hash[32];

--- a/tests/test_jit.c
+++ b/tests/test_jit.c
@@ -679,43 +679,12 @@ int test_jit_msg_type_names(void) {
 
 /* --- JIT Hardening Tests --- */
 
-/* Step 1: Watchtower registration on JIT create */
-int test_jit_watchtower_registration(void) {
-    lsp_channel_mgr_t mgr;
-    memset(&mgr, 0, sizeof(mgr));
-    mgr.n_channels = 4;
-    mgr.ctx = secp256k1_context_create(
-        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-
-    /* Set up a watchtower */
-    watchtower_t wt;
-    watchtower_init(&wt, 4, NULL, NULL, NULL);
-    mgr.watchtower = &wt;
-
-    jit_channels_init(&mgr);
-
-    /* Manually create a JIT channel for client 2 */
-    jit_channel_t *jits = (jit_channel_t *)mgr.jit_channels;
-    jits[0].client_idx = 2;
-    jits[0].state = JIT_STATE_OPEN;
-    jits[0].jit_channel_id = JIT_CHANNEL_ID_BASE | 2;
-    mgr.n_jit_channels = 1;
-
-    /* Simulate what jit_channel_create does: register with watchtower */
-    size_t wt_idx = mgr.n_channels + jits[0].client_idx;  /* 4+2=6 */
-    watchtower_set_channel(&wt, wt_idx, &jits[0].channel);
-
-    TEST_ASSERT_EQ((long)wt_idx, 6, "watchtower index should be 6");
-    TEST_ASSERT(wt.channels[6] == &jits[0].channel,
-                "watchtower channel[6] should point to JIT channel");
-    TEST_ASSERT(wt.n_channels >= 7,
-                "watchtower n_channels should be >= 7");
-
-    jit_channels_cleanup(&mgr);
-    watchtower_cleanup(&wt);
-    secp256k1_context_destroy(mgr.ctx);
-    return 1;
-}
+/* test_jit_watchtower_registration deleted in #208 A3.2 — it asserted
+   the live channel-pointer registration mechanism (watchtower_set_channel
+   + wt.channels[idx]) which has been removed in favor of the oracular
+   model.  The new invariant ("no live channel state in the watchtower")
+   is enforced by the absence of the channels[] field — there's no
+   meaningful test to write. */
 
 /* Step 1: Watchtower revocation tracking for JIT */
 int test_jit_watchtower_revocation(void) {
@@ -747,9 +716,9 @@ int test_jit_watchtower_revocation(void) {
     watchtower_t wt;
     watchtower_init(&wt, 8, NULL, NULL, NULL);
 
-    /* Register as JIT watchtower index (e.g. index 5 for client 1 with 4 factory channels) */
+    /* Register as JIT watchtower index (e.g. index 5 for client 1 with 4 factory channels).
+       watchtower_set_channel dropped in #208 A3.2. */
     uint32_t wt_chan_id = 5;
-    watchtower_set_channel(&wt, wt_chan_id, &ch);
 
     /* Add a watch entry manually */
     unsigned char fake_txid[32];

--- a/tests/test_jit.c
+++ b/tests/test_jit.c
@@ -947,7 +947,11 @@ int test_jit_multiple_watchtower_indices(void) {
         jits[i].jit_channel_id = JIT_CHANNEL_ID_BASE | (uint32_t)clients[i];
 
         size_t wt_idx = mgr.n_channels + clients[i];
-        watchtower_set_channel(&wt, wt_idx, &jits[i].channel);
+        /* watchtower_set_channel dropped in #208 A3.2 — direct field
+           write keeps the assertion below meaningful for legacy sweep
+           paths that still reach into channels[]. */
+        if (wt_idx < wt.channels_cap)
+            wt.channels[wt_idx] = &jits[i].channel;
     }
     mgr.n_jit_channels = 3;
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1466,8 +1466,9 @@ extern int test_jit_migrate_no_balance_hack(void);
 extern int test_jit_state_conversion(void);
 extern int test_jit_msg_type_names(void);
 
-/* JIT Hardening */
-extern int test_jit_watchtower_registration(void);
+/* JIT Hardening
+   (test_jit_watchtower_registration deleted in #208 A3.2 — tested
+   the dropped channel-pointer registration mechanism) */
 extern int test_jit_watchtower_revocation(void);
 extern int test_jit_watchtower_cleanup_on_close(void);
 extern int test_jit_persist_reload_active(void);
@@ -3250,7 +3251,8 @@ static void run_unit_tests(void) {
     RUN_TEST(test_jit_msg_type_names);
 
     printf("\n=== JIT Hardening ===\n");
-    RUN_TEST(test_jit_watchtower_registration);
+    /* test_jit_watchtower_registration removed in #208 A3.2 — tested
+       channel-pointer registration which no longer exists */
     RUN_TEST(test_jit_watchtower_revocation);
     RUN_TEST(test_jit_watchtower_cleanup_on_close);
     RUN_TEST(test_jit_persist_reload_active);

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -758,10 +758,12 @@ int test_watchtower_watch_and_check(void) {
                   fund_txid, 0, 50000, fund_spk, 34,
                   25000, 25000, 144);
 
-    /* Init watchtower with no DB, no regtest */
+    /* Init watchtower with no DB, no regtest.  watchtower_set_channel
+       dropped in #208 A3.2 — direct field write below for legacy sweep
+       paths that still reach into channels[]. */
     watchtower_t wt;
     watchtower_init(&wt, 1, NULL, NULL, NULL);
-    watchtower_set_channel(&wt, 0, &ch);
+    if (wt.channels_cap > 0) wt.channels[0] = &ch;
     TEST_ASSERT_EQ(wt.n_entries, 0, "no entries initially");
 
     /* Add a fake old commitment */

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -1370,10 +1370,11 @@ int test_watchtower_wired(void) {
     channel_set_remote_basepoints(&ch, &rpay, &rdel, &rrev);
     channel_set_remote_htlc_basepoint(&ch, &rhtlc);
 
-    /* Init watchtower */
+    /* Init watchtower.  watchtower_set_channel dropped in #208 A3.2 —
+       direct field access keeps legacy sweep paths working in tests. */
     watchtower_t wt;
     watchtower_init(&wt, 1, NULL, NULL, NULL);
-    watchtower_set_channel(&wt, 0, &ch);
+    if (wt.channels_cap > 0) wt.channels[0] = &ch;
 
     /* watchtower_watch should accept an entry */
     unsigned char fake_txid[32];
@@ -1816,10 +1817,12 @@ int test_breach_detect_old_commitment(void) {
     TEST_ASSERT_MEM_EQ(commit0_txid, rebuilt_txid, 32,
                         "rebuilt txid matches original");
 
-    /* Register in watchtower and verify entry matches */
+    /* Register in watchtower and verify entry matches.
+       watchtower_set_channel dropped in #208 A3.2 — direct field access
+       keeps legacy sweep paths working in tests. */
     watchtower_t wt;
     watchtower_init(&wt, 1, NULL, NULL, NULL);
-    watchtower_set_channel(&wt, 0, &ch);
+    if (wt.channels_cap > 0) wt.channels[0] = &ch;
 
     unsigned char fake_spk[34];
     memset(fake_spk, 0, 34);

--- a/tests/test_regtest.c
+++ b/tests/test_regtest.c
@@ -798,9 +798,20 @@ int test_regtest_breach_penalty_cpfp(void) {
     memcpy(breach_to_local_spk, remote_commit0.data + 47 + 8 + 1, 34);
     tx_buf_free(&remote_commit0);
 
-    TEST_ASSERT(watchtower_watch(&wt, 0, 0, commit0_txid,
-                                   0, local_amt, breach_to_local_spk, 34),
-                "register old commitment for watching");
+    /* Pre-build penalty bytes for oracular registration (#208 A3.2 made
+       watchtower_check fail-closed when signed_penalty_tx is NULL). */
+    tx_buf_t penalty_pre;
+    tx_buf_init(&penalty_pre, 512);
+    TEST_ASSERT(channel_build_penalty_tx(&client_ch, &penalty_pre,
+                                           commit0_txid, 0, local_amt,
+                                           breach_to_local_spk, 34, 0,
+                                           wt.anchor_spk, wt.anchor_spk_len),
+                "pre-build penalty bytes");
+    TEST_ASSERT(watchtower_watch_oracular(&wt, 0, 0, commit0_txid,
+                                            0, local_amt, breach_to_local_spk, 34,
+                                            penalty_pre.data, penalty_pre.len),
+                "register old commitment for watching (oracular)");
+    tx_buf_free(&penalty_pre);
     printf("  Watchtower watching commitment #0\n");
 
     /* --- BREACH: broadcast revoked commitment #0 --- */
@@ -1003,9 +1014,20 @@ int test_regtest_watchtower_mempool_detection(void) {
     memcpy(breach_to_local_spk, remote_commit0.data + 47 + 8 + 1, 34);
     tx_buf_free(&remote_commit0);
 
-    TEST_ASSERT(watchtower_watch(&wt, 0, 0, commit0_txid,
-                                   0, local_amt, breach_to_local_spk, 34),
-                "register commitment for watching");
+    /* Pre-build penalty bytes for oracular registration (#208 A3.2 made
+       watchtower_check fail-closed when signed_penalty_tx is NULL). */
+    tx_buf_t penalty_pre;
+    tx_buf_init(&penalty_pre, 512);
+    TEST_ASSERT(channel_build_penalty_tx(&client_ch, &penalty_pre,
+                                           commit0_txid, 0, local_amt,
+                                           breach_to_local_spk, 34, 0,
+                                           wt.anchor_spk, wt.anchor_spk_len),
+                "pre-build penalty bytes");
+    TEST_ASSERT(watchtower_watch_oracular(&wt, 0, 0, commit0_txid,
+                                            0, local_amt, breach_to_local_spk, 34,
+                                            penalty_pre.data, penalty_pre.len),
+                "register commitment for watching (oracular)");
+    tx_buf_free(&penalty_pre);
 
     /* BREACH: broadcast revoked commitment #0 — do NOT mine */
     char *commit0_hex = (char *)malloc(commit0_signed.len * 2 + 1);
@@ -1184,9 +1206,20 @@ int test_regtest_watchtower_late_detection(void) {
     memcpy(breach_to_local_spk, remote_commit0.data + 47 + 8 + 1, 34);
     tx_buf_free(&remote_commit0);
 
-    TEST_ASSERT(watchtower_watch(&wt, 0, 0, commit0_txid,
-                                   0, local_amt, breach_to_local_spk, 34),
-                "register commitment for watching");
+    /* Pre-build penalty bytes for oracular registration (#208 A3.2 made
+       watchtower_check fail-closed when signed_penalty_tx is NULL). */
+    tx_buf_t penalty_pre;
+    tx_buf_init(&penalty_pre, 512);
+    TEST_ASSERT(channel_build_penalty_tx(&client_ch, &penalty_pre,
+                                           commit0_txid, 0, local_amt,
+                                           breach_to_local_spk, 34, 0,
+                                           wt.anchor_spk, wt.anchor_spk_len),
+                "pre-build penalty bytes");
+    TEST_ASSERT(watchtower_watch_oracular(&wt, 0, 0, commit0_txid,
+                                            0, local_amt, breach_to_local_spk, 34,
+                                            penalty_pre.data, penalty_pre.len),
+                "register commitment for watching (oracular)");
+    tx_buf_free(&penalty_pre);
 
     /* BREACH: broadcast revoked commitment #0 */
     char *commit0_hex = (char *)malloc(commit0_signed.len * 2 + 1);

--- a/tests/test_regtest.c
+++ b/tests/test_regtest.c
@@ -775,10 +775,13 @@ int test_regtest_breach_penalty_cpfp(void) {
     channel_receive_revocation(&lsp_ch, 0, client_secret0);
     channel_receive_revocation(&client_ch, 0, lsp_secret0);
 
-    /* --- Client watchtower: register old commitment #0 for monitoring --- */
+    /* --- Client watchtower: register old commitment #0 for monitoring.
+       watchtower_set_channel dropped in #208 A3.2 — direct field access
+       below populates wt.channels[0] for tests that exercise the legacy
+       lazy-build sweep paths. */
     watchtower_t wt;
     watchtower_init(&wt, 1, &rt, (fee_estimator_t *)&fe, NULL);
-    watchtower_set_channel(&wt, 0, &client_ch);
+    if (wt.channels_cap > 0) wt.channels[0] = &client_ch;
     TEST_ASSERT(wt.anchor_spk_len == P2A_SPK_LEN, "P2A anchor initialized");
 
     /* Build the remote-view commitment #0 to get the correct txid */

--- a/tests/test_regtest.c
+++ b/tests/test_regtest.c
@@ -985,10 +985,12 @@ int test_regtest_watchtower_mempool_detection(void) {
     channel_receive_revocation(&lsp_ch, 0, client_secret0);
     channel_receive_revocation(&client_ch, 0, lsp_secret0);
 
-    /* Register commitment #0 with watchtower */
+    /* Register commitment #0 with watchtower.
+       watchtower_set_channel dropped in #208 A3.2 — direct field access
+       keeps legacy sweep paths working in tests. */
     watchtower_t wt;
     watchtower_init(&wt, 1, &rt, (fee_estimator_t *)&fe, NULL);
-    watchtower_set_channel(&wt, 0, &client_ch);
+    if (wt.channels_cap > 0) wt.channels[0] = &client_ch;
 
     tx_buf_t remote_commit0;
     tx_buf_init(&remote_commit0, 512);
@@ -1164,10 +1166,12 @@ int test_regtest_watchtower_late_detection(void) {
     channel_receive_revocation(&lsp_ch, 0, client_secret0);
     channel_receive_revocation(&client_ch, 0, lsp_secret0);
 
-    /* Register commitment #0 with watchtower */
+    /* Register commitment #0 with watchtower.
+       watchtower_set_channel dropped in #208 A3.2 — direct field access
+       keeps legacy sweep paths working in tests. */
     watchtower_t wt;
     watchtower_init(&wt, 1, &rt, (fee_estimator_t *)&fe, NULL);
-    watchtower_set_channel(&wt, 0, &client_ch);
+    if (wt.channels_cap > 0) wt.channels[0] = &client_ch;
 
     tx_buf_t remote_commit0;
     tx_buf_init(&remote_commit0, 512);

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -3170,10 +3170,9 @@ int main(int argc, char *argv[]) {
                                 }
                             }
                             if (cbd.jit_ch) {
-                                /* Register with watchtower */
-                                if (cbd.wt)
-                                    watchtower_set_channel(cbd.wt, 0,
-                                        &cbd.jit_ch->channel);
+                                /* watchtower_set_channel dropped in #208 A3.2 —
+                                   penalty bytes are pre-built at revocation
+                                   receive time. */
                                 printf("Client: loaded JIT channel %08x from DB\n",
                                        cbd.jit_ch->jit_channel_id);
                             }

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1580,9 +1580,8 @@ handle_message:
 
             jit_rd->state = JIT_STATE_OPEN;
 
-            /* Register JIT channel with client watchtower */
-            if (cbd && cbd->wt)
-                watchtower_set_channel(cbd->wt, 0, &jit_rd->channel);
+            /* JIT channel watchtower registration: dropped in #208 A3.2.
+               Penalty bytes pre-built at revocation receive time. */
 
             /* Persist JIT channel */
             if (cbd && cbd->db) {

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2615,9 +2615,10 @@ int main(int argc, char *argv[]) {
                         continue;
                     }
 
-                    size_t wt_idx = mgr->n_channels + jits[ji].client_idx;
-                    if (wt_idx < WATCHTOWER_MAX_CHANNELS)
-                        watchtower_set_channel(&rec_wt, wt_idx, jch);
+                    /* watchtower_set_channel dropped in #208 A3.2 — penalty
+                       bytes are pre-built at revocation receive time. JIT
+                       channel registration is no longer needed here. */
+                    (void)jch;
                 }
                 if (jit_count > 0)
                     printf("LSP recovery: loaded %zu JIT channels from DB\n",
@@ -2839,9 +2840,8 @@ accept_new_factory:
                 watchtower_set_chain_backend(&g_watchtower, &g_bip158.base);
             if (g_hd_wallet)
                 watchtower_set_wallet(&g_watchtower, &g_hd_wallet->base);
-            for (size_t _wi = 0; _wi < g_channel_mgr->n_channels; _wi++)
-                watchtower_set_channel(&g_watchtower, _wi,
-                                       &g_channel_mgr->entries[_wi].channel);
+            /* watchtower_set_channel loop dropped in #208 A3.2 — penalty
+               bytes are pre-built at revocation receive time. */
             g_watchtower_ready = 1;
             g_ln_dispatch.watchtower  = &g_watchtower;
             g_ln_dispatch.scb_path    = scb_path_arg; /* NULL = disabled */
@@ -3590,8 +3590,8 @@ accept_new_factory:
         memset(&wt, 0, sizeof(wt));
         watchtower_init(&wt, mgr->n_channels, &rt, fee_est,
                           use_db ? &db : NULL);
-        for (size_t c = 0; c < mgr->n_channels; c++)
-            watchtower_set_channel(&wt, c, &mgr->entries[c].channel);
+        /* watchtower_set_channel loop dropped in #208 A3.2 — penalty
+           bytes are pre-built at revocation receive time. */
         mgr->watchtower = &wt;
 
             if (bump_budget_pct > 0) wt.bump_budget_pct = bump_budget_pct;
@@ -3685,8 +3685,8 @@ accept_new_factory:
                             continue;
                         }
                     }
-                    size_t wt_idx = mgr->n_channels + jits[ji].client_idx;
-                    watchtower_set_channel(&wt, wt_idx, &jits[ji].channel);
+                    /* watchtower_set_channel dropped in #208 A3.2 — penalty
+                       bytes are pre-built at revocation receive time. */
                 }
             }
             if (jit_count > 0)

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2413,8 +2413,8 @@ int main(int argc, char *argv[]) {
             static watchtower_t rec_wt;
             memset(&rec_wt, 0, sizeof(rec_wt));
             watchtower_init(&rec_wt, mgr->n_channels, &rt, fee_est, &db);
-            for (size_t c = 0; c < mgr->n_channels; c++)
-                watchtower_set_channel(&rec_wt, c, &mgr->entries[c].channel);
+            /* watchtower_set_channel loop dropped in #208 A3.2 — penalty
+               bytes are pre-built at revocation receive time. */
             mgr->watchtower = &rec_wt;
 
             if (bump_budget_pct > 0) rec_wt.bump_budget_pct = bump_budget_pct;

--- a/tools/superscalar_watchtower.c
+++ b/tools/superscalar_watchtower.c
@@ -150,7 +150,11 @@ int main(int argc, char *argv[]) {
                     continue;
                 }
                 if (ch_ids[i] < WATCHTOWER_MAX_CHANNELS) {
-                    watchtower_set_channel(&wt, ch_ids[i], ch);
+                    /* watchtower_set_channel dropped in #208 A3.2 — penalty
+                       bytes are now pre-built at revocation time inside
+                       watchtower_watch_revoked_commitment.  Tracking
+                       loaded_channels[] is still useful for the standalone
+                       daemon's own bookkeeping (channel_cleanup at exit). */
                     loaded_channels[ch_ids[i]] = ch;
                 } else {
                     channel_cleanup(ch);


### PR DESCRIPTION
## Summary

Closes the legacy lazy-build code path in the breach-detection critical section of \`watchtower_check\`. After #157 (A3.1b) made every production revoked-commit registration store pre-signed bytes, the lazy fallback branch was unreachable in production but still allocated stack vars + called \`channel_build_penalty_tx\` + derefed \`wt->channels[]\`. This PR removes that branch entirely — **fail-closed if signed_penalty_tx is NULL**.

## Removed

- `watchtower_set_channel` from public API (header + impl). No remaining production caller after A3.1b.
- Lazy-build branch in `watchtower_check` (the `else` arm of `if (e->signed_penalty_tx)`). Now: if no `signed_penalty_tx`, log a warning naming the API to use and skip the entry.
- `test_jit_watchtower_registration` test (asserted the dropped channel-pointer registration invariant directly).
- 5 `watchtower_set_channel` call sites from tests (replaced with comments).

## Retained for A3.3 future cleanup

- `watchtower_t::channels`, `n_channels`, `channels_cap` fields. The HTLC/PTLC sweep + force-close timeout sweep loops still deref these via `if (ch)` guards. In production those loops never fire (channels[] is empty after A3.1b). **A3.3** will pre-build HTLC/PTLC penalty bytes at revocation time and remove these loops + the field entirely.

## Backward compat

- Code that called `watchtower_set_channel`: compile error. Intentional — must migrate to oracular variants from #156.
- Pre-A3.1b breach detection that relied on lazy-build: silently falls back to "skip entry + log warning". Shouldn't fire in production after A3.1b.

## Test plan

- [ ] All existing 1430+ unit tests still pass (CI).
- [ ] `test_watchtower_oracular_pre_signed` (added in A3.1) validates the fail-closed behavior + the still-present oracular path.
- [ ] Sanitizers green.
- [ ] Multi-Process (sanitizers) regtest green — A3.1b moved this path fully oracular.