### PR TITLE
fix(reorg): reset in-memory sub-factory chain advance state on reorg

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -534,6 +534,23 @@ int factory_subfactory_chain_advance_unsigned(
     factory_t *f, int leaf_side, int sub_idx_in_leaf,
     int channel_idx_in_sub, uint64_t delta_sats);
 
+/* Reset in-memory sub-factory chain advance state on chain reorg.
+
+   Walks f->nodes[] for NODE_PS_SUBFACTORY entries and zeroes any node
+   whose ps_chain_len > 0 (i.e., has been advanced).  After the reset,
+   force-close falls back to chain[0] (the v23/PR #144 path), which spends
+   the factory leaf output directly and is unaffected by reorg of chain[N]
+   parent UTXOs.
+
+   The on-disk ps_subfactory_chains rows are preserved for forensics
+   (operator audit, dashboard observability) — only the in-memory state
+   is reset.  This is a conservative response: a deep reorg of a confirmed
+   chain[N-1] invalidates chain[N]'s prev-output reference, so signing or
+   broadcasting chain[N] from the divergent in-memory state would fail.
+
+   Returns the count of sub-factories reset (for observability). */
+int factory_reset_all_subfactory_chains(factory_t *f);
+
 /* Compute the factory_early_warning_time (blocks) per BLIP-56.
    This is the worst-case blocks needed for full unilateral close from
    the current state. PS leaves contribute 0 blocks (no nSequence at leaf level). */

--- a/src/factory.c
+++ b/src/factory.c
@@ -2446,6 +2446,21 @@ int factory_subfactory_chain_advance_unsigned(
     return 1;
 }
 
+int factory_reset_all_subfactory_chains(factory_t *f) {
+    if (!f) return 0;
+    int n_reset = 0;
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        factory_node_t *node = &f->nodes[i];
+        if (node->type != NODE_PS_SUBFACTORY) continue;
+        if (node->ps_chain_len == 0) continue;
+        node->ps_chain_len = 0;
+        node->ps_n_prev_outputs = 0;
+        memset(node->ps_prev_txid, 0, 32);
+        n_reset++;
+    }
+    return n_reset;
+}
+
 /* --- Per-node split-round signing helpers --- */
 
 int factory_session_init_node(factory_t *f, size_t node_idx) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -5771,6 +5771,21 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                         /* Re-validate watchtower entries */
                         watchtower_on_reorg(mgr->watchtower, height,
                                            daemon_last_height);
+                        /* Drop in-memory sub-factory chain advance state.
+                           A reorg of chain[N-1] would invalidate chain[N]'s
+                           prev-output reference; resetting forces force-close
+                           to fall back to chain[0] (v23/PR #144 path), which
+                           spends the factory leaf output directly. DB rows
+                           in ps_subfactory_chains are preserved for forensics. */
+                        {
+                            int n_sub_reset =
+                                factory_reset_all_subfactory_chains(&lsp->factory);
+                            if (n_sub_reset > 0)
+                                fprintf(stderr,
+                                    "LSP reorg: reset chain advance state for "
+                                    "%d sub-factory(s); force-close falls back "
+                                    "to chain[0]\n", n_sub_reset);
+                        }
                         /* Immediate watchtower check to re-detect breaches */
                         watchtower_check(mgr->watchtower);
                         /* Re-run factory recovery to re-broadcast lost TXs */


### PR DESCRIPTION
## Summary

The daemon-loop reorg detector calls `watchtower_on_reorg` to re-validate WT entries and mark `broadcast_log` / `tree_nodes` / `jit_channels` / `ladder_factories` rows stale (added in PRs #201/#202/#204), but no code path drops in-memory sub-factory chain advance state. After a deep reorg of chain[N-1], chain[N]'s prev-output reference is invalid; the LSP keeps `sub->ps_chain_len` non-zero in memory and force-close attempts would try to broadcast chain[N] against a non-existent parent UTXO.

Add `factory_reset_all_subfactory_chains()`: walks `f->nodes[]`, zeroes `ps_chain_len` for any `NODE_PS_SUBFACTORY` with `ps_chain_len > 0`, clears the captured `ps_prev_outputs`. Call it from the daemon-loop reorg path right after `watchtower_on_reorg`. Force-close from a reset sub-factory falls back to chain[0] (v23/PR #144 path), which spends the factory leaf output directly and is unaffected by chain[N>0] reorgs.

DB rows in `ps_subfactory_chains` are intentionally preserved for forensics (operator audit, dashboard observability). A future PR should add `validated_at_height` / `reorg_stale` columns for height-aware staleness; this is the minimum viable response to close the gap identified in the sub-factory deep audit (Phase 5).

Conservative: resets ALL advanced sub-factories regardless of reorg depth. Height-aware refinement requires schema changes; deferred.

## Test plan

- [x] Builds clean on regtest (`cmake --build . --target superscalar_lsp`)
- [x] `--demo --test-subfactory-advance` smoke test: factory creation + 4 cross-payments + sub-factory chain extension + coop-close all succeed; `signing_rounds` shows `factory_creation` + `sub_factory_advance` both `success`
- [ ] CI passes (regtest integration + sanitizers)
- [ ] Manual reorg simulation: `bitcoin-cli invalidateblock` then `generatetoaddress` a competing branch deeper than chain[0]'s confirm depth — verify stderr emits `"LSP reorg: reset chain advance state for N sub-factory(s)"` and force-close falls back to chain[0] cleanly. (Punt to follow-up if too heavy for this PR; the path is exercised by existing reorg tests once they grow a sub-factory-advance precondition.)

## Why this is conservative

Resetting all advanced sub-factories on any detected reorg sacrifices the advance state of deeply-confirmed entries that were never actually rolled back. The alternative (height-aware reset) requires a `confirmed_height` column on `ps_subfactory_chains` and tracking per-entry confirmation depth. That schema bump is out of scope here; this PR is the safety-first response so the LSP never tries to broadcast a chain[N] whose parent is gone.