### PR TITLE
fix(reorg): wait loops use stable-confirmation helper (R2 mainnet pre-flight)

### DIFF
--- a/include/superscalar/regtest.h
+++ b/include/superscalar/regtest.h
@@ -114,6 +114,15 @@ void regtest_faucet_health_report(void);
 int regtest_wait_for_confirmation(regtest_t *rt, const char *txid,
                                     int timeout_secs);
 
+/* CL8: reorg-aware confirmation wait.
+   Returns 1 when txid stably has >= target_depth confirmations (verified
+   by a second poll after a delay; if conf drops more than
+   max_tolerated_reorg_depth, restart the wait). Returns 0 on timeout. */
+int regtest_wait_for_stable_confirmation(regtest_t *rt, const char *txid,
+                                          int target_depth,
+                                          int max_tolerated_reorg_depth,
+                                          int timeout_secs);
+
 /* Find a wallet UTXO suitable for CPFP bump funding.
    Locks the selected UTXO via lockunspent so concurrent callers cannot
    pick the same coin.  Call regtest_release_utxo() after broadcast.

--- a/src/jit_channel.c
+++ b/src/jit_channel.c
@@ -279,7 +279,12 @@ int jit_channel_create(void *mgr_ptr, void *lsp_ptr,
                           mgr->confirm_timeout_secs : 7200;
         int confirmed = 0;
         for (int attempt = 0; attempt < 2; attempt++) {
-            if (regtest_wait_for_confirmation(rt, fund_txid_hex, jit_timeout) >= 1) {
+            /* R2 (mainnet pre-flight): reorg-resilient confirmation wait —
+               re-verifies after a delay and restarts on reorg-induced drop. */
+            if (regtest_wait_for_stable_confirmation(rt, fund_txid_hex,
+                                                      /*target_depth=*/1,
+                                                      /*max_reorg_depth=*/3,
+                                                      jit_timeout) >= 1) {
                 confirmed = 1;
                 break;
             }

--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -450,7 +450,11 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
                         continue;
                     }
                 } else {
-                    if (regtest_wait_for_confirmation(rt, rc_txid, rot_timeout) >= 1) {
+                    /* R2 (mainnet pre-flight): reorg-resilient confirmation wait. */
+                    if (regtest_wait_for_stable_confirmation(rt, rc_txid,
+                                                              /*target_depth=*/1,
+                                                              /*max_reorg_depth=*/3,
+                                                              rot_timeout) >= 1) {
                         confirmed = 1; break;
                     }
                     if (regtest_is_in_mempool(rt, rc_txid)) {
@@ -546,7 +550,11 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
                     continue;
                 }
             } else {
-                if (regtest_wait_for_confirmation(rt, fund_txid_hex, rot_timeout) >= 1) {
+                /* R2 (mainnet pre-flight): reorg-resilient confirmation wait. */
+                if (regtest_wait_for_stable_confirmation(rt, fund_txid_hex,
+                                                          /*target_depth=*/1,
+                                                          /*max_reorg_depth=*/3,
+                                                          rot_timeout) >= 1) {
                     confirmed = 1; break;
                 }
                 if (regtest_is_in_mempool(rt, fund_txid_hex)) {

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -791,14 +791,26 @@ static int broadcast_one_signed_tx(regtest_t *rt, const char *mine_addr,
         return 0;
     }
 
-    /* Confirm it */
+    /* Confirm it.
+       R2 (mainnet pre-flight): use the stable-confirmation variant so we
+       re-verify after a delay and restart the wait if a reorg drops the
+       TX between confirmation and the recheck.  target_depth=1 preserves
+       the prior shallow-confirmation semantics; max_tolerated_reorg_depth=3
+       is a conservative threshold for restart-on-drop. */
     if (is_regtest) {
         regtest_mine_blocks(rt, 1, mine_addr);
     } else {
-        printf("  %s broadcast OK (txid=%.16s...), waiting for confirmation...\n",
+        printf("  %s broadcast OK (txid=%.16s...), waiting for stable confirmation...\n",
                log_source, txid_out);
         fflush(stdout);
-        regtest_wait_for_confirmation(rt, txid_out, confirm_timeout);
+        if (!regtest_wait_for_stable_confirmation(rt, txid_out,
+                                                    /*target_depth=*/1,
+                                                    /*max_reorg_depth=*/3,
+                                                    confirm_timeout)) {
+            fprintf(stderr,
+                    "  %s confirmation wait timed out or stuck on reorg — "
+                    "downstream may need to re-broadcast\n", log_source);
+        }
     }
 
     if (display_txid_internal_be) {
@@ -4075,8 +4087,12 @@ accept_new_factory:
     if (is_regtest) {
         regtest_mine_blocks(&rt, 1, mine_addr);
     } else {
-        printf("LSP: waiting for close tx confirmation on %s...\n", network);
-        regtest_wait_for_confirmation(&rt, close_txid, confirm_timeout_secs);
+        printf("LSP: waiting for stable close tx confirmation on %s...\n", network);
+        /* R2 (mainnet pre-flight): reorg-resilient confirmation wait. */
+        regtest_wait_for_stable_confirmation(&rt, close_txid,
+                                              /*target_depth=*/1,
+                                              /*max_reorg_depth=*/3,
+                                              confirm_timeout_secs);
     }
     tx_buf_free(&close_tx);
 


### PR DESCRIPTION
## Summary

5 production confirmation-wait callsites used \`regtest_wait_for_confirmation\`, which returns at \`conf>=1\` with **no re-check**. If a reorg drops the TX between confirmation and the caller's next action, the caller proceeds as if the TX were final.

Force-close, JIT funding, rotation close, rotation funding, and coop close all had this gap.

## Fix

Switch to \`regtest_wait_for_stable_confirmation(rt, txid, 1, 3, timeout)\`. The stable variant:

- Polls for \`target_depth\` confirmations
- Re-verifies after a delay (30s on non-regtest, 2s on regtest)
- Restarts the wait if confirmation drops more than \`max_tolerated_reorg_depth\` (3)

\`target_depth=1\` preserves the prior shallow-confirmation semantics. \`max_tolerated_reorg_depth=3\` is the restart threshold.

## Sites updated

| File | Site |
|---|---|
| \`tools/superscalar_lsp.c\` | \`broadcast_one_signed_tx\` confirmation wait |
| \`tools/superscalar_lsp.c\` | cooperative close TX confirmation |
| \`src/jit_channel.c\` | JIT funding TX confirmation |
| \`src/lsp_rotation.c\` | rotation close TX confirmation |
| \`src/lsp_rotation.c\` | rotation new factory funding confirmation |

Also: \`regtest_wait_for_stable_confirmation\` existed in \`src/regtest.c\` since CL8 but **was never declared** in \`include/superscalar/regtest.h\`. Add the prototype so callers outside regtest.c can link.

## Context

This is **R2** of the mainnet reorg-readiness audit. R1 (#201) added daemon-loop same-height + forward-reorg detection. Follow-up needed:

- **R3** — confirmation-depth policy (per-network safe depths > 1; JIT/rotation/coop should target ≥6 on mainnet)
- **R5** — funding-TX-reorged-out failure mode (mark channel invalid)

## Regression

Unit tests: **1453 OK + 3 pre-existing wallet-pollution FAILs**, no new failures.

## Test plan

- [x] Build clean on Linux (passed missing-prototype check after header fix)
- [x] \`test_superscalar\` clean regression
- [ ] CI: confirm all sanitizer + regtest jobs pass
- [ ] Manual: drive a controlled regtest reorg between commit broadcast and confirmation; verify R2 detects + recovers