### PR TITLE
fix(channel): swap PTLC directions in commit_tx_for_remote (#211, completes #206)

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -892,6 +892,17 @@ int channel_build_commitment_tx_for_remote(const channel_t *ch,
         rv.htlcs = htlc_copy;
     }
 
+    /* SF-W-PTLC #211: ptlcs is also a pointer (dynamic allocation); copy
+     * the array separately so the upcoming direction swap does not mutate
+     * the caller-owned ch->ptlcs storage. */
+    ptlc_t *ptlc_copy = NULL;
+    if (rv.n_ptlcs > 0) {
+        ptlc_copy = (ptlc_t *)malloc(rv.n_ptlcs * sizeof(ptlc_t));
+        if (!ptlc_copy) { free(htlc_copy); return 0; }
+        memcpy(ptlc_copy, ch->ptlcs, rv.n_ptlcs * sizeof(ptlc_t));
+        rv.ptlcs = ptlc_copy;
+    }
+
     /* Swap amounts */
     rv.local_amount = ch->remote_amount;
     rv.remote_amount = ch->local_amount;
@@ -911,8 +922,19 @@ int channel_build_commitment_tx_for_remote(const channel_t *ch,
             rv.htlcs[i].direction = HTLC_OFFERED;
     }
 
+    /* SF-W-PTLC #211: flip PTLC directions for remote view, analogous to
+     * the HTLC swap above.  Without this the remote-view commit and the
+     * WT's lazy-built penalty TX disagree on the script for OFFERED PTLCs. */
+    for (size_t i = 0; i < rv.n_ptlcs; i++) {
+        if (rv.ptlcs[i].direction == PTLC_OFFERED)
+            rv.ptlcs[i].direction = PTLC_RECEIVED;
+        else
+            rv.ptlcs[i].direction = PTLC_OFFERED;
+    }
+
     int result = channel_build_commitment_tx_impl(&rv, unsigned_tx_out, txid_out32, &remote_pcp);
     free(htlc_copy);
+    free(ptlc_copy);
     return result;
 }
 


### PR DESCRIPTION
## Summary
Follow-up to PR #268 (task #206). The main penalty leg of `test_regtest_ptlc_breach_chain.sh` was fixed by removing the eager remote-PCP overwrite, but the PTLC penalty leg still failed Schnorr verify because `channel_build_commitment_tx_for_remote` did not swap PTLC directions in its remote-view rebuild -- only HTLC directions.

## Fix
- Allocate a fresh copy of `rv.ptlcs` (the bare struct copy from `channel_t rv = *ch` is a shallow copy of the array pointer; mutating `rv.ptlcs[i]` would corrupt `ch->ptlcs[i]` in the caller).
- Flip `PTLC_OFFERED <-> PTLC_RECEIVED` in the copy, mirroring the existing HTLC swap.
- `free(ptlc_copy)` before return.

Without this, an OFFERED PTLC (LSP's view) appeared in the remote-view commit as OFFERED still; `channel_build_commitment_tx_impl` picked the wrong direction branch, producing a tapscript that did not match the on-chain output, so `channel_build_ptlc_penalty_tx` signed against the wrong script.

## Test plan
- [x] `tools/test_regtest_ptlc_breach_chain.sh`: `broadcast_log: penalty=1 ptlc_penalty=1` (was 1/0), PASS (was FAIL).
- [x] `tools/test_regtest_ptlc_breach.sh`: still passes, no regression.
- [x] Unit tests: 1457/1458 pass on this branch; the single `test_regtest_ps_chain_close` failure is a pre-existing bitcoind wallet-collision flake unrelated to this change.