### PR TITLE
feat(persist): watchtower penalty TX persist (Phase A) + C3 signing_rounds journal (Phase B)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 24
+#define PERSIST_SCHEMA_VERSION 26
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -339,6 +339,105 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       unsigned char (*spks)[34],
                                       size_t *spk_lens,
                                       size_t max_entries);
+
+/* --- Pre-signed penalty TX persistence (v25) ---
+
+   Closes a critical restart-time defense gap: watchtower_watch_revoked_commitment
+   (and its variants) pre-builds the penalty TX bytes at registration time and
+   stashes them in watchtower_entry_t.signed_penalty_tx (heap).  The restart
+   loader at watchtower.c:60-115 re-creates the entries from old_commitments
+   but never reloads signed_penalty_tx.  At broadcast time, the oracular
+   fast-path skips the entry with "no signed_penalty_tx — skipping" and the
+   channel goes undefended.
+
+   These two functions persist the pre-built bytes to a new column on
+   old_commitments and reload them at restart.  Same key as the parent row:
+   (factory_id implicitly via channel_id, commit_num).  Empty/missing bytes
+   degrade gracefully to the legacy lazy-build path (which requires channel_t
+   present — not available on the oracular path). */
+
+/* Persist the pre-built signed penalty TX bytes for a given (channel, commit_num).
+   Idempotent (UPDATE).  Returns 1 on success, 0 on DB error.  Safe to call
+   with NULL/zero bytes — treated as a no-op. */
+int persist_save_old_commitment_witness(persist_t *p, uint32_t channel_id,
+                                          uint64_t commit_num,
+                                          const unsigned char *signed_penalty_tx,
+                                          size_t signed_penalty_tx_len);
+
+/* Load the pre-built signed penalty TX bytes for a given (channel, commit_num).
+   *out_bytes is malloc()'d on success — caller must free().
+   Returns 1 if bytes were loaded (out_bytes / out_len populated),
+   0 if the row exists but the column is empty (degrade to legacy path),
+  -1 on DB error or missing row. */
+int persist_load_old_commitment_witness(persist_t *p, uint32_t channel_id,
+                                          uint64_t commit_num,
+                                          unsigned char **out_bytes,
+                                          size_t *out_len);
+
+/* --- v26: signing_rounds journal (C3, ceremony forensics) ---
+
+   Each MuSig2/Tier-B ceremony writes a row at start and updates at end.
+   Tier 2 (per-signer participation) is a future extension; this version
+   is parent-only (Tier 1) to keep the initial PR scope tight.
+
+   See C3_LSP_SCHEMA_HANDOFF.md for the full design.  Tables:
+
+     signing_rounds(id PK, factory_id, node_idx, ceremony_type, epoch,
+                    started_at, completed_at, n_participants,
+                    nonces_collected, partial_sigs_collected,
+                    result, result_txid, error_detail)
+
+     signing_round_participants(round_id, signer_slot, pubnonce_received_at,
+                                partial_sig_received_at, partial_sig_status)
+
+   ceremony_type values: 'factory_creation' | 'leaf_advance' |
+                         'sub_factory_advance' | 'leaf_realloc' |
+                         'tier_b_rollover'
+   result values:        'success' | 'timeout' | 'abort' | 'aborted_crash' | 'error'
+
+   All writes are guarded by if (mgr->persist) { ... }: a DB write failure
+   does NOT abort the ceremony itself.  persist_sweep_incomplete_signing_rounds
+   is called once at LSP startup to mark in-flight rows from a crashed
+   previous run as 'aborted_crash'. */
+
+/* Start a ceremony row.  Returns 1 on success and writes the row id into
+   *out_row_id (use as the round_id parameter to participant/done calls).
+   0 on DB error — caller should NOT abort the ceremony. */
+int persist_save_signing_round_start(persist_t *p,
+                                       uint32_t factory_id,
+                                       uint32_t node_idx,
+                                       const char *ceremony_type,
+                                       uint32_t epoch,
+                                       uint32_t n_participants,
+                                       int64_t *out_row_id);
+
+/* Optional Tier 2: log per-signer pubnonce receipt timestamp.  Idempotent
+   (UPDATE).  No-op if round_id <= 0 or persist is NULL.  Returns 1 on success. */
+int persist_save_signing_round_participant_nonce(persist_t *p,
+                                                   int64_t round_id,
+                                                   uint32_t signer_slot);
+
+/* Optional Tier 2: log per-signer partial-sig receipt + verification status.
+   Status values: 'received' | 'verified' | 'invalid'.  Idempotent. */
+int persist_save_signing_round_participant_psig(persist_t *p,
+                                                  int64_t round_id,
+                                                  uint32_t signer_slot,
+                                                  const char *status);
+
+/* Finalize a ceremony row.  result must be one of the documented values.
+   result_txid may be NULL.  error_detail may be NULL for success. */
+int persist_save_signing_round_done(persist_t *p,
+                                      int64_t round_id,
+                                      uint32_t nonces_collected,
+                                      uint32_t partial_sigs_collected,
+                                      const char *result,
+                                      const char *result_txid,
+                                      const char *error_detail);
+
+/* Crash-recovery sweep: mark any row with completed_at IS NULL as
+   'aborted_crash'.  Called once at LSP startup right after persist_open.
+   Returns number of rows swept (>= 0); 0 is normal on a clean restart. */
+int persist_sweep_incomplete_signing_rounds(persist_t *p);
 
 /* --- Old commitment HTLC outputs (watchtower) --- */
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1947,6 +1947,25 @@ int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     factory_t *f = &lsp->factory;
     if (!mgr || !lsp) return 0;
 
