### PR TITLE
dashboard: render Old Commitments table with reserve badge, not red 'not on chain'

### DIFF
--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -2052,7 +2052,7 @@ function rWatchtower(D){
  if(oc.length){h+=`<div class="st" style="margin-top:8px"><span>Old Commitments (breach detection)</span><span class="c">${oc.length}</span></div>`;
   h+=`<table><tr><th>CH</th><th>Commit#</th><th>TXID</th><th>On-chain</th><th>Vout</th><th class="r">To-Local</th></tr>`;
   for(const o of oc.slice(0,15)){const jitBadge=o.channel_id>=4?' <span class="b i">JIT</span>':'';
-   h+=`<tr><td>${o.channel_id}${jitBadge}</td><td>${o.commit_num}</td><td class="h">${th(o.txid)}</td><td>${txBadge(D,o.txid)}</td><td>${o.to_local_vout??'\u2014'}</td><td class="r">${fs(o.to_local_amount)}</td></tr>`;}
+   h+=`<tr><td>${o.channel_id}${jitBadge}</td><td>${o.commit_num}</td><td class="h">${th(o.txid)}</td><td>${txBadge(D,o.txid,'reserve')}</td><td>${o.to_local_vout??'\u2014'}</td><td class="r">${fs(o.to_local_amount)}</td></tr>`;}
   if(oc.length>15)h+=`<tr><td colspan="6" class="mu">\u2026 and ${oc.length-15} more</td></tr>`;
   h+=`</table>`;}
  // Old commitment HTLCs (breach penalty HTLCs)


### PR DESCRIPTION
## Summary

In Watchtower → **Old Commitments (breach detection)**, every row showed a red `not on chain` badge against the revoked commitment txid.  This reads as a failure to a fresh operator, but it's the *expected* state — old commitments are revoked, the watchtower holds penalty TXes ready, and those revoked commits are SUPPOSED to never appear on chain.

Verified visually in the cheat-leaf DB: 16 revoked commitments shown red despite the system working as intended.

## Fix

Pass `'reserve'` as the third arg to `txBadge()` (the API already supported this — was used elsewhere for pre-signed defense bytes).  Renders the neutral-blue `signed, in reserve` badge with tooltip:

> signed and persisted on disk; not broadcast (held in reserve for unilateral exit)

This matches the semantic for the analogous columns in TX Inventory ("Channel commitments" etc.) where pre-signed defense bytes use the reserve badge for the same reason.

## Test plan

- [x] Verified visually with Playwright against `lsp_cheat-leaf.db` (16 revoked commits, all showed red before this fix)
- [ ] CI passes (Python-only change to JS string within dashboard.py)