### PR TITLE
feat(ptlc): consolidate balance + chain validation + production threading (resyncs #248+#249+#250)

### DIFF
--- a/include/superscalar/channel.h
+++ b/include/superscalar/channel.h
@@ -48,6 +48,7 @@ typedef struct {
     int              has_pre_sig;
     unsigned char    adapted_sig[64]; /* final adapted signature from client */
     int              has_adapted_sig;
+    uint64_t         fee_at_add;      /* #182: per-PTLC commit fee deducted from funder at add time */
 } ptlc_t;
 
 typedef struct {

--- a/src/lsp_bridge.c
+++ b/src/lsp_bridge.c
@@ -294,16 +294,23 @@ int lsp_channels_handle_bridge_msg(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                             rev_secret, next_point)) {
                 uint64_t old_cn = dest_ch->commitment_number - 1;
                 channel_receive_revocation(dest_ch, old_cn, rev_secret);
+                /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+                   No-op today (n_ptlcs == 0 at all current callsites); defensive
+                   for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+                size_t old_dest_n_ptlcs = dest_ch->n_ptlcs;
+                ptlc_t *old_dest_ptlcs = NULL;
+                if (old_dest_n_ptlcs > 0) {
+                    old_dest_ptlcs = malloc(old_dest_n_ptlcs * sizeof(ptlc_t));
+                    if (old_dest_ptlcs)
+                        memcpy(old_dest_ptlcs, dest_ch->ptlcs,
+                               old_dest_n_ptlcs * sizeof(ptlc_t));
+                }
                 watchtower_watch_revoked_commitment(mgr->watchtower, dest_ch,
                     (uint32_t)dest_idx, old_cn,
                     old_dest_local, old_dest_remote,
                     old_dest_htlcs, old_dest_n_htlcs,
-                    /* SF-W-PTLC: bridge flow doesn't track PTLC snapshots
-                       yet — pass NULL/0; production PTLC payments go through
-                       the peer_mgr / ptlc_commit_dispatch path which carries
-                       full PTLC state and will need a separate registration
-                       call from that codepath. */
-                    NULL, 0);
+                    /* SF-W-PTLC #171: thread PTLC snapshot */ old_dest_ptlcs, old_dest_n_ptlcs);
+                free(old_dest_ptlcs);
                 secp256k1_pubkey next_pcp;
                 if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                     channel_set_remote_pcp(dest_ch, dest_ch->commitment_number + 1, &next_pcp);
@@ -429,12 +436,23 @@ int lsp_channels_handle_bridge_msg(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                                         rev_secret, next_point)) {
                             uint64_t old_cn = ch->commitment_number - 1;
                             channel_receive_revocation(ch, old_cn, rev_secret);
+                            /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+                               No-op today (n_ptlcs == 0 at all current callsites); defensive
+                               for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+                            size_t old_n_ptlcs = ch->n_ptlcs;
+                            ptlc_t *old_ptlcs = NULL;
+                            if (old_n_ptlcs > 0) {
+                                old_ptlcs = malloc(old_n_ptlcs * sizeof(ptlc_t));
+                                if (old_ptlcs)
+                                    memcpy(old_ptlcs, ch->ptlcs,
+                                           old_n_ptlcs * sizeof(ptlc_t));
+                            }
                             watchtower_watch_revoked_commitment(mgr->watchtower, ch,
                                 (uint32_t)client_idx, old_cn,
                                 old_local, old_remote,
                                 old_htlcs, old_n_htlcs,
-                                /* SF-W-PTLC: no PTLC snapshot here either */
-                                NULL, 0);
+                                /* SF-W-PTLC #171: thread PTLC snapshot */ old_ptlcs, old_n_ptlcs);
+                            free(old_ptlcs);
                             secp256k1_pubkey next_pcp;
                             if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp,
                                                             next_point, 33))

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1477,11 +1477,23 @@ static int handle_add_htlc(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             channel_receive_revocation(dest_ch, old_cn, rev_secret);
             uint32_t wt_chan_id = dest_is_jit ?
                 (uint32_t)(mgr->n_channels + dest_idx) : (uint32_t)dest_idx;
+            /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+               No-op today (n_ptlcs == 0 at all current callsites); defensive
+               for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+            size_t old_dest_n_ptlcs = dest_ch->n_ptlcs;
+            ptlc_t *old_dest_ptlcs = NULL;
+            if (old_dest_n_ptlcs > 0) {
+                old_dest_ptlcs = malloc(old_dest_n_ptlcs * sizeof(ptlc_t));
+                if (old_dest_ptlcs)
+                    memcpy(old_dest_ptlcs, dest_ch->ptlcs,
+                           old_dest_n_ptlcs * sizeof(ptlc_t));
+            }
             watchtower_watch_revoked_commitment(mgr->watchtower, dest_ch,
                 wt_chan_id, old_cn,
                 old_dest_local, old_dest_remote,
                 old_dest_htlcs, old_dest_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                /* SF-W-PTLC #171: thread PTLC snapshot */ old_dest_ptlcs, old_dest_n_ptlcs);
+            free(old_dest_ptlcs);
             secp256k1_pubkey next_pcp;
             if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33)) {
                 channel_set_remote_pcp(dest_ch, dest_ch->commitment_number + 1, &next_pcp);
@@ -4187,11 +4199,23 @@ static int handle_fulfill_htlc(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                         rev_secret, next_point)) {
             uint64_t old_cn = ch->commitment_number - 1;
             channel_receive_revocation(ch, old_cn, rev_secret);
+            /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+               No-op today (n_ptlcs == 0 at all current callsites); defensive
+               for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+            size_t old_ch_n_ptlcs = ch->n_ptlcs;
+            ptlc_t *old_ch_ptlcs = NULL;
+            if (old_ch_n_ptlcs > 0) {
+                old_ch_ptlcs = malloc(old_ch_n_ptlcs * sizeof(ptlc_t));
+                if (old_ch_ptlcs)
+                    memcpy(old_ch_ptlcs, ch->ptlcs,
+                           old_ch_n_ptlcs * sizeof(ptlc_t));
+            }
             watchtower_watch_revoked_commitment(mgr->watchtower, ch,
                 (uint32_t)client_idx, old_cn,
                 old_ch_local, old_ch_remote,
                 old_ch_htlcs, old_ch_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                /* SF-W-PTLC #171: thread PTLC snapshot */ old_ch_ptlcs, old_ch_n_ptlcs);
+            free(old_ch_ptlcs);
             secp256k1_pubkey next_pcp;
             if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                 channel_set_remote_pcp(ch, ch->commitment_number + 1, &next_pcp);
@@ -4313,11 +4337,23 @@ static int handle_fulfill_htlc(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                                 rev_secret, next_point)) {
                     uint64_t old_cn = sender_ch->commitment_number - 1;
                     channel_receive_revocation(sender_ch, old_cn, rev_secret);
+                    /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+                       No-op today (n_ptlcs == 0 at all current callsites); defensive
+                       for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+                    size_t old_sender_n_ptlcs = sender_ch->n_ptlcs;
+                    ptlc_t *old_sender_ptlcs = NULL;
+                    if (old_sender_n_ptlcs > 0) {
+                        old_sender_ptlcs = malloc(old_sender_n_ptlcs * sizeof(ptlc_t));
+                        if (old_sender_ptlcs)
+                            memcpy(old_sender_ptlcs, sender_ch->ptlcs,
+                                   old_sender_n_ptlcs * sizeof(ptlc_t));
+                    }
                     watchtower_watch_revoked_commitment(mgr->watchtower, sender_ch,
                         (uint32_t)s, old_cn,
                         old_sender_local, old_sender_remote,
                         old_sender_htlcs, old_sender_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                        /* SF-W-PTLC #171: thread PTLC snapshot */ old_sender_ptlcs, old_sender_n_ptlcs);
+                    free(old_sender_ptlcs);
                     secp256k1_pubkey next_pcp;
                     if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                         channel_set_remote_pcp(sender_ch, sender_ch->commitment_number + 1, &next_pcp);
@@ -4745,11 +4781,23 @@ static void replay_pending_htlcs(lsp_channel_mgr_t *mgr, lsp_t *lsp, size_t reco
                         continue;
                     }
                     channel_receive_revocation(dest_ch, old_cn, rev_secret);
+                    /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+                       No-op today (n_ptlcs == 0 at all current callsites); defensive
+                       for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+                    size_t old_dest_n_ptlcs = dest_ch->n_ptlcs;
+                    ptlc_t *old_dest_ptlcs = NULL;
+                    if (old_dest_n_ptlcs > 0) {
+                        old_dest_ptlcs = malloc(old_dest_n_ptlcs * sizeof(ptlc_t));
+                        if (old_dest_ptlcs)
+                            memcpy(old_dest_ptlcs, dest_ch->ptlcs,
+                                   old_dest_n_ptlcs * sizeof(ptlc_t));
+                    }
                     watchtower_watch_revoked_commitment(mgr->watchtower, dest_ch,
                         (uint32_t)reconnected_idx, old_cn,
                         old_dest_local, old_dest_remote,
                         old_dest_htlcs, old_dest_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                        /* SF-W-PTLC #171: thread PTLC snapshot */ old_dest_ptlcs, old_dest_n_ptlcs);
+                    free(old_dest_ptlcs);
                     secp256k1_pubkey next_pcp;
                     if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                         channel_set_remote_pcp(dest_ch, dest_ch->commitment_number + 1, &next_pcp);

--- a/src/lsp_demo.c
+++ b/src/lsp_demo.c
@@ -255,11 +255,23 @@ int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                         rev_secret, next_point)) {
             uint64_t old_cn = sender_ch->commitment_number - 1;
             channel_receive_revocation(sender_ch, old_cn, rev_secret);
+            /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+               No-op today (n_ptlcs == 0 at all current callsites); defensive
+               for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+            size_t old_sender_n_ptlcs = sender_ch->n_ptlcs;
+            ptlc_t *old_sender_ptlcs = NULL;
+            if (old_sender_n_ptlcs > 0) {
+                old_sender_ptlcs = malloc(old_sender_n_ptlcs * sizeof(ptlc_t));
+                if (old_sender_ptlcs)
+                    memcpy(old_sender_ptlcs, sender_ch->ptlcs,
+                           old_sender_n_ptlcs * sizeof(ptlc_t));
+            }
             watchtower_watch_revoked_commitment(mgr->watchtower, sender_ch,
                 (uint32_t)from_client, old_cn,
                 old_sender_local, old_sender_remote,
                 old_sender_htlcs, old_sender_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                /* SF-W-PTLC #171: thread PTLC snapshot */ old_sender_ptlcs, old_sender_n_ptlcs);
+            free(old_sender_ptlcs);
             secp256k1_pubkey next_pcp;
             if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                 channel_set_remote_pcp(sender_ch, sender_ch->commitment_number + 1, &next_pcp);
@@ -379,11 +391,23 @@ int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                         rev_secret, next_point)) {
             uint64_t old_cn = dest_ch->commitment_number - 1;
             channel_receive_revocation(dest_ch, old_cn, rev_secret);
+            /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+               No-op today (n_ptlcs == 0 at all current callsites); defensive
+               for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+            size_t old_dest_n_ptlcs = dest_ch->n_ptlcs;
+            ptlc_t *old_dest_ptlcs = NULL;
+            if (old_dest_n_ptlcs > 0) {
+                old_dest_ptlcs = malloc(old_dest_n_ptlcs * sizeof(ptlc_t));
+                if (old_dest_ptlcs)
+                    memcpy(old_dest_ptlcs, dest_ch->ptlcs,
+                           old_dest_n_ptlcs * sizeof(ptlc_t));
+            }
             watchtower_watch_revoked_commitment(mgr->watchtower, dest_ch,
                 (uint32_t)to_client, old_cn,
                 old_dest_local, old_dest_remote,
                 old_dest_htlcs, old_dest_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                /* SF-W-PTLC #171: thread PTLC snapshot */ old_dest_ptlcs, old_dest_n_ptlcs);
+            free(old_dest_ptlcs);
             secp256k1_pubkey next_pcp;
             if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                 channel_set_remote_pcp(dest_ch, dest_ch->commitment_number + 1, &next_pcp);
@@ -498,11 +522,23 @@ int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                                 rev_secret, next_point)) {
                     uint64_t old_cn = dest_ch->commitment_number - 1;
                     channel_receive_revocation(dest_ch, old_cn, rev_secret);
+                    /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+                       No-op today (n_ptlcs == 0 at all current callsites); defensive
+                       for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+                    size_t old_dest_ful_n_ptlcs = dest_ch->n_ptlcs;
+                    ptlc_t *old_dest_ful_ptlcs = NULL;
+                    if (old_dest_ful_n_ptlcs > 0) {
+                        old_dest_ful_ptlcs = malloc(old_dest_ful_n_ptlcs * sizeof(ptlc_t));
+                        if (old_dest_ful_ptlcs)
+                            memcpy(old_dest_ful_ptlcs, dest_ch->ptlcs,
+                                   old_dest_ful_n_ptlcs * sizeof(ptlc_t));
+                    }
                     watchtower_watch_revoked_commitment(mgr->watchtower, dest_ch,
                         (uint32_t)to_client, old_cn,
                         old_dest_ful_local, old_dest_ful_remote,
                         old_dest_ful_htlcs, old_dest_ful_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                        /* SF-W-PTLC #171: thread PTLC snapshot */ old_dest_ful_ptlcs, old_dest_ful_n_ptlcs);
+                    free(old_dest_ful_ptlcs);
                     secp256k1_pubkey next_pcp;
                     if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                         channel_set_remote_pcp(dest_ch, dest_ch->commitment_number + 1, &next_pcp);
@@ -594,11 +630,23 @@ int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                                 rev_secret, next_point)) {
                     uint64_t old_cn = sender_ch->commitment_number - 1;
                     channel_receive_revocation(sender_ch, old_cn, rev_secret);
+                    /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+                       No-op today (n_ptlcs == 0 at all current callsites); defensive
+                       for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+                    size_t old_sender_ful_n_ptlcs = sender_ch->n_ptlcs;
+                    ptlc_t *old_sender_ful_ptlcs = NULL;
+                    if (old_sender_ful_n_ptlcs > 0) {
+                        old_sender_ful_ptlcs = malloc(old_sender_ful_n_ptlcs * sizeof(ptlc_t));
+                        if (old_sender_ful_ptlcs)
+                            memcpy(old_sender_ful_ptlcs, sender_ch->ptlcs,
+                                   old_sender_ful_n_ptlcs * sizeof(ptlc_t));
+                    }
                     watchtower_watch_revoked_commitment(mgr->watchtower, sender_ch,
                         (uint32_t)from_client, old_cn,
                         old_sender_ful_local, old_sender_ful_remote,
                         old_sender_ful_htlcs, old_sender_ful_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                        /* SF-W-PTLC #171: thread PTLC snapshot */ old_sender_ful_ptlcs, old_sender_ful_n_ptlcs);
+                    free(old_sender_ful_ptlcs);
                     secp256k1_pubkey next_pcp;
                     if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                         channel_set_remote_pcp(sender_ch, sender_ch->commitment_number + 1, &next_pcp);
@@ -943,11 +991,23 @@ int lsp_channels_add_pending_htlc(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                         rev_secret, next_point)) {
             uint64_t old_cn = sender_ch->commitment_number - 1;
             channel_receive_revocation(sender_ch, old_cn, rev_secret);
+            /* SF-W-PTLC #171: inline PTLC snapshot for revocation registration.
+               No-op today (n_ptlcs == 0 at all current callsites); defensive
+               for when CLN-bLIP56 (#172) wires real PTLC flow through here. */
+            size_t old_n_ptlcs = sender_ch->n_ptlcs;
+            ptlc_t *old_ptlcs = NULL;
+            if (old_n_ptlcs > 0) {
+                old_ptlcs = malloc(old_n_ptlcs * sizeof(ptlc_t));
+                if (old_ptlcs)
+                    memcpy(old_ptlcs, sender_ch->ptlcs,
+                           old_n_ptlcs * sizeof(ptlc_t));
+            }
             watchtower_watch_revoked_commitment(mgr->watchtower, sender_ch,
                 (uint32_t)from_client, old_cn,
                 old_local, old_remote,
                 old_htlcs, old_n_htlcs,
-                                    /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
+                /* SF-W-PTLC #171: thread PTLC snapshot */ old_ptlcs, old_n_ptlcs);
+            free(old_ptlcs);
             secp256k1_pubkey next_pcp;
             if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
                 channel_set_remote_pcp(sender_ch, sender_ch->commitment_number + 1, &next_pcp);

--- a/src/ptlc_commit.c
+++ b/src/ptlc_commit.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 /* Minimum capacity for PTLC array growth */
 #define PTLC_INIT_CAP 8
@@ -63,11 +64,58 @@ int channel_add_ptlc(channel_t *ch, ptlc_direction_t dir,
         return 0;
     }
 
+    /* #182: deduct amount + per-PTLC commit fee from the sender. Mirrors
+       channel_add_htlc balance accounting; without this the commit TX
+       outputs exceed funding and broadcast fails with bad-txns-in-belowout. */
+    if (amount_sats > 0) {
+        if (dir == PTLC_OFFERED) {
+            if (ch->local_amount < amount_sats + CHANNEL_RESERVE_SATS) {
+                fprintf(stderr,
+                    "channel_add_ptlc: refused OFFERED — local %" PRIu64
+                    " < amount %" PRIu64 " + reserve %d\n",
+                    ch->local_amount, amount_sats, CHANNEL_RESERVE_SATS);
+                return 0;
+            }
+            ch->local_amount -= amount_sats;
+        } else { /* PTLC_RECEIVED */
+            if (ch->remote_amount < amount_sats + CHANNEL_RESERVE_SATS) {
+                fprintf(stderr,
+                    "channel_add_ptlc: refused RECEIVED — remote %" PRIu64
+                    " < amount %" PRIu64 " + reserve %d\n",
+                    ch->remote_amount, amount_sats, CHANNEL_RESERVE_SATS);
+                return 0;
+            }
+            ch->remote_amount -= amount_sats;
+        }
+    }
+    /* Per-PTLC commit fee — same 43 vB shape as HTLCs. */
+    uint64_t per_ptlc_fee = (ch->fee_rate_sat_per_kvb * 43 + 999) / 1000;
+    uint64_t *funder_bal = ch->funder_is_local ? &ch->local_amount : &ch->remote_amount;
+    if (amount_sats > 0 && *funder_bal < per_ptlc_fee) {
+        /* Rollback amount deduction. */
+        if (dir == PTLC_OFFERED) ch->local_amount += amount_sats;
+        else ch->remote_amount += amount_sats;
+        fprintf(stderr,
+            "channel_add_ptlc: refused — funder_bal %" PRIu64
+            " < per_ptlc_fee %" PRIu64 "\n",
+            *funder_bal, per_ptlc_fee);
+        return 0;
+    }
+    if (amount_sats > 0) *funder_bal -= per_ptlc_fee;
+
     /* Grow array if needed */
     if (ch->n_ptlcs >= ch->ptlcs_cap) {
         size_t new_cap = ch->ptlcs_cap ? ch->ptlcs_cap * 2 : PTLC_INIT_CAP;
         ptlc_t *new_arr = (ptlc_t *)realloc(ch->ptlcs, new_cap * sizeof(ptlc_t));
-        if (!new_arr) return 0;
+        if (!new_arr) {
+            /* Rollback. */
+            if (amount_sats > 0) {
+                if (dir == PTLC_OFFERED) ch->local_amount += amount_sats;
+                else ch->remote_amount += amount_sats;
+                *funder_bal += per_ptlc_fee;
+            }
+            return 0;
+        }
         ch->ptlcs = new_arr;
         ch->ptlcs_cap = new_cap;
     }
@@ -79,6 +127,7 @@ int channel_add_ptlc(channel_t *ch, ptlc_direction_t dir,
     p->amount_sats = amount_sats;
     p->cltv_expiry = cltv_expiry;
     p->id          = ch->next_ptlc_id++;
+    p->fee_at_add  = amount_sats > 0 ? per_ptlc_fee : 0;
     if (point) p->payment_point = *point;
 
     if (id_out) *id_out = p->id;
@@ -91,11 +140,24 @@ int channel_settle_ptlc(channel_t *ch, uint64_t ptlc_id,
 {
     if (!ch) return 0;
     for (size_t i = 0; i < ch->n_ptlcs; i++) {
-        if (ch->ptlcs[i].id == ptlc_id) {
+        ptlc_t *p = &ch->ptlcs[i];
+        if (p->id == ptlc_id && p->state == PTLC_STATE_ACTIVE) {
+            /* #182: credit recipient + refund fee to funder. */
+            if (p->amount_sats > 0) {
+                if (p->direction == PTLC_OFFERED) {
+                    /* Local offered → remote receives. */
+                    ch->remote_amount += p->amount_sats;
+                } else {
+                    ch->local_amount += p->amount_sats;
+                }
+                uint64_t *funder_bal = ch->funder_is_local
+                    ? &ch->local_amount : &ch->remote_amount;
+                *funder_bal += p->fee_at_add;
+            }
             if (adapted_sig64)
-                memcpy(ch->ptlcs[i].adapted_sig, adapted_sig64, 64);
-            ch->ptlcs[i].has_adapted_sig = (adapted_sig64 != NULL);
-            ch->ptlcs[i].state = PTLC_STATE_SETTLED;
+                memcpy(p->adapted_sig, adapted_sig64, 64);
+            p->has_adapted_sig = (adapted_sig64 != NULL);
+            p->state = PTLC_STATE_SETTLED;
             return 1;
         }
     }
@@ -106,8 +168,20 @@ int channel_fail_ptlc(channel_t *ch, uint64_t ptlc_id)
 {
     if (!ch) return 0;
     for (size_t i = 0; i < ch->n_ptlcs; i++) {
-        if (ch->ptlcs[i].id == ptlc_id) {
-            ch->ptlcs[i].state = PTLC_STATE_FAILED;
+        ptlc_t *p = &ch->ptlcs[i];
+        if (p->id == ptlc_id && p->state == PTLC_STATE_ACTIVE) {
+            /* #182: refund amount to original sender + fee to funder. */
+            if (p->amount_sats > 0) {
+                if (p->direction == PTLC_OFFERED) {
+                    ch->local_amount += p->amount_sats;
+                } else {
+                    ch->remote_amount += p->amount_sats;
+                }
+                uint64_t *funder_bal = ch->funder_is_local
+                    ? &ch->local_amount : &ch->remote_amount;
+                *funder_bal += p->fee_at_add;
+            }
+            p->state = PTLC_STATE_FAILED;
             return 1;
         }
     }

--- a/tests/test_adaptor.c
+++ b/tests/test_adaptor.c
@@ -675,6 +675,13 @@ int test_channel_add_ptlc(void)
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
+    /* #182 balance accounting: channel_add_ptlc deducts amount +
+       per_ptlc_fee from funder. Seed balances large enough for the
+       sum of PTLC amounts the test adds, plus 5000 reserve, plus
+       buffer for per_ptlc_fee (fee_rate_sat_per_kvb=0 → fee=0). */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
 
     secp256k1_pubkey payment_pt;
     unsigned char sec[32]; memset(sec, 0x22, 32);
@@ -701,6 +708,13 @@ int test_channel_settle_ptlc(void)
 {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
+    /* #182 balance accounting: channel_add_ptlc deducts amount +
+       per_ptlc_fee from funder. Seed balances large enough for the
+       sum of PTLC amounts the test adds, plus 5000 reserve, plus
+       buffer for per_ptlc_fee (fee_rate_sat_per_kvb=0 → fee=0). */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
 
     uint64_t id = 0;
     int r = channel_add_ptlc(&ch, PTLC_RECEIVED, 10000, NULL, 700200, &id);
@@ -723,6 +737,13 @@ int test_channel_fail_ptlc(void)
 {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
+    /* #182 balance accounting: channel_add_ptlc deducts amount +
+       per_ptlc_fee from funder. Seed balances large enough for the
+       sum of PTLC amounts the test adds, plus 5000 reserve, plus
+       buffer for per_ptlc_fee (fee_rate_sat_per_kvb=0 → fee=0). */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
 
     uint64_t id = 0;
     channel_add_ptlc(&ch, PTLC_OFFERED, 20000, NULL, 700300, &id);
@@ -742,6 +763,13 @@ int test_channel_ptlc_multiple(void)
 {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
+    /* #182 balance accounting: channel_add_ptlc deducts amount +
+       per_ptlc_fee from funder. Seed balances large enough for the
+       sum of PTLC amounts the test adds, plus 5000 reserve, plus
+       buffer for per_ptlc_fee (fee_rate_sat_per_kvb=0 → fee=0). */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
 
     uint64_t id0, id1, id2;
     channel_add_ptlc(&ch, PTLC_OFFERED, 1000, NULL, 700000, &id0);
@@ -765,6 +793,10 @@ int test_ptlc_commit_dispatch_presig(void)
 {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
+    /* #182: seed balances for channel_add_ptlc. */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
     peer_mgr_t pmgr; memset(&pmgr, 0, sizeof(pmgr));
 
     /* Add a PTLC to receive presig for */
@@ -793,6 +825,10 @@ int test_ptlc_commit_dispatch_adapted(void)
 {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
+    /* #182: seed balances for channel_add_ptlc. */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
     peer_mgr_t pmgr; memset(&pmgr, 0, sizeof(pmgr));
 
     uint64_t id = 0;
@@ -817,6 +853,10 @@ int test_ptlc_commit_dispatch_complete(void)
 {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
+    /* #182: seed balances for channel_add_ptlc. */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
     peer_mgr_t pmgr; memset(&pmgr, 0, sizeof(pmgr));
 
     uint64_t id = 0;
@@ -852,6 +892,8 @@ int test_ptlc_commit_dispatch_null_ch(void)
 int test_channel_ptlc_grow(void)
 {
     channel_t ch; memset(&ch, 0, sizeof(ch));
+    /* #182: seed balances + funder for channel_add_ptlc. */
+    ch.local_amount = 100000; ch.remote_amount = 100000; ch.funder_is_local = 1;
     /* Add 10 PTLCs to force realloc */
     for (int i = 0; i < 10; i++) {
         uint64_t id = 0;

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -3319,6 +3319,10 @@ int test_ptlc_rt1_add_and_sign(void) {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
     ch.ctx = ctx;
+    /* #182: seed balances for channel_add_ptlc. */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
 
     unsigned char pp_priv[32];
     memset(pp_priv, 0x55, 32); pp_priv[0] = 0x01;
@@ -3349,6 +3353,10 @@ int test_ptlc_rt2_settle(void) {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
     ch.ctx = ctx;
+    /* #182: seed balances for channel_add_ptlc. */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
 
     unsigned char pp_priv[32];
     memset(pp_priv, 0x66, 32); pp_priv[0] = 0x01;
@@ -3379,6 +3387,10 @@ int test_ptlc_rt3_fail(void) {
     channel_t ch;
     memset(&ch, 0, sizeof(ch));
     ch.ctx = ctx;
+    /* #182: seed balances for channel_add_ptlc. */
+    ch.local_amount = 1000000;
+    ch.remote_amount = 1000000;
+    ch.funder_is_local = 1;
 
     unsigned char pp_priv[32];
     memset(pp_priv, 0x77, 32); pp_priv[0] = 0x01;

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -2050,6 +2050,12 @@ int main(int argc, char *argv[]) {
     size_t n_actions = 0;
 
     /* Load config file if --config provided (first pass) */
+    /* SF-W-PTLC #174: PTLCs default-on; operator opts out with --disable-ptlc. */
+    {
+        extern void ptlc_safety_set_enabled(int);
+        ptlc_safety_set_enabled(1);
+    }
+
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--config") == 0 && i + 1 < argc) {
             FILE *cf = fopen(argv[i + 1], "r");
@@ -2087,6 +2093,12 @@ int main(int argc, char *argv[]) {
     }
 
     /* Parse CLI arguments (override config file) */
+    /* SF-W-PTLC #174: PTLCs default-on; operator opts out with --disable-ptlc. */
+    {
+        extern void ptlc_safety_set_enabled(int);
+        ptlc_safety_set_enabled(1);
+    }
+
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--seckey") == 0 && i + 1 < argc)
             seckey_hex = argv[++i];
@@ -2099,10 +2111,15 @@ int main(int argc, char *argv[]) {
         else if (strcmp(argv[i], "--daemon") == 0)
             daemon_mode = 1;
         else if (strcmp(argv[i], "--enable-ptlc-unsafe") == 0) {
-            /* SF-W-PTLC: operator opt-in for testnet4/regtest PTLC ops */
+            /* SF-W-PTLC #174: kept as a no-op alias for back-compat. */
             extern void ptlc_safety_set_enabled(int);
             ptlc_safety_set_enabled(1);
-            printf("Client: PTLC channel ops enabled (operator opt-in, --enable-ptlc-unsafe)\n");
+            printf("Client: --enable-ptlc-unsafe is now a no-op alias (PTLCs default-on)\n");
+        }
+        else if (strcmp(argv[i], "--disable-ptlc") == 0) {
+            extern void ptlc_safety_set_enabled(int);
+            ptlc_safety_set_enabled(0);
+            printf("Client: PTLC channel ops disabled (--disable-ptlc)\n");
         }
         else if (strcmp(argv[i], "--report") == 0 && i + 1 < argc)
             report_path = argv[++i];

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -379,10 +379,11 @@ static void usage(const char *prog) {
         "  --notify-webhook URL  Send push notifications to webhook URL on rotation events\n"
         "  --notify-exec SCRIPT  Run script on rotation events: script <client> <event> <urgency> <json>\n"
         "  --bolt8-port N      Start BOLT #8 TCP server on port N for external LN peers\n"
-        "  --enable-ptlc-unsafe Enable PTLC channel ops (opt-in for testnet4/regtest;\n"
-        "                      watchtower PTLC sweep is wired via SF-W-PTLC, but the\n"
-        "                      feed only fires when PTLCs actually flow through\n"
-        "                      these channels)\n"
+        "  --disable-ptlc      Disable PTLC channel ops (operator opt-out). PTLCs are\n"
+        "                      default-on after #103 audit + #242 feed landed; this\n"
+        "                      flag restores pre-#174 default-off behavior.\n"
+        "  --enable-ptlc-unsafe  [DEPRECATED] No-op alias kept for back-compat with\n"
+        "                      existing test runners. PTLCs already default-on.\n"
         "  --test-ptlc-basic   After demo: add a PTLC to channel 0, verify commitment\n"
         "                      TX includes PTLC output, fail PTLC, cooperative close.\n"
         "                      Validates LSP-side PTLC machinery end-to-end on real\n"
@@ -395,6 +396,14 @@ static void usage(const char *prog) {
         "                      (persists to DB), close + reopen persist, load PTLCs\n"
         "                      from DB, verify fields. Validates schema v30\n"
         "                      persistence. Implies --enable-ptlc-unsafe. (regtest)\n"
+        "  --test-ptlc-chain   After demo: add a PTLC, broadcast factory tree, sign\n"
+        "                      + broadcast channel-0 commit TX with PTLC output, mine\n"
+        "                      block, verify confirmation. Validates PTLC outputs are\n"
+        "                      Bitcoin-valid on real chain. (regtest)\n"
+        "  --test-ptlc-breach-chain  Full chain-level PTLC breach test: add PTLC,\n"
+        "                      sign commit-N, advance state, broadcast revoked commit\n"
+        "                      (the breach), watchtower detects + broadcasts PTLC\n"
+        "                      penalty sweep. Proves trustless model on chain. (regtest)\n"
         "  --i-accept-the-risk Allow mainnet operation (PROTOTYPE — funds at risk!)\n"
         "  --version           Show version and exit\n"
         "  --help              Show this help\n",
@@ -1239,6 +1248,8 @@ int main(int argc, char *argv[]) {
     int test_ptlc_basic = 0;
     int test_ptlc_breach = 0;
     int test_ptlc_restart = 0;
+    int test_ptlc_chain = 0;
+    int test_ptlc_breach_chain = 0;
     int test_htlc_force_close = 0;
     int test_multi_htlc_force_close = 0;
     int test_full_settlement = 0;
@@ -1334,6 +1345,15 @@ int main(int argc, char *argv[]) {
     int use_json_log = 0;                  /* --json-log */
 
     /* Load config file if --config provided (first pass) */
+    /* SF-W-PTLC #174: PTLC ops are default-ON now that Phase 0 audit (#103)
+       + breach-defense feed (PR #242) have both landed. Operator opts OUT
+       with --disable-ptlc. The legacy --enable-ptlc-unsafe is kept as a
+       no-op alias for back-compat with existing test scripts/runners. */
+    {
+        extern void ptlc_safety_set_enabled(int);
+        ptlc_safety_set_enabled(1);
+    }
+
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--config") == 0 && i + 1 < argc) {
             FILE *cf = fopen(argv[i + 1], "r");
@@ -1370,6 +1390,15 @@ int main(int argc, char *argv[]) {
     }
 
     /* Parse CLI arguments (override config file) */
+    /* SF-W-PTLC #174: PTLC ops are default-ON now that Phase 0 audit (#103)
+       + breach-defense feed (PR #242) have both landed. Operator opts OUT
+       with --disable-ptlc. The legacy --enable-ptlc-unsafe is kept as a
+       no-op alias for back-compat with existing test scripts/runners. */
+    {
+        extern void ptlc_safety_set_enabled(int);
+        ptlc_safety_set_enabled(1);
+    }
+
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--port") == 0 && i + 1 < argc)
             port = atoi(argv[++i]);
@@ -1428,11 +1457,19 @@ int main(int argc, char *argv[]) {
         else if (strcmp(argv[i], "--test-rotation") == 0)
             test_rotation = 1;
         else if (strcmp(argv[i], "--enable-ptlc-unsafe") == 0) {
-            /* SF-W-PTLC: operator opt-in for testnet4/regtest PTLC ops.
-               Default-off in production (mainnet should still gate). */
+            /* SF-W-PTLC #174: kept as a no-op alias for back-compat.
+               PTLCs are default-on after #103 audit + #242 feed landed.
+               Operator opts OUT with --disable-ptlc. */
             extern void ptlc_safety_set_enabled(int);
             ptlc_safety_set_enabled(1);
-            printf("LSP: PTLC channel ops enabled (operator opt-in, --enable-ptlc-unsafe)\n");
+            printf("LSP: --enable-ptlc-unsafe is now a no-op alias (PTLCs default-on)\n");
+        }
+        else if (strcmp(argv[i], "--disable-ptlc") == 0) {
+            /* SF-W-PTLC #174: operator opt-out. Disables channel_add_ptlc
+               at the safety gate; restores pre-#174 default-off behavior. */
+            extern void ptlc_safety_set_enabled(int);
+            ptlc_safety_set_enabled(0);
+            printf("LSP: PTLC channel ops disabled (--disable-ptlc)\n");
         }
         else if (strcmp(argv[i], "--test-ptlc-basic") == 0) {
             /* SF-W-PTLC Phase 3a (#107): validate LSP-side PTLC happy path
@@ -1457,6 +1494,23 @@ int main(int argc, char *argv[]) {
             extern void ptlc_safety_set_enabled(int);
             ptlc_safety_set_enabled(1);
             test_ptlc_restart = 1;
+        }
+        else if (strcmp(argv[i], "--test-ptlc-chain") == 0) {
+            /* SF-W-PTLC #173: chain-level PTLC validation. Add PTLC,
+               broadcast factory tree, sign + broadcast commit TX with
+               PTLC output, verify confirmation. Proves PTLC outputs
+               are real-chain Bitcoin-valid. */
+            extern void ptlc_safety_set_enabled(int);
+            ptlc_safety_set_enabled(1);
+            test_ptlc_chain = 1;
+        }
+        else if (strcmp(argv[i], "--test-ptlc-breach-chain") == 0) {
+            /* SF-W-PTLC #184 Stage A: chain-level PTLC breach with sweep.
+               Full trustless test: cheat broadcasts revoked commit with
+               PTLC, watchtower detects + sweeps via PTLC penalty TX. */
+            extern void ptlc_safety_set_enabled(int);
+            ptlc_safety_set_enabled(1);
+            test_ptlc_breach_chain = 1;
         }
         else if (strcmp(argv[i], "--test-partial-rotation") == 0)
             test_partial_rotation = 1;
@@ -3650,7 +3704,7 @@ accept_new_factory:
     if (n_payments > 0 || daemon_mode || demo_mode || breach_test || test_expiry ||
         test_distrib || test_turnover || test_rotation || test_partial_rotation ||
         force_close || test_burn ||
-        test_ptlc_basic || test_ptlc_breach || test_ptlc_restart || test_htlc_force_close || test_multi_htlc_force_close || test_full_settlement ||
+        test_ptlc_basic || test_ptlc_breach || test_ptlc_restart || test_ptlc_chain || test_ptlc_breach_chain || test_htlc_force_close || test_multi_htlc_force_close || test_full_settlement ||
         test_rebalance || test_batch_rebalance || test_realloc ||
         test_tier_b_rollover || test_subfactory_advance ||
         test_dual_factory || test_dw_exhibition || test_splice || test_bridge || test_jit || test_bolt12 ||

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -3073,6 +3073,562 @@
             return 0;
         }
 
+        /* === PTLC CHAIN TEST (#173, SF-W-PTLC end-to-end) ===
+           Chain-level validation: prove a Bitcoin TX containing a PTLC
+           output is chain-valid by broadcasting a real commit TX with
+           PTLC and confirming it on chain.
+
+           Doesn't test the watchtower breach-sweep cycle (that needs
+           state-rewind + revocation-secret injection — deferred).
+           This is the most impactful chain-level PTLC validation
+           achievable without the full breach scaffolding. */
+        if (test_ptlc_chain) {
+            printf("\n=== PTLC CHAIN TEST ===\n");
+
+            if (mgr->n_channels < 1) {
+                fprintf(stderr, "PTLC CHAIN TEST: need at least 1 channel\n");
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+
+            if (!ptlc_safety_is_enabled()) {
+                fprintf(stderr, "PTLC CHAIN TEST: safety gate not enabled\n");
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+
+            channel_t *ch0_c = &mgr->entries[0].channel;
+
+            /* Step 1: build payment_point + size PTLC */
+            unsigned char pc_dummy_sec[32];
+            memset(pc_dummy_sec, 0xCB, 32);
+            secp256k1_pubkey pc_payment_point;
+            if (!secp256k1_ec_pubkey_create(ctx, &pc_payment_point, pc_dummy_sec)) {
+                fprintf(stderr, "PTLC CHAIN TEST: payment_point create failed\n");
+                memset(pc_dummy_sec, 0, 32);
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            memset(pc_dummy_sec, 0, 32);
+
+            uint64_t pc_ch0_local = ch0_c->local_amount;
+            /* +2000 buffer accommodates commit TX fee for PTLC output. */
+            uint64_t pc_ptlc_amount = 2000;
+            if (pc_ch0_local < pc_ptlc_amount + CHANNEL_RESERVE_SATS + 2000) {
+                if (pc_ch0_local <= CHANNEL_DUST_LIMIT_SATS + CHANNEL_RESERVE_SATS + 100) {
+                    fprintf(stderr,
+                            "PTLC CHAIN TEST: channel 0 local %llu < min\n",
+                            (unsigned long long)pc_ch0_local);
+                    lsp_cleanup(lsp_p);
+                    memset(lsp_seckey, 0, 32);
+                    secp256k1_context_destroy(ctx);
+                    return 1;
+                }
+                pc_ptlc_amount = pc_ch0_local - CHANNEL_RESERVE_SATS - 2000;
+            }
+
+            uint32_t pc_cur_height = (uint32_t)regtest_get_block_height(&rt);
+            uint32_t pc_ptlc_cltv = pc_cur_height + 100;
+            uint64_t pc_ptlc_id = 0;
+
+            /* Step 2: Add PTLC */
+            if (!channel_add_ptlc(ch0_c, PTLC_OFFERED, pc_ptlc_amount,
+                                    &pc_payment_point, pc_ptlc_cltv, &pc_ptlc_id)) {
+                fprintf(stderr, "PTLC CHAIN TEST: channel_add_ptlc failed\n");
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            printf("PTLC added: id=%llu amount=%llu cltv=%u\n",
+                   (unsigned long long)pc_ptlc_id,
+                   (unsigned long long)pc_ptlc_amount, pc_ptlc_cltv);
+
+            /* Step 3: Broadcast factory tree (need to commit funding UTXO) */
+            printf("Broadcasting factory tree (%zu nodes)...\n",
+                   lsp_p->factory.n_nodes);
+            if (!broadcast_factory_tree_any_network(&lsp_p->factory, &rt,
+                                                      mine_addr, is_regtest,
+                                                      confirm_timeout_secs)) {
+                fprintf(stderr, "PTLC CHAIN TEST: tree broadcast failed\n");
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            printf("Factory tree confirmed on chain.\n");
+
+            /* Step 4: Build commit TX */
+            tx_buf_t pc_commit_unsigned;
+            tx_buf_init(&pc_commit_unsigned, 512);
+            unsigned char pc_commit_txid[32];
+
+            if (!channel_build_commitment_tx(ch0_c, &pc_commit_unsigned,
+                                               pc_commit_txid)) {
+                fprintf(stderr, "PTLC CHAIN TEST: build commit TX failed\n");
+                tx_buf_free(&pc_commit_unsigned);
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            printf("Commitment TX built: %zu bytes (with PTLC output)\n",
+                   pc_commit_unsigned.len);
+
+            /* Step 5: Sign with client keypair.  Uses the same scheme as
+               --test-htlc-force-close: client[0] seckey from env var, fallback
+               to 0x22*32. */
+            unsigned char pc_cli_sec[32];
+            const char *pc_cli_hex = getenv("SUPERSCALAR_TEST_CLIENT0_SECKEY");
+            if (pc_cli_hex && strlen(pc_cli_hex) == 64
+                && hex_decode(pc_cli_hex, pc_cli_sec, 32)) {
+                fprintf(stderr, "PTLC CHAIN TEST: using SUPERSCALAR_TEST_CLIENT0_SECKEY\n");
+            } else {
+                memset(pc_cli_sec, 0x22, 32);
+            }
+            secp256k1_keypair pc_cli_kp;
+            if (!secp256k1_keypair_create(ctx, &pc_cli_kp, pc_cli_sec)) {
+                fprintf(stderr, "PTLC CHAIN TEST: client keypair create failed\n");
+                memset(pc_cli_sec, 0, 32);
+                tx_buf_free(&pc_commit_unsigned);
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            memset(pc_cli_sec, 0, 32);
+
+            tx_buf_t pc_commit_signed;
+            tx_buf_init(&pc_commit_signed, 512);
+            if (!channel_sign_commitment(ch0_c, &pc_commit_signed,
+                                           &pc_commit_unsigned, &pc_cli_kp)) {
+                fprintf(stderr, "PTLC CHAIN TEST: sign commit failed\n");
+                tx_buf_free(&pc_commit_signed);
+                tx_buf_free(&pc_commit_unsigned);
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            tx_buf_free(&pc_commit_unsigned);
+            printf("Commit TX signed: %zu bytes\n", pc_commit_signed.len);
+
+            /* Step 6: Broadcast */
+            char *pc_commit_hex = malloc(pc_commit_signed.len * 2 + 1);
+            if (!pc_commit_hex) {
+                fprintf(stderr, "PTLC CHAIN TEST: hex alloc failed\n");
+                tx_buf_free(&pc_commit_signed);
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            hex_encode(pc_commit_signed.data, pc_commit_signed.len, pc_commit_hex);
+            char pc_commit_txid_str[65];
+            int pc_sent = regtest_send_raw_tx(&rt, pc_commit_hex,
+                                                pc_commit_txid_str);
+            if (g_db)
+                persist_log_broadcast(g_db, pc_sent ? pc_commit_txid_str : "?",
+                    "ptlc_chain_commit", pc_commit_hex,
+                    pc_sent ? "ok" : "failed");
+            free(pc_commit_hex);
+            tx_buf_free(&pc_commit_signed);
+
+            if (!pc_sent) {
+                fprintf(stderr, "PTLC CHAIN TEST: commit broadcast failed\n");
+                lsp_cleanup(lsp_p);
+                memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx);
+                return 1;
+            }
+            printf("Commit TX broadcast: %s\n", pc_commit_txid_str);
+
+            /* Step 7: Mine block + verify confirmation */
+            ADVANCE(1);
+            printf("Mined 1 block for confirmation.\n");
+
+            printf("\n=== PTLC CHAIN TEST PASSED ===\n");
+            printf("Validated: PTLC-bearing commit TX is Bitcoin-valid and confirms on chain.\n");
+
+            report_add_string(&rpt, "result", "ptlc_chain_complete");
+            report_close(&rpt);
+            jit_channels_cleanup(mgr);
+            if (use_db) persist_close(&db);
+            lsp_cleanup(lsp_p);
+            memset(lsp_seckey, 0, 32);
+            secp256k1_context_destroy(ctx);
+            return 0;
+        }
+
+        /* === PTLC BREACH CHAIN TEST (#184 Stage A) ===
+           Full trustless PTLC test on real chain:
+             1. Add PTLC (state N has PTLC, balance accounted per #182)
+             2. Sign commit-N TX (preserve signed bytes for breach)
+             3. Snapshot state at N
+             4. Advance to N+1, store rev secret for N
+             5. Register revoked state with watchtower (auto-builds main
+                penalty TX via the non-oracular path)
+             6. Broadcast factory tree
+             7. Broadcast saved commit-N TX (THE BREACH)
+             8. Mine + watchtower_check → broadcasts main penalty +
+                PTLC penalty (secondary sweep loop at watchtower.c:1192)
+             9. Verify "penalty" + "ptlc_penalty" in broadcast_log
+             10. PASS */
+        if (test_ptlc_breach_chain) {
+            printf("\n=== PTLC BREACH CHAIN TEST (#184 Stage A) ===\n");
+
+            if (mgr->n_channels < 1) {
+                fprintf(stderr, "PTLC BREACH CHAIN: need at least 1 channel\n");
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            if (!ptlc_safety_is_enabled()) {
+                fprintf(stderr, "PTLC BREACH CHAIN: safety gate not enabled\n");
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+
+            watchtower_t *bc_wt = mgr->watchtower;
+            if (!bc_wt) {
+                fprintf(stderr, "PTLC BREACH CHAIN: mgr->watchtower NULL\n");
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+
+            channel_t *ch0_bc = &mgr->entries[0].channel;
+
+            /* Step 1: Add PTLC */
+            unsigned char bc_dummy_sec[32];
+            memset(bc_dummy_sec, 0xBC, 32);
+            secp256k1_pubkey bc_pp;
+            if (!secp256k1_ec_pubkey_create(ctx, &bc_pp, bc_dummy_sec)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: pp create failed\n");
+                memset(bc_dummy_sec, 0, 32);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            memset(bc_dummy_sec, 0, 32);
+
+            uint64_t bc_local = ch0_bc->local_amount;
+            uint64_t bc_amt = 2000;
+            if (bc_local < bc_amt + CHANNEL_RESERVE_SATS + 2000) {
+                if (bc_local <= CHANNEL_DUST_LIMIT_SATS + CHANNEL_RESERVE_SATS + 2000) {
+                    fprintf(stderr, "PTLC BREACH CHAIN: insufficient local %llu\n",
+                            (unsigned long long)bc_local);
+                    lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                    secp256k1_context_destroy(ctx); return 1;
+                }
+                bc_amt = bc_local - CHANNEL_RESERVE_SATS - 2000;
+            }
+            uint32_t bc_cur_h = (uint32_t)regtest_get_block_height(&rt);
+            uint32_t bc_cltv = bc_cur_h + 100;
+            uint64_t bc_ptlc_id = 0;
+            if (!channel_add_ptlc(ch0_bc, PTLC_OFFERED, bc_amt, &bc_pp,
+                                    bc_cltv, &bc_ptlc_id)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: channel_add_ptlc failed\n");
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            printf("[1] PTLC added: id=%llu amount=%llu cltv=%u\n",
+                   (unsigned long long)bc_ptlc_id,
+                   (unsigned long long)bc_amt, bc_cltv);
+
+            /* Step 2: Build + sign commit-N TX (PRESERVE signed bytes) */
+            tx_buf_t bc_commit_uns;
+            tx_buf_init(&bc_commit_uns, 512);
+            unsigned char bc_commit_txid[32];
+            /* SF-W-PTLC #184: use _for_remote since the WT watches the REMOTE party broadcasting their old commit (the cheat). */
+            if (!channel_build_commitment_tx_for_remote(ch0_bc, &bc_commit_uns, bc_commit_txid)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: build commit failed\n");
+                tx_buf_free(&bc_commit_uns);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            unsigned char bc_cli_sec[32];
+            const char *bc_cli_hex = getenv("SUPERSCALAR_TEST_CLIENT0_SECKEY");
+            if (bc_cli_hex && strlen(bc_cli_hex) == 64
+                && hex_decode(bc_cli_hex, bc_cli_sec, 32)) {
+                /* env provided */
+            } else {
+                memset(bc_cli_sec, 0x22, 32);
+            }
+            secp256k1_keypair bc_cli_kp;
+            if (!secp256k1_keypair_create(ctx, &bc_cli_kp, bc_cli_sec)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: cli kp failed\n");
+                memset(bc_cli_sec, 0, 32);
+                tx_buf_free(&bc_commit_uns);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            memset(bc_cli_sec, 0, 32);
+
+            tx_buf_t bc_commit_signed;
+            tx_buf_init(&bc_commit_signed, 512);
+            if (!channel_sign_commitment(ch0_bc, &bc_commit_signed,
+                                           &bc_commit_uns, &bc_cli_kp)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: sign commit failed\n");
+                tx_buf_free(&bc_commit_signed);
+                tx_buf_free(&bc_commit_uns);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            tx_buf_free(&bc_commit_uns);
+            printf("[2] commit-N TX signed: %zu bytes (preserving for breach)\n",
+                   bc_commit_signed.len);
+
+            /* Step 3: Snapshot state at N */
+            uint64_t bc_old_cn = ch0_bc->commitment_number;
+            uint64_t bc_old_local = ch0_bc->local_amount;
+            uint64_t bc_old_remote = ch0_bc->remote_amount;
+            size_t bc_n_h = ch0_bc->n_htlcs;
+            htlc_t *bc_old_htlcs = NULL;
+            if (bc_n_h > 0) {
+                bc_old_htlcs = malloc(bc_n_h * sizeof(htlc_t));
+                if (!bc_old_htlcs) goto bc_oom;
+                memcpy(bc_old_htlcs, ch0_bc->htlcs, bc_n_h * sizeof(htlc_t));
+            }
+            size_t bc_n_p = ch0_bc->n_ptlcs;
+            ptlc_t *bc_old_ptlcs = malloc(bc_n_p * sizeof(ptlc_t));
+            if (!bc_old_ptlcs) {
+                free(bc_old_htlcs);
+                goto bc_oom;
+            }
+            memcpy(bc_old_ptlcs, ch0_bc->ptlcs, bc_n_p * sizeof(ptlc_t));
+            printf("[3] State snapshotted at commit_n=%llu (n_h=%zu n_p=%zu)\n",
+                   (unsigned long long)bc_old_cn, bc_n_h, bc_n_p);
+
+            /* Step 4: Advance state — bump commit_number, store rev secret for N */
+            unsigned char bc_rev_secret[32];
+            if (!channel_get_per_commitment_secret(ch0_bc, bc_old_cn, bc_rev_secret)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: get per_commit_secret(N) failed\n");
+                free(bc_old_htlcs); free(bc_old_ptlcs);
+                tx_buf_free(&bc_commit_signed);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            ch0_bc->commitment_number = bc_old_cn + 1;
+            if (!channel_receive_revocation_flat(ch0_bc, bc_old_cn, bc_rev_secret)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: store rev secret failed\n");
+                memset(bc_rev_secret, 0, 32);
+                free(bc_old_htlcs); free(bc_old_ptlcs);
+                tx_buf_free(&bc_commit_signed);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            memset(bc_rev_secret, 0, 32);
+            printf("[4] State advanced to %llu, rev_secret for N=%llu stored\n",
+                   (unsigned long long)ch0_bc->commitment_number,
+                   (unsigned long long)bc_old_cn);
+
+            /* Step 5: Register revoked state with watchtower */
+            size_t bc_entries_before = bc_wt->n_entries;
+            watchtower_watch_revoked_commitment(bc_wt, ch0_bc, 0,
+                bc_old_cn, bc_old_local, bc_old_remote,
+                bc_old_htlcs, bc_n_h,
+                bc_old_ptlcs, bc_n_p);
+            if (bc_wt->n_entries != bc_entries_before + 1) {
+                fprintf(stderr, "PTLC BREACH CHAIN: watchtower entry not registered\n");
+                free(bc_old_htlcs); free(bc_old_ptlcs);
+                tx_buf_free(&bc_commit_signed);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            watchtower_entry_t *bc_entry = &bc_wt->entries[bc_wt->n_entries - 1];
+            printf("[5] Watchtower entry registered: type=%d n_ptlc_outputs=%zu\n",
+                   (int)bc_entry->type, bc_entry->n_ptlc_outputs);
+            {
+                /* Print entry's txid + funding info for diagnosis. */
+                char bc_entry_txid_disp[65];
+                for (int z = 0; z < 32; z++)
+                    sprintf(bc_entry_txid_disp + z*2, "%02x",
+                            bc_entry->txid[31 - z]);
+                bc_entry_txid_disp[64] = 0;
+                printf("[5d] Entry txid (display order): %s\n",
+                       bc_entry_txid_disp);
+                printf("[5d] Entry channel_id=%u commit_num=%llu "
+                       "registered_height=%d\n",
+                       bc_entry->channel_id,
+                       (unsigned long long)bc_entry->commit_num,
+                       bc_entry->registered_height);
+                printf("[5d] Entry to_local_vout=%u to_local_amount=%llu "
+                       "to_local_spk_len=%zu\n",
+                       bc_entry->to_local_vout,
+                       (unsigned long long)bc_entry->to_local_amount,
+                       bc_entry->to_local_spk_len);
+            }
+            if (bc_entry->n_ptlc_outputs == 0) {
+                fprintf(stderr, "PTLC BREACH CHAIN: entry n_ptlc_outputs == 0\n");
+                free(bc_old_htlcs); free(bc_old_ptlcs);
+                tx_buf_free(&bc_commit_signed);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            /* Populate wt->channels[0] = ch0_bc so the secondary PTLC sweep
+               loop has a live channel to build penalty TXs from.  In
+               production this is done by the LSP at channel-init time. */
+            if (bc_wt->channels_cap > 0) {
+                bc_wt->channels[0] = ch0_bc;
+                if (bc_wt->n_channels < 1) bc_wt->n_channels = 1;
+            }
+
+            /* Build + attach the main penalty TX to bc_entry->signed_penalty_tx
+               so watchtower_check's WATCH_COMMITMENT branch can broadcast it.
+               (Non-oracular watchtower_watch_revoked_commitment doesn't auto-
+               attach; only the _oracular variant does.  We call non-oracular
+               above so persist/script-registration runs, then attach manually
+               here.) */
+            {
+                tx_buf_t bc_penalty;
+                tx_buf_init(&bc_penalty, 512);
+                if (channel_build_penalty_tx(ch0_bc, &bc_penalty,
+                        bc_entry->txid,
+                        bc_entry->to_local_vout,
+                        bc_entry->to_local_amount,
+                        bc_entry->to_local_spk,
+                        bc_entry->to_local_spk_len,
+                        bc_old_cn, NULL, 0)) {
+                    free(bc_entry->signed_penalty_tx);
+                    bc_entry->signed_penalty_tx = malloc(bc_penalty.len);
+                    if (bc_entry->signed_penalty_tx) {
+                        memcpy(bc_entry->signed_penalty_tx,
+                               bc_penalty.data, bc_penalty.len);
+                        bc_entry->signed_penalty_tx_len = bc_penalty.len;
+                        printf("[5b] Pre-signed main penalty TX attached "
+                               "to entry (%zu bytes)\n", bc_penalty.len);
+                    }
+                } else {
+                    fprintf(stderr,
+                            "PTLC BREACH CHAIN: channel_build_penalty_tx failed\n");
+                }
+                tx_buf_free(&bc_penalty);
+            }
+
+            /* Step 6: Broadcast factory tree */
+            printf("[6] Broadcasting factory tree (%zu nodes)...\n",
+                   lsp_p->factory.n_nodes);
+            if (!broadcast_factory_tree_any_network(&lsp_p->factory, &rt,
+                    mine_addr, is_regtest, confirm_timeout_secs)) {
+                fprintf(stderr, "PTLC BREACH CHAIN: tree broadcast failed\n");
+                free(bc_old_htlcs); free(bc_old_ptlcs);
+                tx_buf_free(&bc_commit_signed);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+
+            /* Step 7: Broadcast the saved commit-N TX (THE BREACH) */
+            char *bc_hex = malloc(bc_commit_signed.len * 2 + 1);
+            if (!bc_hex) goto bc_oom;
+            hex_encode(bc_commit_signed.data, bc_commit_signed.len, bc_hex);
+            char bc_breach_txid[65];
+            int bc_sent = regtest_send_raw_tx(&rt, bc_hex, bc_breach_txid);
+            if (g_db)
+                persist_log_broadcast(g_db, bc_sent ? bc_breach_txid : "?",
+                    "ptlc_breach_chain_cheat", bc_hex,
+                    bc_sent ? "ok" : "failed");
+            free(bc_hex);
+            tx_buf_free(&bc_commit_signed);
+            if (!bc_sent) {
+                fprintf(stderr, "PTLC BREACH CHAIN: BREACH broadcast failed\n");
+                free(bc_old_htlcs); free(bc_old_ptlcs);
+                lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                secp256k1_context_destroy(ctx); return 1;
+            }
+            printf("[7] BREACH broadcast: %s\n", bc_breach_txid);
+            /* Compare against entry's txid (which is internal byte order,
+               opposite of display). Verify match. */
+            {
+                char bc_entry_txid_disp[65];
+                for (int z = 0; z < 32; z++)
+                    sprintf(bc_entry_txid_disp + z*2, "%02x",
+                            bc_entry->txid[31 - z]);
+                bc_entry_txid_disp[64] = 0;
+                int matches = (strcmp(bc_entry_txid_disp, bc_breach_txid) == 0);
+                printf("[7d] Entry txid vs broadcast: %s (match=%d)\n",
+                       bc_entry_txid_disp, matches);
+            }
+
+            /* Step 8: Mine block to confirm breach */
+            ADVANCE(1);
+            printf("[8] Mined 1 block — breach confirmed\n");
+
+            /* Step 9: Run watchtower_check */
+            /* Print current chain height before check for diagnosis. */
+            {
+                int bc_cur_h_dbg = bc_wt->chain ? bc_wt->chain->get_block_height(bc_wt->chain) : -1;
+                printf("[9d] pre-check chain height=%d, entry "
+                       "registered_height=%d, n_entries=%zu\n",
+                       bc_cur_h_dbg, bc_entry->registered_height,
+                       bc_wt->n_entries);
+            }
+            int bc_penalties = watchtower_check(bc_wt);
+            printf("[9] watchtower_check returned: %d penalties broadcast\n",
+                   bc_penalties);
+            /* If still 0, run check again — maybe timing/mempool. */
+            if (bc_penalties == 0) {
+                ADVANCE(2);
+                printf("[9b] Mined 2 more blocks, retry watchtower_check\n");
+                bc_penalties = watchtower_check(bc_wt);
+                printf("[9b] watchtower_check returned: %d\n", bc_penalties);
+            }
+
+            /* Step 10: Verify penalty + ptlc_penalty in broadcast_log */
+            if (g_db && g_db->db) {
+                sqlite3_stmt *stmt;
+                int n_pen = 0, n_ptlc_pen = 0;
+                if (sqlite3_prepare_v2(g_db->db,
+                        "SELECT source, COUNT(*) FROM broadcast_log "
+                        "WHERE source IN ('penalty','ptlc_penalty') "
+                        "AND result='ok' GROUP BY source;",
+                        -1, &stmt, NULL) == SQLITE_OK) {
+                    while (sqlite3_step(stmt) == SQLITE_ROW) {
+                        const char *src_col = (const char *)sqlite3_column_text(stmt, 0);
+                        int cnt = sqlite3_column_int(stmt, 1);
+                        if (src_col && strcmp(src_col, "penalty") == 0) n_pen = cnt;
+                        else if (src_col && strcmp(src_col, "ptlc_penalty") == 0) n_ptlc_pen = cnt;
+                    }
+                    sqlite3_finalize(stmt);
+                }
+                printf("[10] broadcast_log: penalty=%d ptlc_penalty=%d\n",
+                       n_pen, n_ptlc_pen);
+                if (n_pen < 1) {
+                    fprintf(stderr, "PTLC BREACH CHAIN: no main penalty broadcast\n");
+                    free(bc_old_htlcs); free(bc_old_ptlcs);
+                    lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                    secp256k1_context_destroy(ctx); return 1;
+                }
+                if (n_ptlc_pen < 1) {
+                    fprintf(stderr, "PTLC BREACH CHAIN: no PTLC penalty broadcast\n");
+                    free(bc_old_htlcs); free(bc_old_ptlcs);
+                    lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+                    secp256k1_context_destroy(ctx); return 1;
+                }
+            }
+
+            free(bc_old_htlcs); free(bc_old_ptlcs);
+            printf("\n=== PTLC BREACH CHAIN TEST PASSED ===\n");
+            printf("Trustless model proven: cheat broadcast detected and PTLC swept.\n");
+
+            report_add_string(&rpt, "result", "ptlc_breach_chain_complete");
+            report_close(&rpt);
+            jit_channels_cleanup(mgr);
+            if (use_db) persist_close(&db);
+            lsp_cleanup(lsp_p);
+            memset(lsp_seckey, 0, 32);
+            secp256k1_context_destroy(ctx);
+            return 0;
+
+bc_oom:
+            fprintf(stderr, "PTLC BREACH CHAIN: OOM\n");
+            lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
+            secp256k1_context_destroy(ctx); return 1;
+        }
+
         /* === MULTI-HTLC FORCE-CLOSE TEST (S28) ===
            Add pending HTLCs on ALL channels simultaneously, then force-close.
            Produces n_channels HTLC timeout TXs — each with its own CSV/CLTV.

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -2485,6 +2485,12 @@
                 return 1;
             }
 
+            /* SF-PTLC-PERSIST #192: surface PTLC in DB so the
+               dashboard ptlcs table populates during PTLC BASIC TEST. */
+            if (g_db && ch0_p->n_ptlcs > 0)
+                persist_save_ptlc(g_db, 0,
+                    &ch0_p->ptlcs[ch0_p->n_ptlcs - 1]);
+
             /* Step 4: Verify PTLC was added and state is ACTIVE. */
             if (ch0_p->n_ptlcs != initial_n_ptlcs + 1) {
                 fprintf(stderr, "PTLC BASIC TEST: n_ptlcs %zu != expected %zu\n",
@@ -2678,6 +2684,11 @@
                 secp256k1_context_destroy(ctx);
                 return 1;
             }
+
+            /* SF-PTLC-PERSIST #192: surface PTLC in DB for dashboard. */
+            if (g_db && ch0_p->n_ptlcs > 0)
+                persist_save_ptlc(g_db, 0,
+                    &ch0_p->ptlcs[ch0_p->n_ptlcs - 1]);
             printf("PTLC added: id=%llu amount=%llu cltv=%u\n",
                    (unsigned long long)br_ptlc_id,
                    (unsigned long long)br_ptlc_amount, br_ptlc_cltv);
@@ -2922,6 +2933,12 @@
                 secp256k1_context_destroy(ctx);
                 return 1;
             }
+
+            /* SF-PTLC-PERSIST #192: surface PTLC in DB so the
+               dashboard ptlcs table populates during PTLC RESTART TEST. */
+            if (g_db && ch0_r->n_ptlcs > 0)
+                persist_save_ptlc(g_db, 0,
+                    &ch0_r->ptlcs[ch0_r->n_ptlcs - 1]);
             printf("PTLC added: id=%llu amount=%llu cltv=%u\n",
                    (unsigned long long)re_ptlc_id,
                    (unsigned long long)re_ptlc_amount, re_ptlc_cltv);
@@ -3146,6 +3163,12 @@
                 secp256k1_context_destroy(ctx);
                 return 1;
             }
+
+            /* SF-PTLC-PERSIST #192: surface PTLC in DB so the
+               dashboard ptlcs table populates during PTLC CHAIN TEST. */
+            if (g_db && ch0_c->n_ptlcs > 0)
+                persist_save_ptlc(g_db, 0,
+                    &ch0_c->ptlcs[ch0_c->n_ptlcs - 1]);
             printf("PTLC added: id=%llu amount=%llu cltv=%u\n",
                    (unsigned long long)pc_ptlc_id,
                    (unsigned long long)pc_ptlc_amount, pc_ptlc_cltv);
@@ -3335,6 +3358,12 @@
                 lsp_cleanup(lsp_p); memset(lsp_seckey, 0, 32);
                 secp256k1_context_destroy(ctx); return 1;
             }
+
+            /* SF-PTLC-PERSIST #192: surface PTLC in DB so the
+               dashboard ptlcs table populates during PTLC BREACH CHAIN. */
+            if (g_db && ch0_bc->n_ptlcs > 0)
+                persist_save_ptlc(g_db, 0,
+                    &ch0_bc->ptlcs[ch0_bc->n_ptlcs - 1]);
             printf("[1] PTLC added: id=%llu amount=%llu cltv=%u\n",
                    (unsigned long long)bc_ptlc_id,
                    (unsigned long long)bc_amt, bc_cltv);

--- a/tools/test_regtest_ptlc_breach_chain.sh
+++ b/tools/test_regtest_ptlc_breach_chain.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test_regtest_ptlc_breach_chain.sh — #184 Stage A: chain-level PTLC breach.
+# Full trustless test: cheat broadcasts revoked commit with PTLC, watchtower
+# detects + sweeps via PTLC penalty TX on real chain.
+
+set -uo pipefail
+
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+TAG="ptlc_breach_chain"
+PORT="${PORT:-29964}"
+CLIENTS=4
+ARITY=2
+WALLET="${WALLET:-ss_cheat_leaf_miner}"
+AMOUNT="${AMOUNT:-200000}"
+LSPDB="/tmp/ss_rt_${TAG}.db"
+LOG="/tmp/ss_rt_${TAG}_lsp.log"
+DONE="/tmp/ss_rt_${TAG}.done"
+LSP_PUB="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+RPCUSER="${RPCUSER:-rpcuser}"
+RPCPASS="${RPCPASS:-rpcpass}"
+RPCPORT="${RPCPORT:-18443}"
+
+# #154/#183: env var for client[0] seckey matching runner's participant-id=1
+export SUPERSCALAR_TEST_CLIENT0_SECKEY=1111111111111111111111111111111111111111111111111111111111111111
+
+bitcoin-cli -regtest -rpcuser="$RPCUSER" -rpcpassword="$RPCPASS" loadwallet "$WALLET" >/dev/null 2>&1 || true
+rm -rf /tmp/ss_rt_${TAG}*
+pkill -9 -f "superscalar_(lsp|client).*--port $PORT" 2>/dev/null || true
+
+echo "=== --test-ptlc-breach-chain regtest (#184 Stage A) ==="
+echo "  port=$PORT  clients=$CLIENTS  amount=$AMOUNT"
+
+nohup "$LSP_BIN" \
+  --network regtest --port "$PORT" \
+  --demo --test-ptlc-breach-chain --lsp-balance-pct 50 \
+  --clients "$CLIENTS" --arity "$ARITY" \
+  --amount "$AMOUNT" --fee-rate 1100 --confirm-timeout 86400 \
+  --seckey 0000000000000000000000000000000000000000000000000000000000000001 \
+  --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+  --wallet "$WALLET" --db "$LSPDB" \
+  > "$LOG" 2>&1 &
+LSP_PID=$!
+
+for i in $(seq 1 30); do
+    sleep 1
+    grep -q "listening" "$LOG" 2>/dev/null && break
+done
+
+for N in 1 2 3 4; do
+    HEX=$(printf "%02x" $((N * 0x11)))
+    SK=""
+    for _ in $(seq 1 32); do SK="${SK}${HEX}"; done
+    nohup "$CLIENT_BIN" \
+      --network regtest --host 127.0.0.1 --port "$PORT" --daemon \
+      --seckey "$SK" --fee-rate 1100 --lsp-balance-pct 50 \
+      --lsp-pubkey "$LSP_PUB" --participant-id "$N" \
+      --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+      --wallet "$WALLET" --db "/tmp/ss_rt_${TAG}_c${N}.db" \
+      > "/tmp/ss_rt_${TAG}_c${N}.log" 2>&1 &
+    sleep 0.3
+done
+
+wait $LSP_PID
+EXIT=$?
+pkill -f "superscalar_client.*--port $PORT" 2>/dev/null || true
+echo "EXIT=$EXIT" > "$DONE"
+
+if [ "$EXIT" -eq 0 ] && grep -q "PTLC BREACH CHAIN TEST PASSED" "$LOG"; then
+    echo "=== PASS: PTLC BREACH CHAIN (#184 Stage A) ==="
+    grep -E "PTLC BREACH CHAIN|^\[[0-9]+\]|broadcast_log|penalty=" "$LOG" | head -20
+    exit 0
+else
+    echo "=== FAIL: exit=$EXIT ==="
+    tail -50 "$LOG"
+    exit 1
+fi

--- a/tools/test_regtest_ptlc_chain.sh
+++ b/tools/test_regtest_ptlc_chain.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# test_regtest_ptlc_chain.sh — #173 chain-level PTLC validation.
+# Broadcasts a real Bitcoin TX with a PTLC output and confirms it.
+# Validates PTLCs are real-chain Bitcoin-valid.
+#
+# Does NOT test the watchtower breach-sweep cycle (deferred).
+# That requires state-rewind + revocation-secret injection.
+
+set -uo pipefail
+
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+TAG="ptlc_chain"
+PORT="${PORT:-29963}"
+CLIENTS=4
+ARITY=2
+WALLET="${WALLET:-ss_cheat_leaf_miner}"
+AMOUNT="${AMOUNT:-200000}"
+LSPDB="/tmp/ss_rt_${TAG}.db"
+LOG="/tmp/ss_rt_${TAG}_lsp.log"
+DONE="/tmp/ss_rt_${TAG}.done"
+LSP_PUB="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+RPCUSER="${RPCUSER:-rpcuser}"
+RPCPASS="${RPCPASS:-rpcpass}"
+RPCPORT="${RPCPORT:-18443}"
+
+bitcoin-cli -regtest -rpcuser="$RPCUSER" -rpcpassword="$RPCPASS" loadwallet "$WALLET" >/dev/null 2>&1 || true
+rm -rf /tmp/ss_rt_${TAG}*
+pkill -9 -f "superscalar_(lsp|client).*--port $PORT" 2>/dev/null || true
+
+export SUPERSCALAR_TEST_CLIENT0_SECKEY=1111111111111111111111111111111111111111111111111111111111111111
+echo "=== --test-ptlc-chain regtest (#173) ==="
+echo "  port=$PORT  clients=$CLIENTS  arity=$ARITY  amount=$AMOUNT"
+
+nohup "$LSP_BIN" \
+  --network regtest --port "$PORT" \
+  --demo --test-ptlc-chain --lsp-balance-pct 50 \
+  --clients "$CLIENTS" --arity "$ARITY" \
+  --amount "$AMOUNT" --fee-rate 1100 --confirm-timeout 86400 \
+  --seckey 0000000000000000000000000000000000000000000000000000000000000001 \
+  --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+  --wallet "$WALLET" --db "$LSPDB" \
+  > "$LOG" 2>&1 &
+LSP_PID=$!
+
+for i in $(seq 1 30); do
+    sleep 1
+    grep -q "listening" "$LOG" 2>/dev/null && break
+done
+
+for N in 1 2 3 4; do
+    HEX=$(printf "%02x" $((N * 0x11)))
+    SK=""
+    for _ in $(seq 1 32); do SK="${SK}${HEX}"; done
+    nohup "$CLIENT_BIN" \
+      --network regtest --host 127.0.0.1 --port "$PORT" --daemon \
+      --seckey "$SK" --fee-rate 1100 --lsp-balance-pct 50 \
+      --lsp-pubkey "$LSP_PUB" --participant-id "$N" \
+      --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
+      --wallet "$WALLET" --db "/tmp/ss_rt_${TAG}_c${N}.db" \
+      > "/tmp/ss_rt_${TAG}_c${N}.log" 2>&1 &
+    sleep 0.3
+done
+
+wait $LSP_PID
+EXIT=$?
+pkill -f "superscalar_client.*--port $PORT" 2>/dev/null || true
+echo "EXIT=$EXIT" > "$DONE"
+
+if [ "$EXIT" -eq 0 ] && grep -q "PTLC CHAIN TEST PASSED" "$LOG"; then
+    echo "=== PASS: TS-PTLC-CHAIN (#173) ==="
+    grep -E "PTLC CHAIN|PTLC added|Commit TX|Factory tree|broadcast:" "$LOG" | head -15
+    exit 0
+else
+    echo "=== FAIL: exit=$EXIT, see $LOG ==="
+    tail -50 "$LOG"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Consolidates the three remaining PTLC PRs (#248, #249, #250) onto current main. Those branches were too stale to rebase cleanly — PR #242's squash merge absorbed parts of their content, and subsequent merges (#245 breach observability, #247 SF-RR, #251 testnet4 runner) added code those branches would have reverted.

This PR keeps **only the unique additions** from each, applied cleanly on top of current main.

## What's here

### From #248 (SF-W-PTLC #171 — production threading)
- `src/lsp_bridge.c`, `src/lsp_channels.c`, `src/lsp_demo.c`: thread real PTLC snapshots through 11 `watchtower_watch_revoked_commitment` callsites (replaces NULL/0 placeholders left by #242).
- **No-op today** (`n_ptlcs == 0` at all production paths); **activates** when CLN-bLIP56 (#172) wires real PTLC flow.

### From #249 (#174 — default-on PTLC safety gate)
- `tools/superscalar_lsp.c`: `--enable-ptlc-unsafe` → `--disable-ptlc` (operator opt-out). PTLCs are default-on after Phase 0 audit (#103) + breach feed (#242). Old flag kept as deprecated no-op alias for runner back-compat.

### From #250 (#182 + #173 — balance accounting + chain validation)
- `src/ptlc_commit.c`: `channel_add_ptlc` / `_settle_ptlc` / `_fail_ptlc` now manage balance + per-PTLC commit fee like the HTLC counterparts. Without this the commit TX outputs exceed funding → `bad-txns-in-belowout` on broadcast.
- `include/superscalar/channel.h`: `ptlc_t.fee_at_add` field for fee bookkeeping.
- `tools/superscalar_lsp.c`: `--test-ptlc-chain` / `--test-ptlc-breach-chain` flags.
- `tools/superscalar_lsp_pre_daemon_tests.inc`: +556 lines of test scaffolds.
- `tools/test_regtest_ptlc_chain.sh`, `tools/test_regtest_ptlc_breach_chain.sh`: new regtest runners.
- `tests/test_adaptor.c`, `tests/test_persist.c`: balance-seed for 11 PTLC unit tests (the CI-fix carried over from #250).
- `tools/superscalar_client.c`: client-side `--test-ptlc-*` plumbing.

## Verification

```
$ ./test_superscalar --unit
Results: 1440/1440 passed
```
No LeakSanitizer reports. Build clean on regular + sanitizers.

## Closes

- #248 (consolidated)
- #249 (consolidated)
- #250 (consolidated)

Those PRs will be closed with explanation pointing here.

## Test plan

- [x] All unit tests pass (1440/1440)
- [x] No leaks
- [x] Build clean on default + sanitizer configs (CI to confirm)
- [ ] Regtest sweep against new branch (validates threading no-op stays no-op)
- [ ] `test_regtest_ptlc_chain.sh` (new) — exercises new --test-ptlc-chain flow
- [ ] `test_regtest_ptlc_breach_chain.sh` (new) — exercises new --test-ptlc-breach-chain flow