### PR TITLE
fix(test): splice runner launches 1 client, set N_CLIENTS=1 (#193)

### DIFF
--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -27,7 +27,7 @@ RPCPORT="${RPCPORT:-48332}"
 WALLET="${WALLET:-superscalar_test}"
 
 PORT="${PORT:-9935}"
-N_CLIENTS=2  # splice tests need just 1 client + LSP
+N_CLIENTS=1  # splice test = 1 client + LSP (was N=2 with only 1 launched — #193)
 AMOUNT="${AMOUNT:-200000}"
 
 TAG="ts_splice"


### PR DESCRIPTION
## Summary

The splice runner declared `N_CLIENTS=2` but the client launch loop only fires once. LSP started with `--clients 2` and required 2 clients forming a permutation of 1..2, but only one client connected with `--participant-id 1`, so the LSP errored:

\`\`\`
LSP: ERROR — require_slot_hints is set but not all clients supplied a valid slot_hint forming a permutation of 1..2. Funding-address derivation would be non-deterministic across restarts (fund-loss risk). Each client must launch with --participant-id N (unique value 1..2).
\`\`\`

The script header comment says "splice tests need just 1 client + LSP", so `N_CLIENTS=1` is the intended value.

## Verification

Will re-launch TS-SPLICE testnet4 on `ss_pool_2` after this lands.

## Test plan

- [ ] Splice testnet4 (TS-SPLICE) reaches "splice complete" with N=1