### PR TITLE
dashboard: fix old_commitment_htlcs collector — payments tab showed 0 sat

### DIFF
--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -310,10 +310,16 @@ def collect_databases(cfg):
             "SELECT txid, anchor_vout, anchor_amount, cycles_in_mempool, bump_count "
             "FROM watchtower_pending ORDER BY bump_count DESC")
         data[label]["watchtower_pending"] = rows if not err else []
-        # Old commitment HTLCs — HTLCs attached to old (revoked) commitments
+        # Old commitment HTLCs — HTLCs attached to old (revoked) commitments.
+        # Schema uses htlc_vout/htlc_amount and integer direction (0=offered,
+        # 1=received per htlc_direction_t).  Alias to match the live htlcs
+        # row shape (htlc_index, amount, string direction) so rPayments and
+        # the per-channel rollup can consume both lists uniformly without
+        # special-casing the historical table.
         rows, err = query_db(path,
-            "SELECT channel_id, commit_num, htlc_index, direction, amount, "
-            "payment_hash, cltv_expiry "
+            "SELECT channel_id, commit_num, htlc_vout AS htlc_index, "
+            "CASE direction WHEN 0 THEN 'offered' ELSE 'received' END AS direction, "
+            "htlc_amount AS amount, payment_hash, cltv_expiry "
             "FROM old_commitment_htlcs ORDER BY channel_id, commit_num DESC LIMIT 50")
         data[label]["old_commitment_htlcs"] = rows if not err else []
         # PR #181 Phase A consumer: count old_commitments rows with persisted


### PR DESCRIPTION
## Summary
- The collector's SELECT against `old_commitment_htlcs` used the live-`htlcs` field names (`htlc_index`, `amount`, string `direction`), but the historical table uses `htlc_vout`, `htlc_amount`, and integer `direction` (0/1).
- The query failed with "no such column" and the rows defaulted to `[]`, so the Payments tab showed "Volume routed: 0 sat" and 0 sat per row despite real HTLC traffic.
- Fix is SQL-only: alias the columns and map `direction` with `CASE WHEN 0 THEN 'offered' ELSE 'received'`. No renderer changes — `rPayments` and the per-channel rollup now consume both tables uniformly.

## Test plan
- [x] On a clean regtest `--demo` run with 4 payments (1000/1500/2000/1000 sats), confirm 8 rows in `old_commitment_htlcs` come through `/api/status` with `amount` populated and `direction` as `'offered'`/`'received'`.
- [x] Confirm "Volume routed", per-channel "Vol out"/"Vol in", and per-payment amounts render real numbers.
- [ ] CI passes.