### PR TITLE
fix(reorg): height-aware sub-factory chain reset (#146, schema v33)

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -177,6 +177,12 @@ typedef struct {
     uint64_t ps_prev_chan_amount;      /* amount_sats of the channel output spent by current TX
                                           (legacy 1-input shape; for multi-input PS sub-factory
                                           chain advances see ps_prev_amounts[] below) */
+    /* #146: height-aware reset.  Block height at which the latest chain
+       entry was observed confirmed (0 = unset / legacy).  Used by
+       factory_reset_subfactory_chains_above_height to leave chain state
+       intact through reorgs that don't go deep enough to bury this
+       entry. */
+    uint32_t ps_chain_confirmed_height;
 
     /* Multi-input PS sub-factory chain advance state (#207).
        When a NODE_PS_SUBFACTORY chain extends, the new TX consumes ALL
@@ -550,6 +556,30 @@ int factory_subfactory_chain_advance_unsigned(
 
    Returns the count of sub-factories reset (for observability). */
 int factory_reset_all_subfactory_chains(factory_t *f);
+
+/* #146: height-aware variant.  Only resets sub-factory chain state for
+   nodes whose ps_chain_confirmed_height > reorg_max_safe_height (i.e.,
+   their latest confirmation is no longer on the active chain).  Nodes
+   with ps_chain_confirmed_height == 0 (legacy / unset) are reset
+   conservatively (matches pre-#146 behavior) so a missing confirmation
+   record never silently leaves stale state.  Returns the count reset.
+
+   reorg_max_safe_height is the highest block height that's still
+   confirmed on the new tip — typically the new tip height itself minus
+   a safety buffer.  Anything strictly above that may have been reorged
+   out and needs invalidation. */
+int factory_reset_subfactory_chains_above_height(factory_t *f,
+                                                  uint32_t reorg_max_safe_height);
+
+/* #146: record the height at which a sub-factory chain entry was
+   observed confirmed.  Stamped by the reorg detector / heartbeat when
+   it sees the latest chain TX in a block, so subsequent reorgs can use
+   factory_reset_subfactory_chains_above_height to avoid wiping
+   still-confirmed state.  No-op when the node isn't a PS sub-factory or
+   has ps_chain_len == 0. */
+void factory_set_subfactory_chain_confirmed_height(factory_t *f,
+                                                    size_t node_idx,
+                                                    uint32_t confirmed_height);
 
 /* Compute the factory_early_warning_time (blocks) per BLIP-56.
    This is the worst-case blocks needed for full unilateral close from

--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 32
+#define PERSIST_SCHEMA_VERSION 33
 
 /* Open or create database at path. Creates schema if needed.
    Runs migrations if DB version < code version.

--- a/src/factory.c
+++ b/src/factory.c
@@ -2506,9 +2506,52 @@ int factory_reset_all_subfactory_chains(factory_t *f) {
         node->ps_chain_len = 0;
         node->ps_n_prev_outputs = 0;
         memset(node->ps_prev_txid, 0, 32);
+        node->ps_chain_confirmed_height = 0;
         n_reset++;
     }
     return n_reset;
+}
+
+/* #146: height-aware reset.  Walks PS sub-factories and resets only those
+   whose latest confirmation is now above the safe height (i.e., possibly
+   reorged out).  Legacy entries with confirmed_height == 0 are reset
+   conservatively — better-safe-than-sorry until they're stamped. */
+int factory_reset_subfactory_chains_above_height(factory_t *f,
+                                                  uint32_t reorg_max_safe_height)
+{
+    if (!f) return 0;
+    int n_reset = 0;
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        factory_node_t *node = &f->nodes[i];
+        if (node->type != NODE_PS_SUBFACTORY) continue;
+        if (node->ps_chain_len == 0) continue;
+
+        /* Keep state when confirmation is at-or-below the safe height
+           AND we have a real confirmation record.  Reset otherwise:
+             - confirmed_height == 0 → no record → conservative reset
+             - confirmed_height > reorg_max_safe_height → reorged out */
+        if (node->ps_chain_confirmed_height > 0 &&
+            node->ps_chain_confirmed_height <= reorg_max_safe_height) {
+            continue;
+        }
+        node->ps_chain_len = 0;
+        node->ps_n_prev_outputs = 0;
+        memset(node->ps_prev_txid, 0, 32);
+        node->ps_chain_confirmed_height = 0;
+        n_reset++;
+    }
+    return n_reset;
+}
+
+void factory_set_subfactory_chain_confirmed_height(factory_t *f,
+                                                    size_t node_idx,
+                                                    uint32_t confirmed_height)
+{
+    if (!f || node_idx >= f->n_nodes) return;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (node->type != NODE_PS_SUBFACTORY) return;
+    if (node->ps_chain_len == 0) return;
+    node->ps_chain_confirmed_height = confirmed_height;
 }
 
 /* --- Per-node split-round signing helpers --- */

--- a/src/persist.c
+++ b/src/persist.c
@@ -1182,6 +1182,28 @@ int persist_open(persist_t *p, const char *path) {
             NULL, NULL, NULL);
     }
 
+    /* v33 (#146): height-aware sub-factory chain reset.  Before this,
+       factory_reset_all_subfactory_chains (PR #208) wiped EVERY advanced
+       sub-factory's in-memory state on any reorg, regardless of depth —
+       even a 1-block reorg that doesn't affect previously-confirmed
+       chain[N] entries would clobber them.  Adding confirmed_height (block
+       height at which this chain entry was observed confirmed) and
+       reorg_stale (1 = this entry's confirmation was reorged out) lets
+       the reset logic only zero entries whose confirmation is actually
+       gone.  Both default to 0/0 for backward compatibility — legacy
+       rows behave like the pre-#146 reset-everything path until they're
+       refreshed by the next observation. */
+    if (db_version < 33) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE ps_subfactory_chains ADD COLUMN confirmed_height "
+            "INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE ps_subfactory_chains ADD COLUMN reorg_stale "
+            "INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+    }
+
     /* Record the current version if not already present */
     if (db_version < PERSIST_SCHEMA_VERSION) {
         char vsql[128];

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -261,7 +261,7 @@ int test_persist_schema_v3(void)
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 32, "schema version is 32 (v32 adds old_commitments.csv_delay — SF-WTC #149)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 33, "schema version is 33 (v33 adds ps_subfactory_chains.confirmed_height + reorg_stale — SF-followup #146)");
     persist_close(&p);
     return 1;
 }


### PR DESCRIPTION
Adds height-awareness to PR #208's factory_reset_all_subfactory_chains so shallow reorgs don't wipe still-confirmed chain state.

## Schema v33
- ps_subfactory_chains.confirmed_height (default 0, legacy-safe)
- ps_subfactory_chains.reorg_stale (default 0)

## New API
- factory_reset_subfactory_chains_above_height(f, reorg_max_safe_height) — only resets nodes with confirmed_height==0 OR > safe height
- factory_set_subfactory_chain_confirmed_height(f, node_idx, height) — stamp when reorg detector / heartbeat observes confirmation
- factory_node_t.ps_chain_confirmed_height — in-memory mirror

## Followups (NOT in this PR)
- Persist save/load wiring for confirmed_height column
- Migrate reorg detector callsites from factory_reset_all_* → height-aware variant

## Test plan
- [x] Build clean (build-release)
- [ ] Smoke regtest: confirm schema v33 migration runs and the helpers compile-link clean
- [ ] Follow-up PR: wire stamp + persist + detector to actually exercise the new path

Pure foundation work — no behavior change yet for code paths that haven't migrated.