### PR TITLE
fix(persist): SF-RR — chain-state guard on pending broadcast retries (#150)

### DIFF
--- a/include/superscalar/chain_backend.h
+++ b/include/superscalar/chain_backend.h
@@ -106,6 +106,17 @@ struct chain_backend {
     bool (*is_in_mempool)(chain_backend_t *self, const char *txid_hex);
 
     /*
+     * SF-RR #150: check whether a specific outpoint (txid:vout) is unspent.
+     * Returns 1 if unspent, 0 if spent (or txid not found), -1 on error or
+     * if not implemented. Used by persist_retry_pending_broadcasts to skip
+     * stale pending broadcasts (input UTXO already spent by a later state).
+     * Optional — may be NULL; callers must handle.
+     */
+    int  (*is_outpoint_unspent)(chain_backend_t *self,
+                                  const char *txid_hex_display,
+                                  uint32_t vout);
+
+    /*
      * Broadcast a raw transaction. Writes the resulting txid (64 hex chars
      * + NUL) to txid_out if non-NULL. Returns 1 on success, 0 on failure.
      */

--- a/include/superscalar/regtest.h
+++ b/include/superscalar/regtest.h
@@ -74,6 +74,12 @@ int   regtest_fund_address_with_fee_rate(regtest_t *rt, const char *address,
                                           char *txid_out);
 int   regtest_fund_address(regtest_t *rt, const char *address, double btc_amount, char *txid_out);
 int   regtest_send_raw_tx(regtest_t *rt, const char *tx_hex, char *txid_out);
+
+/* SF-RR #150: query whether an outpoint is unspent via gettxout.
+   Returns 1 if unspent, 0 if spent/missing, -1 on RPC error. */
+int   regtest_outpoint_unspent(regtest_t *rt,
+                                 const char *txid_hex_display,
+                                 uint32_t vout);
 int   regtest_get_confirmations(regtest_t *rt, const char *txid);
 /*
  * Batch confirmations for n_txids display-order hex txids.

--- a/src/chain_backend_regtest.c
+++ b/src/chain_backend_regtest.c
@@ -23,6 +23,13 @@ static bool cb_is_in_mempool(chain_backend_t *self, const char *txid_hex)
     return regtest_is_in_mempool((regtest_t *)self->ctx, txid_hex);
 }
 
+static int cb_is_outpoint_unspent(chain_backend_t *self,
+                                   const char *txid_hex_display,
+                                   uint32_t vout)
+{
+    return regtest_outpoint_unspent((regtest_t *)self->ctx, txid_hex_display, vout);
+}
+
 static int cb_send_raw_tx(chain_backend_t *self, const char *tx_hex,
                           char *txid_out)
 {
@@ -57,6 +64,7 @@ void chain_backend_regtest_init(chain_backend_t *backend, regtest_t *rt)
     backend->get_confirmations       = cb_get_confirmations;
     backend->get_confirmations_batch = cb_get_confirmations_batch;
     backend->is_in_mempool           = cb_is_in_mempool;
+    backend->is_outpoint_unspent     = cb_is_outpoint_unspent;
     backend->send_raw_tx       = cb_send_raw_tx;
     backend->register_script   = cb_register_script;
     backend->unregister_script = cb_unregister_script;

--- a/src/persist.c
+++ b/src/persist.c
@@ -3464,6 +3464,56 @@ int persist_retry_pending_broadcasts(persist_t *p, chain_backend_t *chain) {
         const char *raw_hex = (const char *)sqlite3_column_text(stmt, 1);
         if (!raw_hex) continue;
 
+        /* SF-RR #150: if backend supports outpoint queries, check the first
+           input's outpoint before re-broadcasting. If it has been spent
+           (state moved on while we were down), mark stale and skip — prevents
+           infinite retry on dead pending entries. */
+        if (chain->is_outpoint_unspent) {
+            size_t hex_len = strlen(raw_hex);
+            if (hex_len >= 84) {
+                /* Detect segwit marker at offset 8-11 to compute vin offset. */
+                int is_segwit = (hex_len >= 12 &&
+                                 raw_hex[8] == '0' && raw_hex[9] == '0' &&
+                                 raw_hex[10] == '0' && raw_hex[11] == '1');
+                size_t vin_ofs = is_segwit ? (4 + 2 + 1) * 2 : (4 + 1) * 2;
+                if (hex_len >= vin_ofs + 64 + 8) {
+                    char prev_txid_disp[65];
+                    /* prev_txid is stored LE in raw; display order reverses bytes. */
+                    for (int j = 0; j < 32; j++) {
+                        prev_txid_disp[j*2]   = raw_hex[vin_ofs + (31 - j)*2];
+                        prev_txid_disp[j*2+1] = raw_hex[vin_ofs + (31 - j)*2 + 1];
+                    }
+                    prev_txid_disp[64] = 0;
+                    uint32_t prev_vout = 0;
+                    for (int j = 0; j < 4; j++) {
+                        char hb[3] = { raw_hex[vin_ofs + 64 + j*2],
+                                       raw_hex[vin_ofs + 64 + j*2 + 1], 0 };
+                        prev_vout |= (uint32_t)strtoul(hb, NULL, 16) << (j * 8);
+                    }
+                    int unspent = chain->is_outpoint_unspent(chain,
+                                    prev_txid_disp, prev_vout);
+                    if (unspent == 0) {
+                        fprintf(stderr,
+                            "SF-RR #150: outpoint %s:%u already spent, "
+                            "marking broadcast_log row %d stale_input_spent\n",
+                            prev_txid_disp, prev_vout, row_id);
+                        const char *upd_stale =
+                            "UPDATE broadcast_log "
+                            "SET result='stale_input_spent' WHERE id=?;";
+                        sqlite3_stmt *us;
+                        if (sqlite3_prepare_v2(p->db, upd_stale, -1, &us, NULL)
+                                == SQLITE_OK) {
+                            sqlite3_bind_int(us, 1, row_id);
+                            sqlite3_step(us);
+                            sqlite3_finalize(us);
+                        }
+                        continue;  /* skip this row */
+                    }
+                    /* unspent==1 (good) or unspent==-1 (RPC error) → fall through */
+                }
+            }
+        }
+
         char txid_out[65] = {0};
         if (chain->send_raw_tx(chain, raw_hex, txid_out)) {
             fprintf(stderr, "Watchtower: retry broadcast succeeded: %s\n", txid_out);

--- a/src/regtest.c
+++ b/src/regtest.c
@@ -1268,6 +1268,20 @@ int regtest_get_tx_output(regtest_t *rt, const char *txid, uint32_t vout,
     return 0;
 }
 
+/* SF-RR #150: check outpoint unspent via bitcoin-cli gettxout. */
+int regtest_outpoint_unspent(regtest_t *rt, const char *txid_hex_display,
+                              uint32_t vout) {
+    if (!rt || !txid_hex_display) return -1;
+    char params[128];
+    snprintf(params, sizeof(params), "%s %u true",
+             txid_hex_display, (unsigned)vout);
+    char *result = regtest_exec(rt, "gettxout", params);
+    if (!result) return -1;
+    int spent = (result[0] == '\0' || strncmp(result, "null", 4) == 0);
+    free(result);
+    return spent ? 0 : 1;
+}
+
 int regtest_get_raw_tx(regtest_t *rt, const char *txid,
                          char *tx_hex_out, size_t max_len) {
     if (!rt || !txid || !tx_hex_out || max_len == 0) return 0;


### PR DESCRIPTION
persist_retry_pending_broadcasts re-broadcasts every pending_retry row forever, even when the input UTXO has been spent (state moved on). Adds chain_backend->is_outpoint_unspent method (implemented in regtest backend via gettxout), decodes raw_hex to find first input outpoint, marks row 'stale_input_spent' if input is gone. Defense-in-depth against mid-ceremony stale-broadcast race. Build clean, 1437/1439 unit tests pass (2 pre-existing env fails). cheat-daemon-sub regtest still PASS. Refs #150.