### PR TITLE
feat(persist): force-close watch persist (PR-C-2, schema v28)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 26
+#define PERSIST_SCHEMA_VERSION 27
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -616,20 +616,33 @@ int persist_load_anchor_key(persist_t *p, unsigned char *seckey32_out);
 
 /* --- Watchtower pending entry persistence --- */
 
-/* Save a pending penalty entry (for CPFP bump tracking across restarts). */
+/* Save a pending penalty entry (for CPFP bump tracking across restarts).
+   v27: fb_start_block / fb_deadline_block / fb_budget_sat / fb_start_feerate
+   carry the htlc_fee_bump_t escalation schedule so a mid-escalation restart
+   can resume the linear fee schedule instead of rebasing from zero. */
 int persist_save_pending(persist_t *p, const char *txid,
                            uint32_t anchor_vout, uint64_t anchor_amount,
                            int cycles_in_mempool, int bump_count,
                            uint64_t penalty_value, uint32_t csv_delay,
-                           uint32_t start_height);
+                           uint32_t start_height,
+                           uint32_t fb_start_block,
+                           uint32_t fb_deadline_block,
+                           uint64_t fb_budget_sat,
+                           uint64_t fb_start_feerate);
 
-/* Load all pending entries. Returns count loaded. */
+/* Load all pending entries. Returns count loaded.
+   v27: fb_* arrays may be NULL (legacy callers); when non-NULL they are
+   populated with the persisted htlc_fee_bump_t escalation schedule. */
 size_t persist_load_pending(persist_t *p, char (*txids_out)[65],
                               uint32_t *vouts_out, uint64_t *amounts_out,
                               int *cycles_out, int *bumps_out,
                               uint64_t *penalty_values_out,
                               uint32_t *csv_delays_out,
                               uint32_t *start_heights_out,
+                              uint32_t *fb_start_blocks_out,
+                              uint32_t *fb_deadline_blocks_out,
+                              uint64_t *fb_budget_sats_out,
+                              uint64_t *fb_start_feerates_out,
                               size_t max_entries);
 
 /* Delete a pending entry by txid (e.g., after confirmation). */