+    /* C3 (Tier 1): journal the ceremony.  We log a start row now and update
+       at the success exit below.  Error returns leave the row in flight;
+       persist_sweep_incomplete_signing_rounds at next LSP startup will mark
+       them aborted_crash — operator forensics see the ceremony attempted +
+       didn't finish.  row_id<=0 disables the journal calls (DB unavailable). */
+    int64_t c3_round_id = -1;
+    if (mgr->persist) {
+        const char *ctype = (trigger_leaf_side == -1)
+                            ? "tier_b_rollover"
+                            : "tier_b_rollover";  /* same — leaf-driven Tier B */
+        persist_save_signing_round_start((persist_t *)mgr->persist,
+                                           /* factory_id = */ 0,
+                                           /* node_idx = */ 0,
+                                           ctype,
+                                           f->counter.current_epoch,
+                                           (uint32_t)f->n_participants,
+                                           &c3_round_id);
+    }
+
     /* Capture pre-advance leaf-node state for watchtower overlap window:
        the OLD signed_tx + OLD txid + OLD L-stock vout/amount become the
        parameters used to register a NEW poison/burn TX after the
@@ -2630,6 +2649,17 @@ int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         printf("CL5: SS_KILL_AFTER_STATE_ADVANCE set — clean exit after ceremony\n");
         fflush(stdout);
         exit(0);
+    }
+
+    /* C3 (Tier 1): journal success.  Error returns above leave the row in
+       flight; sweep at next startup marks them aborted_crash. */
+    if (mgr->persist && c3_round_id > 0) {
+        persist_save_signing_round_done((persist_t *)mgr->persist, c3_round_id,
+                                          (uint32_t)n_affected,
+                                          (uint32_t)n_affected,
+                                          "success",
+                                          NULL,
+                                          NULL);
     }
 
     return 1;

--- a/src/persist.c
+++ b/src/persist.c
@@ -88,6 +88,10 @@ static const char *SCHEMA_SQL =
     "  to_local_vout INTEGER NOT NULL,"
     "  to_local_amount INTEGER NOT NULL,"
     "  to_local_spk TEXT NOT NULL,"
+    /* v25: pre-built penalty TX bytes (hex).  Persisted at registration
+       time so the watchtower can broadcast after a process restart.
+       Default '' (empty) preserves legacy lazy-build fallback. */
+    "  signed_penalty_tx_hex TEXT NOT NULL DEFAULT '',"
     "  PRIMARY KEY (channel_id, commit_num)"
     ");"
     "CREATE TABLE IF NOT EXISTS old_commitment_htlcs ("
