### PR TITLE
fix(factory): reset PS sub-factory chain state on DW epoch rollover (SF-G #144)

### DIFF
--- a/src/factory.c
+++ b/src/factory.c
@@ -2408,6 +2408,18 @@ int factory_tick_root(factory_t *f) {
         if (f->nodes[li].is_ps_leaf)
             f->nodes[li].ps_chain_len = 0;
     }
+    /* SF-G #144: also reset NODE_PS_SUBFACTORY chain state on rollover.
+       The leaf-loop above only covers is_ps_leaf nodes (parent of the
+       sub-factory ladder); the sub-factory nodes themselves are
+       NODE_PS_SUBFACTORY type and indexed via f->n_nodes, not
+       leaf_node_indices.  Without this, a sub-factory that advanced in
+       epoch N keeps ps_chain_len > 0 into epoch N+1, and the next
+       chain-advance in the new epoch builds chain[N+1] off stale state
+       (now invalid because the parent leaf-output epoch is different).
+       Same helper as the reorg path (factory_reset_all_subfactory_chains)
+       — clears ps_chain_len, ps_n_prev_outputs, ps_prev_txid, and
+       ps_chain_confirmed_height. */
+    factory_reset_all_subfactory_chains(f);
     if (!update_l_stock_outputs(f)) return 0;
     if (!build_all_unsigned_txs(f)) return 0;
     return -1;


### PR DESCRIPTION
fix(factory): reset PS sub-factory chain state on DW epoch rollover (SF-G #144)

factory_tick_root only reset is_ps_leaf nodes' ps_chain_len when
rolling over to a new DW epoch. NODE_PS_SUBFACTORY entries kept
their pre-rollover ps_chain_len, so the next chain advance in the
new epoch would build chain[N+1] (extending the old chain) instead
of chain[0] (fresh for new epoch). The old chain[N-1] prev-output
reference is stale across the rollover because the parent leaf
output's epoch is now different — signing chain[N+1] from that
stale state would fail.

Fix: also call factory_reset_all_subfactory_chains(f) inside
factory_tick_root's rollover branch. Same helper used by the reorg
path (factory.c:2499), which clears ps_chain_len,
ps_n_prev_outputs, ps_prev_txid, and ps_chain_confirmed_height.
On-disk ps_subfactory_chains rows remain intact for forensics.

The PS leaf reset loop (which only walks f->leaf_node_indices for
is_ps_leaf nodes) is unchanged; the new call handles the
NODE_PS_SUBFACTORY type that lives outside leaf_node_indices.

Unit tests:
  - test_factory_tier_b_state_advance_root_rollover: PASS
  - test_factory_ps_subfactory_k2_n4: PASS
  - test_factory_ps_subfactory_chain_extension: PASS
  - test_factory_ps_subfactory_chain_tx_validity: PASS
  - test_factory_ps_subfactory_poison_tx_k2_n4: PASS