### PR TITLE
feat(persist): per-output HTLC sweep TX persistence (schema v35, #207)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 34
+#define PERSIST_SCHEMA_VERSION 35
 
 /* #185 / wallet-team CEREMONY_DESIGN.md §6.1:
    Ceremony state enum (column `ceremonies.state`).
@@ -513,6 +513,26 @@ int persist_save_old_commitment_htlc(persist_t *p, uint32_t channel_id,
 /* Load HTLC output metadata for an old commitment. Returns count loaded. */
 size_t persist_load_old_commitment_htlcs(persist_t *p, uint32_t channel_id,
     uint64_t commit_num, watchtower_htlc_t *htlcs_out, size_t max_htlcs);
+
+/* v35 (#207 / dashboard team SCHEMA_GAPS): persist pre-built signed HTLC
+   sweep TX bytes per HTLC output on a revoked commitment.  Mirrors the
+   v25 penalty TX persistence pair.  Idempotent UPDATE.  Returns 1 on
+   success, 0 on DB error.  Safe to call with NULL/zero bytes — no-op. */
+int persist_save_old_commitment_htlc_sweep(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t htlc_vout,
+                                            const unsigned char *signed_sweep_tx,
+                                            size_t signed_sweep_tx_len);
+
+/* Load pre-built signed HTLC sweep TX bytes for a given (channel, commit,
+   htlc_vout).  *out_bytes is malloc()'d on success — caller must free().
+   Returns 1 if bytes loaded, 0 if row exists but column empty (degrade
+   to legacy lazy-build path), -1 on DB error or missing row. */
+int persist_load_old_commitment_htlc_sweep(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t htlc_vout,
+                                            unsigned char **out_bytes,
+                                            size_t *out_len);
 
 /* --- v30 (PR-PTLC-1): PTLC output metadata persistence ---
    Parallel to old_commitment_htlcs.  Stores PTLC outputs on revoked

--- a/src/persist.c
+++ b/src/persist.c
@@ -113,6 +113,11 @@ static const char *SCHEMA_SQL =
     "  direction INTEGER NOT NULL,"
     "  payment_hash TEXT NOT NULL,"
     "  cltv_expiry INTEGER NOT NULL,"
+    /* v35 (#207): pre-built signed HTLC sweep TX bytes (hex).  Persisted
+       at watch-registration time so the watchtower can broadcast HTLC
+       sweeps after a process restart or from a standalone WT reading the
+       same DB.  Default '' preserves legacy lazy-build fallback. */
+    "  signed_sweep_tx_hex TEXT NOT NULL DEFAULT '',"
     "  PRIMARY KEY (channel_id, commit_num, htlc_vout)"
     ");"
     /* v30 (PR-PTLC-1): parallel to old_commitment_htlcs for PTLC outputs.
@@ -1260,6 +1265,19 @@ int persist_open(persist_t *p, const char *path) {
             p->db = NULL;
             return 0;
         }
+    }
+
+    /* v35 (#207 / dashboard team SCHEMA_GAPS): pre-built signed HTLC sweep TX
+       bytes per HTLC output on a revoked commitment.  Mirrors the v25 pattern
+       for old_commitments.signed_penalty_tx_hex.  Persisted at registration
+       time in watchtower_watch_revoked_commitment so the watchtower can
+       broadcast HTLC sweeps after a process restart, and so a standalone
+       watchtower (reading the same DB) can defend without LSP state.
+       Default empty preserves legacy lazy-build fallback in watchtower_check. */
+    if (db_version < 35) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE old_commitment_htlcs ADD COLUMN signed_sweep_tx_hex TEXT NOT NULL DEFAULT '';",
+            NULL, NULL, NULL);
     }
 
     /* Record the current version if not already present */
