### PR TITLE
feat(persist): fee-bump escalation persist (PR-C-1, schema v27)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 26
+#define PERSIST_SCHEMA_VERSION 27
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -616,20 +616,33 @@ int persist_load_anchor_key(persist_t *p, unsigned char *seckey32_out);
 
 /* --- Watchtower pending entry persistence --- */
 
-/* Save a pending penalty entry (for CPFP bump tracking across restarts). */
+/* Save a pending penalty entry (for CPFP bump tracking across restarts).
+   v27: fb_start_block / fb_deadline_block / fb_budget_sat / fb_start_feerate
+   carry the htlc_fee_bump_t escalation schedule so a mid-escalation restart
+   can resume the linear fee schedule instead of rebasing from zero. */
 int persist_save_pending(persist_t *p, const char *txid,
                            uint32_t anchor_vout, uint64_t anchor_amount,
                            int cycles_in_mempool, int bump_count,
                            uint64_t penalty_value, uint32_t csv_delay,
-                           uint32_t start_height);
+                           uint32_t start_height,
+                           uint32_t fb_start_block,
+                           uint32_t fb_deadline_block,
+                           uint64_t fb_budget_sat,
+                           uint64_t fb_start_feerate);
 
-/* Load all pending entries. Returns count loaded. */
+/* Load all pending entries. Returns count loaded.
+   v27: fb_* arrays may be NULL (legacy callers); when non-NULL they are
+   populated with the persisted htlc_fee_bump_t escalation schedule. */
 size_t persist_load_pending(persist_t *p, char (*txids_out)[65],
                               uint32_t *vouts_out, uint64_t *amounts_out,
                               int *cycles_out, int *bumps_out,
                               uint64_t *penalty_values_out,
                               uint32_t *csv_delays_out,
                               uint32_t *start_heights_out,
+                              uint32_t *fb_start_blocks_out,
+                              uint32_t *fb_deadline_blocks_out,
+                              uint64_t *fb_budget_sats_out,
+                              uint64_t *fb_start_feerates_out,
                               size_t max_entries);
 
 /* Delete a pending entry by txid (e.g., after confirmation). */

--- a/src/persist.c
+++ b/src/persist.c
@@ -246,7 +246,11 @@ static const char *SCHEMA_SQL =
     "  bump_count INTEGER NOT NULL DEFAULT 0,"
     "  penalty_value INTEGER NOT NULL DEFAULT 0,"
     "  csv_delay INTEGER NOT NULL DEFAULT 144,"
-    "  start_height INTEGER NOT NULL DEFAULT 0"
+    "  start_height INTEGER NOT NULL DEFAULT 0,"
+    "  fb_start_block INTEGER NOT NULL DEFAULT 0,"
+    "  fb_deadline_block INTEGER NOT NULL DEFAULT 0,"
+    "  fb_budget_sat INTEGER NOT NULL DEFAULT 0,"
+    "  fb_start_feerate INTEGER NOT NULL DEFAULT 0"
     ");"
     "CREATE TABLE IF NOT EXISTS jit_channels ("
     "  jit_channel_id INTEGER PRIMARY KEY,"
@@ -983,6 +987,32 @@ int persist_open(persist_t *p, const char *path) {
             "  partial_sig_status TEXT,"
             "  PRIMARY KEY (round_id, signer_slot)"
             ");",
+            NULL, NULL, NULL);
+    }
+
+    /* v27 (PR-C-1): fee-bump escalation schedule persistence.
+
+       Before v27, watchtower_pending only stored bump_count (mapped to
+       fee_bump.last_bump_block).  On LSP restart mid-escalation, the
+       loader memset the rest of htlc_fee_bump_t to zero — losing
+       start_block / deadline_block / budget_sat / start_feerate.  The
+       linear fee schedule then rebased from cur_height, risking
+       over-bump (burn budget) or under-bump (miss CSV deadline and let
+       the cheater win).  Additive ALTERs with default 0 — pre-v27 rows
+       still trigger htlc_fee_bump_init at next bump check (legacy
+       rebase-from-zero), but new rows resume their schedule. */
+    if (db_version < 27) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_start_block INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_deadline_block INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_budget_sat INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_start_feerate INTEGER NOT NULL DEFAULT 0;",
             NULL, NULL, NULL);
     }
 