--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 27
+#define PERSIST_SCHEMA_VERSION 28
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -647,6 +647,50 @@ size_t persist_load_pending(persist_t *p, char (*txids_out)[65],
 
 /* Delete a pending entry by txid (e.g., after confirmation). */
 int persist_delete_pending(persist_t *p, const char *txid);
+
+/* --- v28: Force-close watch persistence (PR-C-2) ---
+   Restart-restore for WATCH_FORCE_CLOSE entries.  Unlike WATCH_COMMITMENT
+   (rebuilt from old_commitments) and WATCH_FACTORY_NODE / WATCH_SUBFACTORY_NODE
+   (rebuilt from in-memory factory state via lsp_channels_rehydrate_*),
+   force-close watches have no recovery path today.  Two-table layout:
+   force_close_watches (one row per channel) + force_close_htlcs
+   (one row per HTLC to sweep). */
+
+/* opaque watchtower_htlc layout — declared in watchtower.h.  We expose only
+   the fields the persist layer needs to round-trip. */
+struct watchtower_htlc;
+
+/* Save a force-close watch (channel + HTLC sweep set).
+   commitment_txid32 is 32 raw bytes.  htlcs/n_htlcs are the per-HTLC sweep
+   targets.  out_row_id receives the autoincrement PK (used by delete).
+   INSERT-then-cascade-INSERT — caller must be prepared for two-step write
+   (transactional safety provided by the SQLite default txn). */
+int persist_save_force_close(persist_t *p, uint32_t channel_id,
+                                const unsigned char *commitment_txid32,
+                                const struct watchtower_htlc *htlcs,
+                                size_t n_htlcs,
+                                int64_t *out_row_id);
+
+/* Load all force-close watches.  out parameters mirror the in-memory
+   watchtower_entry_t shape so the loader in watchtower_init can rebuild
+   entries directly:
+     channel_ids_out / commitment_txids_out (32-byte raw)  — one per watch
+     htlcs_out                                              — flat array of all HTLCs
+     n_htlcs_per_watch_out                                  — count per watch
+   Caller-allocated arrays.  max_watches limits the top-level count;
+   max_htlcs_total limits the HTLCs across all watches.  Returns number of
+   watches loaded (0 on no rows or error). */
+size_t persist_load_force_close_watches(persist_t *p,
+                                          uint32_t *channel_ids_out,
+                                          unsigned char (*commitment_txids_out)[32],
+                                          struct watchtower_htlc *htlcs_out,
+                                          size_t *n_htlcs_per_watch_out,
+                                          size_t max_watches,
+                                          size_t max_htlcs_total);
+
+/* Delete a force-close watch by row id (called after the HTLC sweep set
+   has fully confirmed and the entry is removed from the in-memory table). */
+int persist_delete_force_close(persist_t *p, int64_t row_id);
 
 /* --- JIT Channel persistence (Gap #2) --- */
 

--- a/src/persist.c
+++ b/src/persist.c
@@ -105,6 +105,23 @@ static const char *SCHEMA_SQL =
     "  cltv_expiry INTEGER NOT NULL,"
     "  PRIMARY KEY (channel_id, commit_num, htlc_vout)"
     ");"
+    /* v28 (PR-C-2): force-close watch persistence */
+    "CREATE TABLE IF NOT EXISTS force_close_watches ("
+    "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "  channel_id INTEGER NOT NULL,"
+    "  commitment_txid TEXT NOT NULL"
+    ");"
+    "CREATE TABLE IF NOT EXISTS force_close_htlcs ("
+    "  force_close_id INTEGER NOT NULL REFERENCES force_close_watches(id) ON DELETE CASCADE,"
+    "  htlc_vout INTEGER NOT NULL,"
+    "  htlc_amount INTEGER NOT NULL,"
+    "  htlc_spk TEXT NOT NULL,"
+    "  direction INTEGER NOT NULL,"
+    "  payment_hash TEXT NOT NULL,"
+    "  cltv_expiry INTEGER NOT NULL,"
+    "  sweep_txid TEXT NOT NULL DEFAULT '',"
+    "  PRIMARY KEY (force_close_id, htlc_vout)"
+    ");"
     "CREATE TABLE IF NOT EXISTS wire_messages ("
     "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
     "  timestamp INTEGER NOT NULL,"
@@ -1013,6 +1030,37 @@ int persist_open(persist_t *p, const char *path) {
             NULL, NULL, NULL);
         sqlite3_exec(p->db,
             "ALTER TABLE watchtower_pending ADD COLUMN fb_start_feerate INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+    }
+
+    /* v28 (PR-C-2): force-close watch persistence.
+
+       Closes the restart gap for WATCH_FORCE_CLOSE entries identified in
+       the Phase C audit.  Force-close watches are the only entry type
+       without a recovery path (commitment entries are loaded from
+       old_commitments; factory_node / subfactory_node are rebuilt in
+       lsp_channels_rehydrate_watchtower_from_chains).  Two-table layout
+       mirrors old_commitments + old_commitment_htlcs. */
+    if (db_version < 28) {
+        sqlite3_exec(p->db,
+            "CREATE TABLE IF NOT EXISTS force_close_watches ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  channel_id INTEGER NOT NULL,"
+            "  commitment_txid TEXT NOT NULL"
+            ");",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "CREATE TABLE IF NOT EXISTS force_close_htlcs ("
+            "  force_close_id INTEGER NOT NULL REFERENCES force_close_watches(id) ON DELETE CASCADE,"
+            "  htlc_vout INTEGER NOT NULL,"
+            "  htlc_amount INTEGER NOT NULL,"
+            "  htlc_spk TEXT NOT NULL,"
+            "  direction INTEGER NOT NULL,"
+            "  payment_hash TEXT NOT NULL,"
+            "  cltv_expiry INTEGER NOT NULL,"
+            "  sweep_txid TEXT NOT NULL DEFAULT '',"
+            "  PRIMARY KEY (force_close_id, htlc_vout)"
+            ");",
             NULL, NULL, NULL);
     }
 
@@ -4284,6 +4332,164 @@ int persist_delete_pending(persist_t *p, const char *txid) {
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
     return ok;
+}
+
+/* --- v28: Force-close watch persistence (PR-C-2) --- */
+
+#include "superscalar/watchtower.h"  /* for watchtower_htlc_t */
+
+int persist_save_force_close(persist_t *p, uint32_t channel_id,
+                                const unsigned char *commitment_txid32,
+                                const struct watchtower_htlc *htlcs,
+                                size_t n_htlcs,
+                                int64_t *out_row_id) {
+    if (!p || !p->db || !commitment_txid32) return 0;
+    if (n_htlcs > 0 && !htlcs) return 0;
+
+    char txid_hex[65];
+    hex_encode(commitment_txid32, 32, txid_hex);
+    txid_hex[64] = '\0';
+
+    sqlite3_stmt *stmt;
+    const char *sql_top =
+        "INSERT INTO force_close_watches (channel_id, commitment_txid) VALUES (?, ?);";
+    if (sqlite3_prepare_v2(p->db, sql_top, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    sqlite3_bind_int(stmt, 1, (int)channel_id);
+    sqlite3_bind_text(stmt, 2, txid_hex, -1, SQLITE_TRANSIENT);
+    int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE) return 0;
+
+    int64_t row_id = sqlite3_last_insert_rowid(p->db);
+    if (out_row_id) *out_row_id = row_id;
+
+    /* Insert HTLC rows */
+    const char *sql_htlc =
+        "INSERT INTO force_close_htlcs "
+        "(force_close_id, htlc_vout, htlc_amount, htlc_spk, direction, "
+        " payment_hash, cltv_expiry, sweep_txid) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+    for (size_t i = 0; i < n_htlcs; i++) {
+        const watchtower_htlc_t *h = (const watchtower_htlc_t *)&htlcs[i];
+        char spk_hex[69];
+        hex_encode(h->htlc_spk, 34, spk_hex);
+        spk_hex[68] = '\0';
+        char ph_hex[65];
+        hex_encode(h->payment_hash, 32, ph_hex);
+        ph_hex[64] = '\0';
+
+        if (sqlite3_prepare_v2(p->db, sql_htlc, -1, &stmt, NULL) != SQLITE_OK)
+            return 0;
+        sqlite3_bind_int64(stmt, 1, (sqlite3_int64)row_id);
+        sqlite3_bind_int(stmt, 2, (int)h->htlc_vout);
+        sqlite3_bind_int64(stmt, 3, (sqlite3_int64)h->htlc_amount);
+        sqlite3_bind_text(stmt, 4, spk_hex, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(stmt, 5, (int)h->direction);
+        sqlite3_bind_text(stmt, 6, ph_hex, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(stmt, 7, (int)h->cltv_expiry);
+        sqlite3_bind_text(stmt, 8, h->sweep_txid[0] ? h->sweep_txid : "", -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+        sqlite3_finalize(stmt);
+        if (rc != SQLITE_DONE) return 0;
+    }
+    return 1;
+}
+
+size_t persist_load_force_close_watches(persist_t *p,
+                                          uint32_t *channel_ids_out,
+                                          unsigned char (*commitment_txids_out)[32],
+                                          struct watchtower_htlc *htlcs_out,
+                                          size_t *n_htlcs_per_watch_out,
+                                          size_t max_watches,
+                                          size_t max_htlcs_total) {
+    if (!p || !p->db) return 0;
+
+    /* Pass 1: read the top-level watches.  Keep id+ordinal so pass 2 can
+       attach HTLCs back to the right slot. */
+    int64_t row_ids[256];
+    size_t n_watches = 0;
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db,
+            "SELECT id, channel_id, commitment_txid FROM force_close_watches ORDER BY id;",
+            -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    while (sqlite3_step(stmt) == SQLITE_ROW && n_watches < max_watches && n_watches < 256) {
+        row_ids[n_watches] = sqlite3_column_int64(stmt, 0);
+        if (channel_ids_out)
+            channel_ids_out[n_watches] = (uint32_t)sqlite3_column_int(stmt, 1);
+        if (commitment_txids_out) {
+            const char *thex = (const char *)sqlite3_column_text(stmt, 2);
+            if (thex)
+                hex_decode(thex, commitment_txids_out[n_watches], 32);
+        }
+        if (n_htlcs_per_watch_out)
+            n_htlcs_per_watch_out[n_watches] = 0;
+        n_watches++;
+    }
+    sqlite3_finalize(stmt);
+
+    /* Pass 2: HTLCs, distributed back to their watch slot. */
+    size_t htlc_cursor = 0;
+    for (size_t w = 0; w < n_watches; w++) {
+        if (sqlite3_prepare_v2(p->db,
+                "SELECT htlc_vout, htlc_amount, htlc_spk, direction, "
+                "       payment_hash, cltv_expiry, sweep_txid "
+                "FROM force_close_htlcs WHERE force_close_id = ? "
+                "ORDER BY htlc_vout;",
+                -1, &stmt, NULL) != SQLITE_OK) {
+            return n_watches;
+        }
+        sqlite3_bind_int64(stmt, 1, (sqlite3_int64)row_ids[w]);
+
+        while (sqlite3_step(stmt) == SQLITE_ROW && htlc_cursor < max_htlcs_total) {
+            if (htlcs_out) {
+                watchtower_htlc_t *h = (watchtower_htlc_t *)&htlcs_out[htlc_cursor];
+                memset(h, 0, sizeof(*h));
+                h->htlc_vout   = (uint32_t)sqlite3_column_int(stmt, 0);
+                h->htlc_amount = (uint64_t)sqlite3_column_int64(stmt, 1);
+                const char *spk_hex_s = (const char *)sqlite3_column_text(stmt, 2);
+                if (spk_hex_s) hex_decode(spk_hex_s, h->htlc_spk, 34);
+                h->direction = (htlc_direction_t)sqlite3_column_int(stmt, 3);
+                const char *ph_hex_s = (const char *)sqlite3_column_text(stmt, 4);
+                if (ph_hex_s) hex_decode(ph_hex_s, h->payment_hash, 32);
+                h->cltv_expiry = (uint32_t)sqlite3_column_int(stmt, 5);
+                const char *sw = (const char *)sqlite3_column_text(stmt, 6);
+                if (sw && sw[0]) {
+                    strncpy(h->sweep_txid, sw, 64);
+                    h->sweep_txid[64] = '\0';
+                }
+            }
+            if (n_htlcs_per_watch_out)
+                n_htlcs_per_watch_out[w]++;
+            htlc_cursor++;
+        }
+        sqlite3_finalize(stmt);
+    }
+    return n_watches;
+}
+
+int persist_delete_force_close(persist_t *p, int64_t row_id) {
+    if (!p || !p->db) return 0;
+    sqlite3_stmt *stmt;
+    /* Cascade: delete HTLCs first (FK ON DELETE CASCADE only fires when
+       pragma is set; do it explicitly to be portable). */
+    if (sqlite3_prepare_v2(p->db,
+            "DELETE FROM force_close_htlcs WHERE force_close_id = ?;",
+            -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    sqlite3_bind_int64(stmt, 1, (sqlite3_int64)row_id);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+
+    if (sqlite3_prepare_v2(p->db,
+            "DELETE FROM force_close_watches WHERE id = ?;",
+            -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+    sqlite3_bind_int64(stmt, 1, (sqlite3_int64)row_id);
+    int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return (rc == SQLITE_DONE);
 }
 
 /* --- JIT Channel persistence (Gap #2) --- */

--- a/src/persist.c
+++ b/src/persist.c
@@ -246,7 +246,11 @@ static const char *SCHEMA_SQL =
     "  bump_count INTEGER NOT NULL DEFAULT 0,"
     "  penalty_value INTEGER NOT NULL DEFAULT 0,"
     "  csv_delay INTEGER NOT NULL DEFAULT 144,"
-    "  start_height INTEGER NOT NULL DEFAULT 0"
+    "  start_height INTEGER NOT NULL DEFAULT 0,"
+    "  fb_start_block INTEGER NOT NULL DEFAULT 0,"
+    "  fb_deadline_block INTEGER NOT NULL DEFAULT 0,"
+    "  fb_budget_sat INTEGER NOT NULL DEFAULT 0,"
+    "  fb_start_feerate INTEGER NOT NULL DEFAULT 0"
     ");"
     "CREATE TABLE IF NOT EXISTS jit_channels ("
     "  jit_channel_id INTEGER PRIMARY KEY,"
@@ -983,6 +987,32 @@ int persist_open(persist_t *p, const char *path) {
             "  partial_sig_status TEXT,"
             "  PRIMARY KEY (round_id, signer_slot)"
             ");",
+            NULL, NULL, NULL);
+    }
+
+    /* v27 (PR-C-1): fee-bump escalation schedule persistence.
+
+       Before v27, watchtower_pending only stored bump_count (mapped to
+       fee_bump.last_bump_block).  On LSP restart mid-escalation, the
+       loader memset the rest of htlc_fee_bump_t to zero — losing
+       start_block / deadline_block / budget_sat / start_feerate.  The
+       linear fee schedule then rebased from cur_height, risking
+       over-bump (burn budget) or under-bump (miss CSV deadline and let
+       the cheater win).  Additive ALTERs with default 0 — pre-v27 rows
+       still trigger htlc_fee_bump_init at next bump check (legacy
+       rebase-from-zero), but new rows resume their schedule. */
+    if (db_version < 27) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_start_block INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_deadline_block INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_budget_sat INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE watchtower_pending ADD COLUMN fb_start_feerate INTEGER NOT NULL DEFAULT 0;",
             NULL, NULL, NULL);
     }
 
@@ -4145,13 +4175,19 @@ int persist_save_pending(persist_t *p, const char *txid,
                            uint32_t anchor_vout, uint64_t anchor_amount,
                            int cycles_in_mempool, int bump_count,
                            uint64_t penalty_value, uint32_t csv_delay,
-                           uint32_t start_height) {
+                           uint32_t start_height,
+                           uint32_t fb_start_block,
+                           uint32_t fb_deadline_block,
+                           uint64_t fb_budget_sat,
+                           uint64_t fb_start_feerate) {
     if (!p || !p->db || !txid) return 0;
 
     const char *sql =
         "INSERT OR REPLACE INTO watchtower_pending "
-        "(txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, penalty_value, csv_delay, start_height) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+        "(txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, "
+        " penalty_value, csv_delay, start_height, "
+        " fb_start_block, fb_deadline_block, fb_budget_sat, fb_start_feerate) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
     sqlite3_stmt *stmt;
     if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
@@ -4165,6 +4201,10 @@ int persist_save_pending(persist_t *p, const char *txid,
     sqlite3_bind_int64(stmt, 6, (sqlite3_int64)penalty_value);
     sqlite3_bind_int(stmt, 7, (int)csv_delay);
     sqlite3_bind_int(stmt, 8, (int)start_height);
+    sqlite3_bind_int(stmt, 9, (int)fb_start_block);
+    sqlite3_bind_int(stmt, 10, (int)fb_deadline_block);
+    sqlite3_bind_int64(stmt, 11, (sqlite3_int64)fb_budget_sat);
+    sqlite3_bind_int64(stmt, 12, (sqlite3_int64)fb_start_feerate);
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
@@ -4177,11 +4217,17 @@ size_t persist_load_pending(persist_t *p, char (*txids_out)[65],
                               uint64_t *penalty_values_out,
                               uint32_t *csv_delays_out,
                               uint32_t *start_heights_out,
+                              uint32_t *fb_start_blocks_out,
+                              uint32_t *fb_deadline_blocks_out,
+                              uint64_t *fb_budget_sats_out,
+                              uint64_t *fb_start_feerates_out,
                               size_t max_entries) {
     if (!p || !p->db) return 0;
 
     const char *sql =
-        "SELECT txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, penalty_value, csv_delay, start_height "
+        "SELECT txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count, "
+        "       penalty_value, csv_delay, start_height, "
+        "       fb_start_block, fb_deadline_block, fb_budget_sat, fb_start_feerate "
         "FROM watchtower_pending ORDER BY txid;";
 
     sqlite3_stmt *stmt;
@@ -4209,6 +4255,14 @@ size_t persist_load_pending(persist_t *p, char (*txids_out)[65],
             csv_delays_out[count] = (uint32_t)sqlite3_column_int(stmt, 6);
         if (start_heights_out)
             start_heights_out[count] = (uint32_t)sqlite3_column_int(stmt, 7);
+        if (fb_start_blocks_out)
+            fb_start_blocks_out[count] = (uint32_t)sqlite3_column_int(stmt, 8);
+        if (fb_deadline_blocks_out)
+            fb_deadline_blocks_out[count] = (uint32_t)sqlite3_column_int(stmt, 9);
+        if (fb_budget_sats_out)
+            fb_budget_sats_out[count] = (uint64_t)sqlite3_column_int64(stmt, 10);
+        if (fb_start_feerates_out)
+            fb_start_feerates_out[count] = (uint64_t)sqlite3_column_int64(stmt, 11);
         count++;
     }
 

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -143,9 +143,15 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
         uint64_t pending_penalty_values[WATCHTOWER_MAX_PENDING];
         uint32_t pending_csv_delays[WATCHTOWER_MAX_PENDING];
         uint32_t pending_start_heights[WATCHTOWER_MAX_PENDING];
+        uint32_t pending_fb_start_blocks[WATCHTOWER_MAX_PENDING];
+        uint32_t pending_fb_deadlines[WATCHTOWER_MAX_PENDING];
+        uint64_t pending_fb_budgets[WATCHTOWER_MAX_PENDING];
+        uint64_t pending_fb_start_feerates[WATCHTOWER_MAX_PENDING];
         size_t n_loaded = persist_load_pending(db, pending_txids,
             pending_vouts, pending_amounts, pending_cycles, pending_bumps,
             pending_penalty_values, pending_csv_delays, pending_start_heights,
+            pending_fb_start_blocks, pending_fb_deadlines,
+            pending_fb_budgets, pending_fb_start_feerates,
             WATCHTOWER_MAX_PENDING);
         for (size_t i = 0; i < n_loaded && wt->n_pending < wt->pending_cap; i++) {
             watchtower_pending_t *p = &wt->pending[wt->n_pending++];
@@ -156,6 +162,15 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
             p->cycles_in_mempool = pending_cycles[i];
             memset(&p->fee_bump, 0, sizeof(p->fee_bump));
             p->fee_bump.last_bump_block = (uint32_t)pending_bumps[i];
+            /* v27: resume escalation schedule.  tx_vsize is constant
+               WATCHTOWER_CPFP_CHILD_VSIZE (not persisted); pre-v27 rows
+               load as zeros and re-initialize at next bump check. */
+            p->fee_bump.start_block    = pending_fb_start_blocks[i];
+            p->fee_bump.deadline_block = pending_fb_deadlines[i];
+            p->fee_bump.budget_sat     = pending_fb_budgets[i];
+            p->fee_bump.start_feerate  = pending_fb_start_feerates[i];
+            p->fee_bump.tx_vsize       = WATCHTOWER_CPFP_CHILD_VSIZE;
+            p->fee_bump.last_feerate   = 0;  /* re-derived from RBF state */
             p->penalty_value = pending_penalty_values[i];
             p->csv_delay = pending_csv_delays[i];
             p->start_height = pending_start_heights[i];
@@ -877,9 +892,13 @@ int watchtower_check(watchtower_t *wt) {
             p->cycles_in_mempool = 0;
             memset(&p->fee_bump, 0, sizeof(p->fee_bump));
             if (wt->db && wt->db->db) {
+                /* fee_bump is freshly memset above — escalation schedule
+                   not yet initialised; persist zeros so a restart-then-
+                   first-bump path still calls htlc_fee_bump_init normally. */
                 persist_save_pending(wt->db, p->txid, p->anchor_vout,
                                        p->anchor_amount, 0, 0,
-                                       p->penalty_value, p->csv_delay, p->start_height);
+                                       p->penalty_value, p->csv_delay, p->start_height,
+                                       0, 0, 0, 0);
             }
         }
 
@@ -1170,11 +1189,17 @@ int watchtower_check(watchtower_t *wt) {
                         printf("  CPFP child broadcast (feerate %llu): %s\n",
                                (unsigned long long)fr, cpfp_txid);
                         if (wt->db && wt->db->db) {
+                            /* v27: persist the escalation schedule so a
+                               mid-bump restart resumes instead of rebasing. */
                             persist_save_pending(wt->db, p->txid,
                                 p->anchor_vout, p->anchor_amount,
                                 p->cycles_in_mempool,
                                 (int)p->fee_bump.last_bump_block,
-                                p->penalty_value, p->csv_delay, p->start_height);
+                                p->penalty_value, p->csv_delay, p->start_height,
+                                p->fee_bump.start_block,
+                                p->fee_bump.deadline_block,
+                                p->fee_bump.budget_sat,
+                                p->fee_bump.start_feerate);
                             persist_log_broadcast(wt->db, cpfp_txid,
                                                   "cpfp", cpfp_hex, "ok");
                         }
@@ -1331,7 +1356,8 @@ int watchtower_add_pending_tx(watchtower_t *wt,
     if (wt->db && wt->db->db)
         persist_save_pending(wt->db, p->txid, p->anchor_vout,
                                p->anchor_amount, 0, 0,
-                               p->penalty_value, p->csv_delay, p->start_height);
+                               p->penalty_value, p->csv_delay, p->start_height,
+                               0, 0, 0, 0);
     return 1;
 }
 

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -175,6 +175,48 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
             p->csv_delay = pending_csv_delays[i];
             p->start_height = pending_start_heights[i];
         }
+
+        /* v28 (PR-C-2): Load force-close watches.  Reconstruct
+           WATCH_FORCE_CLOSE entries directly into wt->entries (they have no
+           re-build-from-state recovery path like factory_node has). */
+        #define WT_FC_MAX_WATCHES 64
+        #define WT_FC_MAX_HTLCS_TOTAL 256
+        uint32_t fc_channels[WT_FC_MAX_WATCHES];
+        unsigned char fc_txids[WT_FC_MAX_WATCHES][32];
+        watchtower_htlc_t fc_htlcs[WT_FC_MAX_HTLCS_TOTAL];
+        size_t fc_n_per[WT_FC_MAX_WATCHES];
+        size_t n_fc = persist_load_force_close_watches(db,
+            fc_channels, fc_txids, fc_htlcs, fc_n_per,
+            WT_FC_MAX_WATCHES, WT_FC_MAX_HTLCS_TOTAL);
+
+        size_t htlc_cursor = 0;
+        for (size_t w = 0; w < n_fc && wt->n_entries < wt->entries_cap; w++) {
+            watchtower_entry_t *e = &wt->entries[wt->n_entries++];
+            memset(e, 0, sizeof(*e));
+            e->type = WATCH_FORCE_CLOSE;
+            e->channel_id = fc_channels[w];
+            memcpy(e->txid, fc_txids[w], 32);
+            e->registered_height = 0;  /* late-arrival mode after restart */
+
+            if (fc_n_per[w] > 0) {
+                e->htlc_outputs = calloc(fc_n_per[w], sizeof(watchtower_htlc_t));
+                if (e->htlc_outputs) {
+                    memcpy(e->htlc_outputs, &fc_htlcs[htlc_cursor],
+                           fc_n_per[w] * sizeof(watchtower_htlc_t));
+                    e->n_htlc_outputs   = fc_n_per[w];
+                    e->htlc_outputs_cap = fc_n_per[w];
+
+                    /* Re-register HTLC scripts on the chain backend so BIP 158
+                       scanning picks up timeouts post-restart. */
+                    if (wt->chain && wt->chain->register_script) {
+                        for (size_t h = 0; h < fc_n_per[w]; h++)
+                            wt->chain->register_script(wt->chain,
+                                                       e->htlc_outputs[h].htlc_spk, 34);
+                    }
+                }
+            }
+            htlc_cursor += fc_n_per[w];
+        }
     }
 
     return 1;
@@ -1544,6 +1586,16 @@ int watchtower_watch_force_close(watchtower_t *wt, uint32_t channel_id,
     if (wt->chain && wt->chain->register_script)
         for (size_t i = 0; i < n_htlcs; i++)
             wt->chain->register_script(wt->chain, htlcs[i].htlc_spk, 34);
+
+    /* v28 (PR-C-2): persist so the entry survives LSP restart.  Unlike
+       commitment / factory_node / subfactory_node entries, force-close
+       watches have no rebuild-from-state recovery path. */
+    if (wt->db && wt->db->db) {
+        int64_t row_id = -1;
+        persist_save_force_close(wt->db, channel_id, commitment_txid,
+                                   (const struct watchtower_htlc *)htlcs,
+                                   n_htlcs, &row_id);
+    }
     return 1;
 }
 

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -250,13 +250,14 @@ int test_offer_decode_bad_checksum(void)
  * v24=epoch column on ps_leaf_chains / ps_initial_signed_states / ps_subfactory_chains (F2),
  * v25=signed_penalty_tx_hex on old_commitments (closes restart-loses-defense gap),
  * v26=signing_rounds journal + signing_round_participants (C3 ceremony forensics),
- * v27=watchtower_pending.fb_* columns (fee-bump escalation persist; PR-C-1)) */
+ * v27=watchtower_pending.fb_* columns (fee-bump escalation persist; PR-C-1),
+ * v28=force_close_watches + force_close_htlcs (PR-C-2)) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 27, "schema version is 27 (v27 adds fee-bump escalation persistence — PR-C-1)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 28, "schema version is 28 (v28 adds force-close watch persistence — PR-C-2)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -249,13 +249,14 @@ int test_offer_decode_bad_checksum(void)
  * v23=ps_initial_signed_states for force-close-after-advance chain history,
  * v24=epoch column on ps_leaf_chains / ps_initial_signed_states / ps_subfactory_chains (F2),
  * v25=signed_penalty_tx_hex on old_commitments (closes restart-loses-defense gap),
- * v26=signing_rounds journal + signing_round_participants (C3 ceremony forensics)) */
+ * v26=signing_rounds journal + signing_round_participants (C3 ceremony forensics),
+ * v27=watchtower_pending.fb_* columns (fee-bump escalation persist; PR-C-1)) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 26, "schema version is 26 (v26 adds signing_rounds journal for ceremony forensics — C3)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 27, "schema version is 27 (v27 adds fee-bump escalation persistence — PR-C-1)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_cpfp.c
+++ b/tests/test_cpfp.c
@@ -488,17 +488,19 @@ int test_pending_persistence(void) {
     /* Save 2 pending entries */
     TEST_ASSERT(persist_save_pending(&db,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        1, 240, 0, 0, 50000, 144, 100), "save pending 1");
+        1, 240, 0, 0, 50000, 144, 100, 0, 0, 0, 0), "save pending 1");
     TEST_ASSERT(persist_save_pending(&db,
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        1, 240, 5, 2, 50000, 144, 100), "save pending 2");
+        1, 240, 5, 2, 50000, 144, 100, 0, 0, 0, 0), "save pending 2");
 
     /* Load them back */
     char txids[16][65];
     uint32_t vouts[16];
     uint64_t amounts[16];
     int cycles[16], bumps[16];