@@ -921,6 +925,64 @@ int persist_open(persist_t *p, const char *path) {
             NULL, NULL, NULL);
         sqlite3_exec(p->db,
             "ALTER TABLE ps_subfactory_chains ADD COLUMN epoch INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+    }
+
+    /* v25: persist pre-built penalty TX bytes on old_commitments.
+
+       Before this column, watchtower_watch_revoked_commitment built the
+       penalty TX in memory at registration time but never persisted the
+       bytes.  On LSP restart, the entry was re-created from old_commitments
+       with signed_penalty_tx = NULL, and the oracular fast-path skipped
+       broadcast ("entry %u has no signed_penalty_tx — skipping").
+       Channel went undefended.
+
+       Additive ALTER TABLE ADD COLUMN with empty-string default — existing
+       rows degrade to the legacy lazy-build path (which requires channel_t
+       to be present; works for in-memory entries but fails on oracular).
+       Code-side defense: watchtower restart loader now also queries this
+       column and reassigns e->signed_penalty_tx. */
+    if (db_version < 25) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE old_commitments ADD COLUMN signed_penalty_tx_hex TEXT NOT NULL DEFAULT '';",
+            NULL, NULL, NULL);
+    }
+
+    /* v26 (C3): signing_rounds journal — record each MuSig2/Tier-B ceremony's
+       start, per-signer participation, and final outcome.  Supports operator
+       forensics ("which client timed out?") and crash recovery ("was a
+       ceremony in flight when we restarted?"). */
+    if (db_version < 26) {
+        sqlite3_exec(p->db,
+            "CREATE TABLE IF NOT EXISTS signing_rounds ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  factory_id INTEGER NOT NULL,"
+            "  node_idx INTEGER NOT NULL,"
+            "  ceremony_type TEXT NOT NULL,"
+            "  epoch INTEGER NOT NULL DEFAULT 0,"
+            "  started_at INTEGER NOT NULL,"
+            "  completed_at INTEGER,"
+            "  n_participants INTEGER NOT NULL,"
+            "  nonces_collected INTEGER NOT NULL DEFAULT 0,"
+            "  partial_sigs_collected INTEGER NOT NULL DEFAULT 0,"
+            "  result TEXT,"
+            "  result_txid TEXT,"
+            "  error_detail TEXT"
+            ");",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "CREATE INDEX IF NOT EXISTS idx_signing_rounds_factory_started "
+            "ON signing_rounds(factory_id, started_at DESC);",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "CREATE TABLE IF NOT EXISTS signing_round_participants ("
+            "  round_id INTEGER NOT NULL REFERENCES signing_rounds(id) ON DELETE CASCADE,"
+            "  signer_slot INTEGER NOT NULL,"
+            "  pubnonce_received_at INTEGER,"
+            "  partial_sig_received_at INTEGER,"
+            "  partial_sig_status TEXT,"
+            "  PRIMARY KEY (round_id, signer_slot)"
+            ");",
             NULL, NULL, NULL);
     }
 
@@ -2547,6 +2609,214 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
 
     sqlite3_finalize(stmt);
     return count;
