### PR TITLE
fix(reorg): per-network safe confirmation depth (R3 mainnet pre-flight)

### DIFF
--- a/include/superscalar/regtest.h
+++ b/include/superscalar/regtest.h
@@ -123,6 +123,20 @@ int regtest_wait_for_stable_confirmation(regtest_t *rt, const char *txid,
                                           int max_tolerated_reorg_depth,
                                           int timeout_secs);
 
+/* R3: Per-network safe confirmation depth — the number of confirmations
+   beyond which a reorg becoming canonical is operationally negligible.
+
+     regtest               -> 1   (controlled chain, no real reorgs)
+     signet / testnet4     -> 3   (light competitive, daily small reorgs)
+     testnet (legacy)      -> 3
+     mainnet               -> 6   (industry default; ~1h of finality)
+
+   Used by JIT funding, factory rotation, and coop close — paths where
+   we depend on the TX being final before progressing to the next user-
+   facing step.  Pass to regtest_wait_for_stable_confirmation as
+   target_depth. */
+int regtest_network_safe_confirmation_depth(const regtest_t *rt);
+
 /* Find a wallet UTXO suitable for CPFP bump funding.
    Locks the selected UTXO via lockunspent so concurrent callers cannot
    pick the same coin.  Call regtest_release_utxo() after broadcast.

--- a/src/jit_channel.c
+++ b/src/jit_channel.c
@@ -277,12 +277,13 @@ int jit_channel_create(void *mgr_ptr, void *lsp_ptr,
     } else {
         int jit_timeout = mgr->confirm_timeout_secs > 0 ?
                           mgr->confirm_timeout_secs : 7200;
+        int safe_depth = regtest_network_safe_confirmation_depth(rt);
         int confirmed = 0;
         for (int attempt = 0; attempt < 2; attempt++) {
-            /* R2 (mainnet pre-flight): reorg-resilient confirmation wait —
-               re-verifies after a delay and restarts on reorg-induced drop. */
+            /* R2 + R3 (mainnet pre-flight): reorg-resilient + network-safe
+               confirmation depth (regtest=1, signet/testnet4=3, mainnet=6). */
             if (regtest_wait_for_stable_confirmation(rt, fund_txid_hex,
-                                                      /*target_depth=*/1,
+                                                      safe_depth,
                                                       /*max_reorg_depth=*/3,
                                                       jit_timeout) >= 1) {
                 confirmed = 1;

--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -450,9 +450,11 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
                         continue;
                     }
                 } else {
-                    /* R2 (mainnet pre-flight): reorg-resilient confirmation wait. */
+                    /* R2 + R3 (mainnet pre-flight): reorg-resilient + network-safe
+                       confirmation depth (regtest=1, signet/testnet4=3, mainnet=6). */
+                    int safe_depth_close = regtest_network_safe_confirmation_depth(rt);
                     if (regtest_wait_for_stable_confirmation(rt, rc_txid,
-                                                              /*target_depth=*/1,
+                                                              safe_depth_close,
                                                               /*max_reorg_depth=*/3,
                                                               rot_timeout) >= 1) {
                         confirmed = 1; break;
@@ -550,9 +552,11 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
                     continue;
                 }
             } else {
-                /* R2 (mainnet pre-flight): reorg-resilient confirmation wait. */
+                /* R2 + R3 (mainnet pre-flight): reorg-resilient + network-safe
+                   confirmation depth (regtest=1, signet/testnet4=3, mainnet=6). */
+                int safe_depth_fund = regtest_network_safe_confirmation_depth(rt);
                 if (regtest_wait_for_stable_confirmation(rt, fund_txid_hex,
-                                                          /*target_depth=*/1,
+                                                          safe_depth_fund,
                                                           /*max_reorg_depth=*/3,
                                                           rot_timeout) >= 1) {
                     confirmed = 1; break;

--- a/src/regtest.c
+++ b/src/regtest.c
@@ -1485,6 +1485,16 @@ int regtest_wait_for_stable_confirmation(regtest_t *rt, const char *txid,
     return 0;
 }
 
+/* R3: per-network safe confirmation depth — see header for rationale. */
+int regtest_network_safe_confirmation_depth(const regtest_t *rt) {
+    if (!rt) return 6;  /* conservative default */
+    if (strcmp(rt->network, "regtest") == 0) return 1;
+    if (strcmp(rt->network, "signet") == 0)  return 3;
+    if (strcmp(rt->network, "testnet4") == 0) return 3;
+    if (strcmp(rt->network, "testnet") == 0)  return 3;
+    if (strcmp(rt->network, "mainnet") == 0)  return 6;
+    return 6;  /* unknown network → conservative */
+}
 
 int regtest_get_utxo_for_bump(regtest_t *rt, uint64_t min_amount_sats,
                                 char *txid_out, uint32_t *vout_out,

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -4087,10 +4087,13 @@ accept_new_factory:
     if (is_regtest) {
         regtest_mine_blocks(&rt, 1, mine_addr);
     } else {
-        printf("LSP: waiting for stable close tx confirmation on %s...\n", network);
-        /* R2 (mainnet pre-flight): reorg-resilient confirmation wait. */
+        int safe_depth = regtest_network_safe_confirmation_depth(&rt);
+        printf("LSP: waiting for close tx to reach %d confirmations on %s...\n",
+               safe_depth, network);
+        /* R2 + R3 (mainnet pre-flight): reorg-resilient + network-safe
+           confirmation depth (regtest=1, signet/testnet4=3, mainnet=6). */
         regtest_wait_for_stable_confirmation(&rt, close_txid,
-                                              /*target_depth=*/1,
+                                              safe_depth,
                                               /*max_reorg_depth=*/3,
                                               confirm_timeout_secs);
     }


### PR DESCRIPTION
## Summary

R2 (#202) switched 5 confirmation-wait callsites to the reorg-resilient \`regtest_wait_for_stable_confirmation\` helper but kept \`target_depth=1\` (shallow). For mainnet deployment, \`target_depth=1\` is too shallow for paths that gate user-facing state transitions (channel open, factory rotation final, coop close settled).

This PR adds **network-aware safe depth** and applies it at the 4 callsites where the next step depends on TX finality.

## New helper

\`\`\`c
int regtest_network_safe_confirmation_depth(const regtest_t *rt);
\`\`\`

Returns:

| Network | Depth | Rationale |
|---|---|---|
| regtest | 1 | Controlled chain, no real reorgs |
| signet | 3 | Light competitive, daily small reorgs |
| testnet4 | 3 | Same |
| testnet (legacy) | 3 | Same |
| mainnet | **6** | Industry default; ~1h finality |
| unknown | 6 | Conservative |

## Sites updated

| File | Site | New depth |
|---|---|---|
| \`src/jit_channel.c\` | JIT funding TX confirmation | network-safe |
| \`src/lsp_rotation.c\` | rotation close TX confirmation | network-safe |
| \`src/lsp_rotation.c\` | rotation new factory funding | network-safe |
| \`tools/superscalar_lsp.c\` | cooperative close TX confirmation | network-safe |

**Not** changed: \`broadcast_one_signed_tx\` stays at \`target_depth=1\`. That site is a shallow \"did the TX hit a block\" check used inside force-close tree broadcast; the caller (or watchtower recovery) is responsible for the deeper \"is it operationally final\" check separately.

## Compatibility

- **Regtest behavior preserved** — regtest network gets \`target_depth=1\` same as R2, so existing regtest tests are unaffected.
- **Mainnet impact** — JIT funding will take ~60min to confirm (6 blocks × 10min). This is intentional; the client should not treat its channel as funded until reorg risk is negligible.
- **Signet/testnet4 impact** — JIT funding takes ~3 blocks to settle. Acceptable.

## Stack

Stacks on top of #202 (R2 wait-loop stable-confirm). Merging order: #201 (R1) → #202 (R2) → this PR (R3).

## Regression

Unit tests: **1453 OK + 3 pre-existing wallet-pollution FAILs**, no new failures.

## Test plan

- [x] Build clean
- [x] \`test_superscalar\` clean regression
- [ ] CI: confirm all sanitizer + regtest jobs pass on R2's base
- [ ] After R2 merges: rebase + re-run CI
- [ ] On signet/mainnet pre-flight: test JIT funding actually waits the expected depth