### PR TITLE
dashboard: F3b — render DW state widget against real-mode dw_counter_state

### DIFF
--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -1197,7 +1197,49 @@ function rFactory(D){
    h+=`<div class="kv" style="margin-top:4px"><div class="ki"><span class="k">Node ${entries[0].node_index}</span><span class="v">nonces ${nn}/${tot}</span></div><div class="ki"><span class="k">sigs</span><span class="v">${ns}/${tot}</span></div><div style="flex:1">${prog(ns/tot*100,ns===tot?'pg':'po')}</div></div>`;}
   h+=`</div>`;}
  // Protocol + DW
- const proto=D.factory_protocol,dw=D.dw_state;
+ // F3b: in real mode, build a dw_state-shaped object from the live
+ // lsp.dw_counter_state + factory row + bitcoin tip so the existing
+ // DW state widget (which was originally written for demo mode) can
+ // render against real factory data.  Demo mode populates D.dw_state
+ // directly; real mode populates lsp.dw_counter_state via the
+ // collect_databases query.  Fall back to demo shape when present
+ // (so demo mode keeps rendering unchanged).
+ const proto=D.factory_protocol;
+ let dw=D.dw_state;
+ if(!dw){
+  const dwc=(lsp.dw_counter_state||[])[0];
+  const fac0=(lsp.factories||[])[0];
+  const lf0=(lsp.ladder_factories||[]).find(r=>r.factory_id===(fac0&&fac0.id))||{};
+  if(dwc&&fac0){
+   const spl=fac0.states_per_layer||0;
+   const nl=dwc.n_layers||0;
+   const layerStates=(dwc.layer_states||'').split(',').map(s=>parseInt(s,10)||0);
+   const layers=[];
+   for(let i=0;i<nl;i++){
+    layers.push({
+     index:i,
+     current_state:layerStates[i]||0,
+     max_states:spl,
+     // step_blocks per layer = base × states_per_layer^layer_index
+     step_blocks:(fac0.step_blocks||0)*Math.pow(spl||1,i),
+    });
+   }
+   const cb=lf0.created_block||0;
+   const ab=lf0.active_blocks||0;
+   const db_=cb+ab;
+   dw={
+    n_layers:nl,
+    states_per_layer:spl,
+    total_epochs:Math.pow(spl||1,nl),
+    current_epoch:dwc.current_epoch||0,
+    layers:layers,
+    created_block:cb,
+    cltv_timeout:fac0.cltv_timeout||db_,
+    dying_block:db_,
+    current_block:(D.bitcoin&&D.bitcoin.blocks)||cb,
+   };
+  }
+ }
  if(proto||dw){h+=`<div class="g2">`;
   if(proto){h+=`<div class="s"><div class="st">Creation Protocol (4 rounds)</div><div class="pr">`;
    for(let i=0;i<proto.phases.length;i++){if(i)h+=`<span class="pa">\u25B6</span>`;


### PR DESCRIPTION
## Summary

The Factory tab's "Decker-Wattenhofer State" widget — colored state-grid boxes per layer, current state highlighted — was originally written against the demo-shaped `D.dw_state` object that only `collect_demo()` populates. Real mode queries `lsp.dw_counter_state` from SQL (raw rows: `factory_id`, `current_epoch`, `n_layers`, `layer_states` CSV) but the widget never consumed it, so the visual panel was demo-only.

Real mode wasn't completely silent — the Overview tab already renders the data as a text chip (`epoch=X layers=Y states=[…]`) — but the rich Factory-tab visual fell back to "no DW state" when `D.dw_state` was absent.

This PR adds a small JS adapter inside `rFactory()`: when `D.dw_state` is missing, build an equivalent object from real-mode sources:
- `n_layers`, `current_epoch`, `layer_states` from `lsp.dw_counter_state[0]`
- `states_per_layer`, `step_blocks`, `cltv_timeout` from `lsp.factories[0]`
- `created_block`, `active_blocks` from `lsp.ladder_factories[0]`
- `current_block` from `D.bitcoin.blocks` (falls back to `created_block` if bitcoin RPC unavailable, so the widget still renders gracefully)

Per-layer `step_blocks` derived as `base × states_per_layer^layer_idx` (DW odometer semantics — each layer ticks slower than the one below). Each layer's `current_state` parsed from the `layer_states` CSV.

Existing demo-shape rendering unchanged when `D.dw_state` is present.

## Test plan

- [x] Python syntax check (`py_compile`)
- [x] Adapter inputs verified present in real-mode JSON against current regtest k=2 wide-leaves stack:
      `dw_counter_state.current_epoch=1, n_layers=1, layer_states="1"`
      `factories[0].states_per_layer=4, step_blocks=10, cltv_timeout=1058`
      `ladder_factories[0].created_block=1023, active_blocks=20`
- [ ] Browser refresh — visual widget appears on Factory tab in real mode

## Out of scope

This PR addresses **F3b** from the post-#168 follow-up audit (Factory-tab visual panel only). Two related items are owned by the protocol team in separate work:
- **F1** — post-Tier-B PS leaf re-sign + chain[0] persist (correctness bug; new MuSig2 ceremony needed because Tier B explicitly skips PS leaves at `lsp_channels.c:~1992`)
- **F2** — epoch-aware `ps_leaf_chains` schema (cosmetic dashboard inflation post-rollover; depends on F1)
