### PR TITLE
fix(tree): broadcast_factory_tree_any_network skips unsigned nodes (SF-CHEAT-SF #165)

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -855,8 +855,18 @@ static int broadcast_factory_tree_any_network(factory_t *f, regtest_t *rt,
     for (size_t i = 0; i < f->n_nodes; i++) {
         factory_node_t *node = &f->nodes[i];
         if (!node->is_signed) {
-            fprintf(stderr, "force-close: node %zu not signed\n", i);
-            return 0;
+            /* SF-CHEAT-SF #165: unsigned-mid-tree is now a SKIP, not a hard
+               error.  The cheat-subfactory test scaffold deliberately clears
+               is_signed on NODE_PS_SUBFACTORY entries so this loop walks
+               only the parent chain (root → leaf), leaving sub-factories
+               unbroadcast (so they can later be broadcast in a different
+               order with stale state).  Pre-fix this returned 0 with a
+               stderr line, breaking the cheat test.  Logging at info level
+               so legitimate unsigned-state callers still see the warning
+               without aborting the whole broadcast. */
+            printf("force-close: skipping unsigned node %zu (type=%d)\n",
+                   i, (int)node->type);
+            continue;
         }
 
         int is_ps_chain_node = (node->is_ps_leaf ||


### PR DESCRIPTION
## Summary

cheat-subfactory test scaffold clears is_signed on NODE_PS_SUBFACTORY entries to make the broadcast walk only the parent chain. Comment says 'SKIPS them' — but the broadcast function returned 0 with a stderr error on unsigned nodes, breaking the cheat test.

Comment was right, code was wrong. Now skips with an info-level log.

## Test plan

- [x] Build clean (build-release)
- [x] Regtest --test-subfactory-advance + --cheat-subfactory + arity=3: **PS K² SUB-FACTORY TEST: PASS** (was FAIL pre-fix)
- [ ] Regression: existing PS tests still pass (no behavior change on the happy path; only changes the unsigned-node case which was an error before)