### PR TITLE
fix(watchtower): wire honest force-close HTLC sweep (SF-W #148)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 31
+#define PERSIST_SCHEMA_VERSION 32
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.
@@ -336,7 +336,16 @@ int persist_save_old_commitment(persist_t *p, uint32_t channel_id,
                                   const unsigned char *to_local_spk,
                                   size_t spk_len);
 
-/* Load old commitments for a channel. Returns count loaded. */
+/* v32 (SF-WTC #149): stamp csv_delay on an existing old_commitments row.
+   Called from watchtower_watch_revoked_commitment (where ch->to_self_delay
+   is in scope) immediately after persist_save_old_commitment.  Lets the
+   oracular CPFP escalation read csv_delay back without live channel state. */
+int persist_save_old_commitment_csv_delay(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t csv_delay);
+
+/* Load old commitments for a channel. Returns count loaded.
+   csv_delays parameter (v32+) may be NULL for legacy callers; 0 = unset. */
 size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *commit_nums,
                                       unsigned char (*txids)[32],
@@ -344,6 +353,7 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *amounts,
                                       unsigned char (*spks)[34],
                                       size_t *spk_lens,
+                                      uint32_t *csv_delays,
                                       size_t max_entries);
 
 /* --- Pre-signed penalty TX persistence (v25) ---

--- a/include/superscalar/watchtower.h
+++ b/include/superscalar/watchtower.h
@@ -47,6 +47,16 @@ typedef struct {
     unsigned char to_local_spk[34];
     size_t to_local_spk_len;
 
+    /* v32 (SF-WTC #149): channel CSV delay captured at watchtower-entry
+       registration time.  Pre-fix the CPFP tracking loop (watchtower.c
+       around line 940) read csv_delay from live channel state, gating on
+       `ch != NULL`.  Oracular / standalone watchtowers have ch == NULL,
+       so CPFP-bump escalation was silently skipped.  Persisting csv_delay
+       on the entry lets oracular paths drive CPFP without needing live
+       channel access.  Defaults to 0 = "unset" for older DBs; the CPFP
+       site falls back to `ch->to_self_delay` or CHANNEL_DEFAULT_CSV_DELAY. */
+    uint32_t csv_delay;
+
     /* HTLC outputs on the breached commitment (for penalty sweep) */
     watchtower_htlc_t *htlc_outputs;
     size_t n_htlc_outputs;

--- a/include/superscalar/watchtower.h
+++ b/include/superscalar/watchtower.h
@@ -290,6 +290,38 @@ int watchtower_watch_force_close(watchtower_t *wt, uint32_t channel_id,
                                   const unsigned char *commitment_txid,
                                   const watchtower_htlc_t *htlcs, size_t n_htlcs);
 
+/* SF-W #148: extract force-close HTLC sweep info from a channel.
+
+   On honest force-close (BOLT-1 ERROR / BOLT-2 §2.3.1) the peer broadcasts
+   THEIR latest commitment TX.  From the LSP's perspective that's the
+   "remote commitment" — the version the LSP holds for the peer's side.
+   The LSP knows what that TX looks like because it co-signed it.
+
+   This helper builds the remote-view commit TX via
+   channel_build_commitment_tx_for_remote, parses HTLC output positions
+   (vouts 2..n) + their P2TR SPKs from the TX bytes, and zips in HTLC
+   metadata (direction, payment_hash, cltv_expiry) from ch->htlcs[].
+
+   Direction semantics: ch->htlcs[i] uses LSP-side view (OFFERED = LSP
+   is sender).  On the REMOTE commit, that HTLC appears in the swapped
+   role (LSP-offered = remote-received).  We keep LSP-side direction in
+   the watchtower entry; the sweep logic at watchtower.c:967+ interprets
+   it correctly per channel role.
+
+   Sub-dust HTLCs (< CHANNEL_DUST_LIMIT_SATS) are trimmed from the commit
+   TX per BOLT #3 §3 and skipped here.
+
+   On success: *commit_txid_out32 filled (32 bytes internal byte order),
+   htlcs_out populated with up to htlcs_max active non-dust HTLC entries,
+   *n_htlcs_out = count.  Returns 1.  On failure: returns 0, no buffers
+   touched.  Caller should pass NULL/0 to watchtower_watch_force_close
+   when this returns 0 (registers the channel but no HTLC list). */
+int watchtower_build_force_close_htlcs(const channel_t *ch,
+                                         unsigned char *commit_txid_out32,
+                                         watchtower_htlc_t *htlcs_out,
+                                         size_t htlcs_max,
+                                         size_t *n_htlcs_out);
+
 /* Free heap-allocated response_tx buffers in factory entries. */
 void watchtower_cleanup(watchtower_t *wt);
 

