### PR TITLE
operability: factories.state + WAL checkpoint + SKIP markers + sub-factory diag (#156 #157 #159 #167)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -52,6 +52,11 @@ int persist_in_transaction(const persist_t *p);
    Called by factory_recovery_scan() when all leaf TXs are confirmed. */
 int persist_mark_factory_closed(persist_t *p, uint32_t factory_id);
 
+/* SF-WAL #157: force a passive WAL checkpoint so external SQLite readers
+   (dashboard) see committed writes within heartbeat-tick granularity.
+   Best-effort; never blocks. */
+int persist_wal_checkpoint(persist_t *p);
+
 /* Save factory metadata (funding info, participants, step_blocks, etc.).
    factory_id is caller-assigned (typically 0 for single-factory PoC). */
 int persist_save_factory(persist_t *p, const factory_t *f,

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3344,22 +3344,51 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                    int leaf_side, int sub_idx_in_leaf,
                                    int channel_idx_in_sub,
                                    uint64_t delta_sats) {
-    if (!mgr || !lsp) return 0;
+    /* SF-ERR #159: each silent return path now logs to stderr so operators
+       can distinguish "dust" from "invalid leaf_side" from "signing fail"
+       without log-diving the entire LSP loop. */
+    if (!mgr || !lsp) {
+        fprintf(stderr, "lsp_subfactory_chain_advance: refused — null mgr or lsp\n");
+        return 0;
+    }
     factory_t *f = &lsp->factory;
 
-    if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) return 0;
+    if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) {
+        fprintf(stderr, "lsp_subfactory_chain_advance: refused — leaf_side %d "
+                "out of range [0, %d)\n", leaf_side, f->n_leaf_nodes);
+        return 0;
+    }
     size_t leaf_node_idx = f->leaf_node_indices[leaf_side];
     factory_node_t *leaf = &f->nodes[leaf_node_idx];
-    if (sub_idx_in_leaf < 0 || sub_idx_in_leaf >= leaf->n_subfactories)
+    if (sub_idx_in_leaf < 0 || sub_idx_in_leaf >= leaf->n_subfactories) {
+        fprintf(stderr, "lsp_subfactory_chain_advance: refused — "
+                "sub_idx_in_leaf %d out of range [0, %d) on leaf %d\n",
+                sub_idx_in_leaf, leaf->n_subfactories, leaf_side);
         return 0;
+    }
     int sub_node_i = leaf->subfactory_node_indices[sub_idx_in_leaf];
-    if (sub_node_i < 0) return 0;
+    if (sub_node_i < 0) {
+        fprintf(stderr, "lsp_subfactory_chain_advance: refused — leaf %d "
+                "sub %d has invalid sub_node_i=%d\n",
+                leaf_side, sub_idx_in_leaf, sub_node_i);
+        return 0;
+    }
 
     factory_node_t *sub = &f->nodes[sub_node_i];
-    if (sub->type != NODE_PS_SUBFACTORY) return 0;
+    if (sub->type != NODE_PS_SUBFACTORY) {
+        fprintf(stderr, "lsp_subfactory_chain_advance: refused — sub %d "
+                "node type %d != NODE_PS_SUBFACTORY\n",
+                sub_idx_in_leaf, (int)sub->type);
+        return 0;
+    }
     /* k clients on this sub-factory (LSP is signer 0). */
     size_t n_clients_in_sub = sub->n_signers - 1;
-    if (n_clients_in_sub == 0) return 0;
+    if (n_clients_in_sub == 0) {
+        fprintf(stderr, "lsp_subfactory_chain_advance: refused — sub %d "
+                "has n_signers=%zu (need at least 2 for LSP + 1 client)\n",
+                sub_idx_in_leaf, sub->n_signers);
+        return 0;
+    }
 
     /* C3 (Tier 1): journal the ceremony.  Error returns leave the row in
        flight for the startup sweep to mark aborted_crash. */
@@ -6475,6 +6504,10 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                            hb_height, fstate_str, online, mgr->n_channels,
                            uptime_s / 3600, (uptime_s / 60) % 60, uptime_s % 60);
                     fflush(stdout);
+                    /* SF-WAL #157: passive checkpoint so the dashboard reader
+                       sees committed writes within heartbeat granularity. */
+                    if (mgr->persist)
+                        persist_wal_checkpoint((persist_t *)mgr->persist);
                 }
             }
 

--- a/src/persist.c
+++ b/src/persist.c
@@ -1365,6 +1365,20 @@ int persist_mark_factory_closed(persist_t *p, uint32_t factory_id) {
     return rc == SQLITE_DONE ? 1 : 0;
 }
 