+}
+
+/* --- v25: pre-built penalty TX bytes (closes restart-loses-defense gap) --- */
+
+int persist_save_old_commitment_witness(persist_t *p, uint32_t channel_id,
+                                          uint64_t commit_num,
+                                          const unsigned char *signed_penalty_tx,
+                                          size_t signed_penalty_tx_len) {
+    if (!p || !p->db) return 0;
+    if (!signed_penalty_tx || signed_penalty_tx_len == 0) return 1;  /* no-op */
+
+    char *hex = malloc(signed_penalty_tx_len * 2 + 1);
+    if (!hex) return 0;
+    hex_encode(signed_penalty_tx, signed_penalty_tx_len, hex);
+
+    const char *sql =
+        "UPDATE old_commitments SET signed_penalty_tx_hex = ? "
+        "WHERE channel_id = ? AND commit_num = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        free(hex);
+        return 0;
+    }
+    sqlite3_bind_text(stmt, 1, hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, (int)channel_id);
+    sqlite3_bind_int64(stmt, 3, (sqlite3_int64)commit_num);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    free(hex);
+    return ok;
+}
+
+int persist_load_old_commitment_witness(persist_t *p, uint32_t channel_id,
+                                          uint64_t commit_num,
+                                          unsigned char **out_bytes,
+                                          size_t *out_len) {
+    if (!p || !p->db || !out_bytes || !out_len) return -1;
+    *out_bytes = NULL;
+    *out_len = 0;
+
+    const char *sql =
+        "SELECT signed_penalty_tx_hex FROM old_commitments "
+        "WHERE channel_id = ? AND commit_num = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return -1;
+    sqlite3_bind_int(stmt, 1, (int)channel_id);
+    sqlite3_bind_int64(stmt, 2, (sqlite3_int64)commit_num);
+
+    int result = -1;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *hex = (const char *)sqlite3_column_text(stmt, 0);
+        if (!hex || hex[0] == '\0') {
+            result = 0;  /* row exists, column empty — legacy/lazy fallback */
+        } else {
+            size_t hex_len = strlen(hex);
+            size_t byte_len = hex_len / 2;
+            unsigned char *bytes = malloc(byte_len);
+            if (!bytes) {
+                result = -1;
+            } else {
+                int decoded = hex_decode(hex, bytes, byte_len);
+                if (decoded > 0) {
+                    *out_bytes = bytes;
+                    *out_len = (size_t)decoded;
+                    result = 1;
+                } else {
+                    free(bytes);
+                    result = -1;
+                }
+            }
+        }
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+/* --- v26 (C3): signing_rounds journal --- */
+
+int persist_save_signing_round_start(persist_t *p,
+                                       uint32_t factory_id,
+                                       uint32_t node_idx,
+                                       const char *ceremony_type,
+                                       uint32_t epoch,
+                                       uint32_t n_participants,
+                                       int64_t *out_row_id) {
+    if (!p || !p->db || !ceremony_type || !out_row_id) return 0;
+    *out_row_id = -1;
+
+    const char *sql =
+        "INSERT INTO signing_rounds "
+        "(factory_id, node_idx, ceremony_type, epoch, started_at, n_participants) "
+        "VALUES (?, ?, ?, ?, strftime('%s','now'), ?);";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_int(stmt, 2, (int)node_idx);
+    sqlite3_bind_text(stmt, 3, ceremony_type, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 4, (int)epoch);
+    sqlite3_bind_int(stmt, 5, (int)n_participants);
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    if (ok)
+        *out_row_id = sqlite3_last_insert_rowid(p->db);
+    return ok ? 1 : 0;
+}
+
+int persist_save_signing_round_participant_nonce(persist_t *p,
+                                                   int64_t round_id,
+                                                   uint32_t signer_slot) {
+    if (!p || !p->db || round_id <= 0) return 0;
+    /* UPSERT: insert if missing, update timestamp if present */
+    const char *sql =
+        "INSERT INTO signing_round_participants "
+        "(round_id, signer_slot, pubnonce_received_at) "
+        "VALUES (?, ?, strftime('%s','now')) "
+        "ON CONFLICT(round_id, signer_slot) "
+        "DO UPDATE SET pubnonce_received_at = strftime('%s','now');";
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    sqlite3_bind_int64(stmt, 1, round_id);
+    sqlite3_bind_int(stmt, 2, (int)signer_slot);
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return ok ? 1 : 0;
+}
+
+int persist_save_signing_round_participant_psig(persist_t *p,
+                                                  int64_t round_id,
+                                                  uint32_t signer_slot,
+                                                  const char *status) {
+    if (!p || !p->db || round_id <= 0 || !status) return 0;
+    const char *sql =
+        "INSERT INTO signing_round_participants "
+        "(round_id, signer_slot, partial_sig_received_at, partial_sig_status) "
+        "VALUES (?, ?, strftime('%s','now'), ?) "
+        "ON CONFLICT(round_id, signer_slot) "
+        "DO UPDATE SET partial_sig_received_at = strftime('%s','now'), "
+        "              partial_sig_status = excluded.partial_sig_status;";
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    sqlite3_bind_int64(stmt, 1, round_id);
+    sqlite3_bind_int(stmt, 2, (int)signer_slot);
+    sqlite3_bind_text(stmt, 3, status, -1, SQLITE_TRANSIENT);
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return ok ? 1 : 0;
+}
+
+int persist_save_signing_round_done(persist_t *p,
+                                      int64_t round_id,
+                                      uint32_t nonces_collected,
+                                      uint32_t partial_sigs_collected,
+                                      const char *result,
+                                      const char *result_txid,
+                                      const char *error_detail) {
+    if (!p || !p->db || round_id <= 0 || !result) return 0;
+    const char *sql =
+        "UPDATE signing_rounds SET "
+        "  completed_at = strftime('%s','now'), "
+        "  nonces_collected = ?, "
+        "  partial_sigs_collected = ?, "
+        "  result = ?, "
+        "  result_txid = ?, "
+        "  error_detail = ? "
+        "WHERE id = ?;";
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    sqlite3_bind_int(stmt, 1, (int)nonces_collected);
+    sqlite3_bind_int(stmt, 2, (int)partial_sigs_collected);
+    sqlite3_bind_text(stmt, 3, result, -1, SQLITE_TRANSIENT);
+    if (result_txid)
+        sqlite3_bind_text(stmt, 4, result_txid, -1, SQLITE_TRANSIENT);
+    else
+        sqlite3_bind_null(stmt, 4);
+    if (error_detail)
+        sqlite3_bind_text(stmt, 5, error_detail, -1, SQLITE_TRANSIENT);
+    else
+        sqlite3_bind_null(stmt, 5);
+    sqlite3_bind_int64(stmt, 6, round_id);
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return ok ? 1 : 0;
+}
+
+int persist_sweep_incomplete_signing_rounds(persist_t *p) {
+    if (!p || !p->db) return 0;
+    const char *sql =
+        "UPDATE signing_rounds SET "
+        "  completed_at = strftime('%s','now'), "
+        "  result = 'aborted_crash', "
+        "  error_detail = 'LSP restarted while ceremony in flight' "
+        "WHERE completed_at IS NULL;";
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    int changes = sqlite3_changes(p->db);
+    sqlite3_finalize(stmt);
+    return ok ? changes : 0;
 }
 
 /* --- Old commitment HTLC outputs (watchtower) --- */

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -93,6 +93,25 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
                 e->n_htlc_outputs = 0;
                 e->response_tx = NULL;
                 e->response_tx_len = 0;
+                e->signed_penalty_tx = NULL;
+                e->signed_penalty_tx_len = 0;
+
+                /* v25 restart-defense load: pull the pre-built penalty TX
+                   bytes if they were persisted.  Without this, the oracular
+                   fast-path skips broadcast post-restart and the channel goes
+                   undefended.  rc=0 (row exists, column empty) is the legacy
+                   fallback path — leaves signed_penalty_tx NULL and channel_t
+                   re-attaches later via watchtower_set_channel. */
+                if (db && db->db) {
+                    unsigned char *bytes = NULL;
+                    size_t blen = 0;
+                    if (persist_load_old_commitment_witness(db, (uint32_t)c,
+                            commit_nums[i], &bytes, &blen) == 1
+                        && bytes && blen > 0) {
+                        e->signed_penalty_tx = bytes;
+                        e->signed_penalty_tx_len = blen;
+                    }
+                }
 
                 /* Load persisted HTLC output data for this commitment */
                 if (db && db->db) {
@@ -218,6 +237,14 @@ int watchtower_watch_oracular(watchtower_t *wt, uint32_t channel_id,
         free(e->signed_penalty_tx);
         e->signed_penalty_tx = copy;
         e->signed_penalty_tx_len = signed_penalty_tx_len;
+        /* v25: persist the pre-built bytes so they survive LSP restart.
+           Without this, the restart loader can't reattach the bytes, the
+           oracular fast-path skips broadcast, and the channel goes
+           undefended. */
+        if (wt->db && wt->db->db)
+            persist_save_old_commitment_witness(wt->db, channel_id, commit_num,
+                                                  signed_penalty_tx,
+                                                  signed_penalty_tx_len);
     }
     return 1;
 }
@@ -341,6 +368,13 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
                             free(just_added->signed_penalty_tx);
                             just_added->signed_penalty_tx = copy;
                             just_added->signed_penalty_tx_len = penalty.len;
+                            /* v25: persist so LSP restart can reattach.  Without
+                               this, oracular fast-path post-restart sees NULL
+                               and skips broadcast. */
+                            if (wt->db && wt->db->db)
+                                persist_save_old_commitment_witness(
+                                    wt->db, channel_id, old_commit_num,
+                                    penalty.data, penalty.len);
                         }
                     }
                     tx_buf_free(&penalty);
