### PR TITLE
test(scaffold): fix soak threshold + cheat_leaf side-aware PASS (#169 + #170)

### DIFF
--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -829,7 +829,21 @@
                 tx_buf_free(&cl1_cheat_stale_leaf_tx);
             }
 
-            int pass = left_changed && right_unchanged && leaf_pass;
+            /* #170: cheat-side-aware PASS criterion. The advance and unchanged checks
+   must follow cl1_cheat_side (0=left, 1=right) — the SIDE=1 path was
+   previously hardcoded to expect left advance + right unchanged, so any
+   right-side cheat always failed despite the WT defense firing. */
+            int cheated_changed = (cl1_cheat_side == 0)
+                ? left_changed
+                : (is_ps_factory
+                    ? (right_chain_pos_after > right_chain_pos_before)
+                    : !right_nseq_unchanged);
+            int other_unchanged = (cl1_cheat_side == 0)
+                ? right_unchanged
+                : (is_ps_factory
+                    ? (left_chain_pos_peak == left_chain_pos_before)
+                    : !left_nseq_changed);
+            int pass = cheated_changed && other_unchanged && leaf_pass;
             printf("\n=== LEAF ADVANCE TEST %s ===\n", pass ? "PASSED" : "FAILED");
             if (tier_b_fired_in_loop)
                 printf("(Tier B fired during the advance loop; chain_pos reset; "

--- a/tools/test_regtest_soak_advances.sh
+++ b/tools/test_regtest_soak_advances.sh
@@ -76,7 +76,7 @@ echo "--- LSP (--demo --test-leaf-advance --cheat-leaf $SIDE --advance-count $AD
 "$LSP_BIN" \
     --network regtest --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
     --amount $FUNDING_SATS --fee-rate 1000 --confirm-timeout 600 \
-    --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
+    --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 50 \
     --seckey "$LSP_SECKEY" \
     --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
     --wallet $MINER_WALLET --db "$LSP_DB" \
@@ -133,7 +133,7 @@ echo "  LSP peak RSS       : $(grep -m1 'LSP peak RSS' "$LSP_LOG" 2>/dev/null ||
 
 echo
 echo "=== Final result ==="
-if grep -q "LEAF ADVANCE TEST PASSED" "$LSP_LOG" 2>/dev/null && [ "${CHAIN_ROWS:-0}" -ge "$ADVANCE_COUNT" ]; then
+if grep -q "LEAF ADVANCE TEST PASSED" "$LSP_LOG" 2>/dev/null && [ "${ADV:-0}" -ge "$ADVANCE_COUNT" ]; then
     echo "  PASS: $ADVANCE_COUNT advances persisted, defense fired"
     exit 0
 else


### PR DESCRIPTION
test(scaffold): fix soak threshold + cheat_leaf side-aware PASS (#169 + #170)

Bundles two test scaffold fixes uncovered while diagnosing FAILs in the
post-SF-G regression sweep.

1. tools/test_regtest_soak_advances.sh (#169 in tracking):
   - Bump --states-per-layer 2 -> 50. With 2 layers in the DW counter
     (tree depth 2 for N=4 arity 2), states-per-layer=2 caps total
     advances at ~5 before the leaf+root exhausts, so the script's
     ADVANCE_COUNT=50 was unreachable. states=50 allows 50+ epochs.
   - Switch PASS gate from CHAIN_ROWS to ADV. ps_leaf_chains gets
     truncated on every Tier B rollover (SF-G #144 / factory.c:2407
     behavior — correct, on-disk rows are preserved for forensics
     elsewhere), so the row count after the run is always < the
     historical advance count.  ADV (grep "PS leaf.*advanced") counts
     cumulative advances, which is what the test is actually
     measuring.

   Verified PASS 2026-05-17: 50 / 50 advances completed, defense fired.

2. tools/superscalar_lsp_pre_daemon_tests.inc (#170 in tracking):
   The LEAF ADVANCE TEST PASS criterion hardcoded
   `left_changed && right_unchanged`, so any SIDE=1 (right-side cheat)
   run failed even though the watchtower defense fired correctly
   (factory_response + factory_burn both broadcast).  Replace with
   cheat-side-aware:
     cheated_changed = (cl1_cheat_side == 0) ? left_changed : right_changed
     other_unchanged = (cl1_cheat_side == 0) ? right_unchanged : left_unchanged
     pass = cheated_changed && other_unchanged && leaf_pass
   Works for both PS factories (chain_pos comparison) and DW factories
   (nSequence comparison) by reusing the existing is_ps_factory branch.

   Verified PASS 2026-05-17: SIDE=1 regtest produces
   "PASS: PS leaf cheat detection end-to-end" with factory_response +
   factory_burn fired.

Cumulative regtest matrix now PASSING (post-SF-G/SF-ROT, build-release):
  - k=3, k=4, k=5, k=6 sub-factory breach
  - N=64+k=4 sub-factory breach
  - tier_b_rollover_ps
  - cheat_leaf left + right (right was #170)
  - cheat_client, cheat_daemon_leaf, cheat_daemon_subfactory,
    cheat_daemon_leaf_late_wt, cheat_leaf_multistate
  - same_height_reorg, kill_after_state_advance
  - multiprocess_subfactory_advance, dual_factory
  - soak_advances 50/50 (was failing at iter 5)