-    size_t n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps, NULL, NULL, NULL, 16);
+    size_t n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps,
+                                      NULL, NULL, NULL,
+                                      NULL, NULL, NULL, NULL, 16);
     TEST_ASSERT_EQ(n, 2, "loaded 2 pending entries");
 
     /* Verify first entry */
@@ -517,15 +519,19 @@ int test_pending_persistence(void) {
     TEST_ASSERT(persist_delete_pending(&db,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         "delete pending 1");
-    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps, NULL, NULL, NULL, 16);
+    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps,
+                               NULL, NULL, NULL,
+                               NULL, NULL, NULL, NULL, 16);
     TEST_ASSERT_EQ(n, 1, "1 entry after delete");
     TEST_ASSERT(strncmp(txids[0], "bbbb", 4) == 0, "remaining entry is bbbb");
 
     /* Update via upsert */
     TEST_ASSERT(persist_save_pending(&db,
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        1, 240, 10, 3, 50000, 144, 100), "upsert pending");
-    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps, NULL, NULL, NULL, 16);
+        1, 240, 10, 3, 50000, 144, 100, 0, 0, 0, 0), "upsert pending");
+    n = persist_load_pending(&db, txids, vouts, amounts, cycles, bumps,
+                               NULL, NULL, NULL,
+                               NULL, NULL, NULL, NULL, 16);
     TEST_ASSERT_EQ(n, 1, "still 1 entry after upsert");
     TEST_ASSERT_EQ(cycles[0], 10, "updated cycles = 10");
     TEST_ASSERT_EQ(bumps[0], 3, "updated bumps = 3");
