### PR TITLE
dashboard: freshness banner — sample .db-wal mtime too (WAL-aware)

### DIFF
--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -299,8 +299,13 @@ def collect_databases(cfg):
         # funding + close + sweeps, which the prior LIMIT 50 truncated on
         # the funding-end (so the Events derivation lost the "Factory funded"
         # bookend).  200 matches the wire_messages limit used elsewhere.
+        # reorg_stale (schema v29) — broadcast_log rows whose enclosing block
+        # was invalidated by a tip regression.  Surfacing this lets operators
+        # tell apart "TX failed" from "TX confirmed then orphaned" — same
+        # txid, very different recovery actions.
         rows, err = query_db(path,
-            "SELECT id, txid, source, result, broadcast_time "
+            "SELECT id, txid, source, result, broadcast_time, "
+            "COALESCE(reorg_stale, 0) AS reorg_stale "
             "FROM broadcast_log ORDER BY id DESC LIMIT 200")
         data[label]["broadcast_log"] = rows if not err else []
         # Reorg events (schema v29) — tip regressions detected by the daemon
@@ -2104,7 +2109,8 @@ function rWatchtower(D){
  if(bl.length){h+=`<div class="s"><div class="st"><span>Broadcast Log</span><span class="c">${bl.length}</span></div>`;
   h+=`<table><tr><th>ID</th><th>TXID</th><th>On-chain</th><th>Source</th><th>Result</th><th>Time</th></tr>`;
   for(const b of bl){const rc=b.result==='success'||b.result==='ok'?'b ok':'b dn';
-   h+=`<tr><td>${b.id}</td><td class="h">${th(b.txid)}</td><td>${txBadge(D,b.txid)}</td><td>${b.source||'\u2014'}</td><td><span class="${rc}">${b.result||'?'}</span></td><td>${ta(b.broadcast_time)}</td></tr>`;}
+   const staleBadge=b.reorg_stale?` <span class="b w" style="font-size:9px" title="Block containing this TX was orphaned by a reorg \u2014 broadcast may need to be re-attempted">stale</span>`:'';
+   h+=`<tr><td>${b.id}</td><td class="h">${th(b.txid)}${staleBadge}</td><td>${txBadge(D,b.txid)}</td><td>${b.source||'\u2014'}</td><td><span class="${rc}">${b.result||'?'}</span></td><td>${ta(b.broadcast_time)}</td></tr>`;}
   h+=`</table></div>`;}
  return h;
 }
@@ -2447,7 +2453,8 @@ function rOutcomes(D){
   h+=`<table><tr><th>ID</th><th>Source</th><th>Result</th><th>TXID</th><th>On-chain status</th><th>When</th></tr>`;
   for(const r of log){
    const rc=r.result==='ok'?'b ok':r.result==='failed'?'b dn':'b i';
-   h+=`<tr><td>${r.id}</td><td><code>${r.source||'?'}</code></td><td><span class="${rc}">${r.result||'?'}</span></td><td class="h">${th(r.txid)}</td><td>${txBadge(D,r.txid)}</td><td>${ta(r.broadcast_time)} ago</td></tr>`;
+   const staleBadge=r.reorg_stale?` <span class="b w" style="font-size:9px" title="Block containing this TX was orphaned by a reorg — broadcast may need to be re-attempted">stale</span>`:'';
+   h+=`<tr><td>${r.id}</td><td><code>${r.source||'?'}</code></td><td><span class="${rc}">${r.result||'?'}</span></td><td class="h">${th(r.txid)}${staleBadge}</td><td>${txBadge(D,r.txid)}</td><td>${ta(r.broadcast_time)} ago</td></tr>`;
   }
   h+=`</table></div>`;
  }

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -788,14 +788,24 @@ def _db_freshness(cfg):
     detect a stale browser fetch (operator looks at the page after a wipe
     + restart, sees old data, doesn't realize the tab cached an earlier
     /api/status response).  Times are unix seconds; renderer can compute