@@ -3239,6 +3257,91 @@ size_t persist_load_old_commitment_htlcs(persist_t *p, uint32_t channel_id,
 
     sqlite3_finalize(stmt);
     return count;
+}
+
+/* --- v35 (#207): pre-built signed HTLC sweep TX bytes ---
+   Closes the same restart-loses-defense gap that v25 closed for the
+   to_local penalty TX, but per-HTLC.  Mirrors persist_save/load_
+   old_commitment_witness. */
+
+int persist_save_old_commitment_htlc_sweep(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t htlc_vout,
+                                            const unsigned char *signed_sweep_tx,
+                                            size_t signed_sweep_tx_len) {
+    if (!p || !p->db) return 0;
+    if (!signed_sweep_tx || signed_sweep_tx_len == 0) return 1;  /* no-op */
+
+    char *hex = malloc(signed_sweep_tx_len * 2 + 1);
+    if (!hex) return 0;
+    hex_encode(signed_sweep_tx, signed_sweep_tx_len, hex);
+
+    const char *sql =
+        "UPDATE old_commitment_htlcs SET signed_sweep_tx_hex = ? "
+        "WHERE channel_id = ? AND commit_num = ? AND htlc_vout = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        free(hex);
+        return 0;
+    }
+    sqlite3_bind_text(stmt, 1, hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, (int)channel_id);
+    sqlite3_bind_int64(stmt, 3, (sqlite3_int64)commit_num);
+    sqlite3_bind_int(stmt, 4, (int)htlc_vout);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    free(hex);
+    return ok;
+}
+
+int persist_load_old_commitment_htlc_sweep(persist_t *p, uint32_t channel_id,
+                                            uint64_t commit_num,
+                                            uint32_t htlc_vout,
+                                            unsigned char **out_bytes,
+                                            size_t *out_len) {
+    if (!p || !p->db || !out_bytes || !out_len) return -1;
+    *out_bytes = NULL;
+    *out_len = 0;
+
+    const char *sql =
+        "SELECT signed_sweep_tx_hex FROM old_commitment_htlcs "
+        "WHERE channel_id = ? AND commit_num = ? AND htlc_vout = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return -1;
+    sqlite3_bind_int(stmt, 1, (int)channel_id);
+    sqlite3_bind_int64(stmt, 2, (sqlite3_int64)commit_num);
+    sqlite3_bind_int(stmt, 3, (int)htlc_vout);
+
+    int result = -1;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *hex = (const char *)sqlite3_column_text(stmt, 0);
+        if (!hex || hex[0] == '\0') {
+            result = 0;  /* row exists, column empty — legacy/lazy fallback */
+        } else {
+            size_t hex_len = strlen(hex);
+            size_t byte_len = hex_len / 2;
+            unsigned char *bytes = malloc(byte_len);
+            if (!bytes) {
+                result = -1;
+            } else {
+                int decoded = hex_decode(hex, bytes, byte_len);
+                if (decoded > 0) {
+                    *out_bytes = bytes;
+                    *out_len = (size_t)decoded;
+                    result = 1;
+                } else {
+                    free(bytes);
+                    result = -1;
+                }
+            }
+        }
+    }
+    sqlite3_finalize(stmt);
+    return result;
 }
 
 /* --- v30 (PR-PTLC-1): PTLC output persistence (mirrors HTLC pair above) --- */

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -574,6 +574,63 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
                         persist_rollback(wt->db);
                 }
             }