@@ -650,6 +656,7 @@ int test_watchtower_add_pending_persists(void)
     size_t n = persist_load_pending(&db, loaded_txids, loaded_vouts,
                                      loaded_amounts, loaded_cycles,
                                      loaded_bumps, NULL, NULL, NULL,
+                                     NULL, NULL, NULL, NULL,
                                      WATCHTOWER_MAX_PENDING);
     TEST_ASSERT_EQ((long)n, 1L, "1 entry persisted");
     TEST_ASSERT(strncmp(loaded_txids[0], "ffff", 4) == 0, "txid starts ffff");

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1177,6 +1177,7 @@ extern int test_persist_ps_subfactory_chain_v22_poison_round_trip(void);
 extern int test_persist_ps_initial_signed_state_round_trip(void);
 extern int test_persist_old_commitment_witness_round_trip(void);
 extern int test_persist_signing_rounds_round_trip(void);
+extern int test_persist_pending_fee_bump_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -2984,6 +2985,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_ps_initial_signed_state_round_trip);
     RUN_TEST(test_persist_old_commitment_witness_round_trip);
     RUN_TEST(test_persist_signing_rounds_round_trip);
+    RUN_TEST(test_persist_pending_fee_bump_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1178,6 +1178,7 @@ extern int test_persist_ps_initial_signed_state_round_trip(void);
 extern int test_persist_old_commitment_witness_round_trip(void);
 extern int test_persist_signing_rounds_round_trip(void);
 extern int test_persist_pending_fee_bump_round_trip(void);
+extern int test_persist_force_close_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -2986,6 +2987,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_old_commitment_witness_round_trip);
     RUN_TEST(test_persist_signing_rounds_round_trip);
     RUN_TEST(test_persist_pending_fee_bump_round_trip);