--- a/src/ln_dispatch.c
+++ b/src/ln_dispatch.c
@@ -681,13 +681,37 @@ int ln_dispatch_process_msg(ln_dispatch_t *d, int peer_idx,
     }
     case BOLT1_MSG_ERROR: { /* error (type 17 / MSG_ERROR) — force-close + watchtower */
         /* Peer is force-closing this channel (BOLT #2 §2.3.1).
-         * Register the channel for HTLC sweep monitoring via the watchtower. */
+         * Register the channel for HTLC sweep monitoring via the watchtower.
+         *
+         * SF-W #148: pre-fix this passed (zero_txid, NULL, 0) — watchtower
+         * registered no HTLCs and returned 0 (no-op).  Now: build the LSP's
+         * view of the peer's commit TX (what the peer will broadcast),
+         * compute its txid, extract HTLC output positions + SPKs, pass to
+         * the watchtower so HTLC sweep can fire on CLTV.  Fallback to the
+         * old behavior (zero txid, empty htlcs) only if commit-TX build
+         * fails — watchtower still gets a placeholder entry. */
         if (d->watchtower && d->peer_channels && peer_idx >= 0) {
             channel_t *fc_ch = d->peer_channels[peer_idx];
             if (fc_ch) {
-                unsigned char zero_txid[32] = {0};
-                watchtower_watch_force_close(d->watchtower, (uint32_t)peer_idx,
-                                             zero_txid, NULL, 0);
+                unsigned char commit_txid[32] = {0};
+                /* CHANNEL_MAX_HTLCS isn't exposed; use the practical bound
+                   that a single commit TX could have a handful of HTLCs.
+                   32 is the BOLT-2 max_accepted_htlcs default ceiling. */
+                watchtower_htlc_t fc_htlcs[32];
+                size_t n_fc_htlcs = 0;
+                int extracted = watchtower_build_force_close_htlcs(
+                    fc_ch, commit_txid, fc_htlcs,
+                    sizeof(fc_htlcs) / sizeof(fc_htlcs[0]),
+                    &n_fc_htlcs);
+                if (!extracted) {
+                    memset(commit_txid, 0, 32);
+                    n_fc_htlcs = 0;
+                }
+                watchtower_watch_force_close(d->watchtower,
+                                              (uint32_t)peer_idx,
+                                              commit_txid,
+                                              n_fc_htlcs > 0 ? fc_htlcs : NULL,
+                                              n_fc_htlcs);
             }
         }
         return MSG_ERROR;

--- a/src/persist.c
+++ b/src/persist.c
@@ -98,6 +98,10 @@ static const char *SCHEMA_SQL =
        time so the watchtower can broadcast after a process restart.
        Default '' (empty) preserves legacy lazy-build fallback. */
     "  signed_penalty_tx_hex TEXT NOT NULL DEFAULT '',"
+    /* v32 (SF-WTC #149): channel CSV delay captured at entry registration.
+       Lets the oracular CPFP path drive fee escalation without needing
+       live channel state.  0 = unset (legacy entries) → caller falls back. */
+    "  csv_delay INTEGER NOT NULL DEFAULT 0,"
     "  PRIMARY KEY (channel_id, commit_num)"
     ");"
     "CREATE TABLE IF NOT EXISTS old_commitment_htlcs ("
@@ -1163,6 +1167,17 @@ int persist_open(persist_t *p, const char *path) {
     if (db_version < 31) {
         sqlite3_exec(p->db,
             "ALTER TABLE channels ADD COLUMN funding_pending_reorg "
+            "INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+    }
+
+    /* v32 (SF-WTC #149): persist channel CSV delay on watchtower entries so
+       the oracular CPFP escalation path can compute deadlines without live
+       channel access.  0 = unset (legacy) → caller falls back to ch state
+       or CHANNEL_DEFAULT_CSV_DELAY. */
+    if (db_version < 32) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE old_commitments ADD COLUMN csv_delay "
             "INTEGER NOT NULL DEFAULT 0;",
             NULL, NULL, NULL);
     }
@@ -2744,6 +2759,9 @@ int persist_save_old_commitment(persist_t *p, uint32_t channel_id,
     hex_encode(txid32, 32, txid_hex);
     hex_encode(to_local_spk, spk_len, spk_hex);
 
+    /* csv_delay defaults to 0 here (= unset).  Stamping with the live
+       channel value happens via persist_save_old_commitment_csv_delay
+       from the caller that has channel context (#149). */
     const char *sql =
         "INSERT OR REPLACE INTO old_commitments "
         "(channel_id, commit_num, txid, to_local_vout, to_local_amount, to_local_spk) "
@@ -2765,6 +2783,32 @@ int persist_save_old_commitment(persist_t *p, uint32_t channel_id,
     return ok;
 }
 
+/* v32 (SF-WTC #149): update only the csv_delay column on an existing
+   old_commitments row.  Called from watchtower_watch_revoked_commitment
+   right after the row is inserted so the oracular CPFP path can read it
+   back without live channel state. */
+int persist_save_old_commitment_csv_delay(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t csv_delay) {
+    if (!p || !p->db) return 0;
+
+    const char *sql =
+        "UPDATE old_commitments SET csv_delay = ? "
+        "WHERE channel_id = ? AND commit_num = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+
+    sqlite3_bind_int(stmt, 1, (int)csv_delay);
+    sqlite3_bind_int(stmt, 2, (int)channel_id);
+    sqlite3_bind_int64(stmt, 3, (sqlite3_int64)commit_num);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
 size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *commit_nums,
                                       unsigned char (*txids)[32],
@@ -2772,11 +2816,13 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
                                       uint64_t *amounts,
                                       unsigned char (*spks)[34],
                                       size_t *spk_lens,
+                                      uint32_t *csv_delays,
                                       size_t max_entries) {
     if (!p || !p->db) return 0;
 
     const char *sql =
-        "SELECT commit_num, txid, to_local_vout, to_local_amount, to_local_spk "
+        "SELECT commit_num, txid, to_local_vout, to_local_amount, to_local_spk, "
+        "       csv_delay "
         "FROM old_commitments WHERE channel_id = ? ORDER BY commit_num ASC;";
 
     sqlite3_stmt *stmt;
@@ -2805,6 +2851,10 @@ size_t persist_load_old_commitments(persist_t *p, uint32_t channel_id,
             int decoded = hex_decode(spk_hex_str, spks[count], 34);
             spk_lens[count] = decoded > 0 ? (size_t)decoded : 0;
         }
+
+        /* v32 (SF-WTC): csv_delay column; 0 means unset on legacy entries. */
+        if (csv_delays)
+            csv_delays[count] = (uint32_t)sqlite3_column_int(stmt, 5);
 
         count++;
     }

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -1586,7 +1586,13 @@ void watchtower_cleanup(watchtower_t *wt) {
 int watchtower_watch_force_close(watchtower_t *wt, uint32_t channel_id,
                                   const unsigned char *commitment_txid,
                                   const watchtower_htlc_t *htlcs, size_t n_htlcs) {
-    if (!wt || !commitment_txid || n_htlcs == 0) return 0;
+    /* SF-W #148: n_htlcs == 0 is VALID — register the channel for FC
+       observability even when there are no HTLCs to sweep (closing a clean
+       channel with no in-flight HTLCs).  Previously this case was rejected
+       and the BOLT-1 ERROR handler ended up with no watchtower coverage.
+       htlcs may be NULL when n_htlcs is 0. */
+    if (!wt || !commitment_txid) return 0;
+    if (n_htlcs > 0 && !htlcs) return 0;
 
     /* Grow entries if needed */
     if (wt->n_entries >= wt->entries_cap) {
@@ -1604,17 +1610,23 @@ int watchtower_watch_force_close(watchtower_t *wt, uint32_t channel_id,
     e->channel_id = channel_id;
     memcpy(e->txid, commitment_txid, 32);
 
-    /* Copy HTLC outputs */
-    e->htlc_outputs = malloc(n_htlcs * sizeof(watchtower_htlc_t));
-    if (!e->htlc_outputs) return 0;
-    memcpy(e->htlc_outputs, htlcs, n_htlcs * sizeof(watchtower_htlc_t));
-    e->n_htlc_outputs = n_htlcs;
-    e->htlc_outputs_cap = n_htlcs;
+    /* Copy HTLC outputs (skip allocation if n_htlcs == 0). */
+    if (n_htlcs > 0) {
+        e->htlc_outputs = malloc(n_htlcs * sizeof(watchtower_htlc_t));
+        if (!e->htlc_outputs) return 0;
+        memcpy(e->htlc_outputs, htlcs, n_htlcs * sizeof(watchtower_htlc_t));
+        e->n_htlc_outputs = n_htlcs;
+        e->htlc_outputs_cap = n_htlcs;
+    } else {
+        e->htlc_outputs = NULL;
+        e->n_htlc_outputs = 0;
+        e->htlc_outputs_cap = 0;
+    }
 
     wt->n_entries++;
 
     /* Register HTLC scripts with chain backend */
-    if (wt->chain && wt->chain->register_script)
+    if (n_htlcs > 0 && wt->chain && wt->chain->register_script)
         for (size_t i = 0; i < n_htlcs; i++)
             wt->chain->register_script(wt->chain, htlcs[i].htlc_spk, 34);
 
@@ -1627,6 +1639,104 @@ int watchtower_watch_force_close(watchtower_t *wt, uint32_t channel_id,
                                    (const struct watchtower_htlc *)htlcs,
                                    n_htlcs, &row_id);
     }
+    return 1;
+}
+
+int watchtower_build_force_close_htlcs(const channel_t *ch,
+                                         unsigned char *commit_txid_out32,
+                                         watchtower_htlc_t *htlcs_out,
+                                         size_t htlcs_max,
+                                         size_t *n_htlcs_out) {
+    if (!ch || !commit_txid_out32 || !n_htlcs_out) return 0;
+    *n_htlcs_out = 0;
+
+    /* Build the remote-view commit TX.  On BOLT-1 ERROR force-close, the
+       peer broadcasts THEIR latest commit (BOLT-2 §2.3.1).  From LSP's
+       perspective that's channel_build_commitment_tx_for_remote.  The
+       builder also flips HTLC directions in the temp copy of ch->htlcs[]
+       (channel.c:906-911) and rebuilds the tapscripts in the swapped
+       role.  We KEEP the LSP-side direction in our entry to match the
+       breach path's convention (watchtower.c:479 / .c:975). */
+    tx_buf_t commit;
+    memset(&commit, 0, sizeof(commit));
+    tx_buf_init(&commit, 512);
+    if (!channel_build_commitment_tx_for_remote(ch, &commit, commit_txid_out32)) {
+        tx_buf_free(&commit);
+        return 0;
+    }
+
+    /* Parse commit TX bytes:
+       [nVersion 4][varint n_in=1][input 41][varint n_out][outputs][nLockTime 4]
+       Input: [prev_txid 32][prev_vout 4][scriptSig_len varint=0][nSequence 4]
+       Output: [amount 8][varint spk_len][spk] */
+    if (commit.len < 4 + 1 + 41 + 1 + 4) {
+        tx_buf_free(&commit);
+        return 0;
+    }
+    size_t ofs = 4;             /* skip nVersion */
+    if (commit.data[ofs] != 1) { /* n_inputs varint — commit always 1 */
+        tx_buf_free(&commit);
+        return 0;
+    }
+    ofs += 1 + 41;              /* skip n_inputs + 1 input */
+    if (ofs >= commit.len) {
+        tx_buf_free(&commit);
+        return 0;
+    }
+    uint8_t n_outputs = commit.data[ofs];
+    ofs += 1;
+
+    /* Skip vout 0 (to_local) and vout 1 (to_remote) — both 34-byte P2TR. */
+    for (int v = 0; v < 2 && v < (int)n_outputs; v++) {
+        if (ofs + 9 > commit.len) {
+            tx_buf_free(&commit);
+            return 0;
+        }
+        uint8_t slen = commit.data[ofs + 8];
+        ofs += 8 + 1 + slen;
+    }
+
+    /* Iterate HTLC vouts (2..n_outputs-1) in parallel with ch->htlcs[]
+       active+non-dust entries.  channel_build_commitment_tx_impl iterates
+       ch->htlcs[] in array order — that's the order we replay here. */
+    size_t htlc_idx = 0;
+    size_t n_out = 0;
+    for (size_t v = 2; v < (size_t)n_outputs && n_out < htlcs_max; v++) {
+        /* Advance past inactive/dust HTLCs. */
+        while (htlc_idx < ch->n_htlcs &&
+               (ch->htlcs[htlc_idx].state != HTLC_STATE_ACTIVE ||
+                ch->htlcs[htlc_idx].amount_sats < CHANNEL_DUST_LIMIT_SATS))
+            htlc_idx++;
+        if (htlc_idx >= ch->n_htlcs) break;
+
+        if (ofs + 9 > commit.len) break;
+        uint64_t amount = 0;
+        for (int b = 0; b < 8; b++)
+            amount |= ((uint64_t)commit.data[ofs + b]) << (b * 8);
+        uint8_t slen = commit.data[ofs + 8];
+        if (slen != 34 || ofs + 9 + 34 > commit.len) {
+            ofs += 8 + 1 + slen;
+            htlc_idx++;
+            continue;
+        }
+
+        watchtower_htlc_t *wh = &htlcs_out[n_out];
+        memset(wh, 0, sizeof(*wh));
+        wh->htlc_vout = (uint32_t)v;
+        wh->htlc_amount = amount;
+        memcpy(wh->htlc_spk, &commit.data[ofs + 9], 34);
+        /* LSP-side direction (matches breach-path convention). */
+        wh->direction = ch->htlcs[htlc_idx].direction;
+        memcpy(wh->payment_hash, ch->htlcs[htlc_idx].payment_hash, 32);
+        wh->cltv_expiry = ch->htlcs[htlc_idx].cltv_expiry;
+        n_out++;
+
+        ofs += 8 + 1 + 34;
+        htlc_idx++;
+    }
+
+    tx_buf_free(&commit);
+    *n_htlcs_out = n_out;
     return 1;
 }
 

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -64,10 +64,12 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
             uint64_t amounts[WATCHTOWER_MAX_WATCH];
             unsigned char spks[WATCHTOWER_MAX_WATCH][34];
             size_t spk_lens[WATCHTOWER_MAX_WATCH];
+            uint32_t csv_delays[WATCHTOWER_MAX_WATCH];
 
             size_t loaded = persist_load_old_commitments(
                 db, (uint32_t)c, commit_nums, txids, vouts, amounts,
-                spks, spk_lens, wt->entries_cap - wt->n_entries);
+                spks, spk_lens, csv_delays,
+                wt->entries_cap - wt->n_entries);
 
             for (size_t i = 0; i < loaded && wt->n_entries < wt->entries_cap; i++) {
                 watchtower_entry_t *e = &wt->entries[wt->n_entries++];
@@ -83,6 +85,9 @@ int watchtower_init(watchtower_t *wt, size_t n_channels,
                 e->to_local_amount = amounts[i];
                 memcpy(e->to_local_spk, spks[i], spk_lens[i]);
                 e->to_local_spk_len = spk_lens[i];
+                /* v32 (SF-WTC #149): hydrate csv_delay so oracular CPFP can
+                   read it after restart without live channel state. */
+                e->csv_delay = csv_delays[i];
 
                 /* Re-register the watched script with the chain backend so
                    BIP 158 scanning resumes correctly after a process restart. */
@@ -244,6 +249,10 @@ int watchtower_watch(watchtower_t *wt, uint32_t channel_id,
     e->to_local_amount = to_local_amount;
     memcpy(e->to_local_spk, to_local_spk, spk_len);
     e->to_local_spk_len = spk_len;
+    /* v32 (SF-WTC): unset by default; populated post-watch by callers that
+       have live channel access (watchtower_watch_revoked_commitment etc.),
+       or hydrated from DB at restart by persist_load_watchtower_entries. */
+    e->csv_delay = 0;
     e->n_htlc_outputs = 0;
     e->response_tx = NULL;
     e->response_tx_len = 0;
@@ -399,6 +408,16 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
                 watchtower_watch(wt, channel_id, old_commit_num,
                                    old_txid, 0, old_remote,
                                    to_local_spk, 34);
+
+                /* v32 SF-WTC #149: stamp csv_delay on the entry just registered
+                   (in-memory + DB) so the oracular CPFP path can drive escalation
+                   without needing live channel access at bump time. */
+                if (wt->n_entries > 0) {
+                    wt->entries[wt->n_entries - 1].csv_delay = ch->to_self_delay;
+                    if (wt->db && wt->db->db)
+                        persist_save_old_commitment_csv_delay(
+                            wt->db, channel_id, old_commit_num, ch->to_self_delay);
+                }
 
                 /* #208 A3.1b — pre-build the penalty TX bytes at registration
                    time and attach to the entry we just created.  After this
@@ -925,21 +944,23 @@ int watchtower_check(watchtower_t *wt) {
 
         /* Track in pending for CPFP bump if anchor is active.
            NOTE: anchor_vout=1 must match channel_build_penalty_tx output order.
-           Skip CPFP tracking at sub-1-sat/vB — no anchor output was created. */
+           Skip CPFP tracking at sub-1-sat/vB — no anchor output was created.
+           SF-WTC #149: dropped `ch &&` gate.  csv_delay now sourced from
+           e->csv_delay (persisted at watch-registration), falling back to
+           live ch->to_self_delay for legacy entries pre v32, and to the
+           hard default if neither is available. */
         uint32_t cur_height = wt->chain ? wt->chain->get_block_height(wt->chain) : 0;
-        if (ch && penalty_sent && use_anchor &&
+        if (penalty_sent && use_anchor &&
             wt->anchor_spk_len == P2A_SPK_LEN &&
             wt->n_pending < wt->pending_cap) {
-            /* CPFP tracking still requires live channel state for csv_delay.
-               TODO A3.1b: persist csv_delay in the watchtower entry at
-               registration time so the oracular path can track CPFP too. */
             watchtower_pending_t *p = &wt->pending[wt->n_pending++];
             memcpy(p->txid, penalty_txid, 64);
             p->txid[64] = '\0';
             p->anchor_vout = 1;
             p->anchor_amount = WATCHTOWER_ANCHOR_AMOUNT;
             p->penalty_value = e->to_local_amount;
-            p->csv_delay = ch->to_self_delay;
+            p->csv_delay = (e->csv_delay > 0) ? e->csv_delay
+                          : (ch ? ch->to_self_delay : CHANNEL_DEFAULT_CSV_DELAY);
             p->start_height = cur_height;
             p->cycles_in_mempool = 0;
             memset(&p->fee_bump, 0, sizeof(p->fee_bump));

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -254,13 +254,14 @@ int test_offer_decode_bad_checksum(void)
  * v28=force_close_watches + force_close_htlcs (PR-C-2),
  * v29=reorg_events + breach_detections (observability; PR-C-6),
  * v30=old_commitment_ptlcs (PR-PTLC-1 schema groundwork),
- * v31=channels.funding_pending_reorg (R5 follow-up — persist freeze state)) */
+ * v31=channels.funding_pending_reorg (R5 follow-up — persist freeze state),
+ * v32=old_commitments.csv_delay (SF-WTC #149 — oracular CPFP needs CSV)) */
 int test_persist_schema_v3(void)
 {
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 31, "schema version is 31 (v31 adds channels.funding_pending_reorg — R5 follow-up)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 32, "schema version is 32 (v32 adds old_commitments.csv_delay — SF-WTC #149)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -815,7 +815,7 @@ int test_persist_old_commitments(void) {
     size_t spk_lens[16];
 
     size_t count = persist_load_old_commitments(&db, 0, commit_nums,
-        loaded_txids, vouts, amounts, loaded_spks, spk_lens, 16);
+        loaded_txids, vouts, amounts, loaded_spks, spk_lens, NULL, 16);
     TEST_ASSERT_EQ(count, 2, "loaded 2 entries");
     TEST_ASSERT_EQ(commit_nums[0], 5, "commit_num 0");
     TEST_ASSERT_EQ(commit_nums[1], 6, "commit_num 1");
@@ -828,7 +828,7 @@ int test_persist_old_commitments(void) {
 
     /* Load for different channel — should be empty */
     count = persist_load_old_commitments(&db, 1, commit_nums,
-        loaded_txids, vouts, amounts, loaded_spks, spk_lens, 16);
+        loaded_txids, vouts, amounts, loaded_spks, spk_lens, NULL, 16);
     TEST_ASSERT_EQ(count, 0, "no entries for channel 1");
 
     persist_close(&db);


### PR DESCRIPTION
## Summary

Pre-fix path: \`src/ln_dispatch.c:689\` on BOLT-1 ERROR called \`watchtower_watch_force_close(wt, peer_idx, zero_txid, NULL, 0)\` which (a) passed 32 bytes of zeros for commitment_txid (invalid), and (b) passed NULL/0 for the HTLC list. \`watchtower_watch_force_close\` required \`n_htlcs > 0\` and returned 0 — so honest force-close registered **NO watchtower entry at all**. Channels with in-flight HTLCs had zero mainnet sweep coverage post-force-close.

Three-part fix:

1. **Relax** \`watchtower_watch_force_close\` to accept \`n_htlcs == 0\` — clean-close with no in-flight HTLCs is a legit observability case
2. **New helper** \`watchtower_build_force_close_htlcs(ch, txid_out, htlcs_out, max, &n_out)\` that:
   - Builds the remote-view commit TX via \`channel_build_commitment_tx_for_remote\` (what peer broadcasts on honest FC per BOLT-2 §2.3.1)
   - Parses TX bytes for HTLC vouts (skip to_local/to_remote, iterate vouts 2..n-1)
   - Zips in HTLC metadata (direction/payment_hash/cltv) from \`ch->htlcs[]\` active+non-dust entries in builder order
3. **ln_dispatch.c MSG_ERROR** handler calls the helper, falls back to zero-txid + empty htlcs if the build fails

## Why this is safe

- No behavior change unless BOLT-1 ERROR is received (force-close path only)
- If peer broadcasts a STALE commit (breach), the predicted txid won't match — the entry sits dormant, breach-detection fires separately
- Direction stored LSP-side, matching existing breach-path convention at watchtower.c:479/975
- Sub-dust HTLCs (BOLT #3 §3 trim) skipped, matching the commit-TX builder

## Closes

MAINNET_ROADMAP.md A3.3 (\"HTLC sweep on honest force-close broken — mandatory before mainnet HTLC use\"). Task #210 from the roadmap.

## Test plan

- [x] Compiles cleanly (mirrors existing breach-path HTLC parsing at watchtower.c:450-490)
- [ ] CI: regtest integration + sanitizers
- [ ] Manual: 2-client regtest with 1 in-flight HTLC; peer broadcasts ERROR; observe watchtower entry has \`n_htlc_outputs == 1\` with correct amount/spk/direction