@@ -4145,13 +4175,19 @@ int persist_save_pending(persist_t *p, const char *txid,
                            uint32_t anchor_vout, uint64_t anchor_amount,
                            int cycles_in_mempool, int bump_count,
                            uint64_t penalty_value, uint32_t csv_delay,
-                           uint32_t start_height) {
+                           uint32_t start_height,
+                           uint32_t fb_start_block,
+                           uint32_t fb_deadline_block,
+                           uint64_t fb_budget_sat,
+                           uint64_t fb_start_feerate) {
     if (!p || !p->db || !txid) return 0;
 
     const char *sql =
         "INSERT OR REPLACE INTO watchtower_pending "
-        "(txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, penalty_value, csv_delay, start_height) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+        "(txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, "
+        " penalty_value, csv_delay, start_height, "
+        " fb_start_block, fb_deadline_block, fb_budget_sat, fb_start_feerate) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
     sqlite3_stmt *stmt;
     if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
@@ -4165,6 +4201,10 @@ int persist_save_pending(persist_t *p, const char *txid,
     sqlite3_bind_int64(stmt, 6, (sqlite3_int64)penalty_value);
     sqlite3_bind_int(stmt, 7, (int)csv_delay);
     sqlite3_bind_int(stmt, 8, (int)start_height);
+    sqlite3_bind_int(stmt, 9, (int)fb_start_block);
+    sqlite3_bind_int(stmt, 10, (int)fb_deadline_block);
+    sqlite3_bind_int64(stmt, 11, (sqlite3_int64)fb_budget_sat);
+    sqlite3_bind_int64(stmt, 12, (sqlite3_int64)fb_start_feerate);
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
@@ -4177,11 +4217,17 @@ size_t persist_load_pending(persist_t *p, char (*txids_out)[65],
                               uint64_t *penalty_values_out,
                               uint32_t *csv_delays_out,
                               uint32_t *start_heights_out,
+                              uint32_t *fb_start_blocks_out,
+                              uint32_t *fb_deadline_blocks_out,
+                              uint64_t *fb_budget_sats_out,
+                              uint64_t *fb_start_feerates_out,
                               size_t max_entries) {
     if (!p || !p->db) return 0;
 
     const char *sql =
-        "SELECT txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, penalty_value, csv_delay, start_height "
+        "SELECT txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, "
+        "       penalty_value, csv_delay, start_height, "
+        "       fb_start_block, fb_deadline_block, fb_budget_sat, fb_start_feerate "
         "FROM watchtower_pending ORDER BY txid;";
 
     sqlite3_stmt *stmt;
@@ -4209,6 +4255,14 @@ size_t persist_load_pending(persist_t *p, char (*txids_out)[65],
             csv_delays_out[count] = (uint32_t)sqlite3_column_int(stmt, 6);
         if (start_heights_out)
             start_heights_out[count] = (uint32_t)sqlite3_column_int(stmt, 7);
+        if (fb_start_blocks_out)
+            fb_start_blocks_out[count] = (uint32_t)sqlite3_column_int(stmt, 8);
+        if (fb_deadline_blocks_out)
+            fb_deadline_blocks_out[count] = (uint32_t)sqlite3_column_int(stmt, 9);
+        if (fb_budget_sats_out)
+            fb_budget_sats_out[count] = (uint64_t)sqlite3_column_int64(stmt, 10);
+        if (fb_start_feerates_out)
+            fb_start_feerates_out[count] = (uint64_t)sqlite3_column_int64(stmt, 11);
         count++;
     }
 

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -143,9 +143,15 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
         uint64_t pending_penalty_values[WATCHTOWER_MAX_PENDING];
         uint32_t pending_csv_delays[WATCHTOWER_MAX_PENDING];
         uint32_t pending_start_heights[WATCHTOWER_MAX_PENDING];
+        uint32_t pending_fb_start_blocks[WATCHTOWER_MAX_PENDING];
+        uint32_t pending_fb_deadlines[WATCHTOWER_MAX_PENDING];
+        uint64_t pending_fb_budgets[WATCHTOWER_MAX_PENDING];
+        uint64_t pending_fb_start_feerates[WATCHTOWER_MAX_PENDING];
         size_t n_loaded = persist_load_pending(db, pending_txids,
             pending_vouts, pending_amounts, pending_cycles, pending_bumps,
             pending_penalty_values, pending_csv_delays, pending_start_heights,
+            pending_fb_start_blocks, pending_fb_deadlines,
+            pending_fb_budgets, pending_fb_start_feerates,
             WATCHTOWER_MAX_PENDING);
         for (size_t i = 0; i < n_loaded && wt->n_pending < wt->pending_cap; i++) {
             watchtower_pending_t *p = &wt->pending[wt->n_pending++];
@@ -156,6 +162,15 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
             p->cycles_in_mempool = pending_cycles[i];
             memset(&p->fee_bump, 0, sizeof(p->fee_bump));
             p->fee_bump.last_bump_block = (uint32_t)pending_bumps[i];
+            /* v27: resume escalation schedule.  tx_vsize is constant
+               WATCHTOWER_CPFP_CHILD_VSIZE (not persisted); pre-v27 rows
+               load as zeros and re-initialize at next bump check. */
+            p->fee_bump.start_block    = pending_fb_start_blocks[i];
+            p->fee_bump.deadline_block = pending_fb_deadlines[i];
+            p->fee_bump.budget_sat     = pending_fb_budgets[i];
+            p->fee_bump.start_feerate  = pending_fb_start_feerates[i];
+            p->fee_bump.tx_vsize       = WATCHTOWER_CPFP_CHILD_VSIZE;
+            p->fee_bump.last_feerate   = 0;  /* re-derived from RBF state */
             p->penalty_value = pending_penalty_values[i];
             p->csv_delay = pending_csv_delays[i];
             p->start_height = pending_start_heights[i];
@@ -877,9 +892,13 @@ int watchtower_check(watchtower_t *wt) {
             p->cycles_in_mempool = 0;
             memset(&p->fee_bump, 0, sizeof(p->fee_bump));
             if (wt->db && wt->db->db) {
+                /* fee_bump is freshly memset above — escalation schedule
+                   not yet initialised; persist zeros so a restart-then-
+                   first-bump path still calls htlc_fee_bump_init normally. */
                 persist_save_pending(wt->db, p->txid, p->anchor_vout,
                                        p->anchor_amount, 0, 0,
-                                       p->penalty_value, p->csv_delay, p->start_height);
+                                       p->penalty_value, p->csv_delay, p->start_height,
+                                       0, 0, 0, 0);
             }
         }
 
@@ -1170,11 +1189,17 @@ int watchtower_check(watchtower_t *wt) {
                         printf("  CPFP child broadcast (feerate %llu): %s\n",
                                (unsigned long long)fr, cpfp_txid);
                         if (wt->db && wt->db->db) {
+                            /* v27: persist the escalation schedule so a
+                               mid-bump restart resumes instead of rebasing. */
                             persist_save_pending(wt->db, p->txid,
                                 p->anchor_vout, p->anchor_amount,
                                 p->cycles_in_mempool,
                                 (int)p->fee_bump.last_bump_block,
-                                p->penalty_value, p->csv_delay, p->start_height);
+                                p->penalty_value, p->csv_delay, p->start_height,
+                                p->fee_bump.start_block,
+                                p->fee_bump.deadline_block,
+                                p->fee_bump.budget_sat,
+                                p->fee_bump.start_feerate);
                             persist_log_broadcast(wt->db, cpfp_txid,
                                                   "cpfp", cpfp_hex, "ok");
                         }
@@ -1331,7 +1356,8 @@ int watchtower_add_pending_tx(watchtower_t *wt,
     if (wt->db && wt->db->db)
         persist_save_pending(wt->db, p->txid, p->anchor_vout,
                                p->anchor_amount, 0, 0,
-                               p->penalty_value, p->csv_delay, p->start_height);
+                               p->penalty_value, p->csv_delay, p->start_height,
+                               0, 0, 0, 0);
     return 1;
 }
 

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -249,13 +249,14 @@ int test_offer_decode_bad_checksum(void)
  * v23=ps_initial_signed_states for force-close-after-advance chain history,
  * v24=epoch column on ps_leaf_chains / ps_initial_signed_states / ps_subfactory_chains (F2),
  * v25=signed_penalty_tx_hex on old_commitments (closes restart-loses-defense gap),
- * v26=signing_rounds journal + signing_round_participants (C3 ceremony forensics)) */
+ * v26=signing_rounds journal + signing_round_participants (C3 ceremony forensics),
+ * v27=watchtower_pending.fb_* columns (fee-bump escalation persist; PR-C-1)) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 26, "schema version is 26 (v26 adds signing_rounds journal for ceremony forensics — C3)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 27, "schema version is 27 (v27 adds fee-bump escalation persistence — PR-C-1)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_cpfp.c
+++ b/tests/test_cpfp.c
@@ -488,17 +488,19 @@ int test_pending_persistence(void) {
     /* Save 2 pending entries */
     TEST_ASSERT(persist_save_pending(&db,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        1, 240, 0, 0, 50000, 144, 100), "save pending 1");
+        1, 240, 0, 0, 50000, 144, 100, 0, 0, 0, 0), "save pending 1");
     TEST_ASSERT(persist_save_pending(&db,
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        1, 240, 5, 2, 50000, 144, 100), "save pending 2");
+        1, 240, 5, 2, 50000, 144, 100, 0, 0, 0, 0), "save pending 2");
 
     /* Load them back */
     char txids[16][65];
     uint32_t vouts[16];
     uint64_t amounts[16];
     int cycles[16], bumps[16];