-    'now - api_ts' to flag staleness."""
+    'now - api_ts' to flag staleness.
+
+    WAL mode: the main .db file's mtime only updates on checkpoint (default
+    every ~1000 pages / ~4MB).  Active writes between checkpoints land in
+    .db-wal whose mtime advances per fsync.  Sampling .db alone makes the
+    dashboard report "quiet DB" during heavy ceremony bursts — exactly when
+    the operator most wants the real signal.  Take max(.db, .db-wal); skip
+    .db-shm because reader connections (including the dashboard's own
+    read-only open) touch -shm, which would make every fetch look fresh."""
     out = {"api_ts": int(time.time()),
            "api_time": time.strftime("%H:%M:%S")}
     for label, path in (("lsp_db_mtime", cfg.lsp_db),
                          ("client_db_mtime", cfg.client_db)):
         try:
             if path and os.path.exists(str(path)):
-                out[label] = int(os.path.getmtime(str(path)))
+                paths = [str(path), str(path) + "-wal"]
+                mtimes = [os.path.getmtime(p) for p in paths if os.path.exists(p)]
+                out[label] = int(max(mtimes)) if mtimes else 0
             else:
                 out[label] = 0
         except OSError:

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -2052,7 +2052,7 @@ function rWatchtower(D){
  if(oc.length){h+=`<div class="st" style="margin-top:8px"><span>Old Commitments (breach detection)</span><span class="c">${oc.length}</span></div>`;
   h+=`<table><tr><th>CH</th><th>Commit#</th><th>TXID</th><th>On-chain</th><th>Vout</th><th class="r">To-Local</th></tr>`;
   for(const o of oc.slice(0,15)){const jitBadge=o.channel_id>=4?' <span class="b i">JIT</span>':'';
-   h+=`<tr><td>${o.channel_id}${jitBadge}</td><td>${o.commit_num}</td><td class="h">${th(o.txid)}</td><td>${txBadge(D,o.txid)}</td><td>${o.to_local_vout??'\u2014'}</td><td class="r">${fs(o.to_local_amount)}</td></tr>`;}
+   h+=`<tr><td>${o.channel_id}${jitBadge}</td><td>${o.commit_num}</td><td class="h">${th(o.txid)}</td><td>${txBadge(D,o.txid,'reserve')}</td><td>${o.to_local_vout??'\u2014'}</td><td class="r">${fs(o.to_local_amount)}</td></tr>`;}
   if(oc.length>15)h+=`<tr><td colspan="6" class="mu">\u2026 and ${oc.length-15} more</td></tr>`;
   h+=`</table>`;}
  // Old commitment HTLCs (breach penalty HTLCs)


### PR DESCRIPTION
## Summary

- `_db_freshness` (PR #219) sampled only the main .db file's mtime to detect "lsp.db newer than payload" races.
- In WAL mode, the main .db mtime **only advances on checkpoint** (default `wal_autocheckpoint=1000` pages ≈ 4MB).
- Between checkpoints, all writes land in **.db-wal** whose mtime updates per fsync — but the freshness probe never sampled it.
- Symptom: during heavy ceremony bursts the banner reports a quiet DB even though the LSP is writing continuously — exactly the case the signal was added for.

## Empirical proof

20 INSERTs with a Python connection kept open:

| file | before | after | delta |
|---|---|---|---|
| `.db` | 1778978588 | 1778978588 | **0s** (frozen — pre-checkpoint) |
| `.db-wal` | 1778978588 | 1778978590 | **2s** (correct) |
| `.db-shm` | 1778978588 | 1778978588 | 0s (shared-mem index) |

Old freshness: `1778978588` (lies — says quiet)
New freshness: `1778978590` (correct — shows activity)

Under real LSP load with `wal_autocheckpoint=1000` pages, this gap can stretch many minutes between checkpoints.

## Fix

Sample `max(mtime(.db), mtime(.db-wal))`.

Skipping `.db-shm` intentionally: reader connections (including the dashboard's own read-only open) touch -shm, which would make every fetch look fresh (saw "0s ago" during testing — wrong).

## Why no LSP changes

Read-only WAL reads already work correctly via the shared-memory wal-index. The dashboard always saw the latest data; only the **staleness signal** was lying.

## Test plan

- [x] Quiesced saved DB: freshness reports realistic "X seconds ago" matching actual file mtime
- [x] Connection-held write burst: max(.db, .db-wal) tracks the WAL mtime, not the frozen .db mtime
- [x] `.db-shm` correctly excluded — reader connections don't falsify the signal