+
+            /* v35 (#207): pre-build the signed HTLC sweep TX bytes at
+               registration time and persist them, mirroring the v25 pattern
+               for the to_local penalty TX above.  Closes the restart-loses-
+               HTLC-defense gap: after an LSP crash, watchtower_check no
+               longer needs live channel_t state to broadcast HTLC sweeps —
+               the bytes are durably on disk.  Also enables standalone-WT
+               operation (run superscalar_watchtower against the same DB).
+
+               channel_build_htlc_penalty_tx requires ch->htlcs[0] to carry
+               the HTLC metadata (direction, payment_hash, cltv_expiry) —
+               same shim watchtower_check uses on the lazy-build path. */
+            if (wt->db && wt->db->db && entry->n_htlc_outputs > 0 && ch) {
+                int use_anchor_h = fee_should_use_anchor(wt->fee);
+
+                /* Save + restore ch->htlcs[0] across the per-output build loop. */
+                size_t wt_saved_n = ch->n_htlcs;
+                htlc_t wt_saved_h0 = {0};
+                if (wt_saved_n > 0)
+                    wt_saved_h0 = ch->htlcs[0];
+
+                for (size_t h = 0; h < entry->n_htlc_outputs; h++) {
+                    watchtower_htlc_t *wh_h = &entry->htlc_outputs[h];
+
+                    /* Shim ch->htlcs[0] like the watchtower_check sweep loop. */
+                    ch->n_htlcs = 1;
+                    memset(&ch->htlcs[0], 0, sizeof(htlc_t));
+                    ch->htlcs[0].direction = wh_h->direction;
+                    memcpy(ch->htlcs[0].payment_hash, wh_h->payment_hash, 32);
+                    ch->htlcs[0].cltv_expiry = wh_h->cltv_expiry;
+                    ch->htlcs[0].state = HTLC_STATE_ACTIVE;
+
+                    tx_buf_t sweep;
+                    tx_buf_init(&sweep, 512);
+                    if (channel_build_htlc_penalty_tx(ch, &sweep,
+                            old_txid, wh_h->htlc_vout, wh_h->htlc_amount,
+                            wh_h->htlc_spk, 34, old_commit_num, 0,
+                            use_anchor_h ? wt->anchor_spk : NULL,
+                            use_anchor_h ? wt->anchor_spk_len : 0)) {
+                        persist_save_old_commitment_htlc_sweep(
+                            wt->db, channel_id, old_commit_num,
+                            wh_h->htlc_vout, sweep.data, sweep.len);
+                    } else {
+                        fprintf(stderr,
+                                "watchtower: failed to build HTLC sweep TX "
+                                "(vout %u) at registration time — restart "
+                                "defense will fall back to lazy build\n",
+                                wh_h->htlc_vout);
+                    }
+                    tx_buf_free(&sweep);
+                }
+
+                /* Restore ch->htlcs[0] / ch->n_htlcs. */
+                ch->n_htlcs = wt_saved_n;
+                if (wt_saved_n > 0)
+                    ch->htlcs[0] = wt_saved_h0;
+            }
         }
 
         /* SF-W-PTLC: parse PTLC outputs (vouts after HTLC outputs).  Without

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -261,7 +261,7 @@ int test_persist_schema_v3(void)
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 34, "schema version is 34 (v34 adds ceremonies/ceremony_participants/revocation_releases — #185)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 35, "schema version is 35 (v35 adds old_commitment_htlcs.signed_sweep_tx_hex — #207)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1194,6 +1194,7 @@ extern int test_ceremony_helpers_participant_upsert(void);
 extern int test_persist_ps_subfactory_chain_v22_poison_round_trip(void);
 extern int test_persist_ps_initial_signed_state_round_trip(void);
 extern int test_persist_old_commitment_witness_round_trip(void);
+extern int test_persist_old_commitment_htlc_sweep_round_trip(void);
 extern int test_persist_signing_rounds_round_trip(void);
 extern int test_persist_pending_fee_bump_round_trip(void);
 extern int test_persist_force_close_round_trip(void);
@@ -3031,6 +3032,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_ps_subfactory_chain_v22_poison_round_trip);
     RUN_TEST(test_persist_ps_initial_signed_state_round_trip);
     RUN_TEST(test_persist_old_commitment_witness_round_trip);
+    RUN_TEST(test_persist_old_commitment_htlc_sweep_round_trip);
     RUN_TEST(test_persist_signing_rounds_round_trip);
     RUN_TEST(test_persist_pending_fee_bump_round_trip);
     RUN_TEST(test_persist_force_close_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -3965,6 +3965,137 @@ int test_persist_old_commitment_witness_round_trip(void)
     return 1;
 }
 
+/* v35 (#207): per-output HTLC sweep TX persistence round-trip.
+   Verifies the new save/load pair, idempotency, and the load fallback
+   semantics that watchtower_check relies on (column-empty → 0; missing
+   row → -1; bytes present → 1). */
+int test_persist_old_commitment_htlc_sweep_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    /* Schema must be at least v35 to have the new column. */
+    TEST_ASSERT(persist_schema_version(&db) >= 35,
+                "schema version >= 35 (signed_sweep_tx_hex column present)");
+
+    uint32_t channel_id = 11;
+    uint64_t commit_num = 7;
+    unsigned char txid[32]; memset(txid, 0xAB, 32);
+    unsigned char to_local_spk[34]; memset(to_local_spk, 0xCD, 34);
+
+    /* Parent old_commitments row */
+    TEST_ASSERT(persist_save_old_commitment(&db, channel_id, commit_num,
+                                              txid, 0, 200000, to_local_spk, 34),
+                "save old_commitments parent row");
+
+    /* Two HTLC rows on the breached commitment. */
+    watchtower_htlc_t h0 = {0};
+    h0.htlc_vout = 2;
+    h0.htlc_amount = 12345;
+    memset(h0.htlc_spk, 0x11, 34);
+    h0.direction = HTLC_OFFERED;
+    memset(h0.payment_hash, 0x22, 32);
+    h0.cltv_expiry = 600000;
+
+    watchtower_htlc_t h1 = {0};
+    h1.htlc_vout = 3;
+    h1.htlc_amount = 67890;
+    memset(h1.htlc_spk, 0x33, 34);
+    h1.direction = HTLC_RECEIVED;
+    memset(h1.payment_hash, 0x44, 32);
+    h1.cltv_expiry = 600100;
+
+    TEST_ASSERT(persist_save_old_commitment_htlc(&db, channel_id, commit_num, &h0),
+                "save HTLC row 0");
+    TEST_ASSERT(persist_save_old_commitment_htlc(&db, channel_id, commit_num, &h1),
+                "save HTLC row 1");
+
+    /* Before any sweep persist: load returns 0 (column empty → legacy lazy). */
+    unsigned char *got = NULL;
+    size_t got_len = 0;
+    int rc = persist_load_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                     h0.htlc_vout, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 0, "empty sweep column returns 0 (legacy fallback)");
+    TEST_ASSERT(got == NULL, "empty load returns NULL bytes");
+
+    /* Save sweep bytes for vout 2 and vout 3. */
+    unsigned char sweep0[180];
+    for (size_t i = 0; i < sizeof(sweep0); i++) sweep0[i] = (unsigned char)(i * 3 + 1);
+    unsigned char sweep1[220];
+    for (size_t i = 0; i < sizeof(sweep1); i++) sweep1[i] = (unsigned char)(i * 5 + 9);
+
+    TEST_ASSERT(persist_save_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                        h0.htlc_vout,
+                                                        sweep0, sizeof(sweep0)),
+                "save sweep TX bytes for vout 2");
+    TEST_ASSERT(persist_save_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                        h1.htlc_vout,
+                                                        sweep1, sizeof(sweep1)),
+                "save sweep TX bytes for vout 3");
+
+    /* Round-trip vout 2. */
+    got = NULL; got_len = 0;
+    rc = persist_load_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                  h0.htlc_vout, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "load sweep TX bytes (vout 2)");
+    TEST_ASSERT_EQ(got_len, sizeof(sweep0), "loaded len matches saved (vout 2)");
+    TEST_ASSERT(memcmp(got, sweep0, sizeof(sweep0)) == 0,
+                "loaded bytes match saved (vout 2)");
+    free(got);
+
+    /* Round-trip vout 3 — separate per-output row */
+    got = NULL; got_len = 0;
+    rc = persist_load_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                  h1.htlc_vout, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "load sweep TX bytes (vout 3)");
+    TEST_ASSERT_EQ(got_len, sizeof(sweep1), "loaded len matches saved (vout 3)");
+    TEST_ASSERT(memcmp(got, sweep1, sizeof(sweep1)) == 0,
+                "loaded bytes match saved (vout 3)");
+    free(got);
+
+    /* Idempotent re-save replaces. */
+    unsigned char sweep0b[64];
+    memset(sweep0b, 0x77, sizeof(sweep0b));
+    TEST_ASSERT(persist_save_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                        h0.htlc_vout,
+                                                        sweep0b, sizeof(sweep0b)),
+                "re-save sweep TX bytes (vout 2)");
+    got = NULL; got_len = 0;
+    rc = persist_load_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                  h0.htlc_vout, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "reload after re-save");
+    TEST_ASSERT_EQ(got_len, sizeof(sweep0b), "re-saved len");
+    TEST_ASSERT(memcmp(got, sweep0b, sizeof(sweep0b)) == 0,
+                "re-saved bytes match");
+    free(got);
+
+    /* NULL/zero is a safe no-op. */
+    TEST_ASSERT(persist_save_old_commitment_htlc_sweep(&db, channel_id, commit_num,
+                                                        h0.htlc_vout, NULL, 0),
+                "save NULL is safe no-op (returns 1)");
+
+    /* Missing (channel, commit, vout) → -1. */
+    rc = persist_load_old_commitment_htlc_sweep(&db, 999, 999, 99, &got, &got_len);
+    TEST_ASSERT_EQ(rc, -1, "missing row returns -1");
+
+    /* Coverage query the dashboard team uses: COUNT(*), COUNT(col).
+       After save: count rows with non-empty sweep column. */
+    sqlite3_stmt *stmt = NULL;
+    int prepared = sqlite3_prepare_v2(db.db,
+        "SELECT COUNT(*), SUM(CASE WHEN signed_sweep_tx_hex != '' THEN 1 ELSE 0 END) "
+        "FROM old_commitment_htlcs;", -1, &stmt, NULL);
+    TEST_ASSERT_EQ(prepared, SQLITE_OK, "prepare dashboard coverage query");
+    TEST_ASSERT_EQ(sqlite3_step(stmt), SQLITE_ROW, "step coverage row");
+    int total_rows = sqlite3_column_int(stmt, 0);
+    int rows_with_sweep = sqlite3_column_int(stmt, 1);
+    sqlite3_finalize(stmt);
+    TEST_ASSERT_EQ(total_rows, 2, "two HTLC rows total");
+    TEST_ASSERT_EQ(rows_with_sweep, 2, "both rows have sweep_tx_hex populated");
+
+    persist_close(&db);
+    return 1;
+}
+
 /* v26 (C3) signing_rounds journal round-trip: start → done → sweep. */
 int test_persist_signing_rounds_round_trip(void)
 {


### PR DESCRIPTION
## Summary

- Schema bump **v34 → v35**: `ALTER TABLE old_commitment_htlcs ADD COLUMN signed_sweep_tx_hex TEXT NOT NULL DEFAULT ''`
- New persist API: `persist_save_old_commitment_htlc_sweep` + `persist_load_old_commitment_htlc_sweep` (mirrors the v25 `*_witness` pair)
- New write site in `watchtower_watch_revoked_commitment` (src/watchtower.c): at registration time we now also build the signed HTLC sweep TX bytes per output (via `channel_build_htlc_penalty_tx`, same call the lazy path uses inside `watchtower_check`) and persist them alongside the HTLC row
- New unit test `test_persist_old_commitment_htlc_sweep_round_trip` covering save/load idempotency, empty-column fallback (rc=0), missing row (rc=-1), and the dashboard team's coverage query (`COUNT(*) / SUM(non-empty)`)

This is the **HIGH-priority** dashboard team request from `LSP_TEAM_SCHEMA_GAPS_NOTE_2026-05-18.md`. Closes the restart-loses-defense gap for HTLC sweeps that v25 already closed for the to_local penalty TX.

## Why
1. **Restart survival** — LSP crashes between revoke and breach: HTLC sweep bytes already on disk; `watchtower_check` (after a future read-site change) won't need live `channel_t` to broadcast
2. **Standalone-WT readability** — `superscalar_watchtower` against the same DB can defend without LSP state
3. **Disaster recovery** — revocation secrets lost → still have signed bytes

The dashboard's existing coverage query auto-detects the new column (no dashboard PR needed).

## Compat
- Existing rows degrade to legacy lazy-build (column default '' → load returns 0 → caller falls through)
- `test_persist_schema_v3` bumped from 34 → 35
- Did NOT add the read-site optimization in `watchtower_check` yet (per task instructions — defer to follow-up PR)

## Test plan
- [x] Build clean (build-release, -Werror)
- [x] Unit suite: 1459/1459 passed (added 1 new test)
- [x] `test_regtest_ptlc_breach.sh`: PASS
- [x] `test_regtest_k2_subfactory_breach.sh`: PASS
- [x] `test_regtest_cheat_client.sh`: PASS
- [x] Verified schema v35 + new column present in fresh test DB

## Files changed
- `include/superscalar/persist.h` — schema bump, declarations
- `src/persist.c` — CREATE TABLE column, v34→v35 migration, save/load implementation
- `src/watchtower.c` — build + persist sweep TX in `watchtower_watch_revoked_commitment`
- `tests/test_persist.c` — new round-trip test
- `tests/test_main.c` — register new test
- `tests/test_bolt12.c` — bump `test_persist_schema_v3` assertion