+    RUN_TEST(test_persist_force_close_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -4033,3 +4033,60 @@ int test_persist_signing_rounds_round_trip(void)
     persist_close(&db);
     return 1;
 }
+
+/* v27 (PR-C-1) fee-bump escalation persist round-trip. */
+int test_persist_pending_fee_bump_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    const char *txid = "aa11bb22cc33dd44ee55ff66"
+                       "0011223344556677889900aa"
+                       "bbccddeeff001122334455660011";
+    TEST_ASSERT(persist_save_pending(&db, txid,
+                                       /* anchor_vout    */ 1,
+                                       /* anchor_amount  */ 330,
+                                       /* cycles         */ 3,
+                                       /* bump_count     */ 12345,
+                                       /* penalty_value  */ 100000,
+                                       /* csv_delay      */ 144,
+                                       /* start_height   */ 800000,
+                                       /* fb_start_block */ 800005,
+                                       /* fb_deadline    */ 800500,
+                                       /* fb_budget_sat  */ 50000,
+                                       /* fb_start_fr    */ 5000),
+                "save pending with fee-bump fields");
+
+    char txids[4][65];
+    uint32_t vouts[4];
+    uint64_t amts[4];
+    int cycles[4];
+    int bumps[4];
+    uint64_t pvals[4];
+    uint32_t csvs[4];
+    uint32_t starts[4];
+    uint32_t fb_starts[4];
+    uint32_t fb_deadlines[4];
+    uint64_t fb_budgets[4];
+    uint64_t fb_frs[4];
+
+    size_t n = persist_load_pending(&db, txids, vouts, amts, cycles, bumps,
+                                      pvals, csvs, starts,
+                                      fb_starts, fb_deadlines, fb_budgets, fb_frs,
+                                      4);
+    TEST_ASSERT_EQ((int)n, 1, "exactly 1 row loaded");
+    TEST_ASSERT(strncmp(txids[0], txid, 64) == 0, "txid round-trips");
+    TEST_ASSERT_EQ((int)fb_starts[0], 800005, "fb_start_block round-trips");
+    TEST_ASSERT_EQ((int)fb_deadlines[0], 800500, "fb_deadline_block round-trips");
+    TEST_ASSERT_EQ((long long)fb_budgets[0], 50000LL, "fb_budget_sat round-trips");
+    TEST_ASSERT_EQ((long long)fb_frs[0], 5000LL, "fb_start_feerate round-trips");
+
+    /* NULL-safe out-pointers: legacy callers pass NULL for fb_* and still work. */
+    size_t n2 = persist_load_pending(&db, txids, vouts, amts, cycles, bumps,
+                                       pvals, csvs, starts,
+                                       NULL, NULL, NULL, NULL, 4);
+    TEST_ASSERT_EQ((int)n2, 1, "NULL fb_* out-pointers do not crash");
+
+    persist_close(&db);
+    return 1;
+}

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -4090,3 +4090,88 @@ int test_persist_pending_fee_bump_round_trip(void)
     persist_close(&db);
     return 1;
 }