+/* SF-WAL #157: force a passive WAL checkpoint so external readers (dashboard)
+   see committed writes within heartbeat granularity instead of waiting for
+   sqlite's autocheckpoint to fire.  PASSIVE mode never blocks writers; it
+   just copies as much WAL as possible to the main DB.  Returns 1 on success,
+   0 if no DB attached.  Safe to call any time. */
+int persist_wal_checkpoint(persist_t *p) {
+    if (!p || !p->db) return 0;
+    /* Best-effort: ignore return code (checkpoint can return SQLITE_BUSY
+       under writer contention; that's fine — next tick will retry). */
+    sqlite3_wal_checkpoint_v2(p->db, NULL, SQLITE_CHECKPOINT_PASSIVE,
+                              NULL, NULL);
+    return 1;
+}
+
 /* Save one PS leaf chain entry (called on each PS leaf advance).
    chain_pos: 0-based position in the chain (equal to old ps_chain_len before advance).
    signed_tx / signed_tx_len: the signed TX being stored.

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -706,6 +706,10 @@ static int broadcast_factory_tree(factory_t *f, regtest_t *rt,
         printf("  node[%zu] broadcast: %s (mined %d blocks)\n",
                i, display_hex, blocks_to_mine);
     }
+    /* SF-FS #156: factory tree has been broadcast in full → mark closed in DB.
+       Dashboards filter on state='closed' to suppress operational alerts. */
+    if (g_db)
+        persist_mark_factory_closed(g_db, /*factory_id=*/0);
     return 1;
 }
 
@@ -956,6 +960,10 @@ static int broadcast_factory_tree_any_network(factory_t *f, regtest_t *rt,
             return 0;
         }
     }
+    /* SF-FS #156: factory tree has been broadcast in full → mark closed in DB.
+       Dashboards filter on state='closed' to suppress operational alerts. */
+    if (g_db)
+        persist_mark_factory_closed(g_db, /*factory_id=*/0);
     return 1;
 }
 