@@ -455,6 +489,12 @@ void watchtower_watch_revoked_commitment_oracular(watchtower_t *wt, channel_t *c
     free(e->signed_penalty_tx);
     e->signed_penalty_tx = copy;
     e->signed_penalty_tx_len = signed_penalty_tx_len;
+    /* v25: persist so LSP restart can reattach.  See companion calls in
+       watchtower_watch_oracular and watchtower_watch_revoked_commitment. */
+    if (wt->db && wt->db->db)
+        persist_save_old_commitment_witness(wt->db, channel_id, old_commit_num,
+                                              signed_penalty_tx,
+                                              signed_penalty_tx_len);
 }
 
 void watchtower_set_chain_backend(watchtower_t *wt, chain_backend_t *backend)

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -247,13 +247,15 @@ int test_offer_decode_bad_checksum(void)
  * v21=ps_subfactory_chains with per-channel amounts,
  * v22=poison_tx_hex on ps_leaf_chains + ps_subfactory_chains,
  * v23=ps_initial_signed_states for force-close-after-advance chain history,
- * v24=epoch column on ps_leaf_chains / ps_initial_signed_states / ps_subfactory_chains (F2)) */
+ * v24=epoch column on ps_leaf_chains / ps_initial_signed_states / ps_subfactory_chains (F2),
+ * v25=signed_penalty_tx_hex on old_commitments (closes restart-loses-defense gap),
+ * v26=signing_rounds journal + signing_round_participants (C3 ceremony forensics)) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 24, "schema version is 24 (v24 adds epoch column for post-Tier-B dashboard cost accuracy, F2)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 26, "schema version is 26 (v26 adds signing_rounds journal for ceremony forensics — C3)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1175,6 +1175,8 @@ extern int test_persist_ps_subfactory_chain_v21_round_trip(void);
 extern int test_persist_ps_leaf_chain_v22_poison_round_trip(void);
 extern int test_persist_ps_subfactory_chain_v22_poison_round_trip(void);
 extern int test_persist_ps_initial_signed_state_round_trip(void);
+extern int test_persist_old_commitment_witness_round_trip(void);
+extern int test_persist_signing_rounds_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -2980,6 +2982,8 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_ps_leaf_chain_v22_poison_round_trip);
     RUN_TEST(test_persist_ps_subfactory_chain_v22_poison_round_trip);
     RUN_TEST(test_persist_ps_initial_signed_state_round_trip);
