### PR TITLE
LSP success exit: free lad + call lsp_channels_cleanup

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -4030,13 +4030,27 @@ accept_new_factory:
     report_add_string(&rpt, "result", "success");
     report_close(&rpt);
 
-    /* Clean up this factory's resources */
+    /* Clean up this factory's resources.
+
+       Memory leak fix: also call lsp_channels_cleanup to free the
+       per-channel HTLC/htlc-origin/invoice arrays (entries/invoices/
+       htlc_origins from lsp_channels_init), and free the ladder_t struct
+       itself (sizeof(ladder_t) is ~192 MB inline at
+       LADDER_MAX_FACTORIES=8 since each ladder_factory_t embeds a full
+       factory_t).  Both were previously leaked on the LSP success exit
+       path — ASan flagged this in the testnet4 campaign 2026-05-14. */
     jit_channels_cleanup(mgr);
+    lsp_channels_cleanup(mgr);
     free(mgr);
     mgr = NULL;
     lsp_cleanup(lsp_p);
     free(lsp_p);
     lsp_p = NULL;
+    if (lad) {
+        ladder_free(lad);
+        free(lad);
+        lad = NULL;
+    }
 
     /* Persistent daemon: loop back for a new factory instead of exiting.
        Mark this factory as closed in DB (cooperative close already on chain).


### PR DESCRIPTION
## Summary

The LSP main success exit path (`return 0` after a clean cooperative-close) leaks two things flagged by ASan during the testnet4 campaign:

1. **`ladder_t lad`** — `calloc`'d at `superscalar_lsp.c:3409`. `sizeof(ladder_t)` is ~192 MB inline because each `ladder_factory_t` embeds a full `factory_t` and `LADDER_MAX_FACTORIES=8`. Was only freed on the early `ladder_init` failure path; success path never freed it.

2. **`mgr` per-client arrays** — `lsp_channels_init` populates `entries` / `invoices` / `htlc_origins` via `calloc`. Success path called `free(mgr)` but never `lsp_channels_cleanup(mgr)` — leaking those arrays plus per-channel HTLC arrays via `channel_init`.

## Fix

Add `lsp_channels_cleanup(mgr)` before `free(mgr)` and `ladder_free(lad); free(lad);` at LSP main success exit.

## Why this matters

- Process runtime memory is unchanged — these are one-shot startup allocations, not growth leaks
- This is hygiene for clean ASan process-exit reports
- The 192 MB allocation is what surfaced as the dominant entry in `ts_k2_campaign` LSP run's leak summary

## Not in this PR (deferred as separate refactor)

Error-return paths (20+ sites) have similar exit-time leaks. They're cosmetic since the OS reclaims everything on process exit, and consolidating cleanup across all return sites is a separate refactor. Could ship in a follow-up if ASan-clean error paths matter for CI.

## Test plan

- [x] Builds clean
- [ ] CI run
- [ ] Regtest: `bash tools/test_regtest_cheat_daemon_leaf.sh` then check no ASan leak summary at exit