### PR TITLE
dashboard: fix Outcomes tiles for cheat-* scenarios + unblock DB-fallback factory_config

### DIFF
--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -550,7 +550,11 @@ def collect_factory_config(cfg):
     try:
         r = subprocess.run(["pgrep", "-f", "superscalar_lsp"],
                            capture_output=True, text=True, timeout=2)
-        if r.returncode != 0: return out
+        # pgrep rc=1 (no match) is the common case for saved-DB sessions —
+        # fall through to the DB fallback instead of returning early, which
+        # made factory_config unreachable post-LSP-exit.  The for loop below
+        # is naturally a no-op on empty stdout.
+        if r.returncode not in (0, 1): return out
         for pid in r.stdout.strip().split("\n"):
             if not pid.strip(): continue
             try:
@@ -2384,15 +2388,21 @@ function rOutcomes(D){
    applicable:isDWLegacy,
    notApplicableNote:isPSCanon?'PS canonical (arity 3) — leaves use PS chain advance, not DW state':'',
    blurb:'3-of-3 partial advance of one leaf without rolling the root state.'},
-  {name:'L-stock burn', icon:'🔥', sources:['burn','l_stock_burn'],
+  {name:'L-stock burn', icon:'🔥', sources:['burn','l_stock_burn','factory_burn'],
    readySignal:'',
    applicable:isDWLegacy,
    notApplicableNote:isPSCanon?'PS canonical — uses poison TX (tile below) instead of shachain burn':'',
    blurb:'Burn TX broadcast: OP_RETURN destroys L-stock when LSP publishes old state (deterrence).'},
-  {name:'Trustless poison redistribute', icon:'🛡', sources:['poison'],
+  {name:'Trustless poison redistribute', icon:'🛡', sources:['poison','subfactory_poison'],
    readySignal:(psChain.filter(r=>r.has_poison).length+psSub.filter(r=>r.has_poison).length)+' poison TXs signed',
    blurb:'Pre-signed poison TX redistributes L-stock / sales-stock to clients on cheat.'},
-  {name:'Breach + penalty', icon:'⚔', sources:['penalty','response'],
+  // Breach + penalty: the canonical detection signal is breach_detections
+  // (LSP-side: "we saw a revoked TXID on chain at height H").  factory_response,
+  // cheat_leaf_*, cheat_subfactory_* are the broadcast-side artifacts of the
+  // same event chain (the penalty/poison TX that goes out in response).  Match
+  // any of them so the tile fires under any of the cheat-* test scenarios.
+  {name:'Breach + penalty', icon:'⚔', sources:['penalty','response','factory_response','cheat_leaf','cheat_subfactory','cheat_daemon'],
+   breachSignal:(lsp.breach_detections||[]).length>0,
    readySignal:wtPending.length?wtPending.length+' penalties in flight':'',
    blurb:'Watchtower detects revoked commitment broadcast, broadcasts penalty sweep.'},
   {name:'HTLC force-close', icon:'🪝', sources:['htlc','ptlc'],
@@ -2431,14 +2441,26 @@ function rOutcomes(D){
   // deployment-shape reason in the body.
   const isNA = sc.applicable !== undefined && !sc.applicable;
   const fired=matchAny(sc.sources, sc.ceremonies);
+  // breachSignal: tile fires off table-presence (e.g. breach_detections row)
+  // even when no source/ceremony matched.  Used by 'Breach + penalty' to
+  // light up off the LSP's authoritative detection even before / without
+  // the penalty TX hitting broadcast_log.
+  const breachFired=sc.breachSignal===true;
   let state, badge, lastTx='';
   if(isNA){
    state='na'; badge=`<span class="b" style="background:#0d1117;color:#484f58;border:1px solid #21262d">n/a for this deployment</span>`;
    if(sc.notApplicableNote)lastTx=`<div class="mu" style="font-size:10px;margin-top:4px;font-style:italic">${sc.notApplicableNote}</div>`;
-  } else if(fired.length>0){
-   state='fired'; badge=`<span class="b ok">fired ${fired.length}×</span>`;
-   const latest=fired.reduce((a,b)=>(a.broadcast_time||0)>(b.broadcast_time||0)?a:b);
-   lastTx=`<div class="kv" style="margin-top:4px;gap:2px 8px"><div class="ki"><span class="k">last</span><span class="v h" style="font-size:10px">${th(latest.txid)}</span></div><div class="ki"><span class="k">at</span><span class="v" style="font-size:10px">${ta(latest.broadcast_time)} ago</span></div></div>`;
+  } else if(fired.length>0||breachFired){
+   const count=fired.length||1;
+   const label=fired.length>0?`fired ${count}×`:`detected`;
+   state='fired'; badge=`<span class="b ok">${label}</span>`;
+   if(fired.length>0){
+    const latest=fired.reduce((a,b)=>(a.broadcast_time||0)>(b.broadcast_time||0)?a:b);
+    lastTx=`<div class="kv" style="margin-top:4px;gap:2px 8px"><div class="ki"><span class="k">last</span><span class="v h" style="font-size:10px">${th(latest.txid)}</span></div><div class="ki"><span class="k">at</span><span class="v" style="font-size:10px">${ta(latest.broadcast_time)} ago</span></div></div>`;
+   } else if(breachFired){
+    const bdc=(lsp.breach_detections||[]).length;
+    lastTx=`<div class="mu" style="font-size:10px;margin-top:4px">${bdc} breach detection${bdc===1?'':'s'} logged (see Watchtower tab)</div>`;
+   }
   } else if(sc.readySignal){
    state='ready'; badge=`<span class="b i">ready</span>`;
    lastTx=`<div class="mu" style="font-size:10px;margin-top:4px">${sc.readySignal}</div>`;

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -299,8 +299,13 @@ def collect_databases(cfg):
         # funding + close + sweeps, which the prior LIMIT 50 truncated on
         # the funding-end (so the Events derivation lost the "Factory funded"
         # bookend).  200 matches the wire_messages limit used elsewhere.
+        # reorg_stale (schema v29) — broadcast_log rows whose enclosing block
+        # was invalidated by a tip regression.  Surfacing this lets operators
+        # tell apart "TX failed" from "TX confirmed then orphaned" — same
+        # txid, very different recovery actions.
         rows, err = query_db(path,
-            "SELECT id, txid, source, result, broadcast_time "
+            "SELECT id, txid, source, result, broadcast_time, "
+            "COALESCE(reorg_stale, 0) AS reorg_stale "
             "FROM broadcast_log ORDER BY id DESC LIMIT 200")
         data[label]["broadcast_log"] = rows if not err else []
         # Reorg events (schema v29) — tip regressions detected by the daemon
@@ -2104,7 +2109,8 @@ function rWatchtower(D){
  if(bl.length){h+=`<div class="s"><div class="st"><span>Broadcast Log</span><span class="c">${bl.length}</span></div>`;
   h+=`<table><tr><th>ID</th><th>TXID</th><th>On-chain</th><th>Source</th><th>Result</th><th>Time</th></tr>`;
   for(const b of bl){const rc=b.result==='success'||b.result==='ok'?'b ok':'b dn';
-   h+=`<tr><td>${b.id}</td><td class="h">${th(b.txid)}</td><td>${txBadge(D,b.txid)}</td><td>${b.source||'\u2014'}</td><td><span class="${rc}">${b.result||'?'}</span></td><td>${ta(b.broadcast_time)}</td></tr>`;}
+   const staleBadge=b.reorg_stale?` <span class="b w" style="font-size:9px" title="Block containing this TX was orphaned by a reorg \u2014 broadcast may need to be re-attempted">stale</span>`:'';
+   h+=`<tr><td>${b.id}</td><td class="h">${th(b.txid)}${staleBadge}</td><td>${txBadge(D,b.txid)}</td><td>${b.source||'\u2014'}</td><td><span class="${rc}">${b.result||'?'}</span></td><td>${ta(b.broadcast_time)}</td></tr>`;}
   h+=`</table></div>`;}
  return h;
 }
@@ -2447,7 +2453,8 @@ function rOutcomes(D){
   h+=`<table><tr><th>ID</th><th>Source</th><th>Result</th><th>TXID</th><th>On-chain status</th><th>When</th></tr>`;
   for(const r of log){
    const rc=r.result==='ok'?'b ok':r.result==='failed'?'b dn':'b i';
-   h+=`<tr><td>${r.id}</td><td><code>${r.source||'?'}</code></td><td><span class="${rc}">${r.result||'?'}</span></td><td class="h">${th(r.txid)}</td><td>${txBadge(D,r.txid)}</td><td>${ta(r.broadcast_time)} ago</td></tr>`;
+   const staleBadge=r.reorg_stale?` <span class="b w" style="font-size:9px" title="Block containing this TX was orphaned by a reorg — broadcast may need to be re-attempted">stale</span>`:'';
+   h+=`<tr><td>${r.id}</td><td><code>${r.source||'?'}</code></td><td><span class="${rc}">${r.result||'?'}</span></td><td class="h">${th(r.txid)}${staleBadge}</td><td>${txBadge(D,r.txid)}</td><td>${ta(r.broadcast_time)} ago</td></tr>`;
   }
   h+=`</table></div>`;
  }

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -788,14 +788,24 @@ def _db_freshness(cfg):
     detect a stale browser fetch (operator looks at the page after a wipe
     + restart, sees old data, doesn't realize the tab cached an earlier
     /api/status response).  Times are unix seconds; renderer can compute
-    'now - api_ts' to flag staleness."""
+    'now - api_ts' to flag staleness.
+
+    WAL mode: the main .db file's mtime only updates on checkpoint (default
+    every ~1000 pages / ~4MB).  Active writes between checkpoints land in
+    .db-wal whose mtime advances per fsync.  Sampling .db alone makes the
+    dashboard report "quiet DB" during heavy ceremony bursts — exactly when
+    the operator most wants the real signal.  Take max(.db, .db-wal); skip
+    .db-shm because reader connections (including the dashboard's own
+    read-only open) touch -shm, which would make every fetch look fresh."""
     out = {"api_ts": int(time.time()),
            "api_time": time.strftime("%H:%M:%S")}
     for label, path in (("lsp_db_mtime", cfg.lsp_db),
                          ("client_db_mtime", cfg.client_db)):
         try:
             if path and os.path.exists(str(path)):
-                out[label] = int(os.path.getmtime(str(path)))
+                paths = [str(path), str(path) + "-wal"]
+                mtimes = [os.path.getmtime(p) for p in paths if os.path.exists(p)]
+                out[label] = int(max(mtimes)) if mtimes else 0
             else:
                 out[label] = 0
         except OSError:

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -2052,7 +2052,7 @@ function rWatchtower(D){
  if(oc.length){h+=`<div class="st" style="margin-top:8px"><span>Old Commitments (breach detection)</span><span class="c">${oc.length}</span></div>`;
   h+=`<table><tr><th>CH</th><th>Commit#</th><th>TXID</th><th>On-chain</th><th>Vout</th><th class="r">To-Local</th></tr>`;
   for(const o of oc.slice(0,15)){const jitBadge=o.channel_id>=4?' <span class="b i">JIT</span>':'';
-   h+=`<tr><td>${o.channel_id}${jitBadge}</td><td>${o.commit_num}</td><td class="h">${th(o.txid)}</td><td>${txBadge(D,o.txid)}</td><td>${o.to_local_vout??'\u2014'}</td><td class="r">${fs(o.to_local_amount)}</td></tr>`;}
+   h+=`<tr><td>${o.channel_id}${jitBadge}</td><td>${o.commit_num}</td><td class="h">${th(o.txid)}</td><td>${txBadge(D,o.txid,'reserve')}</td><td>${o.to_local_vout??'\u2014'}</td><td class="r">${fs(o.to_local_amount)}</td></tr>`;}
   if(oc.length>15)h+=`<tr><td colspan="6" class="mu">\u2026 and ${oc.length-15} more</td></tr>`;
   h+=`</table>`;}
  // Old commitment HTLCs (breach penalty HTLCs)


### PR DESCRIPTION
Two real bugs found while doing visual verification of the cheat-leaf / cheat-subfactory / cheat-daemon test DBs against the dashboard.

## Bug 1: `collect_factory_config` DB-fallback unreachable

`dashboard.py:553` had `if r.returncode != 0: return out` which short-circuited the function when pgrep found no live `superscalar_lsp` process. That's exactly the case for saved-DB sessions (post-LSP-exit) — every saved DB.

The DB fallback added in **PR #222** was effectively dead code: it only ran in the narrow case where pgrep happened to find a `superscalar_lsp` build/process that wasn't ours (e.g., during a concurrent `cmake --build` cycle — which is how we accidentally tested the fallback at all).

**Fix:** change to `if r.returncode not in (0, 1): return out` so rc=1 (no match) falls through. The for loop is a natural no-op on empty stdout.

**Symptom before fix:** every saved-DB session shows `factory_config: {available: False}` → every PS-specific Outcomes tile labels as "n/a for this deployment" → wrong.

## Bug 2: Outcomes tile matchers miss cheat-* / factory_burn / subfactory_poison

`matchAny` does prefix matching (`k===p || k.indexOf(p)===0`). These broadcast_log sources didn't match any tile:
- `factory_response` (penalty TX in cheat-leaf)
- `factory_burn` (L-stock destruction TX in cheat-leaf)
- `subfactory_poison` (trustless retaliation TX in cheat-subfactory)
- `cheat_leaf_stale` / `cheat_leaf_parent_tree`
- `cheat_subfactory_stale` / `cheat_subfactory_parent_tree`

So Breach + penalty / L-stock burn / Trustless poison tiles stayed grey under all three cheat-* test scenarios despite the LSP correctly populating `breach_detections` and broadcasting the penalty/poison/burn TX.

**Fix:**
- `L-stock burn`: add `factory_burn` source
- `Trustless poison redistribute`: add `subfactory_poison` source
- `Breach + penalty`: add `factory_response, cheat_leaf, cheat_subfactory, cheat_daemon` sources + new `breachSignal` field that fires off `breach_detections` row presence (the LSP's authoritative detection signal — independent of any broadcast)

## Verification

| DB | Breach+penalty | Notes |
|---|---|---|
| cheat-leaf | green/fired | breach_detections row + factory_response prefix |
| cheat-subfactory | green/fired | cheat_subfactory prefix + Trustless poison also fires off subfactory_poison |
| cheat-daemon | not fired (correct) | LSP-side gap — daemon test ran but never wrote breach_detections and never broadcast penalty TX. Flagged for CLI/lib team handoff. |

## Test plan

- [x] cheat-leaf Outcomes: Breach+penalty + L-stock burn fire green
- [x] cheat-subfactory Outcomes: Breach+penalty + Trustless poison fire green
- [x] cheat-daemon Outcomes: Breach+penalty correctly NOT fired (no detection signal)
- [x] factory_config: available=True with derived_from_db=True for all saved DBs (was False before)