### PR TITLE
fix(lsp-channels): preserve mgr->persist through init memset (F1 + dashboard gap root cause)

### DIFF
--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -158,14 +158,24 @@ int lsp_channels_init(lsp_channel_mgr_t *mgr,
     if (!mgr || !ctx || !factory || !lsp_seckey32) return 0;
     if (n_clients == 0) return 0;
 
-    /* Preserve fee policy set before init (caller may configure these) */
+    /* Preserve fields set before init (caller may configure these).
+       mgr->persist MUST survive the memset so channel_set_persist() below
+       can attach the live DB to each channel — without it, every
+       channel-level persist (revocation_secrets, old_commitment_htlcs)
+       silently no-ops, and lsp_run_state_advance's Step 11 (DW counter
+       persist) and Step 11.5 (F1 chain[0] re-persist) skip the if guard.
+       Caller (tools/superscalar_lsp.c:3591) sets mgr->persist before
+       this call; PR-DASH-PERSIST (#196) added that ordering but didn't
+       extend the memset preservation set. */
     uint64_t saved_fee_ppm = mgr->routing_fee_ppm;
     uint16_t saved_bal_pct = mgr->lsp_balance_pct;
     void *saved_fee = mgr->fee;
+    void *saved_persist = mgr->persist;
     memset(mgr, 0, sizeof(*mgr));
     mgr->routing_fee_ppm = saved_fee_ppm;
     mgr->lsp_balance_pct = saved_bal_pct;
     mgr->fee = saved_fee;
+    mgr->persist = saved_persist;
     mgr->ctx = ctx;
     mgr->n_channels = n_clients;
     mgr->bridge_fd = -1;
@@ -311,10 +321,13 @@ int lsp_channels_init_from_db(lsp_channel_mgr_t *mgr,
     if (!mgr || !ctx || !factory || !lsp_seckey32 || !pdb) return 0;
     if (n_clients == 0) return 0;
 
-    /* Preserve fields set before init (caller may configure these) */
+    /* Preserve fields set before init (caller may configure these).
+       Mirror of lsp_channels_init — see comment there for why mgr->persist
+       must survive the memset. */
     uint64_t saved_fee_ppm = mgr->routing_fee_ppm;
     uint16_t saved_bal_pct = mgr->lsp_balance_pct;
     void *saved_fee2 = mgr->fee;
+    void *saved_persist = mgr->persist;
     economic_mode_t saved_econ = mgr->economic_mode;
     uint16_t saved_profit_bps = mgr->default_profit_bps;
     uint32_t saved_settle_interval = mgr->settlement_interval_blocks;
@@ -322,6 +335,7 @@ int lsp_channels_init_from_db(lsp_channel_mgr_t *mgr,
     mgr->routing_fee_ppm = saved_fee_ppm;
     mgr->lsp_balance_pct = saved_bal_pct;
     mgr->fee = saved_fee2;
+    mgr->persist = saved_persist;
     mgr->economic_mode = saved_econ;
     mgr->default_profit_bps = saved_profit_bps;
     mgr->settlement_interval_blocks = saved_settle_interval;

--- a/tests/test_ladder.c
+++ b/tests/test_ladder.c
@@ -1053,9 +1053,14 @@ int test_rotation_context_save_restore(void) {
     lsp_channels_cleanup(&mgr);
     TEST_ASSERT(lsp_channels_init(&mgr, ctx, f, lsp_sec_local, 4), "reinit mgr");
 
-    /* Verify fields are zeroed */
+    /* Verify field reset semantics after re-init.  persist is in the
+       init preservation set (the caller is expected to attach the live
+       persist_t before init so channel_set_persist() inside init picks
+       it up — see lsp_channels_init comment).  bridge_fd resets to -1,
+       ladder stays zeroed (not in the preservation set). */
     TEST_ASSERT_EQ(mgr.bridge_fd, -1, "bridge_fd reset to -1");
-    TEST_ASSERT_EQ((long)(uintptr_t)mgr.persist, 0, "persist zeroed");
+    TEST_ASSERT_EQ((long)(uintptr_t)mgr.persist, (long)(uintptr_t)0xCAFEBABE,
+                    "persist preserved through reinit");
     TEST_ASSERT_EQ((long)(uintptr_t)mgr.ladder, 0, "ladder zeroed");
     TEST_ASSERT_EQ(mgr.rot_auto_rotate, 0, "rot_auto_rotate zeroed");
 


### PR DESCRIPTION
## Summary

PR #196 (dashboard-persist) added \`mgr->persist = use_db ? &db : NULL\` BEFORE \`lsp_channels_init\` in \`tools/superscalar_lsp.c:3591\`, with the intent that \`channel_set_persist()\` inside init would pick up the live DB.

But \`lsp_channels_init\`'s preservation pattern (\`saved_*\`/\`memset\`/\`restored_*\`) didn't include \`persist\` — so the \`memset\` at line 165 zeroed \`mgr->persist\` immediately after the caller set it.

This made **every** code path that reads \`mgr->persist\` after init silently no-op:

1. **\`channel_set_persist(&entry->channel, mgr->persist, c)\`** at \`lsp_channels.c:289\` received NULL — channels had no DB attached → \`revocation_secrets\` and \`old_commitment_htlcs\` stayed empty under wire activity. **This is the gap the dashboard team originally reported. PR #196 only set persist early; it didn't fix the memset, so the bug remained latent.**
2. **\`lsp_run_state_advance\` Step 11** (DW counter persist) at line 2724: skipped on \`if (mgr->persist)\`.
3. **\`lsp_run_state_advance\` Step 11.5** (F1 chain[0] re-persist) at line 2741: same guard, same skip. This is the **root cause of the F1 sub-factory chain[0] regtest assertion failure** documented today: \`PS nodes 5/7/11/13 chain[0] persisted bytes differ from in-memory signed_tx (stale row)\`.

## Diagnosis

Direct \`fprintf\`-bisection on \`test_regtest_tier_b_rollover_ps.sh\` confirmed:

\`\`\`
F1-GUARD: trigger_leaf_side=-1 mgr->persist=(nil)
\`\`\`

\`trigger_leaf_side\` correctly reflects a root-driven Tier B (-1); \`mgr->persist\` is nil because the memset zeroed it after the caller's earlier assignment.

## Fix

Add \`saved_persist = mgr->persist;\` ... \`mgr->persist = saved_persist;\` to both \`lsp_channels_init\` (fresh-create) and \`lsp_channels_init_from_db\` (recovery) preservation sets.

The recovery path (\`tools/superscalar_lsp.c:2435\`) already assigned persist after init, so the init-path preservation is defense-in-depth for it.  The fresh-create path now works correctly without needing a redundant post-init assignment.

## Regtest validation

\`tools/test_regtest_tier_b_rollover_ps.sh\`: **PASS**

\`\`\`
F1 persist log lines          : 1
ps_initial_signed_states rows : 4 (matches in-memory bytes after Tier B)
PASS: CL2-TB gate accepts arity 3, F1 chain[0] persist verified (4 rows)
TIER B ROLLOVER TEST: PASS
\`\`\`

Previously failed with 4 PS-leaf chain[0] mismatches.

## Unit-test regression

\`test_superscalar\` → 1453 OK + 3 pre-existing wallet-pollution FAILs (\`test_regtest_ps_basic_close\`, \`_chain_close\`, \`_old_state_response\` — all unrelated, environmental, in baseline before this PR).

One test (\`test_rotation_context_save_restore\` in \`tests/test_ladder.c:1058\`) was asserting the buggy zeroing behavior (\`persist=0\` after re-init).  Updated to assert the new contract (\`persist\` preserved across re-init) with a comment explaining the rationale.

## Test plan

- [x] \`test_regtest_tier_b_rollover_ps.sh\` PASS (F1 verified end-to-end)
- [x] \`test_superscalar\` clean regression (1453 OK, 3 pre-existing FAIL)
- [x] Build clean on Linux
- [ ] CI: regtest_tier_b_rollover_ps with FORCE_CLOSE=1 (proves chain[0] bytes are valid on-chain)
- [ ] CI: regtest_tier_b_rollover_ps with PS_SUB_ARITY=2 and PS_SUB_ARITY=4 (sub-factory k=2/k=4 shapes)
- [ ] On merge: verify dashboard's \`revocation_secrets\` and \`old_commitment_htlcs\` tables actually populate now (the original PR #196 motivation)