+
+/* v28 (PR-C-2) force-close watch persistence round-trip. */
+int test_persist_force_close_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    /* Build two watches.  Watch A has 2 HTLCs, watch B has 1. */
+    unsigned char txid_a[32], txid_b[32];
+    memset(txid_a, 0xAA, 32);
+    memset(txid_b, 0xBB, 32);
+
+    watchtower_htlc_t htlcs_a[2];
+    memset(htlcs_a, 0, sizeof(htlcs_a));
+    htlcs_a[0].htlc_vout   = 2;
+    htlcs_a[0].htlc_amount = 100000;
+    memset(htlcs_a[0].htlc_spk, 0x51, 34);
+    htlcs_a[0].direction   = HTLC_OFFERED;
+    memset(htlcs_a[0].payment_hash, 0xCC, 32);
+    htlcs_a[0].cltv_expiry = 800500;
+
+    htlcs_a[1].htlc_vout   = 3;
+    htlcs_a[1].htlc_amount = 50000;
+    memset(htlcs_a[1].htlc_spk, 0x52, 34);
+    htlcs_a[1].direction   = HTLC_RECEIVED;
+    memset(htlcs_a[1].payment_hash, 0xDD, 32);
+    htlcs_a[1].cltv_expiry = 800400;
+
+    watchtower_htlc_t htlcs_b[1];
+    memset(htlcs_b, 0, sizeof(htlcs_b));
+    htlcs_b[0].htlc_vout   = 1;
+    htlcs_b[0].htlc_amount = 75000;
+    memset(htlcs_b[0].htlc_spk, 0x53, 34);
+    htlcs_b[0].direction   = HTLC_OFFERED;
+    memset(htlcs_b[0].payment_hash, 0xEE, 32);
+    htlcs_b[0].cltv_expiry = 800600;
+    strcpy(htlcs_b[0].sweep_txid,
+           "deadbeef00000000000000000000000000000000000000000000000000000000");
+
+    int64_t row_a = -1, row_b = -1;
+    TEST_ASSERT(persist_save_force_close(&db, 7, txid_a,
+                  (const struct watchtower_htlc *)htlcs_a, 2, &row_a),
+                "save watch A");
+    TEST_ASSERT(row_a > 0, "row_a > 0");
+    TEST_ASSERT(persist_save_force_close(&db, 11, txid_b,
+                  (const struct watchtower_htlc *)htlcs_b, 1, &row_b),
+                "save watch B");
+    TEST_ASSERT(row_b > row_a, "row_b > row_a");
+
+    /* Load back */
+    uint32_t channels[4];
+    unsigned char txids[4][32];
+    watchtower_htlc_t loaded_htlcs[8];
+    size_t n_per[4];
+    size_t n_watches = persist_load_force_close_watches(&db,
+        channels, txids, loaded_htlcs, n_per, 4, 8);
+    TEST_ASSERT_EQ((int)n_watches, 2, "loaded 2 watches");
+
+    /* Watch A round-trips */
+    TEST_ASSERT_EQ((int)channels[0], 7,            "watch A channel_id");
+    TEST_ASSERT_EQ((int)n_per[0],    2,            "watch A has 2 HTLCs");
+    TEST_ASSERT(memcmp(txids[0], txid_a, 32) == 0, "watch A txid round-trips");
+    TEST_ASSERT_EQ((long long)loaded_htlcs[0].htlc_amount, 100000LL, "htlc A0 amount");
+    TEST_ASSERT_EQ((int)loaded_htlcs[0].cltv_expiry,        800500,  "htlc A0 cltv");
+    TEST_ASSERT_EQ((int)loaded_htlcs[0].direction,          HTLC_OFFERED, "htlc A0 dir");
+    TEST_ASSERT_EQ((long long)loaded_htlcs[1].htlc_amount, 50000LL,  "htlc A1 amount");
+
+    /* Watch B round-trips */
+    TEST_ASSERT_EQ((int)channels[1], 11,           "watch B channel_id");
+    TEST_ASSERT_EQ((int)n_per[1],    1,            "watch B has 1 HTLC");
+    TEST_ASSERT(memcmp(txids[1], txid_b, 32) == 0, "watch B txid round-trips");
+    TEST_ASSERT_EQ((long long)loaded_htlcs[2].htlc_amount, 75000LL,  "htlc B0 amount");
+    TEST_ASSERT(strncmp(loaded_htlcs[2].sweep_txid, "deadbeef", 8) == 0,
+                "sweep_txid round-trips");
+
+    /* Delete watch A, confirm only B remains. */
+    TEST_ASSERT(persist_delete_force_close(&db, row_a), "delete watch A");
+    size_t n_after = persist_load_force_close_watches(&db,
+        channels, txids, loaded_htlcs, n_per, 4, 8);
+    TEST_ASSERT_EQ((int)n_after, 1, "1 watch after delete");
+    TEST_ASSERT_EQ((int)channels[0], 11, "remaining watch is B");
+
+    persist_close(&db);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes Phase C item #2 from the watchtower restart-correctness audit. `WATCH_FORCE_CLOSE` was the only watchtower entry type without a recovery path on LSP restart — commitment entries reload from `old_commitments`, factory_node / subfactory_node entries are reconstructed by `lsp_channels_rehydrate_watchtower_from_chains`. Force-close watches lived only in RAM, so HTLC sweeps were forgotten after restart.

