### PR TITLE
feat(factory): multi-input MuSig ceremony for sub-factory chain advance (#142)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -2924,6 +2924,288 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
         return 0;
     }
 
+    /* === MULTI-INPUT FORK (SF-A / #142) ===
+       Detect via the optional `n_inputs` + `lsp_pubnonces[]` fields in the
+       PROPOSE we just parsed.  When present and n_inputs > 1, the LSP is
+       running the multi-input ceremony and we must mirror.  Note: we use
+       both wire-presence (PROPOSE has n_inputs) AND local state
+       (factory_node_uses_multi_input) to avoid mode-confusion. */
+    size_t propose_n_inputs = wire_subfactory_propose_get_n_inputs(propose_msg->json);
+    if (propose_n_inputs > 1 &&
+        factory_node_uses_multi_input(factory, (size_t)sub_node_i)) {
+        size_t n_inputs = sub->ps_n_prev_outputs;
+        if (n_inputs != propose_n_inputs) {
+            fprintf(stderr, "Client %u: PROPOSE n_inputs=%zu mismatches "
+                    "local ps_n_prev_outputs=%zu\n",
+                    my_index, propose_n_inputs, n_inputs);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        printf("Client %u: sub-factory %d.%d advance is MULTI-INPUT "
+               "(n_inputs=%zu)\n", my_index, leaf_side, sub_idx, n_inputs);
+
+        /* Parse the LSP's k+1 nonces from the PROPOSE. */
+        unsigned char lsp_pn[FACTORY_MAX_OUTPUTS][66];
+        size_t n_lsp_pn = wire_subfactory_propose_get_pubnonces(
+            propose_msg->json, lsp_pn, FACTORY_MAX_OUTPUTS);
+        if (n_lsp_pn != n_inputs) {
+            fprintf(stderr, "Client %u: PROPOSE lsp_pubnonces count=%zu, "
+                    "expected %zu\n", my_index, n_lsp_pn, n_inputs);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+
+        /* Init n_inputs sessions + poison. */
+        for (size_t i = 0; i < n_inputs; i++) {
+            if (!factory_session_init_node_input(factory, (size_t)sub_node_i, i)) {
+                fprintf(stderr, "Client %u: init_input session %zu failed\n",
+                        my_index, i);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                return 0;
+            }
+        }
+        if (poison_prepared &&
+            !factory_session_init_node_poison(factory, (size_t)sub_node_i)) {
+            fprintf(stderr, "Client %u: poison session_init failed — degrading\n",
+                    my_index);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
+
+        /* Find own slot, gen n_inputs client nonces + poison nonce. */
+        int my_slot = factory_find_signer_slot(factory, (size_t)sub_node_i, my_index);
+        if (my_slot < 0) {
+            fprintf(stderr, "Client %u: not a signer on sub-factory %d.%d\n",
+                    my_index, leaf_side, sub_idx);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        unsigned char my_seckey[32];
+        if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        secp256k1_pubkey my_pubkey;
+        secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+        secp256k1_musig_secnonce *my_secnonces =
+            calloc(n_inputs, sizeof(secp256k1_musig_secnonce));
+        secp256k1_musig_pubnonce *my_pubnonces =
+            calloc(n_inputs, sizeof(secp256k1_musig_pubnonce));
+        unsigned char (*my_pn_ser)[66] = calloc(n_inputs, sizeof(unsigned char[66]));
+        if (!my_secnonces || !my_pubnonces || !my_pn_ser) {
+            free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        for (size_t i = 0; i < n_inputs; i++) {
+            if (!musig_generate_nonce(ctx, &my_secnonces[i], &my_pubnonces[i],
+                                       my_seckey, &my_pubkey,
+                                       &sub->keyagg.cache)) {
+                free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+                memset(my_seckey, 0, 32);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                return 0;
+            }
+            musig_pubnonce_serialize(ctx, my_pn_ser[i], &my_pubnonces[i]);
+        }
+
+        secp256k1_musig_secnonce my_poison_secnonce;
+        secp256k1_musig_pubnonce my_poison_pubnonce;
+        unsigned char my_poison_pn_ser[66] = {0};
+        if (poison_prepared) {
+            if (!musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                       my_seckey, &my_pubkey,
+                                       &sub->keyagg.cache)) {
+                fprintf(stderr, "Client %u: poison nonce gen failed — degrading\n",
+                        my_index);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                poison_prepared = 0;
+            } else {
+                musig_pubnonce_serialize(ctx, my_poison_pn_ser, &my_poison_pubnonce);
+            }
+        }
+
+        /* Send NONCE: legacy single field (my_pn_ser[0]) + array of n_inputs. */
+        cJSON *nm = wire_build_subfactory_nonce(
+            my_pn_ser[0], poison_prepared ? my_poison_pn_ser : NULL);
+        wire_subfactory_nonce_set_pubnonces(nm, n_inputs,
+                                              (const unsigned char (*)[66])my_pn_ser);
+        if (!wire_send(fd, MSG_SUBFACTORY_NONCE, nm)) {
+            cJSON_Delete(nm);
+            free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        cJSON_Delete(nm);
+
+        /* Recv ALL_NONCES with per-input matrix. */
+        wire_msg_t am;
+        if (!wire_recv(fd, &am) || am.msg_type != MSG_SUBFACTORY_ALL_NONCES) {
+            fprintf(stderr, "Client %u: expected ALL_NONCES, got 0x%02x\n",
+                    my_index, am.json ? am.msg_type : 0);
+            if (am.json) cJSON_Delete(am.json);
+            free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        unsigned char *all_pn_per_input = calloc(sub->n_signers * n_inputs, 66);
+        unsigned char all_poison_pn[FACTORY_MAX_SIGNERS][66];
+        if (!all_pn_per_input) {
+            cJSON_Delete(am.json);
+            free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        size_t n_inputs_got = 0;
+        size_t n_signers_got = wire_subfactory_all_nonces_get_per_input(
+            am.json, all_pn_per_input, FACTORY_MAX_SIGNERS,
+            FACTORY_MAX_OUTPUTS, &n_inputs_got);
+
+        /* Optional poison nonces — parse via the legacy helper. */
+        unsigned char legacy_pn_in0[FACTORY_MAX_SIGNERS][66];
+        size_t legacy_n_pn = 0;
+        int parse_an_rc = wire_parse_subfactory_all_nonces(
+            am.json, legacy_pn_in0,
+            poison_prepared ? all_poison_pn : NULL,
+            FACTORY_MAX_SIGNERS, &legacy_n_pn);
+        cJSON_Delete(am.json);
+        if (n_signers_got == 0 || n_inputs_got != n_inputs ||
+            n_signers_got != sub->n_signers) {
+            fprintf(stderr, "Client %u: ALL_NONCES per-input parse failed "
+                    "(signers=%zu/%zu, inputs=%zu/%zu)\n",
+                    my_index, n_signers_got, sub->n_signers,
+                    n_inputs_got, n_inputs);
+            free(all_pn_per_input);
+            free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        if (poison_prepared && parse_an_rc < 2) {
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
+
+        /* Set every nonce on every input session. */
+        for (size_t s = 0; s < sub->n_signers; s++) {
+            for (size_t i = 0; i < n_inputs; i++) {
+                secp256k1_musig_pubnonce pn;
+                if (!musig_pubnonce_parse(ctx, &pn,
+                        all_pn_per_input + (s * n_inputs + i) * 66) ||
+                    !factory_session_set_nonce_input(factory, (size_t)sub_node_i,
+                                                     i, s, &pn)) {
+                    fprintf(stderr, "Client %u: set_nonce_input(s=%zu, i=%zu) failed\n",
+                            my_index, s, i);
+                    free(all_pn_per_input);
+                    free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+                    memset(my_seckey, 0, 32);
+                    factory_session_reset_poison(factory, (size_t)sub_node_i);
+                    return 0;
+                }
+            }
+            if (poison_prepared) {
+                secp256k1_musig_pubnonce ppn;
+                if (!musig_pubnonce_parse(ctx, &ppn, all_poison_pn[s]) ||
+                    !factory_session_set_nonce_poison(factory, (size_t)sub_node_i,
+                                                        s, &ppn)) {
+                    factory_session_reset_poison(factory, (size_t)sub_node_i);
+                    poison_prepared = 0;
+                }
+            }
+        }
+        free(all_pn_per_input);
+
+        /* Finalize every input session + poison. */
+        for (size_t i = 0; i < n_inputs; i++) {
+            if (!factory_session_finalize_node_input(factory, (size_t)sub_node_i, i)) {
+                fprintf(stderr, "Client %u: finalize_input %zu failed\n",
+                        my_index, i);
+                free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+                memset(my_seckey, 0, 32);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                return 0;
+            }
+        }
+        if (poison_prepared &&
+            !factory_session_finalize_node_poison(factory, (size_t)sub_node_i)) {
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
+
+        /* Create + send PSIG (n_inputs partial sigs + poison). */
+        unsigned char (*my_psig_ser)[32] = calloc(n_inputs, sizeof(unsigned char[32]));
+        if (!my_psig_ser) {
+            free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+            memset(my_seckey, 0, 32);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        for (size_t i = 0; i < n_inputs; i++) {
+            secp256k1_musig_partial_sig my_psig_i;
+            if (!musig_create_partial_sig(ctx, &my_psig_i, &my_secnonces[i],
+                                            keypair,
+                                            &sub->input_signing_sessions[i])) {
+                fprintf(stderr, "Client %u: partial_sig input %zu failed\n",
+                        my_index, i);
+                free(my_psig_ser);
+                free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+                memset(my_seckey, 0, 32);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                return 0;
+            }
+            musig_partial_sig_serialize(ctx, my_psig_ser[i], &my_psig_i);
+        }
+        free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+        secp256k1_musig_partial_sig my_poison_psig;
+        unsigned char my_poison_psig_ser[32] = {0};
+        if (poison_prepared) {
+            if (!musig_create_partial_sig(ctx, &my_poison_psig, &my_poison_secnonce,
+                                            keypair, &sub->poison_signing_session)) {
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                poison_prepared = 0;
+            } else {
+                musig_partial_sig_serialize(ctx, my_poison_psig_ser, &my_poison_psig);
+            }
+        }
+        memset(my_seckey, 0, 32);
+        cJSON *pm = wire_build_subfactory_psig(
+            my_psig_ser[0], poison_prepared ? my_poison_psig_ser : NULL);
+        wire_subfactory_psig_set_partial_sigs(pm, n_inputs,
+                                                (const unsigned char (*)[32])my_psig_ser);
+        free(my_psig_ser);
+        if (!wire_send(fd, MSG_SUBFACTORY_PSIG, pm)) {
+            cJSON_Delete(pm);
+            factory_session_reset_poison(factory, (size_t)sub_node_i);
+            return 0;
+        }
+        cJSON_Delete(pm);
+        factory_session_reset_poison(factory, (size_t)sub_node_i);
+
+        /* Wait for DONE. */
+        wire_msg_t dm;
+        if (!wire_recv(fd, &dm) || dm.msg_type != MSG_SUBFACTORY_DONE) {
+            fprintf(stderr, "Client %u: expected SUBFACTORY_DONE, got 0x%02x\n",
+                    my_index, dm.json ? dm.msg_type : 0);
+            if (dm.json) cJSON_Delete(dm.json);
+            return 0;
+        }
+        int dn_leaf, dn_sub;
+        uint32_t dn_chain_len;
+        wire_parse_subfactory_done(dm.json, &dn_leaf, &dn_sub, &dn_chain_len);
+        cJSON_Delete(dm.json);
+        (void)dn_leaf; (void)dn_sub;
+        printf("Client %u: sub-factory %d.%d advanced (MULTI) to chain_len %u "
+               "(channel[%d]+=%llu sats)\n",
+               my_index, leaf_side, sub_idx, dn_chain_len,
+               channel_idx, (unsigned long long)delta_sats);
+        return 1;
+    }
+
     /* Init both signing sessions (state + poison if prepared). */
     if (!factory_session_init_node(factory, (size_t)sub_node_i)) {
         fprintf(stderr, "Client %u: subfactory state session_init failed\n",

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3584,6 +3584,447 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
+    /* Build the client list once (used by both single- and multi-input branches
+       AND by the post-ceremony epilogue for the DONE broadcast). */
+    uint32_t sub_clients[FACTORY_MAX_SIGNERS];
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++)
+        sub_clients[ci] = sub->signer_indices[ci + 1];
+
+    /* === MULTI-INPUT FORK (SF-A / #142) ===
+
+       When the chain has been advanced before (ps_chain_len > 0 after the
+       call above means chain_len now >= 1 AND prev_n_outputs > 1), the
+       NEW chain[N] TX spends k+1 outputs of the prior chain[N-1] TX (k
+       channel UTXOs + sales-stock) instead of a single sales-stock UTXO.
+       This requires k+1 independent MuSig2 sessions (one per input, since
+       BIP-341 sighashes differ per input).
+
+       Detection: factory_node_uses_multi_input returns 1 when
+       (is_ps_leaf && ps_chain_len > 0 && type == PS_SUBFACTORY &&
+        ps_n_prev_outputs > 1).  Note that this is set by
+       factory_subfactory_chain_advance_unsigned, so we detect AFTER the
+       call.
+
+       Poison-TX side-channel is still single-input (spends ONE old
+       sales-stock UTXO), so we run it in parallel using the existing
+       poison_pubnonce/poison_partial_sig wire fields. */
+    if (factory_node_uses_multi_input(f, (size_t)sub_node_i)) {
+        size_t n_inputs = sub->ps_n_prev_outputs;
+        printf("LSP: sub-factory %d.%d chain advance is MULTI-INPUT "
+               "(n_inputs=%zu, ps_chain_len=%d)\n",
+               leaf_side, sub_idx_in_leaf, n_inputs, sub->ps_chain_len);
+
+        /* --- Multi-input Step 2: Init n_inputs state sessions + poison session. --- */
+        for (size_t i = 0; i < n_inputs; i++) {
+            if (!factory_session_init_node_input(f, (size_t)sub_node_i, i)) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "init input session %zu failed\n", i);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+        }
+        if (poison_prepared &&
+            !factory_session_init_node_poison(f, (size_t)sub_node_i)) {
+            fprintf(stderr, "LSP subfactory advance (multi): "
+                    "poison session init failed — degrading\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
+
+        /* --- Multi-input Step 3: Generate n_inputs LSP nonces (one per input) + 1 poison nonce. --- */
+        int lsp_slot = factory_find_signer_slot(f, (size_t)sub_node_i, 0);
+        if (lsp_slot < 0) {
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        unsigned char lsp_seckey[32];
+        if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) {
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        secp256k1_musig_secnonce *lsp_secnonces =
+            calloc(n_inputs, sizeof(secp256k1_musig_secnonce));
+        secp256k1_musig_pubnonce *lsp_pubnonces =
+            calloc(n_inputs, sizeof(secp256k1_musig_pubnonce));
+        unsigned char (*lsp_pn_ser)[66] =
+            calloc(n_inputs, sizeof(unsigned char[66]));
+        if (!lsp_secnonces || !lsp_pubnonces || !lsp_pn_ser) {
+            free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        for (size_t i = 0; i < n_inputs; i++) {
+            if (!musig_generate_nonce(lsp->ctx, &lsp_secnonces[i], &lsp_pubnonces[i],
+                                       lsp_seckey, &lsp->lsp_pubkey,
+                                       &sub->keyagg.cache)) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "nonce gen input %zu failed\n", i);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            musig_pubnonce_serialize(lsp->ctx, lsp_pn_ser[i], &lsp_pubnonces[i]);
+        }
+        secp256k1_musig_secnonce lsp_poison_secnonce;
+        secp256k1_musig_pubnonce lsp_poison_pubnonce;
+        unsigned char lsp_poison_pn_ser[66] = {0};
+        if (poison_prepared) {
+            if (!musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce,
+                                       &lsp_poison_pubnonce,
+                                       lsp_seckey, &lsp->lsp_pubkey,
+                                       &sub->keyagg.cache)) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "poison nonce gen failed — degrading\n");
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                poison_prepared = 0;
+            } else {
+                musig_pubnonce_serialize(lsp->ctx, lsp_poison_pn_ser,
+                                          &lsp_poison_pubnonce);
+            }
+        }
+
+        /* --- Multi-input Step 4: Send PROPOSE with n_inputs + lsp_pubnonces[] array. --- */
+        /* The PROPOSE carries lsp_pn_ser[0] in the single-input field for
+           compatibility with old parsers; multi-aware receivers will use
+           the array attached below. */
+        cJSON *propose = wire_build_subfactory_propose(leaf_side, sub_idx_in_leaf,
+                                                         channel_idx_in_sub,
+                                                         delta_sats,
+                                                         lsp_pn_ser[0]);
+        wire_subfactory_propose_set_inputs(propose, n_inputs,
+                                            (const unsigned char (*)[66])lsp_pn_ser);
+        for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+            size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+            if (!wire_send(lsp->client_fds[fd_idx],
+                           MSG_SUBFACTORY_PROPOSE, propose)) {
+                cJSON_Delete(propose);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+        }
+        cJSON_Delete(propose);
+
+        /* --- Multi-input Step 5: Collect NONCE from each client (k+1 nonces each + poison). --- */
+        /* all_pn_per_input[signer_slot * n_inputs + input_idx] = 66-byte nonce. */
+        unsigned char *all_pn_per_input = calloc(sub->n_signers * n_inputs, 66);
+        unsigned char all_poison_pn[FACTORY_MAX_SIGNERS][66];
+        if (!all_pn_per_input) {
+            free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        /* Seed LSP's own nonces into the matrix. */
+        for (size_t i = 0; i < n_inputs; i++)
+            memcpy(all_pn_per_input + ((size_t)lsp_slot * n_inputs + i) * 66,
+                    lsp_pn_ser[i], 66);
+        if (poison_prepared)
+            memcpy(all_poison_pn[lsp_slot], lsp_poison_pn_ser, 66);
+
+        for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+            size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+            wire_msg_t nmsg;
+            if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                                &nmsg, WIRE_CEREMONY_RECV_TIMEOUT_SEC) ||
+                nmsg.msg_type != MSG_SUBFACTORY_NONCE) {
+                fprintf(stderr, "LSP subfactory advance (multi): expected "
+                        "SUBFACTORY_NONCE from client %u, got 0x%02x\n",
+                        sub_clients[ci], nmsg.msg_type);
+                if (nmsg.json) cJSON_Delete(nmsg.json);
+                free(all_pn_per_input);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            /* Parse single-field + poison via the legacy helper (just for
+               poison side-channel; single-field state nonce is ignored). */
+            unsigned char client_state_pn[66], client_poison_pn[66];
+            int parse_rc = wire_parse_subfactory_nonce(
+                nmsg.json, client_state_pn,
+                poison_prepared ? client_poison_pn : NULL);
+            if (parse_rc == 0) {
+                cJSON_Delete(nmsg.json);
+                free(all_pn_per_input);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            if (poison_prepared && parse_rc < 2) {
+                fprintf(stderr,
+                        "LSP subfactory advance (multi): client %u omitted "
+                        "poison nonce — degrading\n", sub_clients[ci]);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                poison_prepared = 0;
+            }
+            /* Parse the array of k+1 client nonces (REQUIRED in multi-input mode). */
+            unsigned char client_pns[FACTORY_MAX_OUTPUTS][66];
+            size_t n_client_pns = wire_subfactory_nonce_get_pubnonces(
+                nmsg.json, client_pns, FACTORY_MAX_OUTPUTS);
+            cJSON_Delete(nmsg.json);
+            if (n_client_pns != n_inputs) {
+                fprintf(stderr, "LSP subfactory advance (multi): client %u "
+                        "sent %zu nonces, expected %zu\n",
+                        sub_clients[ci], n_client_pns, n_inputs);
+                free(all_pn_per_input);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
+                                                        sub_clients[ci]);
+            if (client_slot < 0) {
+                free(all_pn_per_input);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            for (size_t i = 0; i < n_inputs; i++)
+                memcpy(all_pn_per_input +
+                            ((size_t)client_slot * n_inputs + i) * 66,
+                        client_pns[i], 66);
+            if (poison_prepared)
+                memcpy(all_poison_pn[client_slot], client_poison_pn, 66);
+        }
+
+        /* --- Multi-input Step 6: Set nonces on every input session, broadcast ALL_NONCES. --- */
+        for (size_t s = 0; s < sub->n_signers; s++) {
+            for (size_t i = 0; i < n_inputs; i++) {
+                secp256k1_musig_pubnonce pn;
+                if (!musig_pubnonce_parse(lsp->ctx, &pn,
+                        all_pn_per_input + (s * n_inputs + i) * 66) ||
+                    !factory_session_set_nonce_input(f, (size_t)sub_node_i,
+                                                     i, s, &pn)) {
+                    fprintf(stderr, "LSP subfactory advance (multi): "
+                            "set_nonce_input(signer=%zu, input=%zu) failed\n",
+                            s, i);
+                    free(all_pn_per_input);
+                    free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                    memset(lsp_seckey, 0, 32);
+                    factory_session_reset_poison(f, (size_t)sub_node_i);
+                    return 0;
+                }
+            }
+            if (poison_prepared) {
+                secp256k1_musig_pubnonce ppn;
+                if (!musig_pubnonce_parse(lsp->ctx, &ppn, all_poison_pn[s]) ||
+                    !factory_session_set_nonce_poison(f, (size_t)sub_node_i,
+                                                        s, &ppn)) {
+                    fprintf(stderr, "LSP subfactory advance (multi): "
+                            "poison set_nonce(signer=%zu) failed — degrading\n", s);
+                    factory_session_reset_poison(f, (size_t)sub_node_i);
+                    poison_prepared = 0;
+                }
+            }
+        }
+        /* Build ALL_NONCES with the per-input matrix attached.  Single-field
+           "pubnonces" still carries input-0 nonces for legacy parsers. */
+        unsigned char all_pn_in0[FACTORY_MAX_SIGNERS][66];
+        for (size_t s = 0; s < sub->n_signers; s++)
+            memcpy(all_pn_in0[s], all_pn_per_input + (s * n_inputs) * 66, 66);
+        cJSON *all_nonces = wire_build_subfactory_all_nonces(
+            (const unsigned char (*)[66])all_pn_in0,
+            poison_prepared ? (const unsigned char (*)[66])all_poison_pn : NULL,
+            sub->n_signers);
+        wire_subfactory_all_nonces_set_per_input(all_nonces, sub->n_signers,
+                                                  n_inputs, (const unsigned char (*)[66])all_pn_per_input);
+        for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+            size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+            wire_send(lsp->client_fds[fd_idx],
+                       MSG_SUBFACTORY_ALL_NONCES, all_nonces);
+        }
+        cJSON_Delete(all_nonces);
+        free(all_pn_per_input);
+
+        /* --- Multi-input Step 7: Finalize every input session + poison. --- */
+        for (size_t i = 0; i < n_inputs; i++) {
+            if (!factory_session_finalize_node_input(f, (size_t)sub_node_i, i)) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "finalize input %zu failed\n", i);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                memset(lsp_seckey, 0, 32);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+        }
+        if (poison_prepared &&
+            !factory_session_finalize_node_poison(f, (size_t)sub_node_i)) {
+            fprintf(stderr, "LSP subfactory advance (multi): "
+                    "poison finalize failed — degrading\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
+
+        /* --- Multi-input Step 8: LSP signs each input + poison. --- */
+        secp256k1_keypair lsp_kp;
+        if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
+            free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+            memset(lsp_seckey, 0, 32);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        memset(lsp_seckey, 0, 32);
+        unsigned char (*lsp_psig_ser)[32] =
+            calloc(n_inputs, sizeof(unsigned char[32]));
+        if (!lsp_psig_ser) {
+            free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        for (size_t i = 0; i < n_inputs; i++) {
+            secp256k1_musig_partial_sig lsp_psig_i;
+            if (!musig_create_partial_sig(lsp->ctx, &lsp_psig_i,
+                    &lsp_secnonces[i], &lsp_kp,
+                    &sub->input_signing_sessions[i])) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "create_partial_sig input %zu failed\n", i);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                free(lsp_psig_ser);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            if (!factory_session_set_partial_sig_input(f, (size_t)sub_node_i,
+                                                        i, (size_t)lsp_slot,
+                                                        &lsp_psig_i)) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "set_partial_sig_input(input=%zu) failed\n", i);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                free(lsp_psig_ser);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            musig_partial_sig_serialize(lsp->ctx, lsp_psig_ser[i], &lsp_psig_i);
+        }
+        free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+        secp256k1_musig_partial_sig lsp_poison_psig;
+        if (poison_prepared) {
+            if (!musig_create_partial_sig(lsp->ctx, &lsp_poison_psig,
+                                          &lsp_poison_secnonce, &lsp_kp,
+                                          &sub->poison_signing_session)) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "LSP poison psig failed — degrading\n");
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                poison_prepared = 0;
+            } else if (!factory_session_set_partial_sig_poison(
+                            f, (size_t)sub_node_i,
+                            (size_t)lsp_slot, &lsp_poison_psig)) {
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                poison_prepared = 0;
+            }
+        }
+
+        /* --- Multi-input Step 9: Collect PSIG from each client (k+1 sigs + poison). --- */
+        for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+            size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+            wire_msg_t pmsg;
+            if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                                &pmsg, WIRE_CEREMONY_RECV_TIMEOUT_SEC) ||
+                pmsg.msg_type != MSG_SUBFACTORY_PSIG) {
+                fprintf(stderr, "LSP subfactory advance (multi): expected "
+                        "SUBFACTORY_PSIG from client %u, got 0x%02x\n",
+                        sub_clients[ci], pmsg.msg_type);
+                if (pmsg.json) cJSON_Delete(pmsg.json);
+                free(lsp_psig_ser);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            /* Legacy single-field (ignored for state) + poison. */
+            unsigned char client_psig_legacy[32], client_poison_psig_ser[32];
+            int parse_rc = wire_parse_subfactory_psig(
+                pmsg.json, client_psig_legacy,
+                poison_prepared ? client_poison_psig_ser : NULL);
+            if (parse_rc == 0) {
+                cJSON_Delete(pmsg.json);
+                free(lsp_psig_ser);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            if (poison_prepared && parse_rc < 2) {
+                fprintf(stderr, "LSP subfactory advance (multi): client %u "
+                        "omitted poison psig — degrading\n", sub_clients[ci]);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                poison_prepared = 0;
+            }
+            unsigned char client_psigs[FACTORY_MAX_OUTPUTS][32];
+            size_t n_client_psigs = wire_subfactory_psig_get_partial_sigs(
+                pmsg.json, client_psigs, FACTORY_MAX_OUTPUTS);
+            cJSON_Delete(pmsg.json);
+            if (n_client_psigs != n_inputs) {
+                fprintf(stderr, "LSP subfactory advance (multi): client %u "
+                        "sent %zu psigs, expected %zu\n",
+                        sub_clients[ci], n_client_psigs, n_inputs);
+                free(lsp_psig_ser);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
+                                                       sub_clients[ci]);
+            if (client_slot < 0) {
+                free(lsp_psig_ser);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
+            for (size_t i = 0; i < n_inputs; i++) {
+                secp256k1_musig_partial_sig client_psig_i;
+                if (!musig_partial_sig_parse(lsp->ctx, &client_psig_i,
+                                              client_psigs[i]) ||
+                    !factory_session_set_partial_sig_input(f, (size_t)sub_node_i,
+                                                            i, (size_t)client_slot,
+                                                            &client_psig_i)) {
+                    fprintf(stderr, "LSP subfactory advance (multi): client %u "
+                            "psig parse/set input=%zu failed\n",
+                            sub_clients[ci], i);
+                    free(lsp_psig_ser);
+                    factory_session_reset_poison(f, (size_t)sub_node_i);
+                    return 0;
+                }
+            }
+            if (poison_prepared) {
+                secp256k1_musig_partial_sig client_poison_psig;
+                if (!musig_partial_sig_parse(lsp->ctx, &client_poison_psig,
+                                              client_poison_psig_ser) ||
+                    !factory_session_set_partial_sig_poison(f, (size_t)sub_node_i,
+                                                              (size_t)client_slot,
+                                                              &client_poison_psig)) {
+                    fprintf(stderr, "LSP subfactory advance (multi): client %u "
+                            "poison psig parse/set failed — degrading\n",
+                            sub_clients[ci]);
+                    factory_session_reset_poison(f, (size_t)sub_node_i);
+                    poison_prepared = 0;
+                }
+            }
+        }
+        free(lsp_psig_ser);
+
+        /* --- Multi-input Step 10: Aggregate + assemble the k+1-witness signed TX. --- */
+        if (!factory_session_assemble_signed_tx_multi(f, (size_t)sub_node_i)) {
+            fprintf(stderr, "LSP subfactory advance (multi): "
+                    "assemble_signed_tx_multi failed\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            return 0;
+        }
+        if (poison_prepared &&
+            !factory_session_complete_node_poison(f, (size_t)sub_node_i)) {
+            fprintf(stderr, "LSP subfactory advance (multi): "
+                    "poison complete failed — degrading\n");
+            factory_session_reset_poison(f, (size_t)sub_node_i);
+            poison_prepared = 0;
+        }
+
+        /* Fall through to the common post-ceremony steps (10/10b/11) which
+           handle persist, watchtower, DONE, channel-funding refresh,
+           distribution-TX invalidation. We use a goto to share the
+           epilogue with the single-input path. */
+        goto multi_ceremony_complete;
+    }
+
     /* Step 2: Init BOTH signing sessions (state + poison).  Poison
        session uses the SAME keyagg as state but a separate session so
        nonces are independent (MuSig2 demands fresh nonces per message). */
@@ -3635,10 +4076,7 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     unsigned char lsp_pubnonce_ser[66];
     musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
 
-    /* Build the client list (signer_indices[1..n] are clients; signer 0 is LSP). */
-    uint32_t sub_clients[FACTORY_MAX_SIGNERS];
-    for (size_t ci = 0; ci < n_clients_in_sub; ci++)
-        sub_clients[ci] = sub->signer_indices[ci + 1];
+    /* sub_clients already populated at function entry (used by both branches). */
 
     cJSON *propose = wire_build_subfactory_propose(leaf_side, sub_idx_in_leaf,
                                                      channel_idx_in_sub,
@@ -3866,6 +4304,7 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         }
     }
 
+multi_ceremony_complete:
     /* Step 10: Persist sub-factory chain entry (Phase 4a save +
        Phase 4c per-channel amounts) into the dedicated v21
        `ps_subfactory_chains` table.

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -310,6 +310,7 @@ static void usage(const char *prog) {
         "  --test-leaf-advance After demo: advance left leaf only, force-close (proves per-leaf independence)\n"
         "  --test-tier-b-rollover After demo: drive states_per_layer+1 leaf-0 advances to trigger root rollover; verify Tier B ceremony (Gap B+F)\n"
         "  --test-subfactory-advance After demo: drive a sub-factory chain extension via lsp_subfactory_chain_advance (requires --arity 3 --ps-subfactory-arity K, K>1)\n"
+        "  --test-subfactory-advance-multi  Drive TWO advances back-to-back; the second exercises the multi-input MuSig ceremony (#142 SF-A)\n"
         "  --cheat-subfactory   After --test-subfactory-advance: broadcast stale chain[N-1] sub-factory TX, verify watchtower detects + responds with poison TX (works on regtest + testnet4/signet via confirmation polling; CL1)\n"
         "  --cheat-leaf [SIDE]  After --test-leaf-advance: broadcast stale pre-advance PS leaf state on SIDE (0=left default, 1=right); verify watchtower broadcasts L-stock poison TX. Tests partial-tree integrity. Works on any network (CL1).\n"
         "  --cheat-daemon-leaf [SIDE]  Same as --cheat-leaf but does NOT run LSP-internal watchtower_check; sleeps after broadcast so standalone WT can detect + respond. CL4.B.\n"
@@ -1300,6 +1301,7 @@ int main(int argc, char *argv[]) {
     int test_realloc = 0;
     int test_tier_b_rollover = 0;  /* Tier B (Gap B+F) — drive root rollover */
     int test_subfactory_advance = 0;  /* Phase 2c — drive sub-factory chain extension */
+    int test_subfactory_advance_multi = 0;  /* SF-A #142 — drive a SECOND advance to exercise the multi-input ceremony */
     int cheat_subfactory_after_advance = 0;  /* Gap A test: broadcast stale chain[N-1] post-advance */
     int ps_subfactory_arity_arg = 0;  /* k for PS k² sub-factories (0 = default k=1) */
     int test_jit = 0;
@@ -1526,6 +1528,12 @@ int main(int argc, char *argv[]) {
             test_tier_b_rollover = 1;
         else if (strcmp(argv[i], "--test-subfactory-advance") == 0)
             test_subfactory_advance = 1;
+        else if (strcmp(argv[i], "--test-subfactory-advance-multi") == 0) {
+            /* SF-A #142: drive a SECOND chain advance after the first
+               so the multi-input ceremony fires (n_inputs = k+1). */
+            test_subfactory_advance = 1;
+            test_subfactory_advance_multi = 1;
+        }
         else if (strcmp(argv[i], "--cheat-subfactory") == 0) {
             /* Sub-factory cheating mode: after --test-subfactory-advance
                extends the chain, broadcast the now-stale chain[N-1] TX

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -1446,6 +1446,65 @@
                                sub0->is_signed);
                     }
 
+                    /* === SF-A #142: SECOND advance — multi-input ceremony ===
+                       The first advance produced chain[1] which spends a single
+                       sales-stock UTXO (single-input).  Now drive a SECOND
+                       advance so chain[2] spends ALL k+1 outputs of chain[1]
+                       (k channels + sales-stock).  This is the multi-input
+                       MuSig case (#142 SF-A). */
+                    if (sub_pass && test_subfactory_advance_multi) {
+                        printf("\n--- SF-A: SECOND advance (multi-input ceremony) ---\n");
+                        fflush(stdout);
+                        int chain1 = sub0->ps_chain_len;
+                        uint64_t ch0_b4 = sub0->outputs[0].amount_sats;
+                        uint64_t sstock_b4 =
+                            sub0->outputs[sub0->n_outputs - 1].amount_sats;
+                        /* Auto-scale second-advance delta to remaining sales-stock. */
+                        uint64_t delta2 = sstock_b4 / 4;
+                        if (delta2 < 1000) delta2 = 1000;
+                        if (delta2 + 1000 + 546 > sstock_b4) delta2 = 0;
+
+                        if (delta2 == 0) {
+                            printf("  SKIP: sales-stock too small for 2nd advance "
+                                   "(%llu sats)\n", (unsigned long long)sstock_b4);
+                        } else {
+                            printf("  pre-2nd-advance: chain_len=%d, ch[0]=%llu, "
+                                   "sales-stock=%llu, delta2=%llu, "
+                                   "ps_n_prev_outputs=%zu\n",
+                                   chain1, (unsigned long long)ch0_b4,
+                                   (unsigned long long)sstock_b4,
+                                   (unsigned long long)delta2,
+                                   sub0->ps_n_prev_outputs);
+                            fflush(stdout);
+                            int rc2 = lsp_subfactory_chain_advance(mgr, lsp_p,
+                                                                    /*leaf_side=*/0,
+                                                                    /*sub_idx=*/0,
+                                                                    /*channel_idx=*/0,
+                                                                    delta2);
+                            if (rc2 != 1) {
+                                printf("  FAIL: 2nd lsp_subfactory_chain_advance "
+                                       "returned %d\n", rc2);
+                                sub_pass = 0;
+                            } else if (sub0->ps_chain_len != chain1 + 1) {
+                                printf("  FAIL: chain_len did not increment "
+                                       "(was %d, now %d)\n",
+                                       chain1, sub0->ps_chain_len);
+                                sub_pass = 0;
+                            } else if (!sub0->is_signed) {
+                                printf("  FAIL: chain[N+2] is not signed\n");
+                                sub_pass = 0;
+                            } else {
+                                printf("  post-2nd-advance: chain_len=%d, "
+                                       "ch[0]=%llu, sales-stock=%llu (signed=%d)\n",
+                                       sub0->ps_chain_len,
+                                       (unsigned long long)sub0->outputs[0].amount_sats,
+                                       (unsigned long long)sub0->outputs[sub0->n_outputs - 1].amount_sats,
+                                       sub0->is_signed);
+                                printf("  SF-A MULTI-INPUT CEREMONY: PASS\n");
+                            }
+                        }
+                    }
+
                     /* === Sub-factory CHEATING + WATCHTOWER POISON ===
 
                        The LSP "cheats" by broadcasting the now-stale

--- a/tools/test_regtest_subfactory_chain_advance_multi.sh
+++ b/tools/test_regtest_subfactory_chain_advance_multi.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# test_regtest_subfactory_chain_advance_multi.sh — end-to-end PS k² sub-factory
+# MULTI-INPUT chain advance ceremony (#142 SF-A).
+#
+# Spawns 1 LSP daemon + 4 superscalar_client daemons (5 distinct OS processes),
+# builds a k=2 N=4 PS factory with sub-factories, drives TWO sub-factory chain
+# extensions via lsp_subfactory_chain_advance:
+#
+#   - First advance: chain[0] -> chain[1] (single-input ceremony, the old path)
+#   - Second advance: chain[1] -> chain[2] (MULTI-INPUT ceremony, the new
+#     code path being tested here)
+#
+# The second advance spends k+1 outputs of chain[1] (k channels + sales-stock).
+# Without the multi-input ceremony only one input would be signed and the
+# broadcast would fail; with it, all k+1 witnesses are present and chain[2]
+# is broadcastable.
+#
+# Usage: bash tools/test_regtest_subfactory_chain_advance_multi.sh [BUILD_DIR]
+# BUILD_DIR defaults to /root/SuperScalar/build-release.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build-release}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+# Auto-detect ASan build and preload libasan only if needed.
+if command -v nm >/dev/null 2>&1 && nm -D "$LSP_BIN" 2>/dev/null | grep -q __asan_init; then
+    SS_ASAN_ENV="ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8"
+else
+    SS_ASAN_ENV=""
+fi
+
+N_CLIENTS="${N_CLIENTS:-4}"
+PS_SUB_ARITY="${PS_SUB_ARITY:-2}"
+
+FUNDING_SATS=400000
+LSP_PORT=29950   # distinct from k2_subfactory_breach (29949)
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=()
+for _i in $(seq 2 256); do
+    CLIENT_SECKEYS+=("$(printf '%064x' $_i)")
+done
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+if [ ! -f "$REGTEST_CONF" ]; then
+    REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+fi
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+
+TMPDIR=$(mktemp -d /tmp/ss-subfactory-multi-advance.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"
+LSP_LOG="$TMPDIR/lsp.log"
+
+PIDS=()
+
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    for pid in "${PIDS[@]:-}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do
+        kill -9 "$pid" 2>/dev/null || true
+    done
+    cp "$LSP_LOG" /tmp/subfactory_multi_last_lsp.log 2>/dev/null || true
+    cp "$LSP_DB"  /tmp/subfactory_multi_last_lsp.db  2>/dev/null || true
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        cp "$TMPDIR/client_${i}.log" \
+            "/tmp/subfactory_multi_last_client_${i}.log" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR"
+    echo "  Preserved logs:"
+    echo "    /tmp/subfactory_multi_last_lsp.log"
+    echo "    /tmp/subfactory_multi_last_lsp.db"
+    echo "    /tmp/subfactory_multi_last_client_{0..$((N_CLIENTS - 1))}.log"
+}
+trap cleanup EXIT
+
+echo "=== PS k² sub-factory MULTI-INPUT chain advance (#142 SF-A) ==="
+echo "  build dir         : $BUILD_DIR"
+echo "  N clients         : $N_CLIENTS"
+echo "  PS sub arity (k)  : $PS_SUB_ARITY (canonical k² shape)"
+echo "  funding           : $FUNDING_SATS sats"
+echo "  bitcoind          : $REGTEST_CONF"
+echo ""
+echo "  Test will:"
+echo "    1. Build k=$PS_SUB_ARITY N=$N_CLIENTS PS factory"
+echo "    2. First advance: chain[0] -> chain[1]  (single-input)"
+echo "    3. Second advance: chain[1] -> chain[2] (MULTI-INPUT, k+1 sessions)"
+echo "    4. Verify chain[2] is broadcastable + log markers present"
+
+for bin in "$LSP_BIN" "$CLIENT_BIN"; do
+    if [ ! -x "$bin" ]; then
+        echo "FAIL: missing binary $bin"; exit 1
+    fi
+done
+
+# --- bitcoind regtest reset ---
+echo ""
+echo "--- bitcoind regtest reset ---"
+
+REGTEST_DATADIR=$(grep -E '^datadir=' "$REGTEST_CONF" 2>/dev/null | head -1 | cut -d= -f2)
+if [ -n "$REGTEST_DATADIR" ]; then
+    REGTEST_REGTEST_DIR="$REGTEST_DATADIR/regtest"
+else
+    REGTEST_REGTEST_DIR="$HOME/.bitcoin/regtest"
+fi
+
+$BCLI stop 2>/dev/null || true
+sleep 2
+if pgrep -f "bitcoind.*regtest" > /dev/null; then
+    pkill -f "bitcoind.*regtest" 2>/dev/null || true
+    sleep 2
+fi
+
+DATADIR_OWNER=$(stat -c %U "$REGTEST_DATADIR" 2>/dev/null || echo "$USER")
+if [ "$DATADIR_OWNER" = "bitcoin" ]; then
+    sudo -u bitcoin sh -c "rm -rf '$REGTEST_REGTEST_DIR'" 2>/dev/null || \
+        rm -rf "$REGTEST_REGTEST_DIR"
+    sudo -u bitcoin bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+else
+    rm -rf "$REGTEST_REGTEST_DIR"
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+fi
+
+for i in $(seq 1 30); do
+    $BCLI getblockchaininfo &>/dev/null && break
+    sleep 1
+done
+if ! $BCLI getblockchaininfo &>/dev/null; then
+    echo "FAIL: bitcoind failed to start"; exit 1
+fi
+echo "  bitcoind reachable, fresh chain at height $($BCLI getblockcount)"
+
+$BCLI createwallet "" 2>/dev/null || $BCLI loadwallet "" 2>/dev/null || true
+WALLET_NAME="ss_subfactory_multi_miner"
+$BCLI createwallet "$WALLET_NAME" 2>/dev/null || \
+    $BCLI loadwallet "$WALLET_NAME" 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet="$WALLET_NAME" getnewaddress)
+echo "  miner wallet ready"
+
+# --- LSP daemon ---
+echo ""
+echo "--- LSP daemon (--demo --test-subfactory-advance-multi) ---"
+
+env $SS_ASAN_ENV "$LSP_BIN" \
+    --network regtest \
+    --port "$LSP_PORT" \
+    --seckey "$LSP_SECKEY" \
+    --clients "$N_CLIENTS" \
+    --arity 3 \
+    --ps-subfactory-arity "$PS_SUB_ARITY" \
+    --amount "$FUNDING_SATS" \
+    --step-blocks 1 \
+    --max-conn-rate 1000 --max-handshakes 256 \
+    --demo \
+    --test-subfactory-advance-multi \
+    --db "$LSP_DB" \
+    --cli-path "$(which bitcoin-cli)" \
+    --rpcuser rpcuser --rpcpassword rpcpass \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+PIDS+=("$LSP_PID")
+echo "  LSP started (PID=$LSP_PID, log=$LSP_LOG)"
+
+for i in $(seq 1 30); do
+    grep -q "listening on port" "$LSP_LOG" 2>/dev/null && break
+    sleep 1
+    if ! kill -0 "$LSP_PID" 2>/dev/null; then
+        echo "FAIL: LSP died before listening"; tail -40 "$LSP_LOG"; exit 1
+    fi
+done
+if ! grep -q "listening on port" "$LSP_LOG" 2>/dev/null; then
+    echo "FAIL: LSP did not start listening within 30s"
+    tail -40 "$LSP_LOG"; exit 1
+fi
+echo "  LSP listening on port $LSP_PORT"
+
+# --- Client daemons ---
+echo ""
+echo "--- $N_CLIENTS client daemons ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    CLIENT_LOG="$TMPDIR/client_${i}.log"
+    CLIENT_DB="$TMPDIR/client_${i}.db"
+    env $SS_ASAN_ENV "$CLIENT_BIN" \
+        --seckey "${CLIENT_SECKEYS[$i]}" \
+        --host 127.0.0.1 --port "$LSP_PORT" \
+        --network regtest \
+        --lsp-pubkey "$LSP_PUBKEY" \
+        --daemon \
+        --db "$CLIENT_DB" \
+        --cli-path "$(which bitcoin-cli)" \
+        --rpcuser rpcuser --rpcpassword rpcpass \
+        > "$CLIENT_LOG" 2>&1 &
+    CPID=$!
+    PIDS+=("$CPID")
+    echo "  client[$i] started (PID=$CPID)"
+    sleep 0.1
+done
+
+# --- Background block miner ---
+echo ""
+echo "--- Driving ceremony (mining 1 block / 2s in background) ---"
+(
+    while kill -0 "$LSP_PID" 2>/dev/null; do
+        $BCLI generatetoaddress 1 "$MINE_ADDR" > /dev/null 2>&1 || true
+        sleep 2
+    done
+) &
+MINER_PID=$!
+PIDS+=("$MINER_PID")
+
+# --- Wait for LSP to complete ---
+echo ""
+echo "--- Waiting for multi-input advance test (timeout 600s) ---"
+WAITED=0
+LSP_EXIT=""
+while [ "$WAITED" -lt 600 ]; do
+    if ! kill -0 "$LSP_PID" 2>/dev/null; then
+        wait "$LSP_PID" 2>/dev/null || true
+        LSP_EXIT=$?
+        break
+    fi
+    if [ $((WAITED % 20)) -eq 0 ]; then
+        ADV_COUNT=$(grep -cE "sub-factory.*chain extended" \
+                            "$LSP_LOG" 2>/dev/null || echo 0)
+        MULTI_COUNT=$(grep -cE "MULTI-INPUT|SF-A" \
+                            "$LSP_LOG" 2>/dev/null || echo 0)
+        echo "  ... ${WAITED}s elapsed: advances=$ADV_COUNT, multi-input markers=$MULTI_COUNT"
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+done
+
+if [ -z "$LSP_EXIT" ]; then
+    echo "FAIL: LSP did not exit within 600s"
+    tail -200 "$LSP_LOG"; exit 1
+fi
+
+echo ""
+echo "--- LSP exit=$LSP_EXIT ---"
+if [ "$LSP_EXIT" -ne 0 ]; then
+    echo "FAIL: LSP exited non-zero (exit $LSP_EXIT)"
+    tail -200 "$LSP_LOG"
+    exit 1
+fi
+
+# --- Verify both advances fired ---
+echo ""
+echo "=== Verifying TWO sub-factory advances fired ==="
+ADV_LINES=$(grep -cE "sub-factory.*chain extended" "$LSP_LOG" 2>/dev/null || echo 0)
+if [ "$ADV_LINES" -lt 2 ]; then
+    echo "FAIL: expected >= 2 advance lines, got $ADV_LINES"
+    grep -E "sub-factory|FAIL|chain extended" "$LSP_LOG" | head -30
+    exit 1
+fi
+echo "  $ADV_LINES advance lines:"
+grep "sub-factory.*chain extended" "$LSP_LOG" | sed 's/^/    /'
+
+# --- Verify MULTI-INPUT ceremony marker (LSP side) ---
+echo ""
+echo "=== Verifying MULTI-INPUT ceremony fired ==="
+if ! grep -q "chain advance is MULTI-INPUT" "$LSP_LOG"; then
+    echo "FAIL: MULTI-INPUT ceremony marker missing from LSP log"
+    grep -E "MULTI|SF-A|sub-factory" "$LSP_LOG" | head -20
+    exit 1
+fi
+MULTI_LINE=$(grep "chain advance is MULTI-INPUT" "$LSP_LOG" | head -1)
+echo "  $MULTI_LINE"
+
+# --- Verify client mirror MULTI-INPUT marker ---
+echo ""
+echo "=== Verifying clients ran the MULTI-INPUT mirror ==="
+N_MULTI_CLIENTS=0
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    if grep -q "advance is MULTI-INPUT\|advanced (MULTI)" "$TMPDIR/client_${i}.log" 2>/dev/null; then
+        N_MULTI_CLIENTS=$((N_MULTI_CLIENTS + 1))
+        MARK=$(grep -E "advance is MULTI-INPUT|advanced \(MULTI\)" "$TMPDIR/client_${i}.log" | head -1)
+        echo "    client[$i]: $MARK"
+    fi
+done
+if [ "$N_MULTI_CLIENTS" -lt "$PS_SUB_ARITY" ]; then
+    echo "FAIL: expected >= $PS_SUB_ARITY clients to log MULTI-INPUT, got $N_MULTI_CLIENTS"
+    exit 1
+fi
+
+# --- Verify SF-A test marker ---
+echo ""
+echo "=== Verifying SF-A test marker ==="
+if ! grep -q "SF-A: SECOND advance (multi-input ceremony)" "$LSP_LOG"; then
+    echo "FAIL: SF-A second-advance test block did not run"
+    grep -E "SF-A|FAIL" "$LSP_LOG" | head -10
+    exit 1
+fi
+if ! grep -q "SF-A MULTI-INPUT CEREMONY: PASS" "$LSP_LOG"; then
+    echo "FAIL: SF-A MULTI-INPUT CEREMONY did not report PASS"
+    grep -E "SF-A|FAIL" "$LSP_LOG" | tail -20
+    exit 1
+fi
+echo "  $(grep "SF-A MULTI-INPUT CEREMONY: PASS" "$LSP_LOG" | head -1)"
+
+# --- Verify chain[2] broadcast/sign succeeded ---
+echo ""
+echo "=== Verifying second-advance state is signed ==="
+if ! grep -q "post-2nd-advance.*signed=1" "$LSP_LOG"; then
+    echo "FAIL: post-2nd-advance is_signed=1 marker missing"
+    grep -E "post-2nd|FAIL" "$LSP_LOG" | head -10
+    exit 1
+fi
+echo "  $(grep "post-2nd-advance" "$LSP_LOG" | head -1)"
+
+# --- Verify persist rows exist for both chain entries ---
+echo ""
+echo "=== Verifying broadcast/persist of two chain entries ==="
+if [ -f "$LSP_DB" ]; then
+    NCHAINS=$(sqlite3 "$LSP_DB" \
+        "SELECT COUNT(*) FROM ps_subfactory_chains;" \
+        2>/dev/null || echo 0)
+    echo "  ps_subfactory_chains rows: $NCHAINS"
+    if [ "$NCHAINS" -lt 2 ]; then
+        echo "FAIL: expected >= 2 ps_subfactory_chains rows, got $NCHAINS"
+        exit 1
+    fi
+else
+    echo "  WARN: LSP DB missing — skipping persist verification"
+fi
+
+echo ""
+echo "=== PASS: PS k² sub-factory MULTI-INPUT chain advance end-to-end ==="
+echo "  - $((N_CLIENTS + 1)) distinct OS processes (1 LSP + $N_CLIENTS clients)"
+echo "  - k=$PS_SUB_ARITY canonical sub-factory shape"
+echo "  - First advance: single-input ceremony (chain[0] -> chain[1])"
+echo "  - Second advance: MULTI-INPUT ceremony (chain[1] -> chain[2])"
+echo "  - $N_MULTI_CLIENTS / $PS_SUB_ARITY clients ran the MULTI-INPUT mirror"


### PR DESCRIPTION
## Summary

- Wires the existing per-input MuSig session API (`factory_session_init_node_input` + `factory_session_assemble_signed_tx_multi`) into the orchestrator + client mirror so sub-factory chain advance can sign the k+1 inputs it actually produces.
- Uses the optional array fields on `MSG_SUBFACTORY_PROPOSE / NONCE / ALL_NONCES / PSIG` already added in #207 phase 2c (no new opcodes; backwards-compatible).
- Detection: `factory_node_uses_multi_input` (`ps_chain_len > 0 && ps_n_prev_outputs > 1`) — every sub-factory chain advance with any client channels.

## Why

Before this change, `lsp_subfactory_chain_advance` initialized a single MuSig session and signed input 0 only. The chain[N+1] TX consumes ALL k+1 outputs of chain[N] (k channel UTXOs + sales-stock), so the other k inputs had no witness and broadcast failed.

## What changed

- `src/lsp_channels.c`: new MULTI-INPUT fork in `lsp_subfactory_chain_advance` runs k+1 sessions in lockstep, aggregates via `factory_session_assemble_signed_tx_multi`.
- `src/client.c`: client handler detects `n_inputs > 1` on `MSG_SUBFACTORY_PROPOSE`, mirrors the per-input ceremony.
- Poison-TX side-channel (single-input, spends OLD sales-stock UTXO) keeps running in parallel via the existing `poison_pubnonce / poison_partial_sig` fields — no degradation there.
- `tools/superscalar_lsp.c` + `tools/superscalar_lsp_pre_daemon_tests.inc`: new `--test-subfactory-advance-multi` flag drives a SECOND advance so the multi-input path is exercised end-to-end in the in-process pre-daemon test.
- `tools/test_regtest_subfactory_chain_advance_multi.sh`: new regtest that spawns 1 LSP + 4 clients, drives 2 advances, asserts both are signed and `ps_subfactory_chains` has 2 rows.

## Backwards compat

- Single-input k=0 path: unchanged (existing `MSG_SUBFACTORY_*` opcodes, single-field codec).
- Multi-input: same opcodes, additional optional array fields per the codec spec already on `include/superscalar/wire.h:813-867`.
- Old clients without the multi-input branch will reject `n_inputs > 1` advances (the client checks `wire_subfactory_propose_get_n_inputs(propose) > 1`).

## Verified

- New regtest `tools/test_regtest_subfactory_chain_advance_multi.sh /root/SuperScalar-multi/build-release` — **PASS** (2 advances, MULTI-INPUT marker present on both LSP + clients, ps_subfactory_chains rows = 2)
- Existing `tools/test_regtest_k2_subfactory_breach.sh` — **PASS** (no regression; poison TX still broadcast/confirms)
- All 1458 unit tests pass

## Test plan

- [x] Build clean on `build-release/` (no ASan)
- [x] Unit tests: 1458/1458 pass
- [x] New multi-input regtest: PASS, k+1 witnesses signed, broadcast OK
- [x] Existing k2_subfactory_breach: PASS (no regression)