### PR TITLE
dashboard: surface PTLCs alongside HTLCs (point-locked vs hash-locked differentiation)

### DIFF
--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -240,6 +240,19 @@ def _collect_one_db(path):
         ("participants", "SELECT * FROM factory_participants ORDER BY factory_id, slot"),
         ("channels", "SELECT * FROM channels ORDER BY id"),
         ("htlcs", "SELECT * FROM htlcs ORDER BY id DESC LIMIT 50"),
+        # PTLCs (point-time-locked contracts) — Taproot-era replacement
+        # for HTLCs.  Same role (in-flight payment commitments on a
+        # channel commitment), different lock primitive: payment_point
+        # (33-byte compressed pubkey for adaptor sigs) instead of a
+        # 32-byte payment_hash.  Schema has no AUTOINCREMENT id; PK is
+        # composite (channel_id, ptlc_id) so ORDER BY uses both.  The
+        # dashboard renders HTLCs and PTLCs in parallel sections so
+        # operators can see them differentiated at a glance.
+        ("ptlcs",
+         "SELECT channel_id, ptlc_id, direction, amount, "
+         "lower(hex(payment_point)) AS payment_point, "
+         "cltv_expiry, state "
+         "FROM ptlcs ORDER BY channel_id, ptlc_id DESC LIMIT 50"),
     ]:
         rows, err = query_db(path, sql)
         # Always assign a list on error (matches the pattern used by
@@ -362,6 +375,16 @@ def _collect_one_db(path):
         "htlc_amount AS amount, payment_hash, cltv_expiry "
         "FROM old_commitment_htlcs ORDER BY channel_id, commit_num DESC LIMIT 50")
     out["old_commitment_htlcs"] = rows if not err else []
+    # Same shape for PTLCs attached to revoked commits — payment_point
+    # instead of payment_hash but otherwise parallel.  Aliased columns
+    # match old_commitment_htlcs so downstream code can render in
+    # parallel without per-table special-casing.
+    rows, err = query_db(path,
+        "SELECT channel_id, commit_num, ptlc_vout AS ptlc_index, "
+        "CASE direction WHEN 0 THEN 'offered' ELSE 'received' END AS direction, "
+        "ptlc_amount AS amount, payment_point, cltv_expiry "
+        "FROM old_commitment_ptlcs ORDER BY channel_id, commit_num DESC LIMIT 50")
+    out["old_commitment_ptlcs"] = rows if not err else []
     # PR #181 Phase A consumer: count old_commitments rows with persisted
     # penalty TX bytes vs total rows.  Column was added in schema v25
     # (old_commitments.signed_penalty_tx_hex).  If column is missing
