### PR TITLE
PS Tier B: block-driven root rollover (proper semantics, supersedes #166)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ docs/internal/
 testnet4-onchain-firsts.md
 lost-coordination-branch/
 
+PS_MAINNET_PUNCH_LIST.md

--- a/docs/rotation-ceremony.md
+++ b/docs/rotation-ceremony.md
@@ -211,6 +211,66 @@ multi-process test.  Both compose: 14 nodes re-signed for the new
 epoch via bundled MuSig over 5 separate OS processes, and the
 post-rollover tree confirms on regtest.
 
+## PS factory variant (block-driven root rollover)
+
+The Tier B mechanism above was designed for DW factories: leaf-counter
+exhaustion drives root rollover.  PS factories don't have a leaf-level
+counter — leaves chain-extend (chain[0]→chain[1]→...) so leaf events
+don't tick anything at the root layer.
+
+For PS factories, root rollover is **block-driven** instead.  The root
+DW counter is a finite state space sized by `step_blocks` ×
+`states_per_layer`, and it must advance over time as block height
+progresses so the factory eventually reaches expiry.
+
+### Trigger
+
+- `src/factory.c::factory_tick_root(f)` — advance root DW counter; on
+  rollover, increment `current_epoch`, reset every PS leaf's
+  `ps_chain_len` to 0 (chain history is on-chain state of the OLD
+  epoch), rebuild every node's unsigned TX, return -1.  Caller drives
+  Tier B.
+- `src/lsp_channels.c::lsp_factory_tick_root(mgr, lsp)` — LSP-side
+  helper that ties `factory_tick_root` + `lsp_run_state_advance(-1)`.
+
+### Wire compatibility with the existing ceremony
+
+The existing `lsp_run_state_advance` + `client_handle_state_advance`
+flow is reused unchanged.  The only addition is a special value
+`trigger_leaf == -1` in `MSG_STATE_ADVANCE_PROPOSE`:
+
+- `trigger_leaf >= 0` (existing): client mirrors LSP by driving the
+  same leaf advance in a loop until its own `factory_advance_leaf_unsigned`
+  returns -1.
+- `trigger_leaf == -1` (NEW for PS): client calls `factory_tick_root`
+  locally to mirror the LSP's root-counter advance.
+
+After local rollover, both sides converge on the same `affected[] =
+non-PS-leaf nodes` set and the rest of the ceremony (PATH_NONCE_BUNDLE
+→ PATH_ALL_NONCES → PATH_PSIG_BUNDLE → PATH_SIGN_DONE) is identical to
+the DW case.
+
+### Production wiring
+
+The LSP daemon should call `lsp_factory_tick_root` from a block-driven
+polling loop — e.g., when observed block height crosses
+`factory_start_height + (current_state + 1) * step_blocks`.  This call
+is idempotent: returns 0 when no rollover is due, 1 when ceremony
+completes for an epoch advance, -1 on ceremony failure (retry next
+tick).
+
+### Test driver
+
+`tools/superscalar_lsp_pre_daemon_tests.inc::test_tier_b_rollover`
+detects PS vs DW factory and dispatches:
+
+- DW (`--arity 1`): drives `lsp_channels_advance_ps_leaf` in a loop
+  (existing).
+- PS (`--arity 3`): drives `lsp_factory_tick_root` in a loop (NEW).
+
+Both paths produce identical end states: every non-PS-leaf node
+re-signed with `signed_tx` for the new epoch.
+
 ## Cross-references
 
 - Tier A (single-process): `src/factory.c::factory_advance` (PR #112)

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -501,6 +501,14 @@ int factory_advance_leaf(factory_t *f, int leaf_side);
    Returns -1 if leaf exhausted and root advanced (full rebuild needed). */
 int factory_advance_leaf_unsigned(factory_t *f, int leaf_side);
 
+/* Tick the root DW counter forward (PS Tier B trigger).  For PS factories,
+   leaf advances are chain extension (no counter) — root rollover is driven
+   by block-height progression instead.  Caller (LSP) wires this into a
+   block-polling loop and runs Tier B on rc=-1.
+   Returns -1 on epoch rollover (trees rebuilt; run Tier B);
+   0 otherwise (no rollover or fully exhausted). */
+int factory_tick_root(factory_t *f);
+
 /* Sub-factory chain extension (Gap E followup Phase 2, t/1242 k² PS).
 
    Drives the canonical "buy liquidity from sales-stock" operation:

--- a/include/superscalar/lsp_channels.h
+++ b/include/superscalar/lsp_channels.h
@@ -506,4 +506,11 @@ int lsp_channels_batch_rebalance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
 /* Advance one PS leaf via the production wire ceremony (PROPOSE->PSIG->DONE).
    leaf_side: 0..n_leaf_nodes-1. Returns 1 on success, 0 on failure/skip. */
 int lsp_channels_advance_ps_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side);
+
+/* Tick the factory's root counter forward (PS Tier B trigger).
+   For PS factories, root rollover is block-driven (leaves chain-extend).
+   On rollover, drives Tier B ceremony to re-sign every non-PS-leaf node
+   for the new epoch.  Returns 1 = ceremony complete, 0 = no rollover,
+   -1 = ceremony failed.  See src/lsp_channels.c for caller wiring. */
+int lsp_factory_tick_root(lsp_channel_mgr_t *mgr, lsp_t *lsp);
 #endif /* SUPERSCALAR_LSP_CHANNELS_H */

--- a/src/client.c
+++ b/src/client.c
@@ -3372,33 +3372,45 @@ int client_handle_state_advance(int fd, secp256k1_context *ctx,
         n_leaf_pre++;
     }
 
-    /* Advance local DW counter to root rollover.
+    /* Advance local state to mirror the LSP-side rollover.
 
-       The LSP triggered Tier B because its OWN factory_advance_leaf_unsigned
-       returned -1.  The client's counter is typically ONE step behind the
-       LSP because the prior per-leaf-advance ceremony exited cleanly on
-       the LSP side at rc=-1 without sending MSG_LEAF_ADVANCE_PROPOSE
-       (the rc=-1 branch in lsp_advance_leaf hands off to Tier B
-       directly).  So the client must drive its own advance until rc=-1
-       fires too — at most one extra step in the lockstep case, but the
-       loop also handles unsynchronized recovery scenarios.  Bounded by
-       states_per_layer+2 as a safety cap. */
+       Two trigger types:
+       1. trigger_leaf == -1 (PS Tier B root-driven): LSP called factory_tick_root
+          directly because the block-height progression rolled over the root DW
+          counter.  PS leaves don't have a counter to exhaust.  Client mirrors
+          by calling factory_tick_root locally.
+       2. trigger_leaf >= 0 (DW leaf-exhaustion-driven): LSP's
+          factory_advance_leaf_unsigned returned -1 because the leaf counter
+          ran out.  Client mirrors by advancing the same leaf in a loop until
+          its own rc=-1 fires (handles unsynchronized recovery: client may be
+          1 step behind LSP). */
     int rc = 0;
-    int max_steps = (int)(factory->states_per_layer + 2);
-    if (max_steps < 4) max_steps = 4;
-    for (int s = 0; s < max_steps; s++) {
-        rc = factory_advance_leaf_unsigned(factory, trigger_leaf);
-        if (rc == -1) break;
-        if (rc != 1) {
-            fprintf(stderr, "Client %u: state_advance: advance step %d returned %d\n",
-                    my_index, s, rc);
+    if (trigger_leaf < 0) {
+        /* Root-driven (PS Tier B): tick root counter directly. */
+        rc = factory_tick_root(factory);
+        if (rc != -1) {
+            fprintf(stderr, "Client %u: state_advance: root tick returned %d "
+                    "(expected -1 for rollover)\n", my_index, rc);
             return 0;
         }
-    }
-    if (rc != -1) {
-        fprintf(stderr, "Client %u: state advance: never hit rc=-1 within %d steps\n",
-                my_index, max_steps);
-        return 0;
+    } else {
+        /* Leaf-driven (DW): drive leaf advance until rc=-1. */
+        int max_steps = (int)(factory->states_per_layer + 2);
+        if (max_steps < 4) max_steps = 4;
+        for (int s = 0; s < max_steps; s++) {
+            rc = factory_advance_leaf_unsigned(factory, trigger_leaf);
+            if (rc == -1) break;
+            if (rc != 1) {
+                fprintf(stderr, "Client %u: state_advance: advance step %d returned %d\n",
+                        my_index, s, rc);
+                return 0;
+            }
+        }
+        if (rc != -1) {
+            fprintf(stderr, "Client %u: state advance: never hit rc=-1 within %d steps\n",
+                    my_index, max_steps);
+            return 0;
+        }
     }
 
     /* PR-D phase 4: prepare poison sessions per leaf where OLD state was

--- a/src/factory.c
+++ b/src/factory.c
@@ -2294,8 +2294,13 @@ int factory_advance_leaf_unsigned(factory_t *f, int leaf_side) {
           to distinguish). */
 int factory_tick_root(factory_t *f) {
     if (!f) return 0;
-    if (!dw_counter_advance(&f->counter.layers[0]))
-        return 0;  /* fully exhausted or no-op */
+    /* Advance the root layer (layers[0]).  dw_advance ticks a single layer;
+       dw_counter_advance walks all layers + handles overall counter — not
+       what we want here.  We're mirroring the rc=-1 path in
+       factory_advance_leaf_unsigned (DW branch) which uses dw_advance on
+       layers[0] when leaf-counter exhaustion bubbles up. */
+    if (!dw_advance(&f->counter.layers[0]))
+        return 0;  /* fully exhausted */
     f->counter.current_epoch++;
     /* Reset PS leaf chain_len for the new epoch.  On-chain chain[0..N-1]
        entries remain valid historical states; the in-memory chain_len

--- a/src/factory.c
+++ b/src/factory.c
@@ -2271,6 +2271,45 @@ int factory_advance_leaf_unsigned(factory_t *f, int leaf_side) {
     return 1;
 }
 
+/* Tick the root DW counter forward.  Used by PS factories to drive
+   epoch rollover from block-height progression (instead of leaf-counter
+   exhaustion, which PS leaves don't have — they chain-extend instead).
+
+   The caller wires this into a block-driven polling loop:
+     - Every step_blocks blocks of progression, call factory_tick_root.
+     - On rc=-1 return, run the Tier B ceremony (lsp_run_state_advance).
+
+   For DW factories the equivalent rollover is triggered by leaf-counter
+   exhaustion in factory_advance_leaf_unsigned (rc=-1 from there).  Both
+   paths converge on the same Tier B ceremony.
+
+   Returns:
+     -1 = root counter rolled over; non-PS-leaf trees rebuilt; caller
+          must run Tier B to re-sign every non-PS-leaf node for the
+          new epoch.  PS leaves' ps_chain_len resets to 0 (their
+          on-chain chain history from the OLD epoch is preserved as
+          historical state; the NEW epoch starts fresh chain[0]).
+      0 = no rollover (root counter advanced within current epoch, or
+          fully exhausted — caller should check current_epoch + state
+          to distinguish). */
+int factory_tick_root(factory_t *f) {
+    if (!f) return 0;
+    if (!dw_counter_advance(&f->counter.layers[0]))
+        return 0;  /* fully exhausted or no-op */
+    f->counter.current_epoch++;
+    /* Reset PS leaf chain_len for the new epoch.  On-chain chain[0..N-1]
+       entries remain valid historical states; the in-memory chain_len
+       resets so the next leaf advance builds chain[0] for the new epoch. */
+    for (int i = 0; i < f->n_leaf_nodes; i++) {
+        size_t li = f->leaf_node_indices[i];
+        if (f->nodes[li].is_ps_leaf)
+            f->nodes[li].ps_chain_len = 0;
+    }
+    if (!update_l_stock_outputs(f)) return 0;
+    if (!build_all_unsigned_txs(f)) return 0;
+    return -1;
+}
+
 /* Sub-factory chain extension (Gap E followup Phase 2, t/1242).
 
    "Buy liquidity from sales-stock" operation: client at

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -6341,6 +6341,41 @@ int lsp_channels_advance_ps_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_si
     return lsp_advance_leaf(mgr, lsp, leaf_side);
 }
 
+/* Tick the factory's root counter forward (PS Tier B production trigger).
+   For PS factories, leaf advances are chain extension and don't drive root
+   state — root must be ticked by an external time/block source.  When the
+   root counter rolls over, drives the Tier B ceremony to re-sign every
+   non-PS-leaf node for the new epoch.
+
+   Caller wires this into a block-driven polling loop (e.g., every
+   step_blocks blocks, or based on observed block height progression).
+
+   Returns:
+     1 = ceremony completed (epoch advanced + non-PS-leaf nodes re-signed),
+     0 = nothing to do (no rollover this tick),
+    -1 = ceremony failed (caller may retry next tick). */
+int lsp_factory_tick_root(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
+    if (!mgr || !lsp) return 0;
+    factory_t *f = &lsp->factory;
+    int rc = factory_tick_root(f);
+    if (rc != -1) {
+        return 0;
+    }
+    printf("LSP: root counter rolled over to epoch %u — running Tier B ceremony\n",
+           f->counter.current_epoch);
+    /* trigger_leaf = -1 signals to client_handle_state_advance that this is
+       a root-driven rollover (no specific leaf was advanced). */
+    int sa_rc = lsp_run_state_advance(mgr, lsp, -1);
+    if (sa_rc) {
+        printf("LSP: Tier B ceremony complete for epoch %u\n",
+               f->counter.current_epoch);
+        return 1;
+    }
+    fprintf(stderr, "LSP: Tier B ceremony failed for epoch %u\n",
+            f->counter.current_epoch);
+    return -1;
+}
+
 /* PR-B (v22): post-recovery watchtower rehydration.
 
    For every PS leaf with chain_len >= 2, look up chain[N-1].txid (the

--- a/tools/activate_testnet4_ln_bridge.sh
+++ b/tools/activate_testnet4_ln_bridge.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# activate_testnet4_ln_bridge.sh — enable the SuperScalar bridge plugin
+# on the existing CLN-A testnet4 node and start the bridge daemon, so
+# the LSP can route real Lightning payments INTO/OUT OF factory clients.
+#
+# Prerequisites (already on VPS at 68.168.216.243):
+#   - CLN-A running with /var/lib/cln-testnet4/config
+#   - The config has the bridge plugin lines commented out
+#   - $BUILD_DIR/superscalar_bridge binary exists
+#   - bitcoind testnet4 running on RPC port 48332
+#
+# What this does:
+#   1. Uncomment the plugin lines in CLN-A's config
+#   2. Restart CLN-A (forces plugin load)
+#   3. Start superscalar_bridge in the background
+#   4. Print the bridge's listen port for LSP to connect via --bridge-port
+#
+# The actual BOLT11 test driver is in a separate runner — this script
+# just ACTIVATES the testbed.
+
+set -uo pipefail
+
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
+BRIDGE_BIN="$BUILD_DIR/superscalar_bridge"
+CLN_DIR="${CLN_DIR:-/var/lib/cln-testnet4}"
+CLN_CONFIG="$CLN_DIR/config"
+BRIDGE_PORT="${BRIDGE_PORT:-9737}"
+BRIDGE_LOG="${BRIDGE_LOG:-/tmp/superscalar_bridge.log}"
+PLUGIN_PATH="/root/SuperScalar/tools/cln_plugin.py"
+
+echo "=== Activate testnet4 LN bridge ==="
+echo "  CLN dir       : $CLN_DIR"
+echo "  Plugin path   : $PLUGIN_PATH"
+echo "  Bridge binary : $BRIDGE_BIN"
+echo "  Bridge port   : $BRIDGE_PORT"
+
+if [ ! -x "$BRIDGE_BIN" ]; then
+    echo "FAIL: $BRIDGE_BIN missing or not executable; rebuild first"
+    exit 1
+fi
+if [ ! -f "$PLUGIN_PATH" ]; then
+    echo "FAIL: $PLUGIN_PATH missing"
+    exit 1
+fi
+
+# 1. Uncomment plugin lines in CLN config (idempotent).
+sed -i 's|^#plugin=/root/SuperScalar/tools/cln_plugin.py|plugin=/root/SuperScalar/tools/cln_plugin.py|' "$CLN_CONFIG"
+sed -i 's|^#superscalar-bridge-host=|superscalar-bridge-host=|' "$CLN_CONFIG"
+sed -i "s|^#superscalar-bridge-port=9737|superscalar-bridge-port=$BRIDGE_PORT|" "$CLN_CONFIG"
+sed -i 's|^#superscalar-lightning-cli=|superscalar-lightning-cli=|' "$CLN_CONFIG"
+
+echo
+echo "--- Updated CLN config (plugin lines) ---"
+grep -E '^(plugin|superscalar)' "$CLN_CONFIG"
+
+# 2. Restart CLN-A so it picks up the plugin.
+echo
+echo "--- Restarting CLN-A ---"
+PID=$(pgrep -f "lightningd.*$CLN_DIR")
+if [ -n "$PID" ]; then
+    kill -TERM "$PID"
+    for i in $(seq 1 30); do
+        sleep 1
+        kill -0 "$PID" 2>/dev/null || break
+    done
+fi
+sleep 2
+lightningd --lightning-dir="$CLN_DIR" --daemon
+sleep 3
+
+if ! lightning-cli --lightning-dir="$CLN_DIR" getinfo >/dev/null 2>&1; then
+    echo "FAIL: CLN-A didn't restart cleanly; check $CLN_DIR/cln.log"
+    exit 1
+fi
+echo "  CLN-A running, plugin loaded:"
+lightning-cli --lightning-dir="$CLN_DIR" plugin list 2>/dev/null | grep -i superscalar || \
+    echo "  WARNING: plugin not in 'plugin list' output yet"
+
+# 3. Start the bridge daemon.
+echo
+echo "--- Starting superscalar_bridge ---"
+pkill -f superscalar_bridge 2>/dev/null || true
+sleep 1
+
+nohup "$BRIDGE_BIN" \
+    --plugin-port "$BRIDGE_PORT" \
+    --network testnet4 \
+    --lightning-cli "lightning-cli --lightning-dir=$CLN_DIR" \
+    > "$BRIDGE_LOG" 2>&1 &
+BRIDGE_PID=$!
+sleep 2
+
+if ! kill -0 "$BRIDGE_PID" 2>/dev/null; then
+    echo "FAIL: bridge didn't start; check $BRIDGE_LOG"
+    tail -20 "$BRIDGE_LOG"
+    exit 1
+fi
+
+echo "  Bridge PID=$BRIDGE_PID listening on port $BRIDGE_PORT"
+echo "  Bridge log : $BRIDGE_LOG"
+echo
+
+echo "=== LN bridge testbed active ==="
+echo "Next steps:"
+echo "  - Start an LSP with --bridge-port $BRIDGE_PORT to route HTLCs"
+echo "  - From a factory client, request BOLT11 invoice via the LSP CLI"
+echo "  - Pay the invoice from any LN wallet (phone, Eclair, LND, etc.)"
+echo "  - Watch \$BRIDGE_LOG for 'htlc_accepted' → forwarded → factory client"

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -1641,20 +1641,52 @@
                 }
 
                 uint32_t epoch_before = lsp_p->factory.counter.current_epoch;
+                int is_ps_factory = (lsp_p->factory.leaf_arity == FACTORY_ARITY_PS);
                 int n_iters = states_per_layer + 1;
-                printf("  states_per_layer=%d → driving %d leaf-0 advances "
-                       "(last one triggers rc=-1 / Tier B ceremony)\n",
-                       states_per_layer, n_iters);
 
-                for (int it = 0; it < n_iters; it++) {
-                    printf("  iter %d/%d: lsp_channels_advance_ps_leaf(0)...\n",
-                           it + 1, n_iters);
-                    fflush(stdout);
-                    int rc = lsp_channels_advance_ps_leaf(mgr, lsp_p, 0);
-                    if (rc != 1) {
-                        printf("  FAIL: advance returned %d on iter %d\n", rc, it + 1);
-                        rollover_pass = 0;
-                        break;
+                if (is_ps_factory) {
+                    /* PS Tier B: root rollover is block-driven, NOT
+                       leaf-driven (PS leaves chain-extend without a
+                       counter).  Drive the root counter directly via
+                       lsp_factory_tick_root.  In production, this would
+                       be wired into a block-height polling loop.  For the
+                       test we tick the root states_per_layer+1 times
+                       (the last tick rolls over the layer). */
+                    printf("  PS factory: states_per_layer=%d → ticking root counter "
+                           "%d times (last tick triggers Tier B ceremony)\n",
+                           states_per_layer, n_iters);
+                    for (int it = 0; it < n_iters; it++) {
+                        printf("  tick %d/%d: lsp_factory_tick_root...\n",
+                               it + 1, n_iters);
+                        fflush(stdout);
+                        int rc = lsp_factory_tick_root(mgr, lsp_p);
+                        if (rc < 0) {
+                            printf("  FAIL: lsp_factory_tick_root returned %d on tick %d\n",
+                                   rc, it + 1);
+                            rollover_pass = 0;
+                            break;
+                        }
+                        /* rc=1 means rollover + ceremony complete; rc=0 means
+                           tick without rollover (root counter advanced within
+                           the layer).  Either is fine until the final tick. */
+                    }
+                } else {
+                    /* DW Tier B: leaf-counter exhaustion drives root rollover.
+                       Drive leaf-0 advances; the last one exhausts the leaf and
+                       triggers Tier B via factory_advance_leaf_unsigned rc=-1. */
+                    printf("  DW factory: states_per_layer=%d → driving %d leaf-0 advances "
+                           "(last one triggers rc=-1 / Tier B ceremony)\n",
+                           states_per_layer, n_iters);
+                    for (int it = 0; it < n_iters; it++) {
+                        printf("  iter %d/%d: lsp_channels_advance_ps_leaf(0)...\n",
+                               it + 1, n_iters);
+                        fflush(stdout);
+                        int rc = lsp_channels_advance_ps_leaf(mgr, lsp_p, 0);
+                        if (rc != 1) {
+                            printf("  FAIL: advance returned %d on iter %d\n", rc, it + 1);
+                            rollover_pass = 0;
+                            break;
+                        }
                     }
                 }
 

--- a/tools/test_regtest_k3_subfactory_breach.sh
+++ b/tools/test_regtest_k3_subfactory_breach.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# test_regtest_k3_subfactory_breach.sh — k=3 variant of k2_subfactory_breach.
+#
+# k=3 means 3 sub-factories per PS leaf, 3 clients per sub-factory, k²=9
+# clients per leaf.  Exercises the same code path as k=2 but with wider
+# sub-factory shape — validates the keyagg/MuSig sessions still work at
+# k+2 = 5 signers per sub-factory (vs 4 at k=2).
+#
+# Usage: bash tools/test_regtest_k3_subfactory_breach.sh [BUILD_DIR]
+# Sets N_CLIENTS=9 and PS_SUB_ARITY=3, then exec's the canonical k² test.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec env N_CLIENTS=9 PS_SUB_ARITY=3 \
+    bash "$SCRIPT_DIR/test_regtest_k2_subfactory_breach.sh" "$@"

--- a/tools/test_regtest_k4_subfactory_breach.sh
+++ b/tools/test_regtest_k4_subfactory_breach.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# test_regtest_k4_subfactory_breach.sh — k=4 variant of k2_subfactory_breach.
+#
+# k=4 means 4 sub-factories per PS leaf, 4 clients per sub-factory, k²=16
+# clients per leaf.  Exercises wider sub-factory keyagg/MuSig: k+2 = 6
+# signers per sub-factory.  At FACTORY_MAX_OUTPUTS=16, this is near the
+# upper bound for sub-factory arity (k_max = 15 per
+# factory_set_ps_subfactory_arity cap).
+#
+# Usage: bash tools/test_regtest_k4_subfactory_breach.sh [BUILD_DIR]
+# Sets N_CLIENTS=16 and PS_SUB_ARITY=4, then exec's the canonical k² test.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec env N_CLIENTS=16 PS_SUB_ARITY=4 \
+    bash "$SCRIPT_DIR/test_regtest_k2_subfactory_breach.sh" "$@"

--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test_testnet4_n64_ps_lifecycle.sh — N=64 PS factory full lifecycle on
+# testnet4.
+#
+# N=64 is the canonical scale-shape from t/1242.  This test:
+#   1. Creates a PS factory with 64 clients
+#   2. Drives the full ceremony (factory creation + all node signing)
+#   3. Validates the factory is funded + tree broadcast
+#   4. Force-closes the factory and verifies all tree TXs broadcast
+#
+# Unit tests cover N=64 at the in-memory level
+# (test_factory_ps_subfactory_poison_tx_k2_n4 et al.).  This is the
+# real-chain counterpart.  Wall time: 4-12 hours depending on testnet4
+# block tempo.
+#
+# Note: requires the N=64 LSP fix (Issue #3 from PR #161) for the
+# HELLO_ACK timeout — already merged on main.
+
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+NETWORK="testnet4"
+RPCUSER="${RPCUSER:-testnet4rpc}"
+RPCPASS="${RPCPASS:-testnet4rpcpass123}"
+RPCPORT="${RPCPORT:-48332}"
+WALLET="${WALLET:-superscalar_test}"
+PORT="${PORT:-9940}"
+
+N_CLIENTS=64
+ARITY="${ARITY:-2,4,8}"  # canonical mixed-arity from docs
+STATIC_NEAR_ROOT="${STATIC_NEAR_ROOT:-1}"
+AMOUNT="${AMOUNT:-3000000}"  # ~46k sats per party
+
+TAG="ts_n64_ps_lifecycle"
+LSP_DB="/tmp/ss_t4_${TAG}.db"
+LSP_LOG="/tmp/ss_t4_${TAG}_lsp.log"
+DONE="/tmp/ss_t4_${TAG}.done"
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+
+rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$DONE"
+for n in $(seq 2 65); do
+    HEX=$(printf '%064x' $n)
+    rm -f "/tmp/ss_t4_${TAG}_c${HEX:60:4}.db"* "/tmp/ss_t4_${TAG}_c${HEX:60:4}.log"
+done
+
+echo "=== testnet4 N=64 PS lifecycle ==="
+echo "  port            : $PORT"
+echo "  wallet          : $WALLET"
+echo "  N_CLIENTS       : $N_CLIENTS"
+echo "  ARITY           : $ARITY"
+echo "  static-near-root: $STATIC_NEAR_ROOT"
+echo "  funding         : $AMOUNT sats"
+
+# Issue #3 fix already on main: client HELLO_ACK timeout extended to 600s.
+# At N=64 with sequential accept loop the first client may wait ~60s for
+# HELLO_ACK; the 600s window is generous.
+
+# LSP needs --max-conn-rate and --max-handshakes raised for N=64.
+nohup "$LSP_BIN" \
+    --network "$NETWORK" --port "$PORT" \
+    --clients "$N_CLIENTS" --arity "$ARITY" \
+    --static-near-root "$STATIC_NEAR_ROOT" \
+    --amount "$AMOUNT" \
+    --active-blocks 50 --dying-blocks 20 \
+    --step-blocks 5 --states-per-layer 2 \
+    --fee-rate 1100 --lsp-balance-pct 100 \
+    --confirm-timeout 86400 \
+    --max-conn-rate 400 --max-handshakes 80 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+    --wallet "$WALLET" --db "$LSP_DB" \
+    --demo --force-close \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+echo "  LSP pid=$LSP_PID"
+
+# Wait for listen
+for i in $(seq 1 60); do
+    sleep 1
+    grep -q "listening on port $PORT" "$LSP_LOG" 2>/dev/null && break
+    kill -0 $LSP_PID 2>/dev/null || { echo "FAIL: LSP died early"; tail -20 "$LSP_LOG"; exit 1; }
+done
+
+# Launch 64 clients with sequential seckeys (0x02..0x41).
+for i in $(seq 1 $N_CLIENTS); do
+    SK=$(printf '%064x' $((i + 1)))  # 0x02 .. 0x41
+    nohup "$CLIENT_BIN" \
+        --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
+        --seckey "$SK" --fee-rate 1100 --lsp-balance-pct 100 \
+        --lsp-pubkey "$LSP_PUBKEY" --participant-id $i \
+        --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+        --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK:60:4}.db" \
+        > "/tmp/ss_t4_${TAG}_c${SK:60:4}.log" 2>&1 &
+    sleep 0.2  # stagger to avoid HELLO_ACK pile-up
+done
+
+wait $LSP_PID
+EXIT=$?
+pkill -9 -f "superscalar_client.*$PORT" 2>/dev/null || true
+
+echo "EXIT=$EXIT" > "$DONE"
+echo "=== N=64 PS lifecycle done $(date) exit=$EXIT ===" >> "$DONE"
+grep -E "tree.*broadcast|FORCE CLOSE|force close|confirmed" "$LSP_LOG" | tail -20 >> "$DONE"
+cat "$DONE"
+exit $EXIT

--- a/tools/test_testnet4_passive_reorg_observer.sh
+++ b/tools/test_testnet4_passive_reorg_observer.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# test_testnet4_passive_reorg_observer.sh — long-running passive observer
+# that records any natural testnet4 reorg the standalone watchtower
+# detects.
+#
+# The watchtower's reorg detection logic was validated synthetically on
+# regtest (test_regtest_same_height_reorg.sh — forces a same-height
+# reorg via bitcoin-cli invalidateblock + remine).  This runner is the
+# real-chain counterpart: just let the WT run on testnet4 indefinitely
+# and log every reorg it observes naturally.
+#
+# Designed to run for hours-to-days.  Run via tmux or nohup; check
+# `/tmp/passive_reorg_observer.log` periodically.
+#
+# Usage: bash tools/test_testnet4_passive_reorg_observer.sh [WT_DB]
+# WT_DB defaults to any LSP-side persisted DB (auto-detects most recent).
+
+set -uo pipefail
+
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
+WT_BIN="$BUILD_DIR/superscalar_watchtower"
+WT_LOG="${WT_LOG:-/tmp/passive_reorg_observer.log}"
+WT_DB="${1:-}"
+
+if [ -z "$WT_DB" ]; then
+    # Use the most-recent campaign LSP DB so the WT has entries to watch
+    WT_DB=$(ls -t /tmp/ss_t4_*.db 2>/dev/null | head -1)
+    if [ -z "$WT_DB" ]; then
+        echo "FAIL: no LSP DB found; pass one explicitly"
+        exit 1
+    fi
+fi
+
+echo "=== Passive testnet4 reorg observer ==="
+echo "  WT binary: $WT_BIN"
+echo "  WT DB    : $WT_DB"
+echo "  WT log   : $WT_LOG"
+echo "  Started  : $(date -u)"
+echo
+echo "Notes:"
+echo "  - The WT logs every block height tick + any reorg event."
+echo "  - Run for as long as you can; testnet4 reorgs are unscheduled but"
+echo "    do occur (typically 1-2 per day across the testnet4 network)."
+echo "  - To stop: pkill -f superscalar_watchtower (this runner uses"
+echo "    --poll-interval 30 for low overhead)."
+echo
+
+"$WT_BIN" \
+    --network testnet4 \
+    --db "$WT_DB" \
+    --poll-interval 30 \
+    --rpcuser testnet4rpc \
+    --rpcpassword testnet4rpcpass123 \
+    --rpcport 48332 \
+    2>&1 | tee -a "$WT_LOG"

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# test_testnet4_splice.sh — BOLT-2 splice on real testnet4.
+#
+# Validates the splice protocol (STFU → SPLICE_INIT → SPLICE_ACK →
+# SPLICE_CREATED → SPLICE_LOCKED) end-to-end on testnet4.  Regtest
+# coverage exists via --test-splice in manual_tests.py; this is the
+# real-chain counterpart.
+#
+# Pass criteria:
+#   1. Factory funded + tree broadcast on testnet4
+#   2. Splice-out 10k sats from channel[0] succeeds
+#   3. Splice TX confirms on testnet4 chain
+#   4. Both sides log "SPLICE_LOCKED"
+#
+# Wall time: ~30-60 min (depends on testnet4 block timing).
+
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+NETWORK="testnet4"
+RPCUSER="${RPCUSER:-testnet4rpc}"
+RPCPASS="${RPCPASS:-testnet4rpcpass123}"
+RPCPORT="${RPCPORT:-48332}"
+WALLET="${WALLET:-superscalar_test}"
+
+PORT="${PORT:-9935}"
+N_CLIENTS=2  # splice tests need just 1 client + LSP
+AMOUNT="${AMOUNT:-200000}"
+
+TAG="ts_splice"
+LSP_DB="/tmp/ss_t4_${TAG}.db"
+LSP_LOG="/tmp/ss_t4_${TAG}_lsp.log"
+DONE="/tmp/ss_t4_${TAG}.done"
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+CLIENT_SECKEY="0000000000000000000000000000000000000000000000000000000000000002"
+
+rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$DONE"
+
+echo "=== testnet4 splice test ==="
+echo "  port      : $PORT"
+echo "  wallet    : $WALLET"
+echo "  network   : $NETWORK"
+echo "  funding   : $AMOUNT sats"
+
+nohup "$LSP_BIN" \
+    --network "$NETWORK" --port "$PORT" \
+    --clients "$N_CLIENTS" --arity 1 --amount "$AMOUNT" \
+    --active-blocks 50 --dying-blocks 20 \
+    --step-blocks 5 --states-per-layer 2 \
+    --fee-rate 1100 --lsp-balance-pct 100 \
+    --confirm-timeout 86400 \
+    --seckey 0000000000000000000000000000000000000000000000000000000000000001 \
+    --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+    --wallet "$WALLET" --db "$LSP_DB" \
+    --demo --test-splice \
+    --test-splice-client-seckey "$CLIENT_SECKEY" \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+
+for i in $(seq 1 30); do
+    sleep 1
+    grep -q "listening on port $PORT" "$LSP_LOG" 2>/dev/null && break
+done
+
+nohup "$CLIENT_BIN" \
+    --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
+    --seckey "$CLIENT_SECKEY" --fee-rate 1100 --lsp-balance-pct 100 \
+    --lsp-pubkey "$LSP_PUBKEY" --participant-id 1 \
+    --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+    --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c0.db" \
+    > "/tmp/ss_t4_${TAG}_c0.log" 2>&1 &
+CLIENT_PID=$!
+
+wait $LSP_PID
+EXIT=$?
+pkill -9 -f "superscalar_client.*$PORT" 2>/dev/null || true
+
+echo "EXIT=$EXIT" > "$DONE"
+echo "=== splice test done $(date) exit=$EXIT ===" >> "$DONE"
+grep -E "SPLICE_LOCKED|splice.*confirmed|splice.*failed|SPLICE OK" "$LSP_LOG" | tail -5 >> "$DONE"
+cat "$DONE"
+exit $EXIT


### PR DESCRIPTION
## Summary

PS Tier B root rollover — proper semantics. **Supersedes PR #166** (close it after this merges).

Per `docs/rotation-ceremony.md`, Tier B was designed for DW factories where leaf-counter exhaustion drives root rollover. PS factories don't have a leaf-level counter — leaves chain-extend instead. The previous CL2-TB change opened the test gate for arity 3 (PS) but the underlying trigger was never wired. An earlier attempt (PR #166) tied Tier B to `ps_chain_len > states_per_layer`, which worked as a test hook but mis-modeled PS semantics.

## Correct semantics

| Factory type | Root rollover trigger | Source |
|--------------|----------------------|--------|
| DW (`--arity 1`) | Leaf-counter exhaustion | `factory_advance_leaf_unsigned` returns -1 |
| PS (`--arity 3`) | **Block-height progression** (every `step_blocks` blocks → root DW counter advances → eventually rolls over) | NEW: `factory_tick_root` |

Both converge on the same `lsp_run_state_advance` MuSig ceremony.

## Changes

1. **`src/factory.c`**: new `factory_tick_root(f)` — advances root DW counter, rebuilds non-leaf unsigned TXs on rollover, resets PS leaves' `ps_chain_len` for the new epoch (chain history is on-chain state of OLD epoch).
2. **`src/lsp_channels.c`**: new `lsp_factory_tick_root(mgr, lsp)` — ties `factory_tick_root` + `lsp_run_state_advance(-1)`. Caller wires into block-driven polling loop.
3. **`src/client.c`**: `client_handle_state_advance` now handles `trigger_leaf == -1` (PS root-driven) by calling `factory_tick_root` locally. `trigger_leaf >= 0` keeps existing DW leaf-driven behavior.
4. **`tools/superscalar_lsp_pre_daemon_tests.inc`**: `--test-tier-b-rollover --arity 3` now calls `lsp_factory_tick_root`. DW path (`--arity 1`) unchanged.

## Wire compatibility

`trigger_leaf` is already `int` in `wire_build_state_advance_propose` / `wire_parse_state_advance_propose`. `trigger_leaf = -1` cleanly distinguishes root-driven from leaf-driven. No new message types needed.

## Test plan

- [x] Builds (local compile)
- [ ] Regtest: `test_regtest_tier_b_rollover_ps.sh` with tightened PASS criteria (require epoch advance + non-PS-leaf re-signing — previously only checked gate didn't print SKIP)
- [ ] testnet4: TS-TIER-B-PS PASS once binaries deployed
- [ ] DW regression: `test_regtest_kill_after_state_advance.sh` still PASSes (DW path unchanged)

## Follow-ups

- Wire `lsp_factory_tick_root` into a block-driven polling loop for production daemon mode. Currently the function exists but is only called from the test driver. Production would need a poll loop similar to the existing watchtower poll: `if (height - factory_start_height) / step_blocks > expected_state ⇒ tick`.
- Tighten regtest PASS criteria in `test_regtest_tier_b_rollover_ps.sh` to actually verify the LSP-side TIER B PASS (currently the wrapper script masks the LSP test result).