### PR TITLE
docs(splice): mark SuperScalar splice as wire-codec stub (#198)

### DIFF
--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4523,6 +4523,20 @@ int lsp_channels_handle_msg(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 1;
     }
 
+    /* === BOLT-2 SPLICE — STUB IMPLEMENTATION (#198 SF-SPLICE-FULL) ===
+       The MSG_SPLICE_* handlers here are a wire-codec stub only:
+         - LSP always responds with acceptor_contribution = 0 (never contributes).
+         - LSP does NOT participate in building the splice TX (no interactive-tx
+           messages: MSG_TX_ADD_INPUT/OUTPUT/COMPLETE/SIGNATURES are absent).
+         - LSP does NOT sign the splice TX (no MuSig ceremony for splice).
+         - SPLICE_LOCKED updates funding_txid/vout but keeps the OLD
+           funding_amount.
+       SuperScalar's own lifecycle doesn't need splice — internal rebalancing
+       uses leaf realloc, sub-factory chain advance, DW rotation, JIT channels,
+       and cooperative close.  These handlers exist for future BOLT-2 wire
+       compatibility with external Lightning peers (e.g. CLN via #172
+       CLN-bLIP56).  A real production splice between SuperScalar and an
+       external LN peer requires the full implementation tracked in #198. */
     case MSG_SPLICE_INIT: {
         /* Initiator sent splice proposal: parse and send SPLICE_ACK */
         uint32_t channel_id = 0;

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
-# test_testnet4_splice.sh — BOLT-2 splice on real testnet4.
+# test_testnet4_splice.sh — BOLT-2 splice WIRE-CODEC SMOKE on real testnet4.
 #
-# Validates the splice protocol (STFU → SPLICE_INIT → SPLICE_ACK →
-# SPLICE_CREATED → SPLICE_LOCKED) end-to-end on testnet4.  Regtest
-# coverage exists via --test-splice in manual_tests.py; this is the
-# real-chain counterpart.
+# CAVEAT: this is NOT a full BOLT-2 splice end-to-end.  SuperScalar's
+# current splice implementation is a wire-codec stub (#198 SF-SPLICE-FULL
+# tracks the real version).  In particular:
+#   - LSP never contributes to the splice TX (acceptor_contribution = 0).
+#   - LSP doesn't participate in building the splice TX (no interactive-tx).
+#   - LSP doesn't sign the splice TX (no MuSig ceremony for splice).
+#   - SPLICE_LOCKED records the new outpoint but keeps the old funding_amount.
 #
-# Pass criteria:
-#   1. Factory funded + tree broadcast on testnet4
-#   2. Splice-out 10k sats from channel[0] succeeds
-#   3. Splice TX confirms on testnet4 chain
-#   4. Both sides log "SPLICE_LOCKED"
+# This runner exercises ONLY:
+#   1. STFU/STFU_ACK quiescence flow.
+#   2. SPLICE_INIT → SPLICE_ACK wire round-trip.
+#   3. Client builds + broadcasts a splice TX externally (NOT collaborative).
+#   4. SPLICE_LOCKED wire round-trip + channel outpoint update on the LSP side.
+#
+# PASS here means the wire codec works on testnet4.  It does NOT prove
+# splice would work against an external Lightning peer (CLN/LND).  That
+# requires the full implementation in #198.
 #
 # Wall time: ~30-60 min (depends on testnet4 block timing).
 


### PR DESCRIPTION
Replaces #258 (closed due to dirty rebase after #256/#257 squash-merges).

## What lands

Two files document that SuperScalar's splice support is a **wire-codec smoke test**, not BOLT-2 splice end-to-end:

- `tools/test_testnet4_splice.sh` — rewrites the preamble to call this what it is: a smoke test of MSG_SPLICE_* wire codec, not an actual splice ceremony.
- `src/lsp_channels.c` — adds a 14-line comment block above the `MSG_SPLICE_INIT` case explaining the stub status, what's missing (interactive-tx, MuSig signing, broadcast), and pointing at #198 for the full implementation.

## Why

A previous session report described the splice runner as "BOLT-2 splice end-to-end" — that overstated coverage. The actual code only validates MSG_SPLICE_INIT/_ACK/_TX/_SIG/_FAIL wire encode/decode (PR #190). A real splice still needs the interactive-tx flow + the MuSig signing ceremony, tracked as #198 SF-SPLICE-FULL.

This PR is documentation-only — no behavior change. #198 covers the real implementation when bLIP-56 CLN integration #172 is closer.

Closes #193 (the runner client count fix already merged via #254; this is just the honesty pass).