### PR TITLE
fix(reorg): R5 funding_pending_reorg channel state (mainnet pre-flight)

### DIFF
--- a/include/superscalar/channel.h
+++ b/include/superscalar/channel.h
@@ -157,6 +157,18 @@ typedef struct {
        Prevents premature HTLC failure when height goes backward during reorg. */
     uint32_t      last_htlc_check_height;
 
+    /* R5 (mainnet pre-flight): set to 1 when a reorg has dropped the funding
+       UTXO this channel depends on (factory leaf state TX or original funding
+       TX, depending on factory shape).  While this flag is set:
+         - channel_add_htlc refuses to add new HTLCs
+         - channel_build_commitment_tx refuses (no valid commit can spend
+           a UTXO that doesn't exist)
+       LN-aligned semantics: channel is FROZEN, not abandoned.  If the funding
+       UTXO re-confirms on the new chain, the flag clears and operation
+       resumes.  Cleared by lsp_channels_revalidate_funding() when the
+       channel's funding_txid is observed confirmed again. */
+    int           funding_pending_reorg;
+
     /* Dynamic commitment: negotiated channel type (BOLT #2 PR #880) */
     uint32_t      channel_type_bits;         /* feature bits from channel_type TLV */
 

--- a/include/superscalar/lsp_channels.h
+++ b/include/superscalar/lsp_channels.h
@@ -374,6 +374,14 @@ int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
    not an error. */
 int lsp_persist_ps_chain0_all(void *persist, factory_t *f);
 
+/* R5 (mainnet pre-flight): revalidate each factory channel's funding UTXO
+   against the active chain.  Sets ch->funding_pending_reorg=1 when the
+   funding TX has been reorged out; clears it back to 0 when re-confirmed.
+   LN-aligned: channel is FROZEN (HTLCs + force-close refused), not
+   abandoned — re-confirmation re-enables it.
+   Returns the number of channels whose flag state changed. */
+int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr);
+
 /* PS k² sub-factory chain extension ceremony driver (Gap E followup
    Phase 2b, t/1242).  Drives the multi-party MuSig signing of a new
    sub-factory state when the LSP "sells liquidity from sales-stock":

--- a/src/channel.c
+++ b/src/channel.c
@@ -857,6 +857,16 @@ commit_tx_done:
 int channel_build_commitment_tx(const channel_t *ch,
                                   tx_buf_t *unsigned_tx_out,
                                   unsigned char *txid_out32) {
+    /* R5 (mainnet pre-flight): refuse to build a commit TX if the funding
+       UTXO has been reorged out.  Any commit TX we'd build spends the
+       funding UTXO — broadcasting it would fail with -25 (missingorspent).
+       Channel is FROZEN until lsp_channels_revalidate_funding() observes
+       the funding TX re-confirmed. */
+    if (ch->funding_pending_reorg) {
+        fprintf(stderr, "channel_build_commitment_tx: refused — funding UTXO "
+                "pending reorg\n");
+        return 0;
+    }
     return channel_build_commitment_tx_impl(ch, unsigned_tx_out, txid_out32, NULL);
 }
 
