### PR TITLE
PS Tier B: client must loop factory_tick_root until rollover

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -3386,11 +3386,25 @@ int client_handle_state_advance(int fd, secp256k1_context *ctx,
           1 step behind LSP). */
     int rc = 0;
     if (trigger_leaf < 0) {
-        /* Root-driven (PS Tier B): tick root counter directly. */
-        rc = factory_tick_root(factory);
+        /* Root-driven (PS Tier B): tick root counter in a loop until
+           rollover.  Mirrors the DW leaf-driven loop below — the client
+           may be N ticks behind the LSP (the LSP's rc=-1 ceremony fires
+           on its tick, but it doesn't send a per-tick PROPOSE before
+           rollover, so the client must catch up locally). */
+        int max_steps = (int)(factory->states_per_layer + 2);
+        if (max_steps < 4) max_steps = 4;
+        for (int s = 0; s < max_steps; s++) {
+            rc = factory_tick_root(factory);
+            if (rc == -1) break;
+            if (rc != 0) {
+                fprintf(stderr, "Client %u: state_advance: root tick step %d "
+                        "returned unexpected %d\n", my_index, s, rc);
+                return 0;
+            }
+        }
         if (rc != -1) {
-            fprintf(stderr, "Client %u: state_advance: root tick returned %d "
-                    "(expected -1 for rollover)\n", my_index, rc);
+            fprintf(stderr, "Client %u: state_advance: root tick never rolled "
+                    "over within %d steps\n", my_index, max_steps);
             return 0;
         }
     } else {

--- a/src/client.c
+++ b/src/client.c
@@ -3343,6 +3343,8 @@ int client_handle_state_advance(int fd, secp256k1_context *ctx,
         fprintf(stderr, "Client %u: failed to parse STATE_ADVANCE_PROPOSE\n", my_index);
         return 0;
     }
+    fprintf(stderr, "Client %u: DEBUG state_advance trigger_leaf=%d epoch=%u n_lsp_nonces=%zu\n",
+            my_index, trigger_leaf, epoch_in, n_lsp_nonces);
 
     /* PR-D phase 4: snapshot per-leaf OLD state BEFORE the advance
        overwrites it, so we can drive the parallel poison MuSig

--- a/src/client.c
+++ b/src/client.c
@@ -3343,8 +3343,6 @@ int client_handle_state_advance(int fd, secp256k1_context *ctx,
         fprintf(stderr, "Client %u: failed to parse STATE_ADVANCE_PROPOSE\n", my_index);
         return 0;
     }
-    fprintf(stderr, "Client %u: DEBUG state_advance trigger_leaf=%d epoch=%u n_lsp_nonces=%zu\n",
-            my_index, trigger_leaf, epoch_in, n_lsp_nonces);
 
     /* PR-D phase 4: snapshot per-leaf OLD state BEFORE the advance
        overwrites it, so we can drive the parallel poison MuSig


### PR DESCRIPTION
## Summary

Follow-up to PR #168 — validated end-to-end fix for PS Tier B ceremony.

PR #168 wired the block-driven trigger correctly, but the ceremony itself still failed (`expected PATH_NONCE_BUNDLE, got 0x00`) because the client-side handler called `factory_tick_root` only ONCE. The LSP rolls over on its own tick (state wraps to 0 → epoch++), but the client may be N-1 ticks behind: the LSP doesn't send a per-tick PROPOSE before rollover.

So the client's single tick advanced state 0→1 (no rollover), returned 0, and the handler returned early without sending `PATH_NONCE_BUNDLE`.

## Fix

Mirror the DW leaf-driven loop: tick `factory_tick_root` up to `states_per_layer+2` times, break on rc=-1, fail if never reached rollover.

## Validation (regtest)

```
=== TIER B STATE-ADVANCE ROLLOVER TEST ===
  PS factory: states_per_layer=2 → ticking root counter 3 times
  tick 1/3: lsp_factory_tick_root...
LSP: root counter rolled over to epoch 2 — running Tier B ceremony
Client 1: state advance complete, epoch 2 (5 nodes signed)
LSP: state advance complete — epoch 2, 10 nodes re-signed (trigger leaf -1)
  epoch advanced 1 → 2 (rc=-1 / Tier B ceremony fired)
  all 10 non-PS-leaf nodes signed after Tier B
TIER B ROLLOVER TEST: PASS

LSP: cooperative close confirmed! txid: c462b9c3fd4199de861e80169d590ad608a7fcd6c0cad4249e49ad08ecfbecbe
LSP: SUCCESS — factory created and closed with 4 clients
```

Full lifecycle: PS factory creation → 3 root ticks (last one rolls over) → Tier B ceremony with all 10 non-PS-leaf nodes re-signed → cooperative close confirmed on regtest.

## Test plan

- [x] Regtest `test_regtest_tier_b_rollover_ps.sh` — **PASS validated on regtest 2026-05-14 21:04 UTC**
- [ ] testnet4 TS-TIER-B-PS re-run with new binaries