### PR TITLE
fix(watchtower): persist csv_delay on entry (SF-WTC #149)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 31
+#define PERSIST_SCHEMA_VERSION 32
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -336,7 +336,16 @@ int persist_save_old_commitment(persist_t *p, uint32_t channel_id,
                                   const unsigned char *to_local_spk,
                                   size_t spk_len);
 
-/* Load old commitments for a channel. Returns count loaded. */
+/* v32 (SF-WTC #149): stamp csv_delay on an existing old_commitments row.
+   Called from watchtower_watch_revoked_commitment (where ch->to_self_delay
+   is in scope) immediately after persist_save_old_commitment.  Lets the
+   oracular CPFP escalation read csv_delay back without live channel state. */
+int persist_save_old_commitment_csv_delay(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t csv_delay);
+
+/* Load old commitments for a channel. Returns count loaded.
+   csv_delays parameter (v32+) may be NULL for legacy callers; 0 = unset. */
 size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *commit_nums,
                                       unsigned char (*txids)[32],
@@ -344,6 +353,7 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *amounts,
                                       unsigned char (*spks)[34],
                                       size_t *spk_lens,
+                                      uint32_t *csv_delays,
                                       size_t max_entries);
 
 /* --- Pre-signed penalty TX persistence (v25) ---

--- a/include/superscalar/watchtower.h
+++ b/include/superscalar/watchtower.h
@@ -47,6 +47,16 @@ typedef struct {
     unsigned char to_local_spk[34];
     size_t to_local_spk_len;
 
+    /* v32 (SF-WTC #149): channel CSV delay captured at watchtower-entry
+       registration time.  Pre-fix the CPFP tracking loop (watchtower.c
+       around line 940) read csv_delay from live channel state, gating on
+       `ch != NULL`.  Oracular / standalone watchtowers have ch == NULL,
+       so CPFP-bump escalation was silently skipped.  Persisting csv_delay
+       on the entry lets oracular paths drive CPFP without needing live
+       channel access.  Defaults to 0 = "unset" for older DBs; the CPFP
+       site falls back to `ch->to_self_delay` or CHANNEL_DEFAULT_CSV_DELAY. */
+    uint32_t csv_delay;
+
     /* HTLC outputs on the breached commitment (for penalty sweep) */
     watchtower_htlc_t *htlc_outputs;
     size_t n_htlc_outputs;

--- a/src/persist.c
+++ b/src/persist.c
@@ -98,6 +98,10 @@ static const char *SCHEMA_SQL =
        time so the watchtower can broadcast after a process restart.
        Default '' (empty) preserves legacy lazy-build fallback. */
     "  signed_penalty_tx_hex TEXT NOT NULL DEFAULT '',"
+    /* v32 (SF-WTC #149): channel CSV delay captured at entry registration.
+       Lets the oracular CPFP path drive fee escalation without needing
+       live channel state.  0 = unset (legacy entries) → caller falls back. */
+    "  csv_delay INTEGER NOT NULL DEFAULT 0,"
     "  PRIMARY KEY (channel_id, commit_num)"
     ");"
     "CREATE TABLE IF NOT EXISTS old_commitment_htlcs ("