+    RUN_TEST(test_persist_old_commitment_witness_round_trip);
+    RUN_TEST(test_persist_signing_rounds_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -3877,3 +3877,159 @@ int test_persist_ps_defense_independent_inputs(void) {
     persist_close(&db);
     return 1;
 }
+
+/* v25 round-trip: persist + reload pre-built penalty TX bytes on old_commitments.
+   Closes the restart-loses-defense gap (watchtower.c:60-115). */
+int test_persist_old_commitment_witness_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    uint32_t channel_id = 7;
+    uint64_t commit_num = 42;
+    unsigned char txid[32]; memset(txid, 0xAB, 32);
+    unsigned char spk[34];  memset(spk, 0xCD, 34);
+
+    /* Parent row must exist for the UPDATE to land. */
+    TEST_ASSERT(persist_save_old_commitment(&db, channel_id, commit_num,
+                                              txid, 0, 100000, spk, 34),
+                "save old_commitments parent row");
+
+    /* Pre-1: row exists but column is empty.  Load returns 0 (degrade
+       to legacy lazy-build). */
+    unsigned char *got_bytes = NULL;
+    size_t got_len = 0;
+    int rc = persist_load_old_commitment_witness(&db, channel_id, commit_num,
+                                                   &got_bytes, &got_len);
+    TEST_ASSERT_EQ(rc, 0, "empty column returns 0 (legacy fallback)");
+    TEST_ASSERT(got_bytes == NULL, "empty load returns NULL bytes");
+    TEST_ASSERT(got_len == 0, "empty load returns 0 len");
+
+    /* Save real bytes and round-trip. */
+    unsigned char penalty[200];
+    for (size_t i = 0; i < sizeof(penalty); i++) penalty[i] = (unsigned char)(i * 7 + 3);
+    TEST_ASSERT(persist_save_old_commitment_witness(&db, channel_id, commit_num,
+                                                      penalty, sizeof(penalty)),
+                "save witness bytes");
+
+    /* Reload + verify exact byte match. */
+    got_bytes = NULL;
+    got_len = 0;
+    rc = persist_load_old_commitment_witness(&db, channel_id, commit_num,
+                                              &got_bytes, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "load witness bytes succeeds");
+    TEST_ASSERT(got_bytes != NULL, "loaded bytes non-NULL");
+    TEST_ASSERT_EQ(got_len, sizeof(penalty), "loaded len matches saved");
+    TEST_ASSERT(memcmp(got_bytes, penalty, sizeof(penalty)) == 0,
+                "loaded bytes match saved");
+    free(got_bytes);
+
+    /* Idempotent re-save replaces. */
+    unsigned char penalty2[150];
+    memset(penalty2, 0x42, sizeof(penalty2));
+    TEST_ASSERT(persist_save_old_commitment_witness(&db, channel_id, commit_num,
+                                                      penalty2, sizeof(penalty2)),
+                "re-save witness bytes (UPDATE)");
+    got_bytes = NULL;
+    got_len = 0;
+    rc = persist_load_old_commitment_witness(&db, channel_id, commit_num,
+                                              &got_bytes, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "reload after re-save");
+    TEST_ASSERT_EQ(got_len, sizeof(penalty2), "re-saved len");
+    TEST_ASSERT(memcmp(got_bytes, penalty2, sizeof(penalty2)) == 0,
+                "re-saved bytes match");
+    free(got_bytes);
+
+    /* Save with NULL/zero is a safe no-op. */
+    TEST_ASSERT(persist_save_old_commitment_witness(&db, channel_id, commit_num,
+                                                      NULL, 0),
+                "save NULL is safe no-op (returns 1)");
+
+    /* Missing row → returns -1. */
+    rc = persist_load_old_commitment_witness(&db, 999, 999, &got_bytes, &got_len);
+    TEST_ASSERT_EQ(rc, -1, "missing row returns -1");
+
+    persist_close(&db);
+    return 1;
+}
+
+/* v26 (C3) signing_rounds journal round-trip: start → done → sweep. */
+int test_persist_signing_rounds_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    /* Round 1: success path (start → participant updates → done). */
+    int64_t round1 = -1;
+    TEST_ASSERT(persist_save_signing_round_start(&db, 0, 5,
+                                                   "leaf_advance", 1, 4,
+                                                   &round1),
+                "start round 1");
+    TEST_ASSERT(round1 > 0, "round 1 row id > 0");
+
+    /* Tier 2 participant calls — just confirm they do not fail. */
+    TEST_ASSERT(persist_save_signing_round_participant_nonce(&db, round1, 0),
+                "participant 0 nonce");
+    TEST_ASSERT(persist_save_signing_round_participant_nonce(&db, round1, 1),
+                "participant 1 nonce");
+    TEST_ASSERT(persist_save_signing_round_participant_psig(&db, round1, 0, "verified"),
+                "participant 0 psig verified");
+    TEST_ASSERT(persist_save_signing_round_participant_psig(&db, round1, 1, "verified"),
+                "participant 1 psig verified");
+
+    TEST_ASSERT(persist_save_signing_round_done(&db, round1, 4, 4,
+                                                  "success",
+                                                  "deadbeef00000000000000000000000000000000000000000000000000000000",
+                                                  NULL),
+                "round 1 done success");
+
+    /* Round 2: leave in flight, then sweep — should be marked aborted_crash. */
+    int64_t round2 = -1;
+    TEST_ASSERT(persist_save_signing_round_start(&db, 0, 5,
+                                                   "tier_b_rollover", 2, 5,
+                                                   &round2),
+                "start round 2");
+    TEST_ASSERT(round2 > round1, "round 2 row id > round 1");
+
+    /* Round 3: explicit timeout. */
+    int64_t round3 = -1;
+    TEST_ASSERT(persist_save_signing_round_start(&db, 0, 7,
+                                                   "leaf_advance", 2, 4,
+                                                   &round3),
+                "start round 3");
+    TEST_ASSERT(persist_save_signing_round_done(&db, round3, 4, 3,
+                                                  "timeout", NULL,
+                                                  "client 3 did not respond"),
+                "round 3 done timeout");
+
+    /* Sweep: round 2 should be marked aborted_crash (it has completed_at IS NULL).
+       Rounds 1 and 3 are already finalized — should be untouched. */
+    int swept = persist_sweep_incomplete_signing_rounds(&db);
+    TEST_ASSERT_EQ(swept, 1, "sweep marked exactly 1 in-flight row");
+
+    /* Verify round 2 is now aborted_crash; rounds 1 and 3 are unchanged. */
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "SELECT id, result FROM signing_rounds ORDER BY id ASC;";
+    TEST_ASSERT(sqlite3_prepare_v2(db.db, sql, -1, &stmt, NULL) == SQLITE_OK,
+                "prepare select");
+    int n_rows = 0;
+    char results[3][32] = {{0}};
+    while (sqlite3_step(stmt) == SQLITE_ROW && n_rows < 3) {
+        const char *r = (const char *)sqlite3_column_text(stmt, 1);
+        if (r) strncpy(results[n_rows], r, 31);
+        n_rows++;
+    }
+    sqlite3_finalize(stmt);
+    TEST_ASSERT_EQ(n_rows, 3, "3 rows present");
+    TEST_ASSERT(strcmp(results[0], "success") == 0, "row 1 is success");
+    TEST_ASSERT(strcmp(results[1], "aborted_crash") == 0, "row 2 is aborted_crash");
+    TEST_ASSERT(strcmp(results[2], "timeout") == 0, "row 3 is timeout");
+
+    /* Sweep again is idempotent — no rows to update. */
+    int swept2 = persist_sweep_incomplete_signing_rounds(&db);
+    TEST_ASSERT_EQ(swept2, 0, "second sweep finds nothing");
+
+    persist_close(&db);
+    return 1;
+}

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2019,6 +2019,16 @@ int main(int argc, char *argv[]) {
         g_db = &db;
         printf("LSP: persistence enabled (%s)\n", db_path);
 
+        /* C3 (Tier 1) crash-recovery sweep: mark any signing_rounds rows
+           with completed_at IS NULL as 'aborted_crash'.  These are
+           ceremonies that were in flight when a previous LSP instance
+           died — operator forensics needs them classified as crash-aborted
+           rather than dangling "in progress" forever. */
+        int swept = persist_sweep_incomplete_signing_rounds(&db);
+        if (swept > 0)
+            printf("LSP: C3 crash sweep: marked %d signing_rounds row(s) as aborted_crash\n",
+                   swept);
+
         /* Wire message logging (Phase 22) */
         wire_set_log_callback(lsp_wire_log_cb, &db);
     }