@@ -1201,6 +1224,12 @@ a{color:#58a6ff;text-decoration:none}
 .s{background:#161b22;border:1px solid #30363d;border-radius:6px;padding:12px 16px;margin-bottom:10px}
 .st{color:#8b949e;font-size:11px;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;display:flex;justify-content:space-between}
 .st .c{color:#58a6ff}
+/* Lock-type badges next to HTLC / PTLC section titles so the lock primitive
+ * (hash vs point) is identifiable at a glance.  Hash = orangey amber,
+ * point = magenta — visually distinct, matches the common convention of
+ * coloring HTLCs warm and PTLCs cool. */
+.st .h-htlc{color:#d29922;font-size:10px;background:#d2992211;padding:1px 6px;border-radius:3px;margin-left:6px;text-transform:none;letter-spacing:0}
+.st .h-ptlc{color:#bc8cff;font-size:10px;background:#bc8cff11;padding:1px 6px;border-radius:3px;margin-left:6px;text-transform:none;letter-spacing:0}
 .kv{display:flex;flex-wrap:wrap;gap:6px 18px}
 .ki{display:flex;align-items:center;gap:5px}
 .ki .k{color:#484f58;font-size:11px}.ki .v{color:#c9d1d9;font-weight:600}
@@ -1867,12 +1896,30 @@ function rChannels(D){
    h+=`<tr><td>0x${(j.jit_channel_id||0).toString(16)}</td><td>${j.client_idx}</td><td>${sb(j.state)}</td><td class="h">${th(j.funding_txid)}</td><td class="r">${fs(j.funding_amount)}</td><td class="r">${fs(jl)}</td><td class="r">${fs(jr)}</td><td>${bar(jl,jr)}</td><td class="r">${j.commitment_number??'?'}</td><td>${j.target_factory_id||'\u2014'}</td><td>${ta(j.created_at)}</td></tr>`;}
   h+=`</table>`;}
  h+=`</div>`;
- // HTLCs
- h+=`<div class="s"><div class="st"><span>HTLCs</span><span class="c">${htlcs.length}</span></div>`;
+ // HTLCs \u2014 hash-locked, payment_hash + preimage reveal.  A 'Lock' header
+ // badge labels the column to make this visually distinct from the PTLCs
+ // section that follows.
+ h+=`<div class="s"><div class="st"><span>HTLCs</span><span class="c h-htlc">hash-locked</span><span class="c">${htlcs.length}</span></div>`;
  if(!htlcs.length)h+=`<p class="mu">No HTLCs</p>`;
  else{h+=`<table><tr><th>ID</th><th>CH</th><th>#</th><th>Dir</th><th class="r">Amount</th><th>State</th><th class="r">CLTV</th><th>Payment Hash</th><th>Preimage</th></tr>`;
   for(const x of htlcs){const dc=x.direction==='offered'?'color:#f0883e':'color:#3fb950';
    h+=`<tr><td>${x.id??'\u2014'}</td><td>${x.channel_id}</td><td>${x.htlc_id??'\u2014'}</td><td style="${dc}">${x.direction||'?'}</td><td class="r">${fs(x.amount)}</td><td>${sb(x.state)}</td><td class="r">${x.cltv_expiry??'\u2014'}</td><td class="h">${th(x.payment_hash)}</td><td class="h">${x.payment_preimage?ts(x.payment_preimage):'\u2014'}</td></tr>`;}
+  h+=`</table>`;}
+ h+=`</div>`;
+ // PTLCs \u2014 point-locked (Taproot adaptor-sig).  Same role as HTLCs but
+ // the in-flight unlock is a payment_point (33-byte compressed pubkey)
+ // rather than a payment_hash, and reveal happens through a Schnorr
+ // adaptor-signature unlock rather than preimage release.  Schema has
+ // no preimage column (the secret is the discrete log of the point,
+ // extracted from the adapted signature) \u2014 column count is smaller as
+ // a result.  Section is parallel to HTLCs above so operators can
+ // compare HTLC vs PTLC activity at a glance.
+ const ptlcs=lsp.ptlcs||[];
+ h+=`<div class="s"><div class="st"><span>PTLCs</span><span class="c h-ptlc">point-locked (Taproot)</span><span class="c">${ptlcs.length}</span></div>`;
+ if(!ptlcs.length)h+=`<p class="mu">No PTLCs</p>`;
+ else{h+=`<table><tr><th>CH</th><th>#</th><th>Dir</th><th class="r">Amount</th><th>State</th><th class="r">CLTV</th><th>Payment Point</th></tr>`;
+  for(const x of ptlcs){const dc=x.direction==='offered'?'color:#f0883e':'color:#3fb950';
+   h+=`<tr><td>${x.channel_id}</td><td>${x.ptlc_id??'\u2014'}</td><td style="${dc}">${x.direction||'?'}</td><td class="r">${fs(x.amount)}</td><td>${sb(x.state)}</td><td class="r">${x.cltv_expiry??'\u2014'}</td><td class="h">${th(x.payment_point)}</td></tr>`;}
   h+=`</table>`;}
  h+=`</div>`;
  // Invoice Registry (Phase 23)
@@ -2155,12 +2202,21 @@ function rWatchtower(D){
    h+=`<tr><td>${o.channel_id}${jitBadge}</td><td>${o.commit_num}</td><td class="h">${th(o.txid)}</td><td>${txBadge(D,o.txid,'reserve')}</td><td>${o.to_local_vout??'\u2014'}</td><td class="r">${fs(o.to_local_amount)}</td></tr>`;}
   if(oc.length>15)h+=`<tr><td colspan="6" class="mu">\u2026 and ${oc.length-15} more</td></tr>`;
   h+=`</table>`;}
- // Old commitment HTLCs (breach penalty HTLCs)
+ // Old commitment HTLCs (breach penalty HTLCs) \u2014 payment_hash secret.
  const och=lsp.old_commitment_htlcs||[];
- if(och.length){h+=`<div class="st" style="margin-top:8px"><span>Old Commitment HTLCs (breach penalty)</span><span class="c">${och.length}</span></div>`;
+ if(och.length){h+=`<div class="st" style="margin-top:8px"><span>Old Commitment HTLCs (breach penalty)</span><span class="c h-htlc">hash-locked</span><span class="c">${och.length}</span></div>`;
   h+=`<table><tr><th>CH</th><th>Commit#</th><th>HTLC#</th><th>Dir</th><th class="r">Amount</th><th>Hash</th><th class="r">CLTV</th></tr>`;
   for(const x of och){const dc=x.direction==='offered'?'color:#f0883e':'color:#3fb950';
    h+=`<tr><td>${x.channel_id}</td><td>${x.commit_num}</td><td>${x.htlc_index}</td><td style="${dc}">${x.direction||'?'}</td><td class="r">${fs(x.amount)}</td><td class="h">${th(x.payment_hash)}</td><td class="r">${x.cltv_expiry??'\u2014'}</td></tr>`;}
+  h+=`</table>`;}
+ // Old commitment PTLCs (breach penalty PTLCs) \u2014 payment_point secret.
+ // Parallel to old_commitment_htlcs above; rendered separately so the
+ // lock primitive (hash vs point) is visually distinct.
+ const ocp=lsp.old_commitment_ptlcs||[];
+ if(ocp.length){h+=`<div class="st" style="margin-top:8px"><span>Old Commitment PTLCs (breach penalty)</span><span class="c h-ptlc">point-locked</span><span class="c">${ocp.length}</span></div>`;
+  h+=`<table><tr><th>CH</th><th>Commit#</th><th>PTLC#</th><th>Dir</th><th class="r">Amount</th><th>Payment Point</th><th class="r">CLTV</th></tr>`;
+  for(const x of ocp){const dc=x.direction==='offered'?'color:#f0883e':'color:#3fb950';
+   h+=`<tr><td>${x.channel_id}</td><td>${x.commit_num}</td><td>${x.ptlc_index}</td><td style="${dc}">${x.direction||'?'}</td><td class="r">${fs(x.amount)}</td><td class="h">${th(x.payment_point)}</td><td class="r">${x.cltv_expiry??'\u2014'}</td></tr>`;}
   h+=`</table>`;}
  // Factory revocation secrets count
  const frs=lsp.factory_revocations_by_factory||[];


### PR DESCRIPTION
LSP-side work on PTLCs is starting.  The schema already has `ptlcs` and `old_commitment_ptlcs` tables alongside the HTLC tables.  Before this PR the dashboard's collector queried only the HTLC tables, so any PTLC traffic the LSP began producing would have been silently invisible.

## Design — hybrid layout

Separate panels for HTLCs and PTLCs (rather than a unified table) so the lock primitive is visually distinct at a glance:

| Type | Badge | Color | Lock primitive | Reveal mechanism |
|---|---|---|---|---|
| HTLC | `hash-locked` | amber | 32-byte `payment_hash` | preimage release |
| PTLC | `point-locked (Taproot)` | magenta | 33-byte `payment_point` | adaptor-sig discrete-log extraction |

Convention: HTLCs warm, PTLCs cool.

## What changed

### Collector
- `_collect_one_db`: added SELECTs for `ptlcs` and `old_commitment_ptlcs`. PK is composite `(channel_id, ptlc_id)` (no AUTOINCREMENT id) so ORDER BY uses both.
- Aliased `old_commitment_ptlcs` columns to mirror `old_commitment_htlcs` row shape (`ptlc_index`, integer→string `direction`, `amount`) for parallel JS rendering.

### CSS
- New `.h-htlc` and `.h-ptlc` inline badge styles next to section headers.

### Channels & HTLCs tab
- New "PTLCs" section right after "HTLCs", same columns minus the preimage column (PTLCs don't have a preimage — the secret is the discrete log, extracted from the adapted signature).

### Watchtower tab
- New "Old Commitment PTLCs (breach penalty)" panel below the existing HTLC equivalent.

## Verification (synthesized PTLC rows)

| Test data | Channels tab | Watchtower tab |
|---|---|---|
| Live PTLCs (channel 0 + 1) | ✓ PTLCs section renders with magenta badge, 2 rows (offered/received) | n/a (live, not revoked) |
| Old-commit PTLC (revoked) | n/a | ✓ Old Commitment PTLCs panel renders with magenta badge, 1 row, payment_point displayed |
| Same DB with HTLCs (empty) | ✓ HTLCs section shows "No HTLCs" with amber badge — visually distinct empty-state | n/a |
| Old-commit HTLCs (existing 8 entries) | n/a | ✓ existing panel renders with amber `hash-locked` badge |

The differentiation is unmistakable in screenshots — operators can see at a glance whether activity is HTLC- or PTLC-flavored.

## Future work (not in this PR)

- **Payments tab PTLC rollup**: groups by `payment_point` (parallel to existing `payment_hash` grouping for HTLCs).  Deferred until PTLC payment flow exists in real test data.
- **TX Inventory PTLC success/timeout TX row**: requires PTLC TX persistence path to land LSP-side first.
- **Defense Status taxonomy update**: failure mode #6 "HTLC times out / preimage not received" should generalize to "HTLC/PTLC timeout" once PTLC failure flow is testable.

## Test plan

- [x] Collector reads `ptlcs` and `old_commitment_ptlcs` tables (verified with synthesized rows)
- [x] Channels tab renders both HTLCs and PTLCs sections with their respective lock-primitive badges
- [x] PTLCs section shows the correct columns (no preimage column, `payment_point` instead of `payment_hash`)
- [x] Watchtower's old-commitment PTLC panel renders parallel to the HTLC panel
- [x] Empty-state copy ("No PTLCs", "No HTLCs") works
- [x] Pre-PTLC LSP DBs (no `ptlcs` table or empty) render without crashing