**Phase C audit revision:** item #4 (subfactory `sub_channel_amounts` reload) was found to be a **false alarm** during this PR's implementation. The rehydrate path at `lsp_channels.c:6588` already populates `chan_amounts` from in-memory factory state — no schema change needed. Documented in the body of this PR.

### Schema v28 (additive)
```sql
CREATE TABLE force_close_watches (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  channel_id INTEGER NOT NULL,
  commitment_txid TEXT NOT NULL
);
CREATE TABLE force_close_htlcs (
  force_close_id INTEGER NOT NULL REFERENCES force_close_watches(id) ON DELETE CASCADE,
  htlc_vout INTEGER NOT NULL,
  htlc_amount INTEGER NOT NULL,
  htlc_spk TEXT NOT NULL,
  direction INTEGER NOT NULL,
  payment_hash TEXT NOT NULL,
  cltv_expiry INTEGER NOT NULL,
  sweep_txid TEXT NOT NULL DEFAULT '',
  PRIMARY KEY (force_close_id, htlc_vout)
);
```

### Wire-up
- `watchtower_watch_force_close` → calls `persist_save_force_close` after the in-memory entry is built
- `watchtower_init` load loop rebuilds `WATCH_FORCE_CLOSE` entries from the two tables and re-registers HTLC scripts with the chain backend so BIP 158 picks up timeouts post-restart

### Note on current trigger surface
The BOLT1_MSG_ERROR force-close path in `ln_dispatch.c:689` today passes `n_htlcs=0`, which is rejected by `watchtower_watch_force_close`. This PR ships the persistence infrastructure ahead of the production HTLC sweep wiring — same posture as Phase A's oracular penalty TX persistence (PR #181), which shipped ahead of the rare-path triggers.

### Verification
- New unit test `test_persist_force_close_round_trip` (save 2 watches with {2,1} HTLCs; load back; delete; verify residue)
- `test_persist_schema_v3` bumped v27 → v28
- Tier B PS regtest PASS with v28 binary
- `schema_version=28` verified live with both tables present
- 1434/1437 unit tests PASS (3 pre-existing wallet-pollution failures unchanged)

## Test plan
- [x] Unit tests pass
- [x] Tier B regtest PASS
- [x] Schema v28 verified live
- [ ] PR-C-1 (#186) merges first (this PR is stacked on top — base is `feat/fee-bump-persist` for now; will retarget to `main` once #186 merges)