### PR TITLE
README: fix CI badge URL — legacy endpoint shows "failing" on cancelled runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SuperScalar
 
-[![CI](https://github.com/8144225309/SuperScalar/workflows/CI/badge.svg)](https://github.com/8144225309/SuperScalar/actions)
+[![CI](https://github.com/8144225309/SuperScalar/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/8144225309/SuperScalar/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/8144225309/SuperScalar)](https://github.com/8144225309/SuperScalar/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Bitcoin](https://img.shields.io/badge/Bitcoin-Lightning-orange.svg)](https://delvingbitcoin.org/t/superscalar-laddered-timeout-tree-structured-decker-wattenhofer-factories/1143)


### PR DESCRIPTION
## Summary

The badge in the README was showing **failing** even though CI on `main` has been passing.

**Root cause:** legacy badge URL `workflows/CI/badge.svg` ingests CI runs across all events / branches and treats cancelled runs as failures.  Branch-push rebases on PR feedback frequently cancel earlier in-flight runs (visible in `gh run list`), which flipped the badge to *failing* even though every **completed** run on `main` was successful.

**Fix:** switch to the modern endpoint with explicit scoping:
- old: `workflows/CI/badge.svg`
- new: `actions/workflows/ci.yml/badge.svg?branch=main&event=push`

## Verification

Fetched both URLs side-by-side against the same workflow state:
- legacy → "failing"
- modern with `?branch=main&event=push` → "passing"

Latest main push runs show `success`; this fix makes the badge reflect that.