### PR TITLE
PS Tier B rollover: wire rc=-1 trigger (trigger only; ceremony follow-up)

### DIFF
--- a/src/factory.c
+++ b/src/factory.c
@@ -2235,11 +2235,39 @@ int factory_advance_leaf_unsigned(factory_t *f, int leaf_side) {
     factory_node_t *node = &f->nodes[node_idx];
 
     /* PS leaf: chain advance, no DW counter. Same passthrough logic as the
-       signed variant — single channel output, no L-stock re-split. */
+       signed variant — single channel output, no L-stock re-split.
+
+       CL-PSTB: PS Tier B rollover — when ps_chain_len exceeds
+       states_per_layer, advance the root DW counter + epoch (analogous to
+       DW leaf exhaustion path below).  build_all_unsigned_txs rebuilds
+       every node (including the leaf) with fresh chain[0] state for the
+       new epoch; lsp_run_state_advance() re-signs every non-PS-leaf node
+       via the Tier B MuSig ceremony.  PS leaves' chain[0..N-1] history is
+       on-chain state — Tier B does not invalidate it; it produces a new
+       chain[0] starting point for the new epoch.  Closes the
+       feature gap surfaced by TS-TIER-B-PS testnet4 (the regtest test had
+       weaker PASS criteria that masked this). */
     if (node->is_ps_leaf) {
         memcpy(node->ps_prev_txid, node->txid, 32);
         node->ps_prev_chan_amount = node->outputs[0].amount_sats;
         node->ps_chain_len++;
+        if ((uint32_t)node->ps_chain_len > f->states_per_layer) {
+            if (!dw_advance(&f->counter.layers[0]))
+                return 0;  /* fully exhausted (all root states consumed) */
+            f->counter.current_epoch++;
+            /* Reset every PS leaf's chain length for the new epoch.  The
+               on-chain chain[0..N-1] entries remain valid as historical
+               states; the in-memory chain_len resets so the next advance
+               builds chain[0] for the new epoch. */
+            for (int i = 0; i < f->n_leaf_nodes; i++) {
+                size_t li = f->leaf_node_indices[i];
+                if (f->nodes[li].is_ps_leaf)
+                    f->nodes[li].ps_chain_len = 0;
+            }
+            if (!update_l_stock_outputs(f)) return 0;
+            if (!build_all_unsigned_txs(f)) return 0;
+            return -1;  /* caller drives Tier B ceremony */
+        }
         if (node->ps_prev_chan_amount <= f->fee_per_tx) return 0;
         uint64_t out_total = node->ps_prev_chan_amount - f->fee_per_tx;
         if (out_total < CHANNEL_DUST_LIMIT_SATS) return 0;


### PR DESCRIPTION
## Summary

Surfaced by **TS-TIER-B-PS testnet4 (FAIL)**: `factory_advance_leaf_unsigned()` PS branch always returned 1, never -1. The `lsp_advance_leaf` rc=-1 path that drives the Tier B ceremony was unreachable for PS leaves. Regtest's `test_regtest_tier_b_rollover_ps.sh` explicitly documents this gap:

> "**--arity 3 (PS) is supported by the CL2-TB gate change but does NOT actually trigger Tier-B — PS leaves have no DW counter to exhaust.**"

The CL2-TB change only updated the LSP test gate to accept arity 3; the underlying mechanism was never wired. The testnet4 runner's stricter PASS bar (which checks actual epoch advance + non-PS-leaf re-signing) exposed this — regtest test bar was just "the gate doesn't print SKIP".

## What this PR does

Wires the PS Tier B **trigger** (not the full ceremony — see follow-up):

1. PS branch now returns -1 when `ps_chain_len > states_per_layer`, mirroring DW exhaustion semantics.
2. Advances root DW counter + increments `current_epoch`.
3. Resets `ps_chain_len` for every PS leaf in the new epoch (chain history is preserved on-chain; the in-memory counter resets so the next advance builds chain[0] for the new epoch).
4. Calls `build_all_unsigned_txs` to rebuild every node's unsigned TX for the new epoch; `is_signed` is cleared, which `lsp_run_state_advance` picks up.

## Validated on regtest

- **DW Tier B (no regression)**: `test_regtest_kill_after_state_advance.sh --arity 1` still PASSes with this change: `state advance complete — epoch 2, 14 nodes re-signed`.
- **PS Tier B trigger fires correctly**: `LSP: leaf 0 exhausted, root advanced — running Tier B state-advance ceremony`. Was unreachable before this PR.

## Known follow-up (NOT in this PR)

The PS Tier B **ceremony** itself (`lsp_run_state_advance` when invoked for PS factories) hits `expected PATH_NONCE_BUNDLE from client 0, got 0x00`. The client closes its connection between `STATE_ADVANCE_PROPOSE` and `PATH_NONCE_BUNDLE`. This issue is **independent** of this PR's trigger fix — it was latent because the trigger never fired before. Investigation suggests it may be a `build_all_unsigned_txs` / per-node keypair coordination issue specific to PS factories. Tracked as separate follow-up.

## Test plan

- [x] `bash tools/test_regtest_kill_after_state_advance.sh` (DW Tier B regression check) — PASS
- [x] `bash tools/test_regtest_tier_b_rollover_ps.sh` (PS Tier B trigger) — trigger now fires correctly (ceremony fails for separate reason documented above)
- [ ] CI run
- [ ] Follow-up PR for PS Tier B ceremony wire/state issue