-    size_t n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps, NULL, NULL, NULL, 16);
+    size_t n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps,
+                                      NULL, NULL, NULL,
+                                      NULL, NULL, NULL, NULL, 16);
     TEST_ASSERT_EQ(n, 2, "loaded 2 pending entries");
 
     /* Verify first entry */
@@ -517,15 +519,19 @@ int test_pending_persistence(void) {
     TEST_ASSERT(persist_delete_pending(&db,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         "delete pending 1");
-    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps, NULL, NULL, NULL, 16);
+    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps,
+                               NULL, NULL, NULL,
+                               NULL, NULL, NULL, NULL, 16);
     TEST_ASSERT_EQ(n, 1, "1 entry after delete");
     TEST_ASSERT(strncmp(txids[0], "bbbb", 4) == 0, "remaining entry is bbbb");
 
     /* Update via upsert */
     TEST_ASSERT(persist_save_pending(&db,
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        1, 240, 10, 3, 50000, 144, 100), "upsert pending");
-    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps, NULL, NULL, NULL, 16);
+        1, 240, 10, 3, 50000, 144, 100, 0, 0, 0, 0), "upsert pending");
+    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps,
+                               NULL, NULL, NULL,
+                               NULL, NULL, NULL, NULL, 16);
     TEST_ASSERT_EQ(n, 1, "still 1 entry after upsert");
     TEST_ASSERT_EQ(cycles[0], 10, "updated cycles = 10");
     TEST_ASSERT_EQ(bumps[0], 3, "updated bumps = 3");
