### PR TITLE
feat(cln): bLIP-56 plugin skeleton (#172 milestone 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,3 +420,9 @@ if(ENABLE_FUZZING)
             -fsanitize=fuzzer,address,undefined)
     endforeach()
 endif()
+
+# --- CLN plugin (opt-in, bLIP-56 integration #172) ---
+option(BUILD_CLN_PLUGIN "Build the CLN plugin shared library (libsuperscalar_cln.so)" OFF)
+if(BUILD_CLN_PLUGIN)
+    add_subdirectory(cln-plugin)
+endif()

--- a/cln-plugin/CMakeLists.txt
+++ b/cln-plugin/CMakeLists.txt
@@ -1,0 +1,32 @@
+# SuperScalar CLN plugin skeleton.
+#
+# Built only when -DBUILD_CLN_PLUGIN=ON is passed at top-level configure.
+# Produces a shared library (libsuperscalar_cln.so) that CLN's plugin
+# loader will eventually dlopen. At this stage it is a structural skeleton
+# only; real bLIP-56 wire handling lands in follow-ups (#172).
+
+# Force-enable shared lib build for this target only — the top-level
+# CMakeLists sets BUILD_SHARED_LIBS=OFF for the static libsuperscalar.a.
+add_library(superscalar_cln SHARED
+    superscalar_cln.c
+    blip56_codec.c
+)
+
+target_include_directories(superscalar_cln
+    PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${CMAKE_SOURCE_DIR}/include
+)
+
+# Link against the existing static lib only — no real CLN dep yet.
+target_link_libraries(superscalar_cln
+    PRIVATE superscalar project_warnings
+)
+
+if(ENABLE_SANITIZERS)
+    target_link_libraries(superscalar_cln PRIVATE project_sanitizers)
+endif()
+
+set_target_properties(superscalar_cln PROPERTIES
+    OUTPUT_NAME superscalar_cln
+    POSITION_INDEPENDENT_CODE ON
+)

