### PR TITLE
fix(test): match new multi-input advance log format in multiprocess test

### DIFF
--- a/tools/test_multiprocess_subfactory_advance.sh
+++ b/tools/test_multiprocess_subfactory_advance.sh
@@ -310,9 +310,13 @@ echo "=== Verifying clients participated in sub-factory ceremony ==="
 PARTICIPATED=0
 for i in $(seq 0 $((N_CLIENTS - 1))); do
     LOG="$TMPDIR/client_${i}.log"
-    if grep -q "sub-factory.*advanced to chain_len" "$LOG" 2>/dev/null; then
+    # Match both legacy single-input ("advanced to chain_len") and the
+    # multi-input ceremony (#142 SF-A) which logs "advanced (MULTI) to
+    # chain_len".  Sub-factories with ps_chain_len>0 + n_prev_outputs>1
+    # use the multi-input MuSig fork added in PR #270.
+    if grep -qE "sub-factory.*advanced( \(MULTI\))? to chain_len" "$LOG" 2>/dev/null; then
         PARTICIPATED=$((PARTICIPATED + 1))
-        SA=$(grep "sub-factory.*advanced to chain_len" "$LOG" | head -1)
+        SA=$(grep -E "sub-factory.*advanced( \(MULTI\))? to chain_len" "$LOG" | head -1)
         echo "  client[$i]: participated — $SA"
     else
         echo "  client[$i]: no sub-factory advance marker (may be in different sub-factory)"


### PR DESCRIPTION
## Summary

PR #270 (multi-input MuSig ceremony for sub-factory chain advance, #142 SF-A)
adds a new client-side log line for sub-factories that use the multi-input
fork (ps_chain_len>0 + n_prev_outputs>1):

```
Client N: sub-factory L.S advanced (MULTI) to chain_len V (channel[I]+=X sats)
```

versus the legacy single-input format:

```
Client N: sub-factory L.S advanced to chain_len V (channel[I]+=X sats)
```

The participation grep in `tools/test_multiprocess_subfactory_advance.sh`
hard-codes the legacy substring `"sub-factory.*advanced to chain_len"` which
does not match the `(MULTI)` form. When PR #270 lands, every sub-factory
client appears as "no sub-factory advance marker" and the test fails with:

```
FAIL: expected >= 2 clients to participate (sub-factory 0 has 2 clients)
```

even though the LSP-side assertions ("chain extended", "PS K² SUB-FACTORY
TEST: PASS", "wire-ceremony poison TX signed") all pass.

## Fix

Widen the participation match to an extended regex that accepts an optional
` (MULTI)` token between `advanced` and `to chain_len`:

```
sub-factory.*advanced( \(MULTI\))? to chain_len
```

Both the legacy single-input path (`client.c:3107` on main, `:3389` on
the #270 branch) and the multi-input path (`client.c:3202` on the #270
branch) now count toward `PARTICIPATED`.

No `client.c` changes — both log lines are intentional (the `(MULTI)`
marker is operationally useful for distinguishing which ceremony actually
fired) and the test should cover whichever shape the sub-factory's
chain-advance takes.

## Test plan

- [x] Regtest end-to-end on the #270 branch worktree
      (`/root/SuperScalar-test270`, base = origin/feat-subfactory-multi-input-musig):
      multi-input ceremony fires (`advanced (MULTI) to chain_len 1`),
      both sub-factory 0 clients counted, test PASSes with
      `2 clients on sub-factory 0 logged completion (>= 2 required)`,
      exit 0.
- [x] Regtest end-to-end on origin/main (legacy path, no `(MULTI)`):
      legacy log format still matches via the optional group, both
      clients counted, test PASSes with the same final assertion, exit 0.

## Notes

- Single-commit PR off origin/main; forward-compatible (matches both
  legacy and multi-input formats) so order of merge with #270 is
  irrelevant.
- No new code paths added; pure test-script regex widening.