### PR DESCRIPTION
Two related persistence additions in a single PR — both add columns/tables to the same `persist.c` schema migration set.

## Phase A — Watchtower penalty TX persistence (schema v25)

**Closes a real correctness gap.**  Discovered by the dashboard team's AI while building the TX-Inventory + Defense-Status panels.

### The bug

`watchtower.c:319-347` pre-builds the penalty TX bytes at *registration* time (when the LSP receives a revocation secret from a counterparty) and stashes them in `watchtower_entry_t.signed_penalty_tx` (heap).  The restart path at `watchtower.c:60-115` re-creates entries from `old_commitments` but **never reloads `signed_penalty_tx`**.  Post-restart, the broadcast site at `watchtower.c:765-775` skips with:

```
Watchtower: entry %u has no signed_penalty_tx — skipping
```

**The channel goes undefended after any LSP restart.**  Real-money mainnet correctness bug.

### The fix

Mirrors the existing `signed_*_tx_hex` pattern used by every other table with pre-signed bytes (`tree_nodes`, `signed_commitments`, `distribution_txs`, `ps_leaf_chains`, `ps_initial_signed_states`, `ps_subfactory_chains`, `jit_channels`):

```sql
ALTER TABLE old_commitments ADD COLUMN signed_penalty_tx_hex TEXT NOT NULL DEFAULT '';
```