@@ -650,6 +656,7 @@ int test_watchtower_add_pending_persists(void)
     size_t n = persist_load_pending(&db, loaded_txids, loaded_vouts,
                                      loaded_amounts, loaded_cycles,
                                      loaded_bumps, NULL, NULL, NULL,
+                                     NULL, NULL, NULL, NULL,
                                      WATCHTOWER_MAX_PENDING);
     TEST_ASSERT_EQ((long)n, 1L, "1 entry persisted");
     TEST_ASSERT(strncmp(loaded_txids[0], "ffff", 4) == 0, "txid starts ffff");

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1177,6 +1177,7 @@ extern int test_persist_ps_subfactory_chain_v22_poison_round_trip(void);
 extern int test_persist_ps_initial_signed_state_round_trip(void);
 extern int test_persist_old_commitment_witness_round_trip(void);
 extern int test_persist_signing_rounds_round_trip(void);
+extern int test_persist_pending_fee_bump_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -2984,6 +2985,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_ps_initial_signed_state_round_trip);
     RUN_TEST(test_persist_old_commitment_witness_round_trip);
     RUN_TEST(test_persist_signing_rounds_round_trip);
+    RUN_TEST(test_persist_pending_fee_bump_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -4033,3 +4033,60 @@ int test_persist_signing_rounds_round_trip(void)
     persist_close(&db);
     return 1;
 }
