### PR TITLE
fix(watchtower): remove eager remote-PCP overwrite + sync test scaffold (#206)

### DIFF
--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -390,17 +390,14 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
             n_active_ptlcs++;
     }
 
-    /* Ensure old remote PCP is available: derive from stored revocation secret */
-    {
-        unsigned char old_rev_secret[32];
-        if (channel_get_received_revocation(ch, old_commit_num, old_rev_secret)) {
-            secp256k1_pubkey old_pcp;
-            if (secp256k1_ec_pubkey_create(ch->ctx, &old_pcp, old_rev_secret)) {
-                channel_set_remote_pcp(ch, old_commit_num, &old_pcp);
-            }
-            secure_zero(old_rev_secret, 32);
-        }
-    }
+    /* #206 fix: NO eager remote-PCP install.  channel_get_remote_pcp's
+     * fallback handles derive-from-rev-secret when the slot is missing.
+     * Eagerly overwriting a still-present slot was a regression — the slot
+     * holds the REAL remote PCP from state exchange, and "rev_secret * G"
+     * produces the LOCAL party's pubkey in unit-test scenarios (where the
+     * test self-revokes), not the remote's.  In production, rev_secret and
+     * slot pcp are guaranteed equal by protocol invariant, so removing this
+     * block is safe. */
 
     tx_buf_t old_tx;
     tx_buf_init(&old_tx, 512);

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -3368,6 +3368,28 @@
                    (unsigned long long)bc_ptlc_id,
                    (unsigned long long)bc_amt, bc_cltv);
 
+            /* #206 fix: override remote_pcp slot with rev_secret*G so that
+             * commit-N, WT entry, and penalty TX all derive from the same PCP.
+             * In production the LSP receives a real remote PCP during state
+             * exchange + a real rev_secret from the remote; protocol invariant
+             * guarantees rev_secret*G == slot_pcp.  In this single-process
+             * test scaffold we self-revoke (LOCAL secret stored as if it were
+             * the remote's revelation), so we must sync the slot to match. */
+            {
+                uint64_t bc_preview_cn = ch0_bc->commitment_number;
+                unsigned char bc_preview_secret[32];
+                if (channel_get_per_commitment_secret(ch0_bc, bc_preview_cn,
+                                                       bc_preview_secret)) {
+                    secp256k1_pubkey bc_synth_pcp;
+                    if (secp256k1_ec_pubkey_create(ctx, &bc_synth_pcp,
+                                                    bc_preview_secret)) {
+                        channel_set_remote_pcp(ch0_bc, bc_preview_cn,
+                                                &bc_synth_pcp);
+                    }
+                    secure_zero(bc_preview_secret, 32);
+                }
+            }
+
             /* Step 2: Build + sign commit-N TX (PRESERVE signed bytes) */
             tx_buf_t bc_commit_uns;
             tx_buf_init(&bc_commit_uns, 512);


### PR DESCRIPTION
## Summary

Two-part fix for the `ptlc_breach_chain` regtest regression (#206).

## Watchtower side

`src/watchtower.c` line 393-403 had an eager `channel_set_remote_pcp(ch, old_commit_num, &rev_secret*G)` at the top of `watchtower_watch_revoked_commitment`. The block was a latent bug that masqueraded as correctness:

- In production, the slot holds the **REAL** remote PCP from state exchange. `rev_secret*G` only equals that real value because by protocol invariant `rev_secret` IS the remote party's per-commitment-secret.
- In the test scaffold, we self-revoke (LOCAL's own secret stored as 'received from remote'). The eager install overwrites the real slot value with `LOCAL_secret * G`, corrupting subsequent commitment-TX rebuilds inside the WT.
- The fallback path in `channel_get_remote_pcp` (lines 539-547, derive-from-received-revocation when slot is missing) already handles the recovery-after-eviction case correctly. No eager install needed.

Diff: 11-line block deleted, replaced with explanatory comment.

## Test side

`tools/superscalar_lsp_pre_daemon_tests.inc` PTLC BREACH CHAIN scaffold: sync the remote_pcp slot to `rev_secret*G` **before** building commit-N. This makes commit-N, the WT entry, and the penalty TX all derive from the same PCP, mirroring the protocol invariant that holds in production.

Diff: ~18 lines added before Step 2.

## Verified

`bash tools/test_regtest_ptlc_breach_chain.sh`:
- BEFORE: txid match=0, `broadcast_log: penalty=0 ptlc_penalty=0`, FAIL "no main penalty broadcast"
- AFTER: txid match=1 ✓, `broadcast_log: penalty=1 ptlc_penalty=0`, FAIL "no PTLC penalty broadcast"

Main penalty leg now works. Unit suite still passes.

## Known follow-up (separate bug, not blocking)

The PTLC penalty leg still fails Schnorr verify. Root cause: `channel_build_commitment_tx_for_remote` swaps HTLC directions in its rebuild (line 907-913) but does NOT swap PTLC directions. So OFFERED PTLCs use one set of htlc basepoint roles in commit-N construction and the opposite roles in `channel_build_ptlc_penalty_tx`. Will be filed as a separate follow-up task.