--- a/tools/superscalar_lsp_post_daemon_tests.inc
+++ b/tools/superscalar_lsp_post_daemon_tests.inc
@@ -1010,10 +1010,10 @@
 
         if (leaf_arity != 2) {
             printf("  SKIP: --test-realloc requires --leaf-arity 2\n");
-            printf("LEAF REALLOC TEST: SKIP\n");
+            printf("LEAF REALLOC TEST: SKIP (gate=arity)\n");
         } else if (n_clients < 2) {
             printf("  SKIP: --test-realloc requires --clients >= 2\n");
-            printf("LEAF REALLOC TEST: SKIP\n");
+            printf("LEAF REALLOC TEST: SKIP (gate=clients)\n");
         } else {
             /* Record current leaf node output amounts (authoritative source) */
             size_t leaf_node_idx = lsp_p->factory.leaf_node_indices[0];
@@ -1254,7 +1254,7 @@
 
         if (leaf_arity != 2) {
             printf("  SKIP: --test-buy-liquidity requires --leaf-arity 2\n");
-            printf("BUY LIQUIDITY TEST: SKIP\n");
+            printf("BUY LIQUIDITY TEST: SKIP (gate=arity)\n");
         } else {
             /* Buy 1000 sats of inbound liquidity for client 0 from L-stock */
             uint64_t buy_amount = 1000;
@@ -1307,7 +1307,7 @@
         /* Verify we have more than 4 clients */
         if (n_clients <= 4) {
             printf("  SKIP: --test-large-factory requires --clients > 4\n");
-            printf("LARGE FACTORY TEST: SKIP\n");
+            printf("LARGE FACTORY TEST: SKIP (gate=clients)\n");
         } else {
             /* Verify all channels are active */
             int active = 0;

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -1351,10 +1351,10 @@
                 lsp_p->factory.ps_subfactory_arity <= 1) {
                 printf("  SKIP: --test-subfactory-advance requires --arity 3 "
                        "and --ps-subfactory-arity K (K>1)\n");
-                printf("PS K² SUB-FACTORY TEST: SKIP\n");
+                printf("PS K² SUB-FACTORY TEST: SKIP (gate=arity)\n");
             } else if (lsp_p->factory.n_leaf_nodes < 1) {
                 printf("  SKIP: no leaves built\n");
-                printf("PS K² SUB-FACTORY TEST: SKIP\n");
+                printf("PS K² SUB-FACTORY TEST: SKIP (gate=no-leaves)\n");
             } else {
                 /* Pick leaf 0, sub-factory 0, channel 0; transfer 50000 sats
                    from sales-stock to channel 0. */
@@ -1362,7 +1362,7 @@
                 factory_node_t *leaf = &lsp_p->factory.nodes[leaf0_idx];
                 if (leaf->n_subfactories < 1) {
                     printf("  SKIP: leaf 0 has no sub-factories\n");
-                    printf("PS K² SUB-FACTORY TEST: SKIP\n");
+                    printf("PS K² SUB-FACTORY TEST: SKIP (gate=no-subfactories)\n");
                 } else {
                     int sub0_node_i = leaf->subfactory_node_indices[0];
                     factory_node_t *sub0 =
@@ -1611,7 +1611,7 @@
             if (lsp_p->factory.leaf_arity != FACTORY_ARITY_1 &&
                 lsp_p->factory.leaf_arity != FACTORY_ARITY_PS) {
                 printf("  SKIP: --test-tier-b-rollover requires --arity 1 (DW) or --arity 3 (PS)\n");
-                printf("TIER B ROLLOVER TEST: SKIP\n");
+                printf("TIER B ROLLOVER TEST: SKIP (gate=arity)\n");
             } else {
                 /* Populate factory.keypairs[] for the LSP's local
                    factory_build_burn_tx call inside lsp_advance_leaf.


### PR DESCRIPTION
## Summary

Four small mainnet-readiness operability fixes bundled into one atomic PR. Each is independent of the others; bundled because each is too small for its own PR and they ship to the same surface.

| # | Fix | Lines |
|---|-----|------:|
| **#156** SF-FS | factories.state bump to 'closed' after force-close | +8 |
| **#157** SF-WAL | passive WAL checkpoint in LSP heartbeat tick | +19 |
| **#159** SF-ERR | sub-factory advance error classification | +31 |
| **#167** SF-RUN | test SKIP markers grep-distinct | 6 lines updated |

## #156 — factories.state bump

`broadcast_factory_tree()` and `broadcast_factory_tree_any_network()` now call `persist_mark_factory_closed()` on success. Previously the UPDATE was only reached via `factory_recovery_scan()` at startup, so live force-close left the row at `state='active'` indefinitely. Dashboard alert filters now work as intended.

## #157 — WAL checkpoint pacing

New `persist_wal_checkpoint()` wraps `sqlite3_wal_checkpoint_v2` in `PASSIVE` mode. Called once per heartbeat tick. External SQLite readers (dashboard) now see committed writes within `heartbeat_interval` seconds (default 5s) instead of waiting for sqlite's autocheckpoint, which can lag minutes under low write rate. PASSIVE never blocks writers; failures are silently ignored (next tick retries).

## #159 — sub-factory advance diagnostics

`lsp_subfactory_chain_advance()` had 6 silent `return 0` paths at the front-of-function preconditions:

- null mgr/lsp
- `leaf_side` out of range
- `sub_idx_in_leaf` out of range
- invalid `sub_node_i`
- wrong node type
- `n_clients_in_sub == 0`

Each now emits a stderr line naming the branch and the relevant index/limit. Same pattern as `channel_add_htlc` diagnostics in PR #223. Deeper ceremony paths (signing/nonce-gen) already log on their own — only the operator-misuse preconditions needed treatment here.

## #167 — test SKIP markers

Matrix-runner audit found that tests which legitimately SKIP under arity/client gates (`--test-realloc`, `--test-buy-liquidity`, `--test-large-factory`, `--test-subfactory-advance`, `--test-tier-b-rollover`) emitted generic `FOO TEST: SKIP`. The runner couldn't distinguish skip-then-cooperative-close-says-SUCCESS from a real pass.

Each SKIP line now includes `(gate=<reason>)`:

- `(gate=arity)` — wrong --leaf-arity
- `(gate=clients)` — n_clients gate
- `(gate=no-leaves)` — factory built no leaves
- `(gate=no-subfactories)` — leaf has no subfactories

Six call sites updated across `tools/superscalar_lsp_pre_daemon_tests.inc` and `tools/superscalar_lsp_post_daemon_tests.inc`.

## Test plan

- [x] Build clean (build-release) on Linux — no warnings
- [ ] Run any existing regtest that exercises force-close: verify `SELECT state FROM factories` returns `'closed'` after tree broadcast (was `'active'`)
- [ ] Run a daemon-mode test with dashboard attached: verify rows appear within ~heartbeat_interval instead of needing manual `PRAGMA wal_checkpoint(TRUNCATE)`
- [ ] Run `lsp_subfactory_chain_advance` with deliberately bad leaf_side: verify new stderr line names the branch and index
- [ ] Run `--test-realloc` with `--leaf-arity 3`: verify log contains `LEAF REALLOC TEST: SKIP (gate=arity)`

## Mainnet impact

Pure observability + operability. No on-chain behavior changes. No protocol semantics changes. No new dependencies. Independent of any in-flight feature work. Safe to ship hot.

## Context

Bundled in response to the post-PR-#222 matrix audit which identified these four items as small but operationally costly. Companion PR #223 fixes the related `channel_add_htlc` silent-failure problem in the channel layer.
