### PR TITLE
fix(lsp): set mgr->persist BEFORE lsp_channels_init (dashboard regtest gap)

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -3558,6 +3558,14 @@ accept_new_factory:
         mgr->economic_mode = (economic_mode_t)economic_mode_arg;
         mgr->default_profit_bps = default_profit_bps;
         mgr->settlement_interval_blocks = settlement_interval;
+        /* Persist pointer MUST be set BEFORE lsp_channels_init so the
+           channel_set_persist() calls inside it pick up the live DB.
+           Without this, channels stay with persist_db=NULL and every
+           subsequent persist_save_revocation / persist_save_old_commitment_htlc
+           silently no-ops — the gap reported by the dashboard team in the
+           regtest validation of --demo --payments 4 (revocation_secrets
+           and old_commitment_htlcs both empty despite wire activity). */
+        mgr->persist = use_db ? &db : NULL;
         if (!lsp_channels_init(mgr, ctx, &lsp_p->factory, lsp_seckey, (size_t)n_clients)) {
             fprintf(stderr, "LSP: channel init failed\n");
             lsp_cleanup(lsp_p);
@@ -3594,8 +3602,10 @@ accept_new_factory:
             }
         }
 
-        /* Set persistence pointer (Phase 23) */
-        mgr->persist = use_db ? &db : NULL;
+        /* mgr->persist was set above, before lsp_channels_init, so
+           channel_set_persist() calls inside it picked up the live DB.
+           (Previously assigned here, after init — that left channels with
+           persist_db=NULL and silently dropped revocation/HTLC saves.) */
 
         /* Set configurable confirmation timeout */
         mgr->confirm_timeout_secs = confirm_timeout_secs;


### PR DESCRIPTION
## Summary

Dashboard team's regtest validation of `LSP --demo --payments 4` found 2 persistence tables empty after **wire-confirmed protocol activity**:

- `revocation_secrets`: 0 rows (expected: 16, one per revoked commit)
- `old_commitment_htlcs`: 0 rows (expected: per-HTLC rows on each old commit)

The protocol works correctly on the wire (16× REVOKE_AND_ACK exchanged, commitment_number advanced 0→4 on every channel). But the persistence side silently no-ops.

## Root cause

**Ordering bug in `tools/superscalar_lsp.c`**:

```c
// line 3561 (before fix)
lsp_channels_init(mgr, ...);   // reads mgr->persist (still NULL)

// ... 37 lines later ...

// line 3598 (before fix)
mgr->persist = use_db ? &db : NULL;   // sets it too late
```

Inside `lsp_channels_init`, `channel_set_persist(&entry->channel, mgr->persist, ...)` runs at `src/lsp_channels.c:268` and `:425`. With `mgr->persist == NULL` at that point, every channel gets `ch->persist_db = NULL`. All subsequent `persist_save_revocation` and per-HTLC saves silently skip (they all gate on `ch->persist_db != NULL`).

## Fix

Move the `mgr->persist = use_db ? &db : NULL` assignment **before** `lsp_channels_init` so channels capture the live DB pointer at creation time.

## What this fixes for the dashboard team

| Gap | Before | After |
|---|---|---|
| A — `revocation_secrets` empty | wire works, persist silent | populates 1 row per revoke |
| B — `old_commitment_htlcs` empty | same root cause | populates per-HTLC on revoked commit |

## What this does NOT fix (informational)

- **Gap C** (only Tier B ceremony journaled): already fixed in **PR #190** (`feat/ceremony-hooks-followup`). Separate merge.
- **`invoice_registry created_at = '%s'` "bug"**: NOT a bug. That's SQLite's `strftime('%s','now')` format specifier, passed directly to `sqlite3_exec` — no printf interpolation. Intentional and correct.

## Test plan

- [x] Build clean
- [ ] **Dashboard team to re-verify** — re-run `LSP --demo --payments 4` with patched binary; query `revocation_secrets` + `old_commitment_htlcs` counts after the 4 payments. Expect 16 + 16+ rows respectively.
- [x] Diff is minimal (12 insertions, 2 deletions) — low merge risk.

Note: existing Tier B PS regtest exposes a separate known issue when run on this branch — chain[0] persisted bytes differ from in-memory post-Tier-B bytes. This is the SAME issue PR-C-1 (#186) fixes; it surfaces here because my fix now makes chain[0] persist correctly at initial state, but `origin/main` doesn't yet have PR-C-1's post-Tier-B re-persist logic. **Not a regression** — fix exposes a pre-existing gap that PR #186 already addresses. When #186 + this PR both merge, Tier B regtest passes.