### PR TITLE
fix(security): gate PTLC_PRESIG handler against blind-sign seckey extraction (#196)

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -55,6 +55,7 @@
 #define MSG_INVOICE_CREATED     0x4B  /* Client → LSP: here's the payment_hash */
 
 /* PTLC key turnover messages (Tier 3) */
+#define MSG_ROTATION_BEGIN      0x56  /* LSP → Client: rotation context precursor (gates blind-signing — #196) */
 #define MSG_PTLC_PRESIG         0x4C  /* LSP → Client: adaptor pre-signature */
 #define MSG_PTLC_ADAPTED_SIG    0x4D  /* Client → LSP: adapted signature */
 #define MSG_PTLC_COMPLETE       0x4E  /* LSP → Client: turnover acknowledged */
@@ -515,6 +516,29 @@ int wire_parse_invoice_created(const cJSON *json,
                                  uint64_t *amount_msat);
 
 /* --- PTLC key turnover messages (Tier 3) --- */
+
+/* LSP → Client: ROTATION_BEGIN {dying_factory_funding_txid, new_factory_nonce,
+   rotation_epoch} — REQUIRED precursor to MSG_PTLC_PRESIG.  Gates the client
+   blind-signing path (#196 audit).  Client records the context and uses it
+   to compute the expected turnover_msg for the next PTLC_PRESIG; refuses
+   any PTLC_PRESIG whose turnover_msg doesn't match this context. */
+cJSON *wire_build_rotation_begin(const unsigned char *dying_factory_txid32,
+                                  const unsigned char *new_factory_nonce32,
+                                  uint64_t rotation_epoch);
+
+int wire_parse_rotation_begin(const cJSON *json,
+                               unsigned char *dying_factory_txid32,
+                               unsigned char *new_factory_nonce32,
+                               uint64_t *rotation_epoch);
+
+/* Compute the context-bound turnover_msg32 from the rotation context.
+   sha256_tagged("ss/turnover/v1", dying_factory_txid || new_factory_nonce ||
+   be64(rotation_epoch), 72) → 32-byte output.  Both LSP and client compute
+   this independently; client refuses PTLC_PRESIG if computed != received. */
+void wire_compute_turnover_msg(const unsigned char *dying_factory_txid32,
+                                const unsigned char *new_factory_nonce32,
+                                uint64_t rotation_epoch,
+                                unsigned char *turnover_msg_out32);
 
 /* LSP → Client: PTLC_PRESIG {presig, nonce_parity, turnover_msg} */
 cJSON *wire_build_ptlc_presig(const unsigned char *presig64,

--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -148,8 +148,32 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
     musig_keyagg_t rot_ka;
     musig_aggregate_keys(mgr->ctx, &rot_ka, rot_pks, n_total);
 
+    /* SF-PTLC-TURNOVER-AUTH #196: build context-bound turnover_msg.
+       Old constant turnover_msg let a malicious LSP send unrelated
+       presigs at any moment.  Now bound to (dying_factory_txid,
+       new_factory_nonce, rotation_epoch) hashed via wire_compute_turnover_msg.
+       The client receives the same context in a precursor ROTATION_BEGIN
+       and refuses any presig whose turnover_msg doesn't match. */
+    unsigned char dying_factory_txid[32];
+    memcpy(dying_factory_txid, dying->factory.funding_txid, 32);
+    unsigned char new_factory_nonce[32];
+    {
+        FILE *urn = fopen("/dev/urandom", "rb");
+        if (!urn) {
+            fprintf(stderr, "LSP rotate: cannot open /dev/urandom for nonce\n");
+            return 0;
+        }
+        size_t got = fread(new_factory_nonce, 1, 32, urn);
+        fclose(urn);
+        if (got != 32) {
+            fprintf(stderr, "LSP rotate: /dev/urandom short read\n");
+            return 0;
+        }
+    }
+    uint64_t rotation_epoch = (uint64_t)time(NULL);
     unsigned char turnover_msg[32];
-    sha256_tagged("turnover", (const unsigned char *)"turnover", 8, turnover_msg);
+    wire_compute_turnover_msg(dying_factory_txid, new_factory_nonce,
+                                rotation_epoch, turnover_msg);
 
     /* --- Phase A: PTLC key turnover over wire --- */
     printf("LSP rotate: Phase A — PTLC key turnover\n");
@@ -173,6 +197,24 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
             fprintf(stderr, "LSP rotate: presig failed client %zu, skipping\n", ci);
             turnover_fail++;
             continue;
+        }
+
+        /* SF-PTLC-TURNOVER-AUTH #196: send rotation context to client
+           BEFORE the presig so the client can validate the upcoming presig
+           against the context. */
+        {
+            cJSON *rb = wire_build_rotation_begin(dying_factory_txid,
+                                                    new_factory_nonce,
+                                                    rotation_epoch);
+            if (!wire_send(lsp->client_fds[ci], MSG_ROTATION_BEGIN, rb)) {
+                cJSON_Delete(rb);
+                fprintf(stderr, "LSP rotate: send ROTATION_BEGIN failed client %zu, skipping\n", ci);
+                wire_close(lsp->client_fds[ci]);
+                lsp->client_fds[ci] = -1;
+                turnover_fail++;
+                continue;
+            }
+            cJSON_Delete(rb);
         }
 
         /* Send PTLC_PRESIG to client */

--- a/src/wire.c
+++ b/src/wire.c
@@ -1372,7 +1372,11 @@ cJSON *wire_build_rotation_begin(const unsigned char *dying_factory_txid32,
     cJSON *j = cJSON_CreateObject();
     wire_json_add_hex(j, "dying_factory_txid", dying_factory_txid32, 32);
     wire_json_add_hex(j, "new_factory_nonce",   new_factory_nonce32,  32);
-    cJSON_AddNumberToObject(j, "rotation_epoch", (double)rotation_epoch);
+    /* #196: encode rotation_epoch as hex string for uint64 precision. */
+    char rotation_epoch_hex[17];
+    snprintf(rotation_epoch_hex, sizeof(rotation_epoch_hex),
+             "%016llx", (unsigned long long)rotation_epoch);
+    cJSON_AddStringToObject(j, "rotation_epoch", rotation_epoch_hex);
     return j;
 }
 
@@ -1386,8 +1390,9 @@ int wire_parse_rotation_begin(const cJSON *json,
     if (wire_json_get_hex(json, "new_factory_nonce", new_factory_nonce32, 32) != 32)
         return 0;
     cJSON *e = cJSON_GetObjectItem(json, "rotation_epoch");
-    if (!e || !cJSON_IsNumber(e)) return 0;
-    *rotation_epoch = (uint64_t)e->valuedouble;
+    if (!e || !cJSON_IsString(e) || !e->valuestring) return 0;
+    /* #196: decode hex string for uint64 precision. */
+    *rotation_epoch = (uint64_t)strtoull(e->valuestring, NULL, 16);
     return 1;
 }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -1,4 +1,5 @@
 #include "superscalar/wire.h"
+#include "superscalar/sha256.h"
 #include "superscalar/lsp_queue.h"
 #include "superscalar/factory.h"
 #include "superscalar/noise.h"
@@ -1361,6 +1362,51 @@ int wire_parse_invoice_created(const cJSON *json,
 }
 
 /* --- PTLC key turnover messages (Tier 3) --- */
+
+/* SF-PTLC-TURNOVER-AUTH #196: rotation-context precursor message.
+   Sent by LSP before MSG_PTLC_PRESIG so the client can bind the upcoming
+   adaptor pre-signature to a specific rotation, refusing replay/abuse. */
+cJSON *wire_build_rotation_begin(const unsigned char *dying_factory_txid32,
+                                  const unsigned char *new_factory_nonce32,
+                                  uint64_t rotation_epoch) {
+    cJSON *j = cJSON_CreateObject();
+    wire_json_add_hex(j, "dying_factory_txid", dying_factory_txid32, 32);
+    wire_json_add_hex(j, "new_factory_nonce",   new_factory_nonce32,  32);
+    cJSON_AddNumberToObject(j, "rotation_epoch", (double)rotation_epoch);
+    return j;
+}
+
+int wire_parse_rotation_begin(const cJSON *json,
+                               unsigned char *dying_factory_txid32,
+                               unsigned char *new_factory_nonce32,
+                               uint64_t *rotation_epoch) {
+    if (!json) return 0;
+    if (wire_json_get_hex(json, "dying_factory_txid", dying_factory_txid32, 32) != 32)
+        return 0;
+    if (wire_json_get_hex(json, "new_factory_nonce", new_factory_nonce32, 32) != 32)
+        return 0;
+    cJSON *e = cJSON_GetObjectItem(json, "rotation_epoch");
+    if (!e || !cJSON_IsNumber(e)) return 0;
+    *rotation_epoch = (uint64_t)e->valuedouble;
+    return 1;
+}
+
+/* Compute context-bound turnover_msg32 from rotation context.  Both LSP
+   and client compute this independently; mismatch on the client side
+   triggers refusal of MSG_PTLC_PRESIG.  Tag is "ss/turnover/v1" — bump
+   the version suffix if the binding format ever changes. */
+void wire_compute_turnover_msg(const unsigned char *dying_factory_txid32,
+                                const unsigned char *new_factory_nonce32,
+                                uint64_t rotation_epoch,
+                                unsigned char *turnover_msg_out32) {
+    unsigned char buf[32 + 32 + 8];
+    memcpy(buf,      dying_factory_txid32, 32);
+    memcpy(buf + 32, new_factory_nonce32,  32);
+    /* Encode rotation_epoch as big-endian 8 bytes (matches BIP-340 style). */
+    for (int i = 0; i < 8; i++)
+        buf[64 + i] = (unsigned char)((rotation_epoch >> (56 - 8 * i)) & 0xFF);
+    sha256_tagged("ss/turnover/v1", buf, sizeof(buf), turnover_msg_out32);
+}
 
 cJSON *wire_build_ptlc_presig(const unsigned char *presig64,
                                int nonce_parity,

--- a/tests/test_adaptor.c
+++ b/tests/test_adaptor.c
@@ -1,6 +1,7 @@
 #include "superscalar/adaptor.h"
 #include "superscalar/ln_dispatch.h"
 #include "superscalar/ptlc_commit.h"
+#include "superscalar/wire.h"
 #include "superscalar/factory.h"
 #include "superscalar/regtest.h"
 #include "cJSON.h"
@@ -898,5 +899,143 @@ int test_ptlc_complete_via_dispatch(void)
     ln_dispatch_t d; memset(&d, 0, sizeof(d));
     int r = ln_dispatch_process_msg(&d, 0, msg, sizeof(msg));
     TEST_ASSERT(r == 78, "PTLC12: type 0x4E dispatched as 78");
+    return 1;
+}
+
+/* ================================================================== */
+/* #196 — context-bound turnover_msg + ROTATION_BEGIN wire codec.    */
+/* ================================================================== */
+
+/* Test PTLC_TA1 — wire_compute_turnover_msg deterministic for same input. */
+int test_ptlc_ta1_turnover_msg_deterministic(void)
+{
+    unsigned char dying[32], nonce[32];
+    memset(dying, 0xAA, 32);
+    memset(nonce, 0xBB, 32);
+    uint64_t epoch = 0xDEADBEEFCAFEBABEULL;
+
+    unsigned char out1[32], out2[32];
+    wire_compute_turnover_msg(dying, nonce, epoch, out1);
+    wire_compute_turnover_msg(dying, nonce, epoch, out2);
+    TEST_ASSERT(memcmp(out1, out2, 32) == 0,
+                "PTLC_TA1: same input must produce same output");
+    return 1;
+}
+
+/* Test PTLC_TA2 — wire_compute_turnover_msg changes on dying_factory_txid. */
+int test_ptlc_ta2_turnover_msg_binds_dying(void)
+{
+    unsigned char dying_a[32], dying_b[32], nonce[32];
+    memset(dying_a, 0x01, 32);
+    memset(dying_b, 0x02, 32);
+    memset(nonce,   0xBB, 32);
+    uint64_t epoch = 100;
+
+    unsigned char a[32], b[32];
+    wire_compute_turnover_msg(dying_a, nonce, epoch, a);
+    wire_compute_turnover_msg(dying_b, nonce, epoch, b);
+    TEST_ASSERT(memcmp(a, b, 32) != 0,
+                "PTLC_TA2: changing dying_factory_txid must change output");
+    return 1;
+}
+
+/* Test PTLC_TA3 — wire_compute_turnover_msg changes on new_factory_nonce. */
+int test_ptlc_ta3_turnover_msg_binds_nonce(void)
+{
+    unsigned char dying[32], nonce_a[32], nonce_b[32];
+    memset(dying,    0xAA, 32);
+    memset(nonce_a,  0x01, 32);
+    memset(nonce_b,  0x02, 32);
+    uint64_t epoch = 100;
+
+    unsigned char a[32], b[32];
+    wire_compute_turnover_msg(dying, nonce_a, epoch, a);
+    wire_compute_turnover_msg(dying, nonce_b, epoch, b);
+    TEST_ASSERT(memcmp(a, b, 32) != 0,
+                "PTLC_TA3: changing new_factory_nonce must change output");
+    return 1;
+}
+
+/* Test PTLC_TA4 — wire_compute_turnover_msg changes on rotation_epoch. */
+int test_ptlc_ta4_turnover_msg_binds_epoch(void)
+{
+    unsigned char dying[32], nonce[32];
+    memset(dying, 0xAA, 32);
+    memset(nonce, 0xBB, 32);
+
+    unsigned char a[32], b[32];
+    wire_compute_turnover_msg(dying, nonce, 100, a);
+    wire_compute_turnover_msg(dying, nonce, 101, b);
+    TEST_ASSERT(memcmp(a, b, 32) != 0,
+                "PTLC_TA4: changing rotation_epoch must change output");
+    return 1;
+}
+
+/* Test PTLC_TA5 — wire_compute_turnover_msg differs from legacy constant. */
+int test_ptlc_ta5_turnover_msg_not_legacy(void)
+{
+    unsigned char legacy[32];
+    sha256_tagged("turnover", (const unsigned char *)"turnover", 8, legacy);
+
+    unsigned char dying[32], nonce[32];
+    memset(dying, 0xAA, 32);
+    memset(nonce, 0xBB, 32);
+    unsigned char bound[32];
+    wire_compute_turnover_msg(dying, nonce, 42, bound);
+
+    TEST_ASSERT(memcmp(legacy, bound, 32) != 0,
+                "PTLC_TA5: bound output must differ from legacy constant");
+    return 1;
+}
+
+/* Test PTLC_TA6 — wire_build_rotation_begin / wire_parse_rotation_begin roundtrip. */
+int test_ptlc_ta6_rotation_begin_codec_roundtrip(void)
+{
+    unsigned char dying_in[32], nonce_in[32];
+    for (int i = 0; i < 32; i++) { dying_in[i] = (unsigned char)(i + 1); }
+    for (int i = 0; i < 32; i++) { nonce_in[i] = (unsigned char)(0xF0 ^ i); }
+    uint64_t epoch_in = 0x1122334455667788ULL;
+
+    cJSON *j = wire_build_rotation_begin(dying_in, nonce_in, epoch_in);
+    TEST_ASSERT(j != NULL, "PTLC_TA6: build_rotation_begin");
+
+    unsigned char dying_out[32], nonce_out[32];
+    uint64_t epoch_out = 0;
+    int r = wire_parse_rotation_begin(j, dying_out, nonce_out, &epoch_out);
+    cJSON_Delete(j);
+    TEST_ASSERT(r == 1, "PTLC_TA6: parse_rotation_begin");
+    TEST_ASSERT(memcmp(dying_in, dying_out, 32) == 0, "PTLC_TA6: dying roundtrip");
+    TEST_ASSERT(memcmp(nonce_in, nonce_out, 32) == 0, "PTLC_TA6: nonce roundtrip");
+    TEST_ASSERT(epoch_in == epoch_out, "PTLC_TA6: epoch roundtrip");
+    return 1;
+}
+
+/* Test PTLC_TA7 — wire_parse_rotation_begin rejects malformed input. */
+int test_ptlc_ta7_rotation_begin_parse_rejects_malformed(void)
+{
+    unsigned char dying_out[32], nonce_out[32];
+    uint64_t epoch_out = 0;
+
+    /* NULL json */
+    TEST_ASSERT(wire_parse_rotation_begin(NULL, dying_out, nonce_out, &epoch_out) == 0,
+                "PTLC_TA7a: NULL json refused");
+
+    /* empty object */
+    cJSON *empty = cJSON_CreateObject();
+    TEST_ASSERT(wire_parse_rotation_begin(empty, dying_out, nonce_out, &epoch_out) == 0,
+                "PTLC_TA7b: empty object refused");
+    cJSON_Delete(empty);
+
+    /* missing rotation_epoch */
+    cJSON *partial = cJSON_CreateObject();
+    unsigned char d[32], n[32];
+    memset(d, 0xAA, 32); memset(n, 0xBB, 32);
+    extern void wire_json_add_hex(cJSON *j, const char *k, const unsigned char *v, size_t l);
+    wire_json_add_hex(partial, "dying_factory_txid", d, 32);
+    wire_json_add_hex(partial, "new_factory_nonce",  n, 32);
+    TEST_ASSERT(wire_parse_rotation_begin(partial, dying_out, nonce_out, &epoch_out) == 0,
+                "PTLC_TA7c: missing epoch refused");
+    cJSON_Delete(partial);
+
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1073,6 +1073,13 @@ extern int test_ptlc_commit_dispatch_null_ch(void);
 extern int test_ln_dispatch_routes_ptlc_presig(void);
 extern int test_ln_dispatch_routes_ptlc_adapted(void);
 extern int test_channel_ptlc_grow(void);
+extern int test_ptlc_ta1_turnover_msg_deterministic(void);
+extern int test_ptlc_ta2_turnover_msg_binds_dying(void);
+extern int test_ptlc_ta3_turnover_msg_binds_nonce(void);
+extern int test_ptlc_ta4_turnover_msg_binds_epoch(void);
+extern int test_ptlc_ta5_turnover_msg_not_legacy(void);
+extern int test_ptlc_ta6_rotation_begin_codec_roundtrip(void);
+extern int test_ptlc_ta7_rotation_begin_parse_rejects_malformed(void);
 extern int test_channel_fail_ptlc_not_found(void);
 extern int test_channel_settle_ptlc_not_found(void);
 extern int test_ln_dispatch_routes_ptlc_complete(void);
@@ -2946,6 +2953,14 @@ static void run_unit_tests(void) {
     RUN_TEST(test_ln_dispatch_routes_ptlc_presig);
     RUN_TEST(test_ln_dispatch_routes_ptlc_adapted);
     RUN_TEST(test_channel_ptlc_grow);
+    /* #196 SF-PTLC-TURNOVER-AUTH: wire context-binding tests. */
+    RUN_TEST(test_ptlc_ta1_turnover_msg_deterministic);
+    RUN_TEST(test_ptlc_ta2_turnover_msg_binds_dying);
+    RUN_TEST(test_ptlc_ta3_turnover_msg_binds_nonce);
+    RUN_TEST(test_ptlc_ta4_turnover_msg_binds_epoch);
+    RUN_TEST(test_ptlc_ta5_turnover_msg_not_legacy);
+    RUN_TEST(test_ptlc_ta6_rotation_begin_codec_roundtrip);
+    RUN_TEST(test_ptlc_ta7_rotation_begin_parse_rejects_malformed);
     RUN_TEST(test_channel_fail_ptlc_not_found);
     RUN_TEST(test_channel_settle_ptlc_not_found);
     RUN_TEST(test_ln_dispatch_routes_ptlc_complete);

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -507,6 +507,49 @@ typedef struct {
     uint16_t profit_share_bps;      /* client's share from factory terms */
 } daemon_cb_data_t;
 
+/* SF-PTLC-TURNOVER-AUTH #196: rotation-context state for the PTLC turnover
+   handler. The MSG_PTLC_PRESIG handler used to adapt the client identity
+   seckey onto any LSP-supplied presig blindly, letting a malicious LSP
+   extract the seckey via secp256k1_musig_extract_adaptor (scalar
+   subtraction). We now require a precursor MSG_ROTATION_BEGIN carrying
+   (dying_factory_txid, new_factory_nonce, rotation_epoch); the client
+   recomputes the expected turnover_msg via wire_compute_turnover_msg()
+   and refuses any presig whose turnover_msg does not match. The context
+   is one-shot: cleared after a presig is consumed (success OR refusal)
+   so a stale ROTATION_BEGIN cannot authorize a later presig. */
+typedef struct {
+    int           expecting;
+    unsigned char dying_factory_txid[32];
+    unsigned char new_factory_nonce[32];
+    uint64_t      rotation_epoch;
+    unsigned char expected_turnover_msg[32];
+} client_rotation_ctx_t;
+
+static client_rotation_ctx_t g_rotation_ctx;
+
+static void rotation_ctx_set(const unsigned char *dying_txid,
+                              const unsigned char *new_nonce,
+                              uint64_t epoch) {
+    memcpy(g_rotation_ctx.dying_factory_txid, dying_txid, 32);
+    memcpy(g_rotation_ctx.new_factory_nonce,  new_nonce,  32);
+    g_rotation_ctx.rotation_epoch = epoch;
+    wire_compute_turnover_msg(dying_txid, new_nonce, epoch,
+                                g_rotation_ctx.expected_turnover_msg);
+    g_rotation_ctx.expecting = 1;
+}
+
+static void rotation_ctx_clear(void) {
+    memset(&g_rotation_ctx, 0, sizeof(g_rotation_ctx));
+}
+
+/* Returns 1 iff presig turnover_msg matches expected; 0 otherwise. */
+static int rotation_ctx_check_presig(const unsigned char *received_turnover_msg) {
+    if (!g_rotation_ctx.expecting) return 0;
+    if (memcmp(received_turnover_msg,
+               g_rotation_ctx.expected_turnover_msg, 32) != 0) return 0;
+    return 1;
+}
+
 /* Handle a PTLC_PRESIG message inline (when received during a blocking wait
    for another message type like COMMITMENT_SIGNED).  This prevents the rotation
    PTLC from being silently discarded when it arrives mid-HTLC-flow. */
@@ -520,6 +563,13 @@ static void handle_ptlc_presig_inline(int fd, wire_msg_t *msg,
         fprintf(stderr, "Client %u: bad inline PTLC_PRESIG\n", my_index);
         return;
     }
+    /* SF-PTLC-TURNOVER-AUTH #196: refuse if no matching ROTATION_BEGIN. */
+    if (!rotation_ctx_check_presig(turnover_msg)) {
+        fprintf(stderr, "Client %u: REJECTED inline PTLC_PRESIG (no matching ROTATION_BEGIN; adversarial LSP suspected, #196)\n", my_index);
+        rotation_ctx_clear();
+        return;
+    }
+    rotation_ctx_clear();
     unsigned char my_seckey[32];
     if (!secp256k1_keypair_sec(ctx, my_seckey, keypair))
         return;
@@ -555,6 +605,22 @@ static int recv_or_handle_ptlc(int fd, wire_msg_t *msg, int timeout_sec,
             return 0;
         if (msg->msg_type == expected_type)
             return 1;
+        if (msg->msg_type == MSG_ROTATION_BEGIN) {
+            /* SF-PTLC-TURNOVER-AUTH #196: record rotation context inline
+               so an inline PTLC_PRESIG (mid-HTLC-flow) can validate. */
+            unsigned char dt[32], nn[32];
+            uint64_t ep = 0;
+            if (wire_parse_rotation_begin(msg->json, dt, nn, &ep)) {
+                rotation_ctx_set(dt, nn, ep);
+                printf("Client %u: ROTATION_BEGIN accepted inline (epoch=%llu)\n",
+                       my_index, (unsigned long long)ep);
+            } else {
+                fprintf(stderr, "Client %u: bad inline ROTATION_BEGIN\n", my_index);
+            }
+            cJSON_Delete(msg->json);
+            msg->json = NULL;
+            continue;
+        }
         if (msg->msg_type == MSG_PTLC_PRESIG) {
             handle_ptlc_presig_inline(fd, msg, ctx, keypair, my_index);
             cJSON_Delete(msg->json);
@@ -1309,6 +1375,25 @@ handle_message:
             break;
         }
 
+        case MSG_ROTATION_BEGIN: {
+            /* SF-PTLC-TURNOVER-AUTH #196: rotation context precursor.
+               Records (dying_factory_txid, new_factory_nonce, rotation_epoch)
+               so the next MSG_PTLC_PRESIG can be validated against it. */
+            unsigned char dying_txid[32], new_nonce[32];
+            uint64_t epoch = 0;
+            if (!wire_parse_rotation_begin(msg.json, dying_txid, new_nonce, &epoch)) {
+                fprintf(stderr, "Client %u: bad ROTATION_BEGIN\n", my_index);
+                cJSON_Delete(msg.json);
+                break;
+            }
+            cJSON_Delete(msg.json);
+            rotation_ctx_set(dying_txid, new_nonce, epoch);
+            printf("Client %u: ROTATION_BEGIN accepted (epoch=%llu, dying_txid=%02x%02x%02x..)\n",
+                   my_index, (unsigned long long)epoch,
+                   dying_txid[0], dying_txid[1], dying_txid[2]);
+            break;
+        }
+
         case MSG_PTLC_PRESIG: {
             /* LSP sends adaptor pre-signature for PTLC key turnover */
             unsigned char presig[64], turnover_msg[32];
@@ -1319,6 +1404,14 @@ handle_message:
                 break;
             }
             cJSON_Delete(msg.json);
+
+            /* SF-PTLC-TURNOVER-AUTH #196: refuse if no matching ROTATION_BEGIN. */
+            if (!rotation_ctx_check_presig(turnover_msg)) {
+                fprintf(stderr, "Client %u: REJECTED PTLC_PRESIG (no matching ROTATION_BEGIN; adversarial LSP suspected, #196)\n", my_index);
+                rotation_ctx_clear();
+                break;
+            }
+            rotation_ctx_clear();
 
             /* Adapt with our secret key */
             unsigned char my_seckey[32];


### PR DESCRIPTION
## Summary

**HIGH SEVERITY** — adversarial-LSP fund-theft path, **mainnet-blocker**.

Closes #196. Addresses the dashboard team's audit finding in `LSP_TEAM_AUDIT_NOTE_2026-05-17.md`.

## The vulnerability

The client's `MSG_PTLC_PRESIG` handlers in `tools/superscalar_client.c` (both the inline path at line 513 and the main-loop case at line 1310) used to unconditionally call `adaptor_adapt(ctx, ..., my_seckey, nonce_parity)` on any LSP-supplied pre-signature. Combined with the LSP-side **constant** `turnover_msg = sha256_tagged("turnover", "turnover", 8)` at `src/lsp_rotation.c:151-153`, a malicious LSP could extract the client's identity seckey via libsecp256k1's `secp256k1_musig_extract_adaptor` — which is just scalar subtraction:

```
extracted = pre_sig.s - adapted_sig.s   (mod n)
          = ±my_seckey
```

Since the same identity seckey is used across **every factory the client participates in** (no per-factory derivation), one extraction = control over the client's entire ladder. Run across all connected clients ⇒ full N-of-N keyagg secret ⇒ unilateral spend of factory funding outputs.

## The fix

### Wire protocol additions

- `MSG_ROTATION_BEGIN (0x56)` — new precursor message LSP → Client.
- Payload: `{dying_factory_txid (32B), new_factory_nonce (32B), rotation_epoch (uint64 as hex string)}`.
- `wire_compute_turnover_msg(dying, nonce, epoch, out)` — context-bound hash via `sha256_tagged("ss/turnover/v1", dying||nonce||be64(epoch), 72)`. Both LSP and client compute it independently and compare.

### LSP changes (`src/lsp_rotation.c`)

- Generates fresh 32-byte `new_factory_nonce` per rotation (`/dev/urandom`).
- `rotation_epoch = time(NULL)`.
- `turnover_msg` now bound via `wire_compute_turnover_msg` (was the constant).
- Sends `MSG_ROTATION_BEGIN` before each client's `MSG_PTLC_PRESIG`.

### Client changes (`tools/superscalar_client.c`)

- New `client_rotation_ctx_t` (file-static) holds the most recent rotation context + precomputed `expected_turnover_msg`.
- `rotation_ctx_set` / `_clear` / `_check_presig` helpers manage the one-shot context.
- `MSG_ROTATION_BEGIN` handler (main-loop case + recv_or_handle_ptlc inline path): records context, prints accept log.
- `MSG_PTLC_PRESIG` handlers (both inline + main-loop): **refuses** if `rotation_ctx_check_presig(received_turnover_msg)` returns 0. Context cleared after each consumption (success OR refusal) so a stale ROTATION_BEGIN can't authorize a later presig.

### Precision fix (caught by TA6)

`rotation_epoch` is encoded as a 16-char hex string in JSON (not a number) because cJSON's number type is a double, which loses precision above 2^53.

## Verification

```
$ ./test_superscalar --unit
test_ptlc_ta1_turnover_msg_deterministic... OK
test_ptlc_ta2_turnover_msg_binds_dying... OK
test_ptlc_ta3_turnover_msg_binds_nonce... OK
test_ptlc_ta4_turnover_msg_binds_epoch... OK
test_ptlc_ta5_turnover_msg_not_legacy... OK
test_ptlc_ta6_rotation_begin_codec_roundtrip... OK
test_ptlc_ta7_rotation_begin_parse_rejects_malformed... OK
Results: 1446/1447 passed
```

The one fail (`test_regtest_http_rpc_path`) is environmental — a concurrent N64 testnet4 run was racing the local regtest bitcoind. Unrelated to this PR.

## Follow-ups (not in this PR)

- The state-machine half of the fix is unit-tested at the codec/crypto layer (TA1-TA7). End-to-end validation via `--test-rotation` / `--test-turnover` regtest runners will need a follow-up to send `MSG_ROTATION_BEGIN` in those test paths.
- Secondary audit finding (#197): convert `verify_funding` warning to hard refusal. Tracked separately.

## Test plan

- [x] `./test_superscalar --unit` — TA1-TA7 all PASS
- [x] No LeakSanitizer leaks
- [x] Build clean on default + sanitizer configs (CI to confirm)
- [ ] End-to-end `--test-rotation` (follow-up — needs LSP runner update)