### PR TITLE
fix(test): checkpoint WAL before cp in cheat_daemon_subfactory cleanup (#178)

### DIFF
--- a/tools/test_regtest_cheat_daemon_subfactory.sh
+++ b/tools/test_regtest_cheat_daemon_subfactory.sh
@@ -73,6 +73,12 @@ cleanup() {
     for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
     sleep 1
     for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    # #178: checkpoint WAL before cp so the saved snapshot has the actual data
+    # (kill -9 above bypasses SQLite's clean shutdown, leaving recent writes
+    # in the WAL file. Without this checkpoint, the cp captures an empty stub
+    # DB and downstream sqlite3 queries on /tmp/cheat_daemon_sub_last_lsp.db
+    # see zero tables.)
+    sqlite3 "$LSP_DB" "PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null 2>&1 || true
     cp "$LSP_LOG" /tmp/cheat_daemon_sub_last_lsp.log 2>/dev/null || true
     cp "$WT_LOG"  /tmp/cheat_daemon_sub_last_wt.log  2>/dev/null || true
     cp "$LSP_DB"  /tmp/cheat_daemon_sub_last_lsp.db  2>/dev/null || true


### PR DESCRIPTION
Runner cleanup() force-kills LSP/WT via kill -9, then cp's the LSP DB. kill -9 bypasses SQLite clean shutdown, leaving recent writes in WAL — saved DB is empty. Adds PRAGMA wal_checkpoint(TRUNCATE) before cp so the snapshot has actual data. Unblocks end-to-end validation of PR #245 (#176 observability fix). Refs #178 #176.