@@ -1163,6 +1167,17 @@ int persist_open(persist_t *p, const char *path) {
     if (db_version < 31) {
         sqlite3_exec(p->db,
             "ALTER TABLE channels ADD COLUMN funding_pending_reorg "
+            "INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+    }
+
+    /* v32 (SF-WTC #149): persist channel CSV delay on watchtower entries so
+       the oracular CPFP escalation path can compute deadlines without live
+       channel access.  0 = unset (legacy) → caller falls back to ch state
+       or CHANNEL_DEFAULT_CSV_DELAY. */
+    if (db_version < 32) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE old_commitments ADD COLUMN csv_delay "
             "INTEGER NOT NULL DEFAULT 0;",
             NULL, NULL, NULL);
     }
@@ -2744,6 +2759,9 @@ int persist_save_old_commitment(persist_t *p, uint32_t channel_id,
     hex_encode(txid32, 32, txid_hex);
     hex_encode(to_local_spk, spk_len, spk_hex);
 
+    /* csv_delay defaults to 0 here (= unset).  Stamping with the live
+       channel value happens via persist_save_old_commitment_csv_delay
+       from the caller that has channel context (#149). */
     const char *sql =
         "INSERT OR REPLACE INTO old_commitments "
         "(channel_id, commit_num, txid, to_local_vout, to_local_amount, to_local_spk) "
@@ -2765,6 +2783,32 @@ int persist_save_old_commitment(persist_t *p, uint32_t channel_id,
     return ok;
 }
 
+/* v32 (SF-WTC #149): update only the csv_delay column on an existing
+   old_commitments row.  Called from watchtower_watch_revoked_commitment
+   right after the row is inserted so the oracular CPFP path can read it
+   back without live channel state. */
+int persist_save_old_commitment_csv_delay(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t csv_delay) {
+    if (!p || !p->db) return 0;
+
+    const char *sql =
+        "UPDATE old_commitments SET csv_delay = ? "
+        "WHERE channel_id = ? AND commit_num = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+
+    sqlite3_bind_int(stmt, 1, (int)csv_delay);
+    sqlite3_bind_int(stmt, 2, (int)channel_id);
+    sqlite3_bind_int64(stmt, 3, (sqlite3_int64)commit_num);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
 size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *commit_nums,
                                       unsigned char (*txids)[32],
@@ -2772,11 +2816,13 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *amounts,
                                       unsigned char (*spks)[34],
                                       size_t *spk_lens,
+                                      uint32_t *csv_delays,
                                       size_t max_entries) {
     if (!p || !p->db) return 0;
 
     const char *sql =
-        "SELECT commit_num, txid, to_local_vout, to_local_amount, to_local_spk "
+        "SELECT commit_num, txid, to_local_vout, to_local_amount, to_local_spk, "
+        "       csv_delay "
         "FROM old_commitments WHERE channel_id = ? ORDER BY commit_num ASC;";
 
     sqlite3_stmt *stmt;
@@ -2805,6 +2851,10 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
             int decoded = hex_decode(spk_hex_str, spks[count], 34);
             spk_lens[count] = decoded > 0 ? (size_t)decoded : 0;
         }
+
+        /* v32 (SF-WTC): csv_delay column; 0 means unset on legacy entries. */
+        if (csv_delays)
+            csv_delays[count] = (uint32_t)sqlite3_column_int(stmt, 5);
 
         count++;
     }

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -64,10 +64,12 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
             uint64_t amounts[WATCHTOWER_MAX_WATCH];
             unsigned char spks[WATCHTOWER_MAX_WATCH][34];
             size_t spk_lens[WATCHTOWER_MAX_WATCH];
+            uint32_t csv_delays[WATCHTOWER_MAX_WATCH];
 
             size_t loaded = persist_load_old_commitments(
                 db, (uint32_t)c, commit_nums, txids, vouts, amounts,
-                spks, spk_lens, wt->entries_cap - wt->n_entries);
+                spks, spk_lens, csv_delays,
+                wt->entries_cap - wt->n_entries);
 
             for (size_t i = 0; i < loaded && wt->n_entries < wt->entries_cap; i++) {
                 watchtower_entry_t *e = &wt->entries[wt->n_entries++];
@@ -83,6 +85,9 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
                 e->to_local_amount = amounts[i];
                 memcpy(e->to_local_spk, spks[i], spk_lens[i]);
                 e->to_local_spk_len = spk_lens[i];
+                /* v32 (SF-WTC #149): hydrate csv_delay so oracular CPFP can
+                   read it after restart without live channel state. */
+                e->csv_delay = csv_delays[i];
 
                 /* Re-register the watched script with the chain backend so
                    BIP 158 scanning resumes correctly after a process restart. */
@@ -244,6 +249,10 @@ int watchtower_watch(watchtower_t *wt, uint32_t channel_id,
     e->to_local_amount = to_local_amount;
     memcpy(e->to_local_spk, to_local_spk, spk_len);
     e->to_local_spk_len = spk_len;
+    /* v32 (SF-WTC): unset by default; populated post-watch by callers that
+       have live channel access (watchtower_watch_revoked_commitment etc.),
+       or hydrated from DB at restart by persist_load_watchtower_entries. */
+    e->csv_delay = 0;
     e->n_htlc_outputs = 0;
     e->response_tx = NULL;
     e->response_tx_len = 0;
@@ -399,6 +408,16 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
                 watchtower_watch(wt, channel_id, old_commit_num,
                                    old_txid, 0, old_remote,
                                    to_local_spk, 34);
+
+                /* v32 SF-WTC #149: stamp csv_delay on the entry just registered
+                   (in-memory + DB) so the oracular CPFP path can drive escalation
+                   without needing live channel access at bump time. */
+                if (wt->n_entries > 0) {
+                    wt->entries[wt->n_entries - 1].csv_delay = ch->to_self_delay;
+                    if (wt->db && wt->db->db)
+                        persist_save_old_commitment_csv_delay(
+                            wt->db, channel_id, old_commit_num, ch->to_self_delay);
+                }
 
                 /* #208 A3.1b — pre-build the penalty TX bytes at registration
                    time and attach to the entry we just created.  After this
@@ -925,21 +944,23 @@ int watchtower_check(watchtower_t *wt) {
 
         /* Track in pending for CPFP bump if anchor is active.
            NOTE: anchor_vout=1 must match channel_build_penalty_tx output order.
-           Skip CPFP tracking at sub-1-sat/vB — no anchor output was created. */
+           Skip CPFP tracking at sub-1-sat/vB — no anchor output was created.
+           SF-WTC #149: dropped `ch &&` gate.  csv_delay now sourced from
+           e->csv_delay (persisted at watch-registration), falling back to
+           live ch->to_self_delay for legacy entries pre v32, and to the
+           hard default if neither is available. */
         uint32_t cur_height = wt->chain ? wt->chain->get_block_height(wt->chain) : 0;
-        if (ch && penalty_sent && use_anchor &&
+        if (penalty_sent && use_anchor &&
             wt->anchor_spk_len == P2A_SPK_LEN &&
             wt->n_pending < wt->pending_cap) {
-            /* CPFP tracking still requires live channel state for csv_delay.
-               TODO A3.1b: persist csv_delay in the watchtower entry at
-               registration time so the oracular path can track CPFP too. */
             watchtower_pending_t *p = &wt->pending[wt->n_pending++];
             memcpy(p->txid, penalty_txid, 64);
             p->txid[64] = '\0';
             p->anchor_vout = 1;
             p->anchor_amount = WATCHTOWER_ANCHOR_AMOUNT;
             p->penalty_value = e->to_local_amount;
-            p->csv_delay = ch->to_self_delay;
+            p->csv_delay = (e->csv_delay > 0) ? e->csv_delay
+                          : (ch ? ch->to_self_delay : CHANNEL_DEFAULT_CSV_DELAY);
             p->start_height = cur_height;
             p->cycles_in_mempool = 0;
             memset(&p->fee_bump, 0, sizeof(p->fee_bump));

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -254,13 +254,14 @@ int test_offer_decode_bad_checksum(void)
  * v28=force_close_watches + force_close_htlcs (PR-C-2),
  * v29=reorg_events + breach_detections (observability; PR-C-6),
  * v30=old_commitment_ptlcs (PR-PTLC-1 schema groundwork),
- * v31=channels.funding_pending_reorg (R5 follow-up — persist freeze state)) */
+ * v31=channels.funding_pending_reorg (R5 follow-up — persist freeze state),
+ * v32=old_commitments.csv_delay (SF-WTC #149 — oracular CPFP needs CSV)) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 31, "schema version is 31 (v31 adds channels.funding_pending_reorg — R5 follow-up)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 32, "schema version is 32 (v32 adds old_commitments.csv_delay — SF-WTC #149)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -815,7 +815,7 @@ int test_persist_old_commitments(void) {
     size_t spk_lens[16];
 
     size_t count = persist_load_old_commitments(&db, 0, commit_nums,
-        loaded_txids, vouts, amounts, loaded_spks, spk_lens, 16);
+        loaded_txids, vouts, amounts, loaded_spks, spk_lens, NULL, 16);
     TEST_ASSERT_EQ(count, 2, "loaded 2 entries");
     TEST_ASSERT_EQ(commit_nums[0], 5, "commit_num 0");
     TEST_ASSERT_EQ(commit_nums[1], 6, "commit_num 1");
@@ -828,7 +828,7 @@ int test_persist_old_commitments(void) {
 
     /* Load for different channel — should be empty */
     count = persist_load_old_commitments(&db, 1, commit_nums,
-        loaded_txids, vouts, amounts, loaded_spks, spk_lens, 16);
+        loaded_txids, vouts, amounts, loaded_spks, spk_lens, NULL, 16);
     TEST_ASSERT_EQ(count, 0, "no entries for channel 1");
 
     persist_close(&db);


### PR DESCRIPTION
## Summary

The CPFP escalation block at \`src/watchtower.c\` around line 940 reads \`csv_delay\` from the live channel state and was gated behind \`ch != NULL\`. On the oracular / standalone watchtower path, \`ch\` is NULL by design, so the CPFP block was silently skipped: no fee-bump tracking, no escalation, no anchor-spend scheduling. Stale TODO at watchtower.c:933-935 flagged the gap.

## Schema

- v32: \`ALTER TABLE old_commitments ADD COLUMN csv_delay INTEGER NOT NULL DEFAULT 0\`
- Legacy entries (pre v32) load with 0 → \"unset\"; CPFP block falls back to \`ch->to_self_delay\` (live path) or \`CHANNEL_DEFAULT_CSV_DELAY\` (oracular pre-stamp legacy).

## Wiring

- \`watchtower_entry_t\` gains a \`uint32_t csv_delay\` field
- \`watchtower_watch\` initializes it to 0 (no signature change)
- \`watchtower_watch_revoked_commitment\` stamps both in-memory and DB via the new \`persist_save_old_commitment_csv_delay\` helper
- \`persist_load_old_commitments\` grows a \`csv_delays\` output array (legacy callers can pass NULL)
- Watchtower restart hydrates \`e->csv_delay\` from the loaded array
- CPFP gate drops the \`ch &&\` requirement; csv_delay sourced via \`e->csv_delay > 0 ? e->csv_delay : (ch ? ch->to_self_delay : CHANNEL_DEFAULT_CSV_DELAY)\`

## Why this is safe

- No behavior change for the live-channel path (\`ch != NULL\`)
- Pre-v32 DBs migrate cleanly via ALTER + DEFAULT 0
- Combined with PR-C-1 (fee-bump schedule persist) the oracular watchtower can now drive the full CPFP loop without live channel state — closes the MAINNET_ROADMAP A3.1b carve-out

## Test plan

- [x] Compiles (visual review; pure additive on storage + 1 gate predicate change)
- [ ] CI passes (schema-version smoke + sanitizers + regtest integration)
- [ ] Manual: regtest with --test-rotation + LSP restart mid-CPFP-window; verify \`pending\` table reads csv_delay back correctly after restart