@@ -1588,6 +1598,16 @@ static void channel_compact_htlcs(channel_t *ch) {
 int channel_add_htlc(channel_t *ch, htlc_direction_t direction,
                       uint64_t amount_sats, const unsigned char *payment_hash32,
                       uint32_t cltv_expiry, uint64_t *htlc_id_out) {
+    /* R5 (mainnet pre-flight): reject new HTLCs when the channel's funding
+       UTXO has been reorged out.  Channel is FROZEN (LN-aligned): commit
+       TX would spend a UTXO that doesn't exist on the active chain.  Flag
+       clears when lsp_channels_revalidate_funding() observes the funding
+       TX re-confirmed (or stays set until operator intervention). */
+    if (ch->funding_pending_reorg) {
+        fprintf(stderr, "channel_add_htlc: refused — funding UTXO pending "
+                "reorg (waiting for re-confirmation)\n");
+        return 0;
+    }
     if (ch->n_htlcs >= MAX_HTLCS)
         return 0;
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2792,6 +2792,53 @@ int lsp_persist_ps_chain0_all(void *persist, factory_t *f) {
     return saved;
 }
 
+/* R5 (mainnet pre-flight): revalidate each factory channel's funding UTXO
+   against the active chain.  Sets ch->funding_pending_reorg = 1 when the
+   funding TX is no longer findable (reorged out); clears the flag back to
+   0 when a confirmed observation returns.  Mirrors jit_channels_revalidate
+   _funding() (src/jit_channel.c:752) for the factory-channel case.
+
+   Returns the number of channels whose flag state changed (toggled either
+   direction).  Caller may persist or notify clients on a non-zero return.
+
+   Intended call sites (separate PRs will wire these up):
+     1. Daemon startup recovery (one-shot scan, like jit_channels_*)
+     2. R1's reorg handler in lsp_run_state_advance (defense after watchtower_on_reorg)
+     3. Periodic heartbeat (cheap defense)
+*/
+int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr) {
+    if (!mgr || !mgr->watchtower || !mgr->watchtower->rt) return 0;
+    extern void hex_encode(const unsigned char *, size_t, char *);
+    extern void reverse_bytes(unsigned char *, size_t);
+    int changed = 0;
+    for (size_t c = 0; c < mgr->n_channels; c++) {
+        channel_t *ch = &mgr->entries[c].channel;
+        /* Compute display-order hex txid for the chain query. */
+        unsigned char disp[32];
+        memcpy(disp, ch->funding_txid, 32);
+        reverse_bytes(disp, 32);
+        char txid_hex[65];
+        hex_encode(disp, 32, txid_hex);
+        txid_hex[64] = '\0';
+        int conf = regtest_get_confirmations(mgr->watchtower->rt, txid_hex);
+        if (conf < 0 && !ch->funding_pending_reorg) {
+            fprintf(stderr,
+                "LSP revalidate: channel %zu funding %.16s... not on chain — "
+                "FREEZING (funding_pending_reorg=1)\n", c, txid_hex);
+            ch->funding_pending_reorg = 1;
+            changed++;
+        } else if (conf >= 1 && ch->funding_pending_reorg) {
+            fprintf(stderr,
+                "LSP revalidate: channel %zu funding %.16s... back on chain "
+                "(%d confs) — UNFREEZING (funding_pending_reorg=0)\n",
+                c, txid_hex, conf);
+            ch->funding_pending_reorg = 0;
+            changed++;
+        }
+    }
+    return changed;
+}
+
 /* Cooperatively redistribute output amounts on an arity-2 leaf (3-of-3).
    LSP proposes new amounts; both clients agree via 2-round MuSig2 ceremony. */
 int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,


### PR DESCRIPTION
## Summary

When a chain reorg drops the UTXO a channel's funding depends on, the LSP today has no way to express \"this channel is frozen until funding re-confirms\". A force-close would broadcast a commitment TX spending a UTXO that doesn't exist (bitcoind rejects with -25 missingorspent). A new HTLC would mutate channel state under a hollow funding reference.

## LN-aligned design

**LDK / LND / CLN all converged on the same pattern** after years of mainnet operation:

- Channel **REVERTS** state on funding-reorged-out (LND: OPEN → AWAITING_LOCKIN; CLN: CHANNELD_AWAITING_LOCKIN).
- No new HTLCs flow.
- Force-close blocked.
- Funding TX is **NOT abandoned** — polling continues. If it re-confirms on the new chain, channel unfreezes automatically.
- Eventual escalation (~\`mempool_expiry_blocks\`) is the only path to channel abandonment.

This PR adds the **recoverable-freeze primitive**.

## What ships

- \`channel_t.funding_pending_reorg\` flag (default 0 on init).
- \`channel_add_htlc\` refuses while flag set; clear stderr message.
- \`channel_build_commitment_tx\` refuses while flag set.
- \`lsp_channels_revalidate_funding(mgr)\` — iterates factory channels, queries each \`funding_txid\` via \`regtest_get_confirmations\`, sets the flag on \`conf<0\`, clears it when \`conf>=1\`. Returns count of changes.

## Deliberately out of scope (follow-up PRs)

| Task | Description |
|---|---|
| #125 | Persist the flag across LSP restart (schema column) |
| #126 | Wire \`revalidate_funding\` into the daemon reorg handler (depends on R1 #201) |
| #127 | \`MSG_FUNDING_REORG\` wire protocol so clients pause too |
| #128 | Mempool-expiry timeout policy (~2 weeks mainnet → abandon) |

Splitting into separate PRs keeps each diff reviewable and lets the primitive ship without the larger protocol changes.

## Context

R5 of the mainnet reorg-readiness audit:

| | PR |
|---|---|
| R1 (LSP daemon detection) | #201 |
| R2 (wait-loop stable-confirm) | #202 |
| R3 (network-safe depth) | #203 |
| R6 (standalone WT forward-reorg) | #204 |
| **R5 (this PR)** | this |
| R4 (signet adversarial test) | task #129 |

See internal \`PS_MAINNET_PUNCH_LIST.md\` Phase R for full criteria checklist.

## Regression

Unit tests: **1453 OK + 3 pre-existing wallet-pollution FAILs**, no new failures.

## Test plan

- [x] Build clean (Linux)
- [x] \`test_superscalar\` clean regression (matches baseline)
- [ ] CI: confirm all sanitizer + regtest jobs pass
- [ ] Follow-up unit test (own PR): set flag → add_htlc rejected, set flag → build_commitment rejected, clear flag → both succeed
- [ ] Follow-up R4 test (own PR): drive controlled regtest reorg, verify revalidate transitions flag correctly