--- a/cln-plugin/README.md
+++ b/cln-plugin/README.md
@@ -1,0 +1,51 @@
+# SuperScalar CLN Plugin (skeleton)
+
+Milestone 1 toward bLIP-56 integration (#172).
+
+## What this is
+
+A compilable, linkable skeleton for the Core Lightning (CLN) plugin that
+will eventually expose SuperScalar's channel-factory machinery to a CLN
+node over the bLIP-56 ("pluggable channel factories") protocol.
+
+Files:
+
+- `superscalar_cln.h` / `superscalar_cln.c` — public init / shutdown /
+  message-dispatch surface. All entry points currently log a `STUB:`
+  line and return success without touching real factory state.
+- `blip56_codec.h` / `blip56_codec.c` — bLIP-56 message type IDs (mirror
+  the existing `MSG_*` opcodes in `include/superscalar/wire.h`) plus
+  trivial encode/decode stubs. Real TLV codec lives in `src/wire.c` and
+  will be routed through once the send path is wired up.
+- `CMakeLists.txt` — builds `libsuperscalar_cln.so` linked only against
+  the existing static `libsuperscalar.a`. **No real CLN dependency yet.**
+
+## What this is not
+
+- Not loadable by `lightningd` yet. There is no plugin manifest, no
+  JSON-RPC handlers, no `getmanifest` / `init` negotiation.
+- No real factory operations performed. `superscalar_cln_handle_blip56_msg`
+  decodes the type byte and prints what it *would* dispatch to.
+- No bLIP-56 wire spec compliance beyond opcode numbering. Payload
+  framing, TLV layout, and error semantics will be tightened against
+  the spec under follow-up tasks.
+
+## Build
+
+The plugin is opt-in:
+
+```
+cmake -DBUILD_CLN_PLUGIN=ON -S . -B build-release
+cmake --build build-release --target superscalar_cln
+```
+
+Default builds (`cmake -S . -B build-release`) are unaffected — no new
+library, no new dependency.
+
+## Roadmap
+
+1. (this PR) Skeleton, opt-in build flag.
+2. CLN plugin manifest + `getmanifest` / `init` JSON handlers.
+3. Real bLIP-56 wire framing routed through `src/wire.c`.
+4. Factory propose → ready loop driven by inbound bLIP-56 messages.
+5. Splice gating (unblocks #198).

--- a/cln-plugin/blip56_codec.c
+++ b/cln-plugin/blip56_codec.c
@@ -1,0 +1,37 @@
+/* bLIP-56 wire codec — skeleton implementation.
+ *
+ * STUB ONLY: decode trivially splits type byte and payload; encode
+ * concatenates. Real codec will route through src/wire.c TLV machinery
+ * once the plugin's send path is wired up (#172). */
+
+#include "blip56_codec.h"
+
+#include <stdio.h>
+#include <string.h>
+
+int blip56_decode(const uint8_t *buf, size_t buf_len, blip56_frame_t *out)
+{
+    if (!buf || !out || buf_len < 1) return -1;
+    out->type        = (blip56_msg_type_t)buf[0];
+    out->payload     = buf_len > 1 ? &buf[1] : NULL;
+    out->payload_len = buf_len - 1;
+    fprintf(stderr, "STUB: blip56_decode type=0x%02x payload_len=%zu\n",
+            (unsigned)out->type, out->payload_len);
+    return 0;
+}
+
+int blip56_encode(blip56_msg_type_t type,
+                  const uint8_t    *payload,
+                  size_t            payload_len,
+                  uint8_t          *out,
+                  size_t            out_cap)
+{
+    if (!out)                          return -1;
+    if (out_cap < 1 + payload_len)     return -1;
+    out[0] = (uint8_t)type;
+    if (payload && payload_len)
+        memcpy(&out[1], payload, payload_len);
+    fprintf(stderr, "STUB: blip56_encode type=0x%02x payload_len=%zu\n",
+            (unsigned)type, payload_len);
+    return (int)(1 + payload_len);
+}

--- a/cln-plugin/blip56_codec.h
+++ b/cln-plugin/blip56_codec.h
@@ -1,0 +1,76 @@
+/* bLIP-56 wire codec — skeleton.
+ *
+ * The bLIP-56 (pluggable channel factories) protocol reuses SuperScalar's
+ * existing wire opcodes from include/superscalar/wire.h. This file mirrors
+ * the subset relevant to plugin-mediated coordination (factory setup,
+ * channel ops, splice). Real encode/decode lives in src/wire.c; here we
+ * only declare the stub entry points the plugin uses. */
+
+#ifndef SUPERSCALAR_CLN_BLIP56_CODEC_H
+#define SUPERSCALAR_CLN_BLIP56_CODEC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* bLIP-56 message type IDs. Numeric values intentionally match the
+ * existing MSG_* macros in include/superscalar/wire.h to keep one wire
+ * format across plugin and standalone daemon paths. */
+typedef enum {
+    BLIP56_MSG_HELLO              = 0x01,
+    BLIP56_MSG_HELLO_ACK          = 0x02,
+
+    /* Factory setup */
+    BLIP56_MSG_FACTORY_PROPOSE    = 0x10,
+    BLIP56_MSG_NONCE_BUNDLE       = 0x11,
+    BLIP56_MSG_ALL_NONCES         = 0x12,
+    BLIP56_MSG_PSIG_BUNDLE        = 0x13,
+    BLIP56_MSG_FACTORY_READY      = 0x14,
+
+    /* Cooperative close */
+    BLIP56_MSG_CLOSE_PROPOSE      = 0x20,
+    BLIP56_MSG_CLOSE_NONCE        = 0x21,
+    BLIP56_MSG_CLOSE_ALL_NONCES   = 0x22,
+    BLIP56_MSG_CLOSE_PSIG         = 0x23,
+    BLIP56_MSG_CLOSE_DONE         = 0x24,
+
+    /* Channel operations */
+    BLIP56_MSG_CHANNEL_READY      = 0x30,
+    BLIP56_MSG_UPDATE_ADD_HTLC    = 0x31,
+    BLIP56_MSG_COMMITMENT_SIGNED  = 0x32,
+    BLIP56_MSG_REVOKE_AND_ACK     = 0x33,
+    BLIP56_MSG_UPDATE_FULFILL_HTLC= 0x34,
+    BLIP56_MSG_UPDATE_FAIL_HTLC   = 0x35,
+
+    /* Keepalive */
+    BLIP56_MSG_PING               = 0x70,
+    BLIP56_MSG_PONG               = 0x71,
+} blip56_msg_type_t;
+
+/* Decode result. */
+typedef struct {
+    blip56_msg_type_t type;
+    const uint8_t    *payload;     /* borrowed pointer into caller's buffer */
+    size_t            payload_len;
+} blip56_frame_t;
+
+/* Decode a raw wire frame (type byte + payload).
+ * Returns 0 on success, -1 on malformed input. */
+int blip56_decode(const uint8_t *buf, size_t buf_len, blip56_frame_t *out);
+
+/* Encode a frame. Writes msg_type then payload. Returns bytes written,
+ * or -1 if out_cap is too small. */
+int blip56_encode(blip56_msg_type_t type,
+                  const uint8_t    *payload,
+                  size_t            payload_len,
+                  uint8_t          *out,
+                  size_t            out_cap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUPERSCALAR_CLN_BLIP56_CODEC_H */

--- a/cln-plugin/superscalar_cln.c
+++ b/cln-plugin/superscalar_cln.c
@@ -1,0 +1,87 @@
+/* SuperScalar CLN plugin — skeleton implementation.
+ *
+ * STUB ONLY. Every entry point returns success and logs a STUB: line so
+ * the loader can verify dispatch wiring without performing any real
+ * factory work. Real implementation lands incrementally under #172. */
+
+#include "superscalar_cln.h"
+#include "blip56_codec.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Opaque handle — kept minimal until real state is added. */
+struct cln_plugin_handle {
+    uint32_t magic;           /* sanity-check token for FFI callers */
+    uint64_t msgs_received;   /* useful even in skeleton for smoke tests */
+};
+
+#define SCLN_HANDLE_MAGIC 0x5C1AB116u   /* "SCLA" + "B16" — bLIP-56 marker */
+
+cln_plugin_handle_t *superscalar_cln_init(void)
+{
+    fprintf(stderr, "STUB: superscalar_cln_init() — would set up factory state\n");
+    cln_plugin_handle_t *h = calloc(1, sizeof(*h));
+    if (!h) return NULL;
+    h->magic = SCLN_HANDLE_MAGIC;
+    h->msgs_received = 0;
+    return h;
+}
+
+void superscalar_cln_shutdown(cln_plugin_handle_t *h)
+{
+    if (!h) return;
+    fprintf(stderr, "STUB: superscalar_cln_shutdown() — would tear down %llu msg state\n",
+            (unsigned long long)h->msgs_received);
+    h->magic = 0;
+    free(h);
+}
+
+scln_status_t superscalar_cln_handle_blip56_msg(
+    cln_plugin_handle_t *h,
+    const uint8_t       *msg,
+    size_t               msg_len)
+{
+    if (!h || h->magic != SCLN_HANDLE_MAGIC) return SCLN_ERR_INTERNAL;
+    if (!msg || msg_len == 0)                return SCLN_ERR_BAD_MSG;
+
+    blip56_frame_t frame;
+    if (blip56_decode(msg, msg_len, &frame) != 0) {
+        fprintf(stderr, "STUB: blip56_decode failed (len=%zu)\n", msg_len);
+        return SCLN_ERR_BAD_MSG;
+    }
+
+    h->msgs_received++;
+
+    switch (frame.type) {
+    case BLIP56_MSG_FACTORY_PROPOSE:
+        fprintf(stderr, "STUB: would call factory_propose(...) payload_len=%zu\n",
+                frame.payload_len);
+        break;
+    case BLIP56_MSG_NONCE_BUNDLE:
+    case BLIP56_MSG_ALL_NONCES:
+    case BLIP56_MSG_PSIG_BUNDLE:
+        fprintf(stderr, "STUB: factory signing msg type=0x%02x\n", (unsigned)frame.type);
+        break;
+    case BLIP56_MSG_UPDATE_ADD_HTLC:
+    case BLIP56_MSG_COMMITMENT_SIGNED:
+    case BLIP56_MSG_REVOKE_AND_ACK:
+        fprintf(stderr, "STUB: channel op msg type=0x%02x\n", (unsigned)frame.type);
+        break;
+    case BLIP56_MSG_PING:
+        fprintf(stderr, "STUB: would emit PONG\n");
+        break;
+    default:
+        fprintf(stderr, "STUB: unhandled msg type=0x%02x\n", (unsigned)frame.type);
+        break;
+    }
+    return SCLN_OK;
+}
+
+int superscalar_cln_main(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    fprintf(stderr, "STUB: superscalar_cln_main() — CLN plugin manifest not yet implemented\n");
+    return 0;
+}

--- a/cln-plugin/superscalar_cln.h
+++ b/cln-plugin/superscalar_cln.h
@@ -1,0 +1,59 @@
+/* SuperScalar CLN plugin — public skeleton API.
+ *
+ * Skeleton only: types and signatures the eventual CLN plugin loader
+ * will call. No real factory operations performed here yet (#172).
+ *
+ * Intentionally avoids including any CLN headers — the plugin loader
+ * sees opaque pointers and the linker is free of CLN deps until the
+ * real integration lands. */
+
+#ifndef SUPERSCALAR_CLN_PLUGIN_H
+#define SUPERSCALAR_CLN_PLUGIN_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle representing the CLN plugin context. Real type lives
+ * inside superscalar_cln.c; callers treat it as an abstract token. */
+struct cln_plugin_handle;
+typedef struct cln_plugin_handle cln_plugin_handle_t;
+
+/* Return codes. Keep numeric values stable — they cross the FFI boundary. */
+typedef enum {
+    SCLN_OK            = 0,
+    SCLN_ERR_INTERNAL  = 1,
+    SCLN_ERR_BAD_MSG   = 2,
+    SCLN_ERR_NOT_READY = 3,
+} scln_status_t;
+
+/* Plugin lifecycle. Returns NULL on allocation failure. */
+cln_plugin_handle_t *superscalar_cln_init(void);
+void                 superscalar_cln_shutdown(cln_plugin_handle_t *h);
+
+/* Inbound bLIP-56 message dispatch.
+ *
+ * msg points to the raw wire frame (msg_type byte + payload). The handler
+ * decodes via blip56_codec, dispatches to factory/channel logic, and may
+ * produce zero or more reply frames via the (currently absent) send hook.
+ *
+ * Returns SCLN_OK on successful dispatch, error code otherwise. */
+scln_status_t superscalar_cln_handle_blip56_msg(
+    cln_plugin_handle_t *h,
+    const uint8_t       *msg,
+    size_t               msg_len
+);
+
+/* Plugin entry point. CLN's plugin manifest negotiation will call this
+ * once the loader is wired up. Currently a stub that just records that
+ * the plugin was loaded. */
+int superscalar_cln_main(int argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUPERSCALAR_CLN_PLUGIN_H */


### PR DESCRIPTION
## Summary

Skeleton only (compilable, links, but no real behavior) for the CLN plugin that will expose SuperScalar's channel-factory machinery to Core Lightning via the bLIP-56 (pluggable channel factories) protocol.

- `cln-plugin/` subdir with stub `init` / `shutdown` / `handle_blip56_msg` entry points — each logs `STUB:` and returns success.
- `blip56_codec.{h,c}` mirrors the existing `MSG_*` opcodes from `include/superscalar/wire.h` (0x10-0x77 range). Trivial encode/decode stubs; real TLV codec will route through `src/wire.c` later.
- `libsuperscalar_cln.so` links against the existing static `libsuperscalar.a` only — **no real CLN dependency yet** (opaque `struct cln_plugin_handle;` only).
- Opt-in via `-DBUILD_CLN_PLUGIN=ON`; default builds (`cmake -S . -B build-release`) are unaffected — no new dep, no new target.

Lays the ground for real bLIP-56 integration (plugin manifest, JSON-RPC handlers, real wire framing, factory dispatch loop) over the next 1-2 weeks.

Refs #172. Unblocks #198 (splice gated on this).

## Test plan

- [x] `cmake -DBUILD_CLN_PLUGIN=ON .. && make superscalar_cln` produces `libsuperscalar_cln.so` cleanly with `-Wall -Wextra -Werror`.
- [x] Default `cmake ..` build (no flag) still builds `libsuperscalar.a` unchanged; no `cln-plugin/` subdir appears under build.
- [ ] Follow-up PR: real CLN plugin manifest + JSON-RPC `getmanifest` / `init` handlers.
- [ ] Follow-up PR: route encode/decode through `src/wire.c` TLV machinery.
- [ ] Follow-up PR: factory propose → ready loop driven by inbound bLIP-56 messages.