### PR TITLE
fix(tests): PS-ADVANCE broadcast loop waits for BIP68 on non-regtest (#117)

### DIFF
--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -2646,9 +2646,17 @@
              * Custom broadcast loop: for each PS leaf we must broadcast
              * the saved chain[0] TX (pre-advance) before the current
              * signed_tx (chain[1]), because chain[1]->input is chain[0]:0.
-             * Non-leaf nodes (the root/kickoff TX) are broadcast normally. */
+             * Non-leaf nodes (the root/kickoff TX) are broadcast normally.
+             *
+             * #117 fix (2026-05-15): the old loop called regtest_mine_blocks(&rt, 1, ...)
+             * between broadcasts.  That helper has a hard regtest-only guard
+             * (src/regtest.c:786) and silently no-ops on testnet4/signet, so
+             * the next CSV-locked child TX broadcast hit "non-BIP68-final".
+             * Use broadcast_one_signed_tx instead — same helper the production
+             * LSP force-close path uses (tools/superscalar_lsp.c:715), which
+             * properly waits for the parent's BIP68 maturity on non-regtest. */
             if (psa_pass) {
-                printf("\nBroadcasting PS factory tree (%zu nodes + saved chain[0]s) on regtest...\n",
+                printf("\nBroadcasting PS factory tree (%zu nodes + saved chain[0]s)...\n",
                        psa_f->n_nodes);
                 for (size_t i = 0; i < psa_f->n_nodes && psa_pass; i++) {
                     factory_node_t *n = &psa_f->nodes[i];
@@ -2666,46 +2674,31 @@
                     /* PS leaf with prior chain state: broadcast saved chain[0] first */
                     if (leaf_idx >= 0 && n->ps_chain_len > 0
                         && pre_signed_tx[leaf_idx] && pre_signed_tx_len[leaf_idx] > 0) {
-                        char *hex0 = malloc(pre_signed_tx_len[leaf_idx] * 2 + 1);
-                        if (!hex0) { psa_pass = 0; break; }
-                        hex_encode(pre_signed_tx[leaf_idx], pre_signed_tx_len[leaf_idx], hex0);
-                        char txid0[65] = {0};
-                        int ok0 = regtest_send_raw_tx(&rt, hex0, txid0);
-                        free(hex0);
-                        if (!ok0) {
-                            fprintf(stderr, "PS ADVANCE TEST: leaf %d chain[0] broadcast failed\n",
-                                    leaf_idx);
+                        char label0[64];
+                        snprintf(label0, sizeof(label0),
+                                 "ps_advance_leaf_%d_chain0", leaf_idx);
+                        if (!broadcast_one_signed_tx(&rt, mine_addr, is_regtest,
+                                confirm_timeout_secs,
+                                pre_signed_tx[leaf_idx], pre_signed_tx_len[leaf_idx],
+                                n->nsequence, label0, NULL)) {
+                            fprintf(stderr, "PS ADVANCE TEST: leaf %d chain[0] "
+                                    "broadcast failed\n", leaf_idx);
                             psa_pass = 0;
                             break;
                         }
-                        regtest_mine_blocks(&rt, 1, mine_addr);
-                        printf("  leaf[%d] chain[0] broadcast: %s (mined 1 block)\n",
-                               leaf_idx, txid0);
                     }
 
                     /* Broadcast this node's current signed_tx */
-                    char *tx_hex = malloc(n->signed_tx.len * 2 + 1);
-                    if (!tx_hex) { psa_pass = 0; break; }
-                    hex_encode(n->signed_tx.data, n->signed_tx.len, tx_hex);
-                    char txid_cur[65] = {0};
-                    int okN = regtest_send_raw_tx(&rt, tx_hex, txid_cur);
-                    free(tx_hex);
-                    if (!okN) {
+                    char label_n[64];
+                    snprintf(label_n, sizeof(label_n), "ps_advance_node_%zu", i);
+                    if (!broadcast_one_signed_tx(&rt, mine_addr, is_regtest,
+                            confirm_timeout_secs,
+                            n->signed_tx.data, n->signed_tx.len,
+                            n->nsequence, label_n, n->txid)) {
                         fprintf(stderr, "PS ADVANCE TEST: node %zu broadcast failed\n", i);
                         psa_pass = 0;
                         break;
                     }
-                    regtest_mine_blocks(&rt, 1, mine_addr);
-
-                    unsigned char disp[32];
-                    memcpy(disp, n->txid, 32);
-                    reverse_bytes(disp, 32);
-                    char disp_hex[65];
-                    hex_encode(disp, 32, disp_hex);
-                    const char *role = (leaf_idx >= 0 && n->ps_chain_len > 0)
-                                         ? " (chain[1])" : "";
-                    printf("  node[%zu] broadcast: %s%s (mined 1 block)\n",
-                           i, disp_hex, role);
                 }
                 printf("All %zu factory nodes + PS chain TXs confirmed on-chain.\n",
                        psa_f->n_nodes);


### PR DESCRIPTION
## Summary

Fixes bug #117 — TS-PS-ADVANCE on testnet4 fails with \"non-BIP68-final\" when broadcasting tree_node_1 after the PS leaf advance ceremony.

The test driver's broadcast loop called `regtest_mine_blocks(&rt, 1, mine_addr)` between sequential node broadcasts. That helper has a hard regtest-only guard at `src/regtest.c:786`:

\`\`\`c
int regtest_mine_blocks(regtest_t *rt, int n, const char *address) {
    /* Only allow mining on regtest to prevent accidental mining on other networks */
    if (strcmp(rt->network, \"regtest\") != 0) return 0;
    ...
}
\`\`\`

So on testnet4/signet the call silently no-opped, and the next CSV-locked child TX hit mempool rejection.

## Fix

Replaced the manual `regtest_send_raw_tx` + `regtest_mine_blocks` pattern with `broadcast_one_signed_tx` — the same helper the production LSP force-close path already uses (`tools/superscalar_lsp.c:715`). It:

- extracts nSequence's CSV depth (bits 0..15 when bit 31 is clear)
- on regtest: mines `required_depth` blocks before broadcast
- on non-regtest: polls block height until `target_height = start + depth`
- retries the broadcast if BIP68 isn't yet satisfied at submit time
- waits for confirmation after submission (mines on regtest, polls on non-regtest)

Applied at the two broadcast sites in the PS-ADVANCE test loop:
- chain[0] broadcast for leaves with prior chain state
- node's current signed_tx broadcast (chain[1] for advanced leaves)

Both pass `n->nsequence` for the CSV depth — matching the pattern at `tools/superscalar_lsp.c:877` where chain[0] also uses `node->nsequence`.

## Test plan

- [x] Build clean (`cmake --build . --target superscalar_lsp test_superscalar`)
- [x] Combined unit-test run with this + the #119 dust guard returned 1453 OK + 3 pre-existing wallet-pollution FAILs — no new regressions
- [ ] Real-network verification needs a TS-PS-ADVANCE testnet4 run (~1-2 h per attempt). Will run after merge.

## Risk

- Touches only the test driver `pre_daemon_tests.inc`, not production code paths
- Reuses an already-battle-tested helper (`broadcast_one_signed_tx` is the same one production force-close uses)
- Regtest behavior preserved: still mines 1 block per broadcast for nSequence=0 nodes, mines required_depth for CSV-locked nodes