### PR TITLE
feat(reorg): MSG_FUNDING_REORG wire protocol (R5 follow-up)

### DIFF
--- a/include/superscalar/lsp_channels.h
+++ b/include/superscalar/lsp_channels.h
@@ -382,8 +382,10 @@ int lsp_persist_ps_chain0_all(void *persist, factory_t *f);
    funding TX has been reorged out; clears it back to 0 when re-confirmed.
    LN-aligned: channel is FROZEN (HTLCs + force-close refused), not
    abandoned — re-confirmation re-enables it.
+   When `lsp` is non-NULL, sends MSG_FUNDING_REORG to lsp->client_fds[slot]
+   on every flip so the client mirrors the freeze state.
    Returns the number of channels whose flag state changed. */
-int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr);
+int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr, lsp_t *lsp);
 
 /* PS k² sub-factory chain extension ceremony driver (Gap E followup
    Phase 2b, t/1242).  Drives the multi-party MuSig signing of a new

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -128,6 +128,12 @@
 #define MSG_SUBFACTORY_PSIG         0x76  /* Client → LSP: client partial sig */
 #define MSG_SUBFACTORY_DONE         0x77  /* LSP → sub clients: chain extension complete */
 
+/* R5 mainnet pre-flight: funding-UTXO reorg notification.
+   LSP → Client.  Sent when lsp_channels_revalidate_funding observes the
+   funding TX has dropped off chain (frozen=1) or returned (frozen=0).
+   Payload: { "frozen": 0|1, "funding_txid": "<display-hex>" } */
+#define MSG_FUNDING_REORG       0x78
+
 #define MSG_ERROR              0xFF
 
 /* --- Protocol limits --- */

--- a/src/client.c
+++ b/src/client.c
@@ -126,8 +126,16 @@ static void client_send_error(int fd, const char *reason) {
     cJSON_Delete(err);
 }
 