Default `''` preserves the legacy lazy-build fallback (caller has `channel_t`, rebuilds bytes from per-commitment secret).  Code-side defense: the restart loader at `watchtower.c:60-115` now calls `persist_load_old_commitment_witness` and assigns `e->signed_penalty_tx`.

Three call sites that set the bytes now also persist them:
- `watchtower_watch_oracular` (oracular registration with explicit bytes)
- `watchtower_watch_revoked_commitment` (registration-time pre-build via `channel_build_penalty_tx` — the dominant path)
- `watchtower_watch_revoked_commitment_oracular` (oracular revoked variant)

## Phase B — C3 signing_rounds journal Tier 1 (schema v26)

Per `C3_LSP_SCHEMA_HANDOFF.md` from the dashboard team.  Forensics + crash-recovery layer.

### Why

Today, when a ceremony fails in mixed ways ("some signers participated, others didn't"), the LSP has no aggregated record.  `signing_progress` is a live snapshot that clears on success.  `wire_messages` is raw protocol with no per-ceremony view.  Operator questions like "which client timed out?", "did the LSP crash mid-ceremony?", "how long do leaf advances take this week?" are essentially unanswerable.

### What lands

Two new tables (additive, no existing-row impact):

```sql
signing_rounds(id, factory_id, node_idx, ceremony_type, epoch,
               started_at, completed_at, n_participants,
               nonces_collected, partial_sigs_collected,
               result, result_txid, error_detail)

signing_round_participants(round_id, signer_slot,
                           pubnonce_received_at, partial_sig_received_at,
                           partial_sig_status)
```

5 new persist API functions:
- `persist_save_signing_round_start` → start a journal row
- `persist_save_signing_round_participant_nonce` → log per-signer nonce arrival
- `persist_save_signing_round_participant_psig` → log per-signer psig + status
- `persist_save_signing_round_done` → finalize with outcome
- `persist_sweep_incomplete_signing_rounds` → crash-recovery sweep

### Ceremony hook (this PR)

`lsp_run_state_advance` (Tier B ceremony) is hooked.  The other 4 ceremony entry points (factory_creation, leaf_advance, sub_factory_advance, leaf_realloc) can follow as incremental commits to this PR or as Tier 2 follow-up — the pattern is established here.

### Crash recovery

`persist_sweep_incomplete_signing_rounds` is called at LSP startup right after `persist_open`.  Any signing_rounds row with `completed_at IS NULL` from a crashed prior run is marked `'aborted_crash'`.  Operator forensics can then see "yes, ceremony X was in flight when the LSP died."

### Notes

- **`ptlc_turnover` dropped from the v1 ceremony_type enum.**  PTLC isn't implemented yet; adding a placeholder invites schema-vs-reality drift.  Add the value when the actual driver lands.
- **All journal writes guarded by `if (mgr->persist) { ... }`.**  A DB write failure does NOT abort the ceremony itself.

## Test plan

- [x] `test_persist_old_commitment_witness_round_trip`: save bytes → reload → verify exact match; idempotent UPDATE; NULL/zero safe no-op; missing row returns -1.  PASS.
- [x] `test_persist_signing_rounds_round_trip`: start → participant nonce + psig + done(success); leave a 2nd round in-flight; finalize a 3rd as timeout; sweep marks the in-flight one as aborted_crash; sweep is idempotent.  PASS.
- [x] `test_persist_schema_v3` bumped to 26.  PASS.
- [x] `test_regtest_tier_b_rollover_ps.sh` (F1 from PR #175): still PASSes.  Signing_rounds row captured: `id=1, ceremony_type=tier_b_rollover, epoch=2, result=success`.
- [ ] Follow-up: hook the other 4 ceremony entry points (factory_creation, leaf_advance, sub_factory_advance, leaf_realloc).
- [ ] Follow-up: Tier 2 wire-handler instrumentation for per-signer participation timestamps (10-20 instrumentation points inside the nonce/psig receive loops of `lsp_run_state_advance` + `lsp_advance_leaf`).

## Branch base

This PR is stacked on top of `feat/ps-tier-b-leaf-resign-and-leaks` (PR #175 — F1/F7 etc).  Schema versions stack cleanly: v24 → v25 → v26.  If PR #175 merges first, this rebases trivially onto main.

## Dashboard side

Once this lands, dashboard PR #176 can flip the "in memory only" row at `tools/dashboard.py:1564` to "persisted ✓", add a TX-Inventory tile counting `signed_penalty_tx_hex != ''` against `old_commitments` total, and read the ceremonies tab from `signing_rounds` directly instead of reconstructing from `wire_messages`.  ~10 lines on the dashboard side.

## What this changes about the app

- **Phase A** makes the watchtower **survive process restarts** for the proven case (penalty broadcasts).  Mainnet correctness blocker.
- **Phase B** lets operators **see what's happening inside ceremonies** without spelunking raw wire logs.  Forensics + compliance trail.  Not a correctness change.