### PR TITLE
fix(rpc): suppress wallet-RPC error noise in chain-state poll loops (#200)

### DIFF
--- a/src/chain_backend_rpc.c
+++ b/src/chain_backend_rpc.c
@@ -53,9 +53,15 @@ static int rpc_base64(const char *in, size_t in_len, char *out, size_t out_cap)
 /* ------------------------------------------------------------------ */
 
 /* Send a JSON-RPC call to bitcoind and return the parsed "result" field.
-   Caller must cJSON_Delete the returned object. Returns NULL on error. */
-static cJSON *rpc_call(const chain_backend_rpc_ctx_t *rpc,
-                        const char *method, cJSON *params)
+   Caller must cJSON_Delete the returned object. Returns NULL on error.
+
+   If expected_err_code is non-zero and the RPC returns that error code,
+   the call returns NULL silently (no stderr spam). Used by poll loops
+   where -5 "not in mempool/chain" is the expected negative answer,
+   not an operator-visible problem. See task #200. */
+static cJSON *rpc_call_ex(const chain_backend_rpc_ctx_t *rpc,
+                           const char *method, cJSON *params,
+                           int expected_err_code)
 {
     /* Basic Auth header */
     char credentials[512];
@@ -156,10 +162,13 @@ static cJSON *rpc_call(const chain_backend_rpc_ctx_t *rpc,
     if (err && !cJSON_IsNull(err)) {
         cJSON *ecode = cJSON_GetObjectItem(err, "code");
         cJSON *emsg  = cJSON_GetObjectItem(err, "message");
-        fprintf(stderr, "HTTP RPC %s error: {\"code\":%d,\"message\":\"%s\"}\n",
-                method,
-                ecode ? ecode->valueint : 0,
-                emsg && cJSON_IsString(emsg) ? emsg->valuestring : "unknown");
+        int code = ecode ? ecode->valueint : 0;
+        /* Silently swallow the expected "not found" code for poll loops. */
+        if (expected_err_code == 0 || code != expected_err_code) {
+            fprintf(stderr, "HTTP RPC %s error: {\"code\":%d,\"message\":\"%s\"}\n",
+                    method, code,
+                    emsg && cJSON_IsString(emsg) ? emsg->valuestring : "unknown");
+        }
         cJSON_Delete(jresp);
         return NULL;
     }
@@ -168,6 +177,13 @@ static cJSON *rpc_call(const chain_backend_rpc_ctx_t *rpc,
     cJSON *result = cJSON_DetachItemFromObject(jresp, "result");
     cJSON_Delete(jresp);
     return result;
+}
+
+/* Back-compat wrapper: errors always printed. */
+static cJSON *rpc_call(const chain_backend_rpc_ctx_t *rpc,
+                        const char *method, cJSON *params)
+{
+    return rpc_call_ex(rpc, method, params, 0);
 }
 
 /* ------------------------------------------------------------------ */
@@ -190,23 +206,17 @@ static int cb_rpc_get_confirmations(chain_backend_t *self, const char *txid_hex)
 {
     chain_backend_rpc_ctx_t *rpc = (chain_backend_rpc_ctx_t *)self->ctx;
 
-    /* Try gettransaction first (wallet TX) */
+    /* Use getrawtransaction (node-level RPC). Requires -txindex on the
+       bitcoind node OR the tx still in mempool. We do NOT fall back to
+       gettransaction (a wallet RPC) because callers (watchtower, rotation,
+       channel-confirm polling) want chain state, not wallet state — and
+       gettransaction noisily errors with -5/-19 when the tx is not in the
+       wallet or when multiple wallets are loaded. See task #200. */
     cJSON *params = cJSON_CreateArray();
     cJSON_AddItemToArray(params, cJSON_CreateString(txid_hex));
-    cJSON *result = rpc_call(rpc, "gettransaction", params);
-
-    if (result) {
-        cJSON *confs = cJSON_GetObjectItem(result, "confirmations");
-        int c = confs && cJSON_IsNumber(confs) ? (int)confs->valuedouble : 0;
-        cJSON_Delete(result);
-        return c > 0 ? c : 0;
-    }
-
-    /* Fallback: getrawtransaction (requires -txindex or mempool) */
-    params = cJSON_CreateArray();
-    cJSON_AddItemToArray(params, cJSON_CreateString(txid_hex));
     cJSON_AddItemToArray(params, cJSON_CreateBool(1)); /* verbose */
-    result = rpc_call(rpc, "getrawtransaction", params);
+    /* -5 = "No such mempool or blockchain transaction" — normal poll miss. */
+    cJSON *result = rpc_call_ex(rpc, "getrawtransaction", params, -5);
 
     if (result) {
         cJSON *confs = cJSON_GetObjectItem(result, "confirmations");
@@ -233,7 +243,8 @@ static bool cb_rpc_is_in_mempool(chain_backend_t *self, const char *txid_hex)
     chain_backend_rpc_ctx_t *rpc = (chain_backend_rpc_ctx_t *)self->ctx;
     cJSON *params = cJSON_CreateArray();
     cJSON_AddItemToArray(params, cJSON_CreateString(txid_hex));
-    cJSON *result = rpc_call(rpc, "getmempoolentry", params);
+    /* -5 = "Transaction not in mempool" — expected negative answer. */
+    cJSON *result = rpc_call_ex(rpc, "getmempoolentry", params, -5);
     if (result) {
         cJSON_Delete(result);
         return true;

--- a/src/regtest.c
+++ b/src/regtest.c
@@ -16,6 +16,20 @@
 extern void hex_encode(const unsigned char *data, size_t len, char *out);
 extern int hex_decode(const char *hex, unsigned char *out, size_t out_len);
 
+/* Thread-local "quiet poll" flag for the next regtest_exec calls.
+   When set, RPC error codes commonly seen during normal polling are silently
+   swallowed (no stderr spam): -5 "no such mempool/blockchain transaction" or
+   "transaction not in mempool", and -19 "multiple wallets loaded". Used by
+   poll loops where these are the normal negative answers, not operator-visible
+   problems. See task #200. The flag must be cleared by the caller after the
+   logical operation completes (we do NOT auto-clear, since a single logical
+   poll often spans multiple RPCs — e.g. gettransaction then fallback
+   getrawtransaction). */
+static __thread int g_regtest_poll_quiet = 0;
+static inline bool regtest_err_is_expected_poll_miss(int code) {
+    return code == -5 || code == -19;
+}
+
 #ifdef _POSIX_VERSION
 
 /* Default timeout for bitcoin-cli commands (seconds). */
@@ -592,10 +606,18 @@ static char *regtest_http_rpc(const regtest_t *rt,
     /* Check for error */
     cJSON *err = cJSON_GetObjectItem(jresp, "error");
     if (err && !cJSON_IsNull(err)) {
-        char *errstr = cJSON_PrintUnformatted(err);
-        if (errstr) {
-            fprintf(stderr, "HTTP RPC %s error: %s\n", method, errstr);
-            free(errstr);
+        cJSON *ecode = cJSON_GetObjectItem(err, "code");
+        int code = (ecode && cJSON_IsNumber(ecode)) ? ecode->valueint : 0;
+        /* In poll-quiet scope, swallow the codes that are the normal negative
+           answer (tx not in mempool/chain; wallet path wrong because tx not
+           in this wallet). Real errors (-32700 parse, -32601 method missing,
+           etc.) still surface. See task #200. */
+        if (!(g_regtest_poll_quiet && regtest_err_is_expected_poll_miss(code))) {
+            char *errstr = cJSON_PrintUnformatted(err);
+            if (errstr) {
+                fprintf(stderr, "HTTP RPC %s error: %s\n", method, errstr);
+                free(errstr);
+            }
         }
         cJSON_Delete(jresp);
         return NULL;
@@ -932,7 +954,9 @@ int regtest_send_raw_tx(regtest_t *rt, const char *tx_hex, char *txid_out) {
     return 1;
 }
 
-int regtest_get_confirmations(regtest_t *rt, const char *txid) {
+/* Inner worker — flag-clearing wrapper below ensures g_regtest_poll_quiet
+   is reset on every return path (poll-loop quiet scope, task #200). */
+static int regtest_get_confirmations_inner(regtest_t *rt, const char *txid) {
     char params[256];
 
     /* Try gettransaction (wallet txs) */
@@ -1018,6 +1042,15 @@ int regtest_get_confirmations(regtest_t *rt, const char *txid) {
     return -1;
 }
 
+int regtest_get_confirmations(regtest_t *rt, const char *txid) {
+    /* Poll-loop quiet scope: suppress -5/-19 noise. Task #200. */
+    int prev = g_regtest_poll_quiet;
+    g_regtest_poll_quiet = 1;
+    int r = regtest_get_confirmations_inner(rt, txid);
+    g_regtest_poll_quiet = prev;
+    return r;
+}
+
 int regtest_get_confirmations_batch(regtest_t *rt,
                                     const char **txids_hex, size_t n_txids,
                                     int *confs_out)
@@ -1028,6 +1061,12 @@ int regtest_get_confirmations_batch(regtest_t *rt,
         confs_out[i] = -1;
 
     size_t n_remaining = n_txids;
+
+    /* Poll-loop quiet scope: suppress -5/-19 noise. Task #200.
+       Restored at every return point below. */
+    int _ss_prev_quiet = g_regtest_poll_quiet;
+    g_regtest_poll_quiet = 1;
+    #define SS_RET_BATCH(v) do { g_regtest_poll_quiet = _ss_prev_quiet; return (v); } while (0)
 
     /* Step 1: gettransaction for each txid (cheap for wallet txs) */
     for (size_t i = 0; i < n_txids; i++) {
@@ -1046,7 +1085,7 @@ int regtest_get_confirmations_batch(regtest_t *rt,
         cJSON_Delete(json);
     }
 
-    if (n_remaining == 0) return 1;
+    if (n_remaining == 0) SS_RET_BATCH(1);
 
     /* Step 1b: getrawtransaction for remaining txids (works with -txindex=1
        or for mempool TXs).  Same approach as CLN/LND/LDK. */
@@ -1069,13 +1108,13 @@ int regtest_get_confirmations_batch(regtest_t *rt,
         n_remaining--;
     }
 
-    if (n_remaining == 0) return 1;
+    if (n_remaining == 0) SS_RET_BATCH(1);
 
     /* Step 2: scan recent blocks — one getblockhash + one getblock per block,
        then check all remaining txids against the block's tx array in memory.
        O(scan_depth) RPCs regardless of n_txids. */
     char *hcnt = regtest_exec(rt, "getblockcount", "");
-    if (!hcnt) return 1;
+    if (!hcnt) SS_RET_BATCH(1);
     int height = atoi(hcnt);
     free(hcnt);
 
@@ -1130,13 +1169,22 @@ int regtest_get_confirmations_batch(regtest_t *rt,
         cJSON_Delete(block);
     }
 
-    return 1;
+    SS_RET_BATCH(1);
+    #undef SS_RET_BATCH
 }
 
 bool regtest_is_in_mempool(regtest_t *rt, const char *txid) {
     char params[256];
     snprintf(params, sizeof(params), "\"%s\"", txid);
+
+    /* Poll-loop quiet scope: getmempoolentry returns -5 "Transaction not in
+       mempool" as the normal negative answer — not an operator-visible
+       problem. Task #200. */
+    int prev = g_regtest_poll_quiet;
+    g_regtest_poll_quiet = 1;
     char *result = regtest_exec(rt, "getmempoolentry", params);
+    g_regtest_poll_quiet = prev;
+
     if (!result || result[0] == '\0') {
         free(result);
         return false;
@@ -1534,7 +1582,12 @@ int regtest_get_mempool_entry_seconds_ago(regtest_t *rt, const char *txid) {
     if (!rt || !txid) return -1;
     char params[80];
     snprintf(params, sizeof(params), "\"%s\"", txid);
+    /* Poll-loop quiet scope: -5 "Transaction not in mempool" is the normal
+       answer when the tx hasn't entered (or has left) the mempool. Task #200. */
+    int prev = g_regtest_poll_quiet;
+    g_regtest_poll_quiet = 1;
     char *result = regtest_exec(rt, "getmempoolentry", params);
+    g_regtest_poll_quiet = prev;
     if (!result) return -1;
     cJSON *j = cJSON_Parse(result);
     free(result);


### PR DESCRIPTION
## Summary

Two RPC layers (`src/chain_backend_rpc.c`, `src/regtest.c`) were printing `HTTP RPC -5 / -19` errors on **every poll tick** during normal operation. A 36-min testnet4 wait produced 1.5 MB of just these noise lines in the client log; the dual_factory regtest produced **365 noise lines per run**.

**Root cause:** both layers called `gettransaction` (a wallet RPC) first, then fell back to `getrawtransaction`. Multi-wallet bitcoind returns `-19 "Multiple wallets loaded"` on the wallet RPC; missing wallet txs return `-5 "Invalid or non-wallet transaction id"`. `getmempoolentry` returns `-5 "Transaction not in mempool"` as the normal negative answer.

## Fix (least-invasive, hybrid option 1 + option 2)

1. **`chain_backend_rpc.c`** — drop the `gettransaction` call entirely. All callers (watchtower, rotation, channel-confirm polling) want chain state, not wallet state. Use `getrawtransaction` directly and pass an `expected_err_code` (-5) so the normal poll miss is silent.

2. **`regtest.c`** — add a thread-local poll-quiet scope that silently swallows -5 and -19 in the four noisy poll-loop callers:
   - `regtest_get_confirmations`
   - `regtest_get_confirmations_batch`
   - `regtest_is_in_mempool`
   - `regtest_get_mempool_entry_seconds_ago`

Real errors (-32700 parse, -32601 method missing, -4 wallet, etc.) still surface. One-shot setup errors (createwallet, loadwallet) are unchanged.

## Verification

- **Build:** `superscalar_lsp` + `superscalar_client` clean, zero warnings.
- **Unit tests:** 1458/1458 pass.
- **Synthetic poll test** against real testnet4 bitcoind (100 RPC calls, bogus txid): **150 stderr lines -> 0**.
- **Regtest `test_regtest_dual_factory.sh`:** PASSES, **365 noise lines -> 0** from poll loops (2 remaining are legitimate one-shot setup errors at wallet creation).

## Test plan

- [x] `make superscalar_lsp superscalar_client` builds with zero warnings
- [x] `./test_superscalar --unit` passes (1458/1458)
- [x] `bash tools/test_regtest_dual_factory.sh build-release` passes
- [x] Poll-loop noise in client+lsp logs reduced 365 -> 0
- [x] Real errors (one-shot createwallet/loadwallet, wrong-host, auth fail) still surface