+/* Client-side mirror of LSP's funding_pending_reorg flag.  When MSG_FUNDING_
+   REORG arrives, we set this so future cooperative ops / add-htlc paths can
+   check it and refuse.  Best-effort: LSP-side state is authoritative; this
+   is just a UX hint so the client doesn't try to do anything that'll be
+   rejected anyway. */
+static int g_client_funding_pending_reorg = 0;
+
 /* Wrapper around wire_recv_timeout that transparently handles
-   MSG_PING (responds with MSG_PONG) and MSG_PONG (discards).
+   MSG_PING (responds with MSG_PONG), MSG_PONG (discards), and
+   MSG_FUNDING_REORG (updates local freeze mirror, discards).
    Returns 1 on a real (non-keepalive) message, 0 on failure. */
 static int wire_recv_handle_ping(int fd, wire_msg_t *msg, int timeout_sec) {
     for (;;) {
@@ -145,6 +153,24 @@ static int wire_recv_handle_ping(int fd, wire_msg_t *msg, int timeout_sec) {
             if (msg->json) cJSON_Delete(msg->json);
             msg->json = NULL;
             continue;  /* discard pong, wait for real message */
+        }
+        if (msg->msg_type == MSG_FUNDING_REORG) {
+            int frozen = 0;
+            const char *txid_hex = "?";
+            if (msg->json) {
+                cJSON *fr = cJSON_GetObjectItem(msg->json, "frozen");
+                if (fr && cJSON_IsNumber(fr)) frozen = fr->valueint;
+                cJSON *tx = cJSON_GetObjectItem(msg->json, "funding_txid");
+                if (tx && cJSON_IsString(tx)) txid_hex = tx->valuestring;
+            }
+            g_client_funding_pending_reorg = frozen ? 1 : 0;
+            fprintf(stderr, "Client: MSG_FUNDING_REORG funding=%.16s "
+                    "frozen=%d (LSP says funding %s)\n",
+                    txid_hex, frozen,
+                    frozen ? "reorged out" : "back on chain");
+            if (msg->json) cJSON_Delete(msg->json);
+            msg->json = NULL;
+            continue;  /* notification, wait for next real message */
         }
         return 1;  /* real message */
     }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2806,7 +2806,7 @@ int lsp_persist_ps_chain0_all(void *persist, factory_t *f) {
      2. R1's reorg handler in lsp_run_state_advance (defense after watchtower_on_reorg)
      3. Periodic heartbeat (cheap defense)
 */
-int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr) {
+int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
     if (!mgr || !mgr->watchtower || !mgr->watchtower->rt) return 0;
     extern void hex_encode(const unsigned char *, size_t, char *);
     extern void reverse_bytes(unsigned char *, size_t);
@@ -2821,12 +2821,14 @@ int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr) {
         hex_encode(disp, 32, txid_hex);
         txid_hex[64] = '\0';
         int conf = regtest_get_confirmations(mgr->watchtower->rt, txid_hex);
+        int new_state = -1;
         if (conf < 0 && !ch->funding_pending_reorg) {
             fprintf(stderr,
                 "LSP revalidate: channel %zu funding %.16s... not on chain — "
                 "FREEZING (funding_pending_reorg=1)\n", c, txid_hex);
             ch->funding_pending_reorg = 1;
             changed++;
+            new_state = 1;
             /* v31: persist the toggle so a restart mid-reorg reloads frozen. */
             if (mgr->persist)
                 persist_update_channel_funding_reorg(
@@ -2838,9 +2840,24 @@ int lsp_channels_revalidate_funding(lsp_channel_mgr_t *mgr) {
                 c, txid_hex, conf);
             ch->funding_pending_reorg = 0;
             changed++;
+            new_state = 0;
             if (mgr->persist)
                 persist_update_channel_funding_reorg(
                     (persist_t *)mgr->persist, (uint32_t)c, 0);
+        }
+        /* R5 wire: notify the client so it mirrors the freeze state.
+           Best-effort: client may be offline; the LSP-side flag is still
+           authoritative.  A reconnect can resync via the next revalidate
+           cycle if this message was missed. */
+        if (new_state >= 0 && lsp && lsp->client_fds &&
+            c < lsp->n_clients && lsp->client_fds[c] >= 0) {
+            cJSON *j = cJSON_CreateObject();
+            if (j) {
+                cJSON_AddNumberToObject(j, "frozen", new_state);
+                cJSON_AddStringToObject(j, "funding_txid", txid_hex);
+                wire_send(lsp->client_fds[c], MSG_FUNDING_REORG, j);
+                cJSON_Delete(j);
+            }
         }
     }
     return changed;
@@ -5846,7 +5863,7 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                            channel.c gates add_htlc/build_commitment behind
                            that flag so a reorged-out funding TX cannot ship
                            an HTLC that has no on-chain backing. */
-                        int frz = lsp_channels_revalidate_funding(mgr);
+                        int frz = lsp_channels_revalidate_funding(mgr, lsp);
                         if (frz)
                             fprintf(stderr, "LSP: reorg revalidate flipped "
                                     "funding_pending_reorg on %d channel(s)\n",
@@ -6419,7 +6436,7 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                 cbe->reorg_cb(hb_height, mgr->last_known_height,
                                               cbe->reorg_cb_ctx);
                             /* R5: revalidate factory channels' funding UTXOs. */
-                            int hb_frz = lsp_channels_revalidate_funding(mgr);
+                            int hb_frz = lsp_channels_revalidate_funding(mgr, lsp);
                             if (hb_frz)
                                 fprintf(stderr, "LSP: heartbeat revalidate "
                                         "flipped funding_pending_reorg on %d "


### PR DESCRIPTION
## Summary

R5 (PR #206) keeps the LSP-side \`funding_pending_reorg\` flag correct on reorg, and the persist follow-up (PR #211) keeps it correct across LSP restart.  Without a wire notification, the client doesn't know the LSP froze the channel and would happily try to initiate \`add_htlc\` / coop-close paths that the LSP will reject silently.  This PR closes that gap.

## Wire

- New \`MSG_FUNDING_REORG = 0x78\` (LSP → Client only)
- Payload: \`{ \"frozen\": 0|1, \"funding_txid\": \"<display-hex>\" }\`

## LSP side

\`lsp_channels_revalidate_funding(mgr, lsp)\` — added \`lsp\` parameter so the helper can call \`wire_send\` on each flip.  Best-effort: skipped if \`lsp\` is NULL or \`client_fds[slot] < 0\`.

## Client side

\`wire_recv_handle_ping\` intercepts \`MSG_FUNDING_REORG\` just like it already handles PING/PONG: updates a local mirror flag, logs, continues waiting for the next real message.  Static \`g_client_funding_pending_reorg\` is the in-memory mirror.  Future PRs can promote to per-channel state and wire it into client-side add_htlc / coop-close gates once the client-side state machinery is there.

## Why this is safe

- Forward-compat: a client running this build will silently absorb the message; an older client would get \`MSG_ERROR\` via the existing fallback path on the LSP wire layer.  Server enforcement still holds either way.
- No new ceremony stages; the message is asynchronous and decoupled from any in-flight ceremony.
- Signature change to \`lsp_channels_revalidate_funding\` is contained: no callers on main yet (PR #210 adds the first two call sites; this PR may merge before or after).

## Test plan

- [x] Compiles cleanly (visual review — JSON path mirrors existing PING/PONG)
- [ ] CI passes (regtest integration + sanitizers + fuzz)
- [ ] Manual on regtest: \`bitcoin-cli invalidateblock\` the funding block, watch for \`Client: MSG_FUNDING_REORG funding=... frozen=1\` in client stderr; \`reconsiderblock\`, watch for \`frozen=0\`

## R5 follow-up state

- ✅ #126 wire revalidate into R1 handler (PR #210)
- ✅ #125 persist funding_pending_reorg across restart (PR #211)
- ✅ #127 MSG_FUNDING_REORG wire protocol (this PR)
- ⬜ #128 mempool-expiry timeout policy (next)