+
+/* v27 (PR-C-1) fee-bump escalation persist round-trip. */
+int test_persist_pending_fee_bump_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    const char *txid = "aa11bb22cc33dd44ee55ff66"
+                       "0011223344556677889900aa"
+                       "bbccddeeff001122334455660011";
+    TEST_ASSERT(persist_save_pending(&db, txid,
+                                       /* anchor_vout    */ 1,
+                                       /* anchor_amount  */ 330,
+                                       /* cycles         */ 3,
+                                       /* bump_count     */ 12345,
+                                       /* penalty_value  */ 100000,
+                                       /* csv_delay      */ 144,
+                                       /* start_height   */ 800000,
+                                       /* fb_start_block */ 800005,
+                                       /* fb_deadline    */ 800500,
+                                       /* fb_budget_sat  */ 50000,
+                                       /* fb_start_fr    */ 5000),
+                "save pending with fee-bump fields");
+
+    char txids[4][65];
+    uint32_t vouts[4];
+    uint64_t amts[4];
+    int cycles[4];
+    int bumps[4];
+    uint64_t pvals[4];
+    uint32_t csvs[4];
+    uint32_t starts[4];
+    uint32_t fb_starts[4];
+    uint32_t fb_deadlines[4];
+    uint64_t fb_budgets[4];
+    uint64_t fb_frs[4];
+
+    size_t n = persist_load_pending(&db, txids, vouts, amts, cycles, bumps,
+                                      pvals, csvs, starts,
+                                      fb_starts, fb_deadlines, fb_budgets, fb_frs,
+                                      4);
+    TEST_ASSERT_EQ((int)n, 1, "exactly 1 row loaded");
+    TEST_ASSERT(strncmp(txids[0], txid, 64) == 0, "txid round-trips");
+    TEST_ASSERT_EQ((int)fb_starts[0], 800005, "fb_start_block round-trips");
+    TEST_ASSERT_EQ((int)fb_deadlines[0], 800500, "fb_deadline_block round-trips");
+    TEST_ASSERT_EQ((long long)fb_budgets[0], 50000LL, "fb_budget_sat round-trips");
+    TEST_ASSERT_EQ((long long)fb_frs[0], 5000LL, "fb_start_feerate round-trips");
+
+    /* NULL-safe out-pointers: legacy callers pass NULL for fb_* and still work. */
+    size_t n2 = persist_load_pending(&db, txids, vouts, amts, cycles, bumps,
+                                       pvals, csvs, starts,
+                                       NULL, NULL, NULL, NULL, 4);
+    TEST_ASSERT_EQ((int)n2, 1, "NULL fb_* out-pointers do not crash");
+
+    persist_close(&db);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes Phase C item #1 from the watchtower restart-correctness audit. The `htlc_fee_bump_t` escalation schedule (start_block, deadline_block, budget_sat, start_feerate) lived only in RAM. On LSP restart mid-bump, the loader memset the schedule and the linear fee function rebased from scratch — risking over-bump (waste budget) or under-bump (miss CSV deadline → cheater wins).

### Schema v27 (additive)
```
ALTER TABLE watchtower_pending ADD COLUMN fb_start_block    INTEGER NOT NULL DEFAULT 0;
ALTER TABLE watchtower_pending ADD COLUMN fb_deadline_block INTEGER NOT NULL DEFAULT 0;
ALTER TABLE watchtower_pending ADD COLUMN fb_budget_sat     INTEGER NOT NULL DEFAULT 0;
ALTER TABLE watchtower_pending ADD COLUMN fb_start_feerate  INTEGER NOT NULL DEFAULT 0;
```

Pre-v27 rows load as zeros and re-trigger `htlc_fee_bump_init` on the next bump check (legacy rebase-from-zero — no worse than today). New rows resume their schedule.

### Wire-up
- `persist_save_pending` / `persist_load_pending` extended (load out-pointers may be NULL for legacy callers)
- `watchtower_init` repopulates `p->fee_bump.{start_block,deadline_block,budget_sat,start_feerate,tx_vsize}` after the memset
- 3 watchtower.c callsites updated:
  - fresh-pending creation (oracular) → zeros
  - mid-bump RBF save (~line 1173) → persists schedule
  - `watchtower_add_pending_tx` → zeros

### Verification
- Unit: new `test_persist_pending_fee_bump_round_trip` (save → load → match; NULL out-pointer safety)
- Unit: `test_persist_schema_v3` bumped v26 → v27
- Regtest: Tier B PS regtest PASS with v27 binary
- DB schema_version=27 live with the 4 new columns

## Test plan
- [x] Unit tests pass: 1433/1436 (3 pre-existing wallet-pollution failures unchanged)
- [x] Tier B PS regtest PASS
- [x] Schema v27 verified live in `/tmp/tier_b_ps_last_lsp.db`
- [ ] Optional: regtest exercising restart-mid-fee-bump path (Phase C-1 follow-up, scope: separate diff if dashboard AI wants the integration test)