### PR TITLE
feat(persist): schema v36 — HTLC resolution + L-stock burn + agg hard guard (#208 #209 #219)

### DIFF
--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -14,7 +14,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 35
+#define PERSIST_SCHEMA_VERSION 36
 
 /* #185 / wallet-team CEREMONY_DESIGN.md §6.1:
    Ceremony state enum (column `ceremonies.state`).
@@ -533,6 +533,45 @@ int persist_load_old_commitment_htlc_sweep(persist_t *p, uint32_t channel_id,
                                             uint32_t htlc_vout,
                                             unsigned char **out_bytes,
                                             size_t *out_len);
+
+/* v36 (#208 / dashboard team SCHEMA_GAPS §2): persist pre-built signed HTLC
+   resolution TX bytes (timeout for OFFERED, success for RECEIVED).  Used
+   on the Path A force-close path after the LSP broadcasts its own commit.
+   Idempotent UPDATE on (channel_id, htlc_id).  Returns 1 on success, 0 on
+   DB error.  Safe to call with NULL/zero bytes — no-op. */
+int persist_save_htlc_resolution_tx(persist_t *p, uint32_t channel_id,
+                                     uint64_t htlc_id,
+                                     const unsigned char *signed_resolution_tx,
+                                     size_t signed_resolution_tx_len);
+
+/* Load pre-built signed HTLC resolution TX bytes for (channel, htlc_id).
+   *out_bytes is malloc()'d on success — caller must free().  Returns 1
+   if bytes loaded, 0 if row exists but column NULL/empty (legacy lazy
+   fallback), -1 on DB error or missing row. */
+int persist_load_htlc_resolution_tx(persist_t *p, uint32_t channel_id,
+                                     uint64_t htlc_id,
+                                     unsigned char **out_bytes,
+                                     size_t *out_len);
+
+/* v36 (#209 / dashboard team SCHEMA_GAPS §3): persist pre-built signed
+   L-stock burn TX bytes for a revoked commitment.  OP_RETURN destruction
+   of LSP L-stock — additional penalty layer beyond to_local + HTLC
+   sweeps.  Idempotent UPDATE on (channel_id, commit_num) — same row as
+   signed_penalty_tx_hex.  Returns 1 on success, 0 on DB error.  Safe to
+   call with NULL/zero bytes — no-op. */
+int persist_save_old_commitment_burn_tx(persist_t *p, uint32_t channel_id,
+                                         uint64_t commit_num,
+                                         const unsigned char *signed_burn_tx,
+                                         size_t signed_burn_tx_len);
+
+/* Load pre-built signed L-stock burn TX bytes for (channel, commit_num).
+   *out_bytes is malloc()'d on success — caller must free().  Returns 1
+   if bytes loaded, 0 if row exists but column NULL/empty (legacy lazy
+   fallback), -1 on DB error or missing row. */
+int persist_load_old_commitment_burn_tx(persist_t *p, uint32_t channel_id,
+                                         uint64_t commit_num,
+                                         unsigned char **out_bytes,
+                                         size_t *out_len);
 
 /* --- v30 (PR-PTLC-1): PTLC output metadata persistence ---
    Parallel to old_commitment_htlcs.  Stores PTLC outputs on revoked
@@ -1273,7 +1312,16 @@ int persist_update_ceremony_state(persist_t *p,
 
 /* Optional: attach aggregated_nonce when state transitions to
  * NONCES_AGGREGATED, or final_signature when transitioning to FINALIZED.
- * Either field can be NULL to leave unchanged.  Returns 1 on success. */
+ * Either field can be NULL to leave unchanged.  Returns 1 on success.
+ *
+ * #219 SF-AGG-HARD-GUARD (wallet team CEREMONY_COORD_REPLY_2 §2):
+ * when final_signature64_or_null is non-NULL, this function hard-
+ * checks that EVERY ceremony_participants row is at phase=SIGNED
+ * before persisting the aggregated signature.  Mirrors the FINALIZED
+ * state-transition guard.  Returns 0 (refusal) if any participant
+ * is in any other phase, with a fprintf(stderr) explaining why.
+ * Aggregated-nonce / broadcast-txid / abort-reason updates are not
+ * affected by the guard. */
 int persist_update_ceremony_artifacts(persist_t *p,
                                        const unsigned char *ceremony_id8,
                                        const unsigned char *aggregated_nonce66_or_null,

--- a/src/persist.c
+++ b/src/persist.c
@@ -78,6 +78,14 @@ static const char *SCHEMA_SQL =
     "  payment_preimage TEXT,"
     "  cltv_expiry INTEGER,"
     "  state TEXT NOT NULL,"
+    /* v36 (#208 / dashboard team SCHEMA_GAPS section 2): pre-built signed HTLC
+       resolution TX bytes (hex) - timeout for OFFERED, success for
+       RECEIVED.  Persisted at commitment-sign time so the LSP can
+       broadcast resolution TXs after a force-close + restart without
+       reconstructing from secrets.  NULL preserves legacy lazy-build
+       fallback.  BLOB column per dashboard team spec; we write hex
+       strings via the stamper helper (SQLite is type-flexible). */
+    "  signed_resolution_tx_hex BLOB,"
     "  UNIQUE(channel_id, htlc_id)"
     ");"
     "CREATE TABLE IF NOT EXISTS nonce_pools ("
@@ -102,6 +110,13 @@ static const char *SCHEMA_SQL =
        Lets the oracular CPFP path drive fee escalation without needing
        live channel state.  0 = unset (legacy entries) → caller falls back. */
     "  csv_delay INTEGER NOT NULL DEFAULT 0,"
+    /* v36 (#209 / dashboard team SCHEMA_GAPS section 3): pre-built signed L-stock
+       burn TX bytes (hex).  OP_RETURN destruction of LSP L-stock when a
+       revoked state is broadcast - an additional penalty layer beyond
+       the to_local + HTLC sweeps.  Persisted at the same registration
+       moment as signed_penalty_tx_hex; burn and penalty share source
+       data.  NULL preserves legacy lazy-build fallback. */
+    "  signed_burn_tx_hex BLOB,"
     "  PRIMARY KEY (channel_id, commit_num)"
     ");"
     "CREATE TABLE IF NOT EXISTS old_commitment_htlcs ("
@@ -1277,6 +1292,27 @@ int persist_open(persist_t *p, const char *path) {
     if (db_version < 35) {
         sqlite3_exec(p->db,
             "ALTER TABLE old_commitment_htlcs ADD COLUMN signed_sweep_tx_hex TEXT NOT NULL DEFAULT '';",
+            NULL, NULL, NULL);
+    }
+
+    /* v36 (#208 / #209, dashboard team SCHEMA_GAPS sections 2 & 3): two
+       parallel TX-bytes columns to close the same restart-loses-defense
+       gap that v25 (penalty TX) and v35 (HTLC sweep TX) already closed,
+       extended to the remaining two TX classes in the dashboard's
+       TX Inventory tab:
+         - #208 htlcs.signed_resolution_tx_hex: timeout/success TXs for
+           in-flight HTLCs on a force-closed (NOT breached) commitment.
+         - #209 old_commitments.signed_burn_tx_hex: OP_RETURN L-stock
+           burn TX on a breached commitment (additional penalty layer).
+       Both columns default NULL (BLOB) so the dashboard's coverage
+       query (COUNT(col) vs COUNT(*)) auto-detects population without
+       schema-fork awareness, and the lazy-build fallback survives. */
+    if (db_version < 36) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE htlcs ADD COLUMN signed_resolution_tx_hex BLOB;",
+            NULL, NULL, NULL);
+        sqlite3_exec(p->db,
+            "ALTER TABLE old_commitments ADD COLUMN signed_burn_tx_hex BLOB;",
             NULL, NULL, NULL);
     }
 
@@ -3336,6 +3372,181 @@ int persist_load_old_commitment_htlc_sweep(persist_t *p, uint32_t channel_id,
                 } else {
                     free(bytes);
                     result = -1;
+                }
+            }
+        }
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+/* --- v36 (#208): pre-built signed HTLC resolution TX bytes ---
+   Path A force-close path - timeout TX for OFFERED HTLCs, success TX
+   for RECEIVED HTLCs (broadcast with preimage if available).  Persisted
+   at commitment-sign time so the LSP can broadcast after force-close +
+   process restart without reconstructing from secrets.  Identified by
+   the per-channel (channel_id, htlc_id) UNIQUE pair, same key the rest
+   of the htlcs table uses.  Mirrors the v35 sweep stamper. */
+
+int persist_save_htlc_resolution_tx(persist_t *p, uint32_t channel_id,
+                                     uint64_t htlc_id,
+                                     const unsigned char *signed_resolution_tx,
+                                     size_t signed_resolution_tx_len) {
+    if (!p || !p->db) return 0;
+    if (!signed_resolution_tx || signed_resolution_tx_len == 0) return 1;
+
+    char *hex = malloc(signed_resolution_tx_len * 2 + 1);
+    if (!hex) return 0;
+    hex_encode(signed_resolution_tx, signed_resolution_tx_len, hex);
+
+    const char *sql =
+        "UPDATE htlcs SET signed_resolution_tx_hex = ? "
+        "WHERE channel_id = ? AND htlc_id = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        free(hex);
+        return 0;
+    }
+    sqlite3_bind_text(stmt, 1, hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, (int)channel_id);
+    sqlite3_bind_int64(stmt, 3, (sqlite3_int64)htlc_id);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    free(hex);
+    return ok;
+}
+
+int persist_load_htlc_resolution_tx(persist_t *p, uint32_t channel_id,
+                                     uint64_t htlc_id,
+                                     unsigned char **out_bytes,
+                                     size_t *out_len) {
+    if (!p || !p->db || !out_bytes || !out_len) return -1;
+    *out_bytes = NULL;
+    *out_len = 0;
+
+    const char *sql =
+        "SELECT signed_resolution_tx_hex FROM htlcs "
+        "WHERE channel_id = ? AND htlc_id = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return -1;
+    sqlite3_bind_int(stmt, 1, (int)channel_id);
+    sqlite3_bind_int64(stmt, 2, (sqlite3_int64)htlc_id);
+
+    int result = -1;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        if (sqlite3_column_type(stmt, 0) == SQLITE_NULL) {
+            result = 0;
+        } else {
+            const char *hex = (const char *)sqlite3_column_text(stmt, 0);
+            if (!hex || hex[0] == 0) {
+                result = 0;
+            } else {
+                size_t hex_len = strlen(hex);
+                size_t byte_len = hex_len / 2;
+                unsigned char *bytes = malloc(byte_len);
+                if (!bytes) {
+                    result = -1;
+                } else {
+                    int decoded = hex_decode(hex, bytes, byte_len);
+                    if (decoded > 0) {
+                        *out_bytes = bytes;
+                        *out_len = (size_t)decoded;
+                        result = 1;
+                    } else {
+                        free(bytes);
+                        result = -1;
+                    }
+                }
+            }
+        }
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+/* --- v36 (#209): pre-built signed L-stock burn TX bytes ---
+   SuperScalar-specific defense - OP_RETURN destruction of LSP L-stock
+   when a revoked state is broadcast, as an additional penalty layer
+   beyond the to_local + HTLC sweeps.  Burn and penalty share the
+   source data and registration moment; this stamper mirrors the
+   v25 penalty TX persistence on the same row. */
+
+int persist_save_old_commitment_burn_tx(persist_t *p, uint32_t channel_id,
+                                         uint64_t commit_num,
+                                         const unsigned char *signed_burn_tx,
+                                         size_t signed_burn_tx_len) {
+    if (!p || !p->db) return 0;
+    if (!signed_burn_tx || signed_burn_tx_len == 0) return 1;
+
+    char *hex = malloc(signed_burn_tx_len * 2 + 1);
+    if (!hex) return 0;
+    hex_encode(signed_burn_tx, signed_burn_tx_len, hex);
+
+    const char *sql =
+        "UPDATE old_commitments SET signed_burn_tx_hex = ? "
+        "WHERE channel_id = ? AND commit_num = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        free(hex);
+        return 0;
+    }
+    sqlite3_bind_text(stmt, 1, hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, (int)channel_id);
+    sqlite3_bind_int64(stmt, 3, (sqlite3_int64)commit_num);
+
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    free(hex);
+    return ok;
+}
+
+int persist_load_old_commitment_burn_tx(persist_t *p, uint32_t channel_id,
+                                         uint64_t commit_num,
+                                         unsigned char **out_bytes,
+                                         size_t *out_len) {
+    if (!p || !p->db || !out_bytes || !out_len) return -1;
+    *out_bytes = NULL;
+    *out_len = 0;
+
+    const char *sql =
+        "SELECT signed_burn_tx_hex FROM old_commitments "
+        "WHERE channel_id = ? AND commit_num = ?;";
+
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return -1;
+    sqlite3_bind_int(stmt, 1, (int)channel_id);
+    sqlite3_bind_int64(stmt, 2, (sqlite3_int64)commit_num);
+
+    int result = -1;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        if (sqlite3_column_type(stmt, 0) == SQLITE_NULL) {
+            result = 0;
+        } else {
+            const char *hex = (const char *)sqlite3_column_text(stmt, 0);
+            if (!hex || hex[0] == 0) {
+                result = 0;
+            } else {
+                size_t hex_len = strlen(hex);
+                size_t byte_len = hex_len / 2;
+                unsigned char *bytes = malloc(byte_len);
+                if (!bytes) {
+                    result = -1;
+                } else {
+                    int decoded = hex_decode(hex, bytes, byte_len);
+                    if (decoded > 0) {
+                        *out_bytes = bytes;
+                        *out_len = (size_t)decoded;
+                        result = 1;
+                    } else {
+                        free(bytes);
+                        result = -1;
+                    }
                 }
             }
         }
@@ -6605,6 +6816,42 @@ int persist_update_ceremony_artifacts(persist_t *p,
                                        const unsigned char *broadcast_txid32_or_null,
                                        int has_abort_reason, uint8_t abort_reason) {
     if (!p || !p->db || !ceremony_id8) return 0;
+
+    /* #219 (SF-AGG-HARD-GUARD, wallet team CEREMONY_COORD_REPLY_2 §2):
+       hard-check that every participant is at phase=SIGNED before we
+       persist the aggregated final_signature.  Mirrors the FINALIZED
+       state-transition guard in persist_update_ceremony_state (#185).
+       Catches the dual-signature trap window where a crash between the
+       last partial-sig collection and the participant-phase persist
+       could otherwise let the plugin re-ask a participant to sign a
+       different TX for the same epoch boundary.  Refuses + logs.
+       Other artifact updates (aggregated_nonce, broadcast_txid,
+       abort_reason) are unaffected by the guard. */
+    if (final_signature64_or_null) {
+        const char *gsql =
+            "SELECT COUNT(*) FROM ceremony_participants "
+            "WHERE ceremony_id = ? AND phase != ?;";
+        sqlite3_stmt *gst;
+        if (sqlite3_prepare_v2(p->db, gsql, -1, &gst, NULL) != SQLITE_OK)
+            return 0;
+        sqlite3_bind_blob(gst, 1, ceremony_id8, 8, SQLITE_STATIC);
+        sqlite3_bind_int(gst, 2, PERSIST_CEREMONY_PHASE_SIGNED);
+        int unsigned_count = -1;
+        if (sqlite3_step(gst) == SQLITE_ROW)
+            unsigned_count = sqlite3_column_int(gst, 0);
+        sqlite3_finalize(gst);
+        if (unsigned_count < 0) return 0;
+        if (unsigned_count > 0) {
+            fprintf(stderr,
+                "persist_update_ceremony_artifacts: REFUSING final_signature "
+                "write for ceremony %02x%02x%02x..%02x — %d participant(s) "
+                "not yet phase=SIGNED (dual-signature trap guard, #219).\n",
+                ceremony_id8[0], ceremony_id8[1], ceremony_id8[2],
+                ceremony_id8[7], unsigned_count);
+            return 0;
+        }
+    }
+
     /* Build dynamic UPDATE — only set the columns whose args were provided. */
     char sql[256] = "UPDATE ceremonies SET ";
     int sep = 0;

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -261,7 +261,7 @@ int test_persist_schema_v3(void)
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 35, "schema version is 35 (v35 adds old_commitment_htlcs.signed_sweep_tx_hex — #207)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 36, "schema version is 36 (v36 adds htlcs.signed_resolution_tx_hex + old_commitments.signed_burn_tx_hex + #219 agg hard guard)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1191,10 +1191,13 @@ extern int test_ceremony_helpers_scan_by_factory(void);
 extern int test_ceremony_helpers_revocations(void);
 extern int test_ceremony_helpers_scan_in_flight(void);
 extern int test_ceremony_helpers_participant_upsert(void);
+extern int test_ceremony_helpers_aggregate_hard_guard(void);  /* #219 */
 extern int test_persist_ps_subfactory_chain_v22_poison_round_trip(void);
 extern int test_persist_ps_initial_signed_state_round_trip(void);
 extern int test_persist_old_commitment_witness_round_trip(void);
 extern int test_persist_old_commitment_htlc_sweep_round_trip(void);
+extern int test_persist_htlc_resolution_tx_round_trip(void);          /* #208 */
+extern int test_persist_old_commitment_burn_tx_round_trip(void);      /* #209 */
 extern int test_persist_signing_rounds_round_trip(void);
 extern int test_persist_pending_fee_bump_round_trip(void);
 extern int test_persist_force_close_round_trip(void);
@@ -3029,10 +3032,13 @@ static void run_unit_tests(void) {
     RUN_TEST(test_ceremony_helpers_revocations);
     RUN_TEST(test_ceremony_helpers_scan_in_flight);
     RUN_TEST(test_ceremony_helpers_participant_upsert);
+    RUN_TEST(test_ceremony_helpers_aggregate_hard_guard);   /* #219 SF-AGG-HARD-GUARD */
     RUN_TEST(test_persist_ps_subfactory_chain_v22_poison_round_trip);
     RUN_TEST(test_persist_ps_initial_signed_state_round_trip);
     RUN_TEST(test_persist_old_commitment_witness_round_trip);
     RUN_TEST(test_persist_old_commitment_htlc_sweep_round_trip);
+    RUN_TEST(test_persist_htlc_resolution_tx_round_trip);      /* #208 SF-SCHEMA-HTLC-RESOLUTION */
+    RUN_TEST(test_persist_old_commitment_burn_tx_round_trip);  /* #209 SF-SCHEMA-LSTOCK-BURN */
     RUN_TEST(test_persist_signing_rounds_round_trip);
     RUN_TEST(test_persist_pending_fee_bump_round_trip);
     RUN_TEST(test_persist_force_close_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -4096,6 +4096,210 @@ int test_persist_old_commitment_htlc_sweep_round_trip(void)
     return 1;
 }
 
+/* CH_T12 (#208 / SF-SCHEMA-HTLC-RESOLUTION): persist_save_htlc_resolution_tx
+   + persist_load_htlc_resolution_tx round-trip.  Verifies schema v36 column
+   present, idempotent UPDATE, NULL/empty fallback semantics, and the
+   dashboard's coverage query auto-detects population. */
+int test_persist_htlc_resolution_tx_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    TEST_ASSERT(persist_schema_version(&db) >= 36,
+                "schema version >= 36 (signed_resolution_tx_hex column present)");
+
+    uint32_t channel_id = 12;
+    htlc_t h0 = {0};
+    h0.id = 1001;
+    h0.direction = HTLC_OFFERED;
+    h0.amount_sats = 50000;
+    memset(h0.payment_hash, 0x55, 32);
+    memset(h0.payment_preimage, 0x66, 32);
+    h0.cltv_expiry = 700000;
+    h0.state = HTLC_STATE_ACTIVE;
+    h0.fee_at_add = 100;
+
+    htlc_t h1 = {0};
+    h1.id = 1002;
+    h1.direction = HTLC_RECEIVED;
+    h1.amount_sats = 75000;
+    memset(h1.payment_hash, 0x77, 32);
+    h1.cltv_expiry = 700100;
+    h1.state = HTLC_STATE_ACTIVE;
+    h1.fee_at_add = 100;
+
+    TEST_ASSERT(persist_save_htlc(&db, channel_id, &h0), "save HTLC 0");
+    TEST_ASSERT(persist_save_htlc(&db, channel_id, &h1), "save HTLC 1");
+
+    unsigned char *got = NULL;
+    size_t got_len = 0;
+    int rc = persist_load_htlc_resolution_tx(&db, channel_id, h0.id, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 0, "NULL resolution column returns 0");
+    TEST_ASSERT(got == NULL, "empty load returns NULL bytes");
+
+    unsigned char resolve0[150];
+    for (size_t i = 0; i < sizeof(resolve0); i++) resolve0[i] = (unsigned char)(i * 7 + 13);
+    unsigned char resolve1[210];
+    for (size_t i = 0; i < sizeof(resolve1); i++) resolve1[i] = (unsigned char)(i * 11 + 5);
+
+    TEST_ASSERT(persist_save_htlc_resolution_tx(&db, channel_id, h0.id,
+                                                  resolve0, sizeof(resolve0)),
+                "save resolution TX bytes for HTLC 0");
+    TEST_ASSERT(persist_save_htlc_resolution_tx(&db, channel_id, h1.id,
+                                                  resolve1, sizeof(resolve1)),
+                "save resolution TX bytes for HTLC 1");
+
+    got = NULL; got_len = 0;
+    rc = persist_load_htlc_resolution_tx(&db, channel_id, h0.id, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "load resolution TX bytes (HTLC 0)");
+    TEST_ASSERT_EQ(got_len, sizeof(resolve0), "loaded len matches saved (HTLC 0)");
+    TEST_ASSERT(memcmp(got, resolve0, sizeof(resolve0)) == 0,
+                "loaded bytes match saved (HTLC 0)");
+    free(got);
+
+    got = NULL; got_len = 0;
+    rc = persist_load_htlc_resolution_tx(&db, channel_id, h1.id, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "load resolution TX bytes (HTLC 1)");
+    TEST_ASSERT_EQ(got_len, sizeof(resolve1), "loaded len matches saved (HTLC 1)");
+    TEST_ASSERT(memcmp(got, resolve1, sizeof(resolve1)) == 0,
+                "loaded bytes match saved (HTLC 1)");
+    free(got);
+
+    unsigned char resolve0b[80];
+    memset(resolve0b, 0x88, sizeof(resolve0b));
+    TEST_ASSERT(persist_save_htlc_resolution_tx(&db, channel_id, h0.id,
+                                                  resolve0b, sizeof(resolve0b)),
+                "re-save resolution TX bytes (HTLC 0)");
+    got = NULL; got_len = 0;
+    rc = persist_load_htlc_resolution_tx(&db, channel_id, h0.id, &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "reload after re-save");
+    TEST_ASSERT_EQ(got_len, sizeof(resolve0b), "re-saved len");
+    TEST_ASSERT(memcmp(got, resolve0b, sizeof(resolve0b)) == 0,
+                "re-saved bytes match");
+    free(got);
+
+    TEST_ASSERT(persist_save_htlc_resolution_tx(&db, channel_id, h0.id, NULL, 0),
+                "save NULL is safe no-op (returns 1)");
+
+    rc = persist_load_htlc_resolution_tx(&db, 999, 99999, &got, &got_len);
+    TEST_ASSERT_EQ(rc, -1, "missing row returns -1");
+
+    sqlite3_stmt *stmt = NULL;
+    int prepared = sqlite3_prepare_v2(db.db,
+        "SELECT COUNT(*), COUNT(signed_resolution_tx_hex) FROM htlcs;",
+        -1, &stmt, NULL);
+    TEST_ASSERT_EQ(prepared, SQLITE_OK, "prepare dashboard coverage query");
+    TEST_ASSERT_EQ(sqlite3_step(stmt), SQLITE_ROW, "step coverage row");
+    int total_rows = sqlite3_column_int(stmt, 0);
+    int rows_with_resolution = sqlite3_column_int(stmt, 1);
+    sqlite3_finalize(stmt);
+    TEST_ASSERT_EQ(total_rows, 2, "two HTLC rows total");
+    TEST_ASSERT_EQ(rows_with_resolution, 2, "both rows have resolution_tx_hex populated");
+
+    persist_close(&db);
+    return 1;
+}
+
+/* CH_T13 (#209 / SF-SCHEMA-LSTOCK-BURN): persist_save_old_commitment_burn_tx
+   + persist_load_old_commitment_burn_tx round-trip.  Verifies schema v36
+   column present, idempotent UPDATE, NULL/empty fallback semantics, and
+   dashboard coverage auto-detection. */
+int test_persist_old_commitment_burn_tx_round_trip(void)
+{
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open in-memory DB");
+
+    TEST_ASSERT(persist_schema_version(&db) >= 36,
+                "schema version >= 36 (signed_burn_tx_hex column present)");
+
+    uint32_t channel_id = 13;
+    uint64_t commit_num_a = 5;
+    uint64_t commit_num_b = 6;
+    unsigned char txid_a[32]; memset(txid_a, 0xAA, 32);
+    unsigned char txid_b[32]; memset(txid_b, 0xBB, 32);
+    unsigned char to_local_spk[34]; memset(to_local_spk, 0xCC, 34);
+
+    TEST_ASSERT(persist_save_old_commitment(&db, channel_id, commit_num_a,
+                                              txid_a, 0, 300000, to_local_spk, 34),
+                "save old_commitments row A");
+    TEST_ASSERT(persist_save_old_commitment(&db, channel_id, commit_num_b,
+                                              txid_b, 0, 400000, to_local_spk, 34),
+                "save old_commitments row B");
+
+    unsigned char *got = NULL;
+    size_t got_len = 0;
+    int rc = persist_load_old_commitment_burn_tx(&db, channel_id, commit_num_a,
+                                                   &got, &got_len);
+    TEST_ASSERT_EQ(rc, 0, "NULL burn column returns 0 (legacy fallback)");
+    TEST_ASSERT(got == NULL, "empty load returns NULL bytes");
+
+    unsigned char burn_a[120];
+    for (size_t i = 0; i < sizeof(burn_a); i++) burn_a[i] = (unsigned char)(i * 2 + 3);
+    unsigned char burn_b[160];
+    for (size_t i = 0; i < sizeof(burn_b); i++) burn_b[i] = (unsigned char)(i * 4 + 7);
+
+    TEST_ASSERT(persist_save_old_commitment_burn_tx(&db, channel_id, commit_num_a,
+                                                      burn_a, sizeof(burn_a)),
+                "save burn TX bytes for commit A");
+    TEST_ASSERT(persist_save_old_commitment_burn_tx(&db, channel_id, commit_num_b,
+                                                      burn_b, sizeof(burn_b)),
+                "save burn TX bytes for commit B");
+
+    got = NULL; got_len = 0;
+    rc = persist_load_old_commitment_burn_tx(&db, channel_id, commit_num_a,
+                                               &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "load burn TX bytes (commit A)");
+    TEST_ASSERT_EQ(got_len, sizeof(burn_a), "loaded len matches saved (commit A)");
+    TEST_ASSERT(memcmp(got, burn_a, sizeof(burn_a)) == 0,
+                "loaded bytes match saved (commit A)");
+    free(got);
+
+    got = NULL; got_len = 0;
+    rc = persist_load_old_commitment_burn_tx(&db, channel_id, commit_num_b,
+                                               &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "load burn TX bytes (commit B)");
+    TEST_ASSERT_EQ(got_len, sizeof(burn_b), "loaded len matches saved (commit B)");
+    TEST_ASSERT(memcmp(got, burn_b, sizeof(burn_b)) == 0,
+                "loaded bytes match saved (commit B)");
+    free(got);
+
+    unsigned char burn_a2[60];
+    memset(burn_a2, 0x99, sizeof(burn_a2));
+    TEST_ASSERT(persist_save_old_commitment_burn_tx(&db, channel_id, commit_num_a,
+                                                      burn_a2, sizeof(burn_a2)),
+                "re-save burn TX bytes (commit A)");
+    got = NULL; got_len = 0;
+    rc = persist_load_old_commitment_burn_tx(&db, channel_id, commit_num_a,
+                                               &got, &got_len);
+    TEST_ASSERT_EQ(rc, 1, "reload after re-save");
+    TEST_ASSERT_EQ(got_len, sizeof(burn_a2), "re-saved len");
+    TEST_ASSERT(memcmp(got, burn_a2, sizeof(burn_a2)) == 0,
+                "re-saved bytes match");
+    free(got);
+
+    TEST_ASSERT(persist_save_old_commitment_burn_tx(&db, channel_id, commit_num_a,
+                                                      NULL, 0),
+                "save NULL is safe no-op (returns 1)");
+
+    rc = persist_load_old_commitment_burn_tx(&db, 999, 999, &got, &got_len);
+    TEST_ASSERT_EQ(rc, -1, "missing row returns -1");
+
+    sqlite3_stmt *stmt = NULL;
+    int prepared = sqlite3_prepare_v2(db.db,
+        "SELECT COUNT(*), COUNT(signed_burn_tx_hex) FROM old_commitments;",
+        -1, &stmt, NULL);
+    TEST_ASSERT_EQ(prepared, SQLITE_OK, "prepare dashboard coverage query");
+    TEST_ASSERT_EQ(sqlite3_step(stmt), SQLITE_ROW, "step coverage row");
+    int total_rows = sqlite3_column_int(stmt, 0);
+    int rows_with_burn = sqlite3_column_int(stmt, 1);
+    sqlite3_finalize(stmt);
+    TEST_ASSERT_EQ(total_rows, 2, "two old_commitment rows total");
+    TEST_ASSERT_EQ(rows_with_burn, 2, "both rows have burn_tx_hex populated");
+
+    persist_close(&db);
+    return 1;
+}
+
 /* v26 (C3) signing_rounds journal round-trip: start → done → sweep. */
 int test_persist_signing_rounds_round_trip(void)
 {
@@ -4734,6 +4938,84 @@ int test_ceremony_helpers_participant_upsert(void) {
     int n = 0;
     persist_scan_participants(&db, cid, 0xFF, ch_test_count_p_cb, &n);
     TEST_ASSERT(n == 1, "single row after 3 upserts");
+    persist_close(&db);
+    return 1;
+}
+
+/* CH_T14 (#219 / SF-AGG-HARD-GUARD, wallet team CEREMONY_COORD_REPLY_2 §2):
+   persist_update_ceremony_artifacts(final_signature=X) REFUSES when any
+   ceremony_participants row has phase != SIGNED.  Mirrors CH_T3 (the
+   FINALIZED state-transition guard).  Other artifact updates (aggregated
+   nonce, broadcast_txid, abort_reason) are unaffected by the guard. */
+int test_ceremony_helpers_aggregate_hard_guard(void) {
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, ":memory:"), "open");
+    unsigned char cid[8]; memset(cid, 0xD1, 8);
+    unsigned char fid[32]; memset(fid, 0xD2, 32);
+    persist_save_ceremony(&db, cid, fid, PERSIST_CEREMONY_TYPE_INITIAL,
+                           NULL, 1, 100);
+
+    /* Two participants - one SIGNED, one only NONCED. */
+    unsigned char p1[33]; memset(p1, 0x01, 33);
+    unsigned char p2[33]; memset(p2, 0x02, 33);
+    persist_save_participant_phase(&db, cid, p1,
+                                    PERSIST_CEREMONY_PHASE_SIGNED,
+                                    NULL, NULL, 0, 0);
+    persist_save_participant_phase(&db, cid, p2,
+                                    PERSIST_CEREMONY_PHASE_NONCED,
+                                    NULL, NULL, 0, 0);
+
+    /* Attempt to persist a final_signature -> MUST refuse. */
+    unsigned char final_sig[64]; memset(final_sig, 0xAB, 64);
+    int rc = persist_update_ceremony_artifacts(&db, cid,
+                                                NULL,       /* nonce */
+                                                final_sig,  /* GUARDED */
+                                                NULL,       /* broadcast_txid */
+                                                0, 0);      /* abort_reason */
+    TEST_ASSERT(rc == 0, "final_signature persist refused when one participant !=SIGNED");
+
+    /* Verify final_signature was NOT written. */
+    sqlite3_stmt *stmt = NULL;
+    TEST_ASSERT(sqlite3_prepare_v2(db.db,
+        "SELECT final_signature FROM ceremonies WHERE ceremony_id = ?;",
+        -1, &stmt, NULL) == SQLITE_OK, "prepare check");
+    sqlite3_bind_blob(stmt, 1, cid, 8, SQLITE_STATIC);
+    TEST_ASSERT(sqlite3_step(stmt) == SQLITE_ROW, "row exists");
+    TEST_ASSERT(sqlite3_column_type(stmt, 0) == SQLITE_NULL,
+                "final_signature still NULL (guard rejected write)");
+    sqlite3_finalize(stmt);
+
+    /* Aggregated_nonce update without final_signature should succeed. */
+    unsigned char agg_nonce[66]; memset(agg_nonce, 0x7F, 66);
+    rc = persist_update_ceremony_artifacts(&db, cid,
+                                            agg_nonce,
+                                            NULL,
+                                            NULL,
+                                            0, 0);
+    TEST_ASSERT(rc == 1, "nonce-only artifact update bypasses guard");
+
+    /* Promote p2 to SIGNED -> final_signature write should succeed. */
+    persist_save_participant_phase(&db, cid, p2,
+                                    PERSIST_CEREMONY_PHASE_SIGNED,
+                                    NULL, NULL, 0, 0);
+    rc = persist_update_ceremony_artifacts(&db, cid,
+                                            NULL,
+                                            final_sig,
+                                            NULL,
+                                            0, 0);
+    TEST_ASSERT(rc == 1, "final_signature persists when all participants SIGNED");
+
+    /* Verify it was actually written. */
+    TEST_ASSERT(sqlite3_prepare_v2(db.db,
+        "SELECT final_signature FROM ceremonies WHERE ceremony_id = ?;",
+        -1, &stmt, NULL) == SQLITE_OK, "prepare verify");
+    sqlite3_bind_blob(stmt, 1, cid, 8, SQLITE_STATIC);
+    TEST_ASSERT(sqlite3_step(stmt) == SQLITE_ROW, "row exists post-write");
+    TEST_ASSERT(sqlite3_column_bytes(stmt, 0) == 64, "final_signature 64 bytes");
+    TEST_ASSERT(memcmp(sqlite3_column_blob(stmt, 0), final_sig, 64) == 0,
+                "final_signature bytes match");
+    sqlite3_finalize(stmt);
+
     persist_close(&db);
     return 1;
 }


### PR DESCRIPTION
## Summary

Single combined schema bump v35 → v36 covering three independent persist additions that all touch `src/persist.c`, so combining them avoids serial schema-version conflicts. Pattern follows PR #271 (v35, signed_sweep_tx_hex).

### #208 SF-SCHEMA-HTLC-RESOLUTION (MEDIUM, dashboard team)
- `ALTER TABLE htlcs ADD COLUMN signed_resolution_tx_hex BLOB`
- New stamper/loader pair: `persist_save_htlc_resolution_tx` / `persist_load_htlc_resolution_tx`
- For Path A force-close: timeout TX for OFFERED HTLCs, success TX for RECEIVED
- Build site left for a follow-up (commitment-sign time); column stays NULL until then. Dashboard's coverage query auto-detects via `COUNT(col)`.

### #209 SF-SCHEMA-LSTOCK-BURN (LOW, dashboard team)
- `ALTER TABLE old_commitments ADD COLUMN signed_burn_tx_hex BLOB`
- New stamper/loader pair: `persist_save_old_commitment_burn_tx` / `persist_load_old_commitment_burn_tx`
- OP_RETURN L-stock destruction TX, parallel to `signed_penalty_tx_hex` (v25)
- Same registration moment as the penalty TX; build site is a follow-up.

### #219 SF-AGG-HARD-GUARD (wallet team CEREMONY_COORD_REPLY_2 §2)
- `persist_update_ceremony_artifacts(final_signature=X)` now hard-checks that every `ceremony_participants` row is at `phase=SIGNED` before persisting the aggregated signature
- Mirrors the FINALIZED state-transition guard (PR #185) — catches the dual-signature trap window
- Other artifact updates (aggregated_nonce, broadcast_txid, abort_reason) are unaffected

## New unit tests

| Test | Issue | Description |
| --- | --- | --- |
| `CH_T12 test_persist_htlc_resolution_tx_round_trip` | #208 | save + load roundtrip, idempotent re-save, NULL fallback, missing row, dashboard coverage query |
| `CH_T13 test_persist_old_commitment_burn_tx_round_trip` | #209 | save + load roundtrip, idempotent re-save, NULL fallback, missing row, dashboard coverage query |
| `CH_T14 test_ceremony_helpers_aggregate_hard_guard` | #219 | mirrors CH_T3 — guard refuses final_sig write when any participant phase != SIGNED, allows nonce-only update, succeeds after promotion to SIGNED |

## Test plan

- [x] `make -j` clean build (Release, no ASan per memory rule)
- [x] `./test_superscalar --unit` — 1462/1462 passing (existing 1459 + 3 new)
- [x] `tools/test_regtest_dual_factory.sh build-release-schema` — PASS

## References

- Dashboard team note: `C:\pirq\dashboard-upgrade\LSP_TEAM_SCHEMA_GAPS_NOTE_2026-05-18.md` §2 (#208) and §3 (#209)
- Wallet team note: `C:\pirq\superscalar-blip56-soupwallet\wallet\docs\CEREMONY_COORD_REPLY_2.md` §2 (#219)
- Established schema-extension pattern: PR #271 (v35 signed_sweep_tx_hex, dashboard SCHEMA_GAPS §1)
- Established FINALIZED guard pattern: PR #185 (`persist_update_ceremony_state`)

## What this is NOT

- No build-site wiring for resolution_tx / burn_tx — columns stay NULL until follow-up PRs wire the build sites (commitment-sign for #208, watchtower-watch for #209). Dashboard's coverage query handles this gracefully.
- No live behaviour change for #208/#209 — these are pure schema + persist API additions.
- For #219, this is a defensive library-boundary check that turns the previously-documented soft invariant into a hard enforcement. The wallet team's note explicitly recommended "hard" enforcement; this matches.