### PR TITLE
fix(testnet4): self-respawn runner scripts under setsid for session detachment

### DIFF
--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Self-respawn in own session so systemd-logind cleanup on SSH session end
+# doesn't kill us mid-run (lesson from 2026-05-18 dual #112/#189 deaths).
+# Skip if already respawned or if running interactively (stdin is a tty).
+if [ -z "${_SS_TESTNET4_DETACHED:-}" ] && [ ! -t 0 ]; then
+    export _SS_TESTNET4_DETACHED=1
+    exec setsid "$0" "$@"
+fi
+
 # test_testnet4_n64_ps_lifecycle.sh — N=64 PS factory full lifecycle on
 # testnet4.
 #

--- a/tools/test_testnet4_passive_reorg_observer.sh
+++ b/tools/test_testnet4_passive_reorg_observer.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Self-respawn in own session so systemd-logind cleanup on SSH session end
+# doesn't kill us mid-run (lesson from 2026-05-18 dual #112/#189 deaths).
+# Skip if already respawned or if running interactively (stdin is a tty).
+if [ -z "${_SS_TESTNET4_DETACHED:-}" ] && [ ! -t 0 ]; then
+    export _SS_TESTNET4_DETACHED=1
+    exec setsid "$0" "$@"
+fi
+
 # test_testnet4_passive_reorg_observer.sh — long-running passive observer
 # that records any natural testnet4 reorg the standalone watchtower
 # detects.

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Self-respawn in own session so systemd-logind cleanup on SSH session end
+# doesn't kill us mid-run (lesson from 2026-05-18 dual #112/#189 deaths).
+# Skip if already respawned or if running interactively (stdin is a tty).
+if [ -z "${_SS_TESTNET4_DETACHED:-}" ] && [ ! -t 0 ]; then
+    export _SS_TESTNET4_DETACHED=1
+    exec setsid "$0" "$@"
+fi
+
 # test_testnet4_splice.sh — BOLT-2 splice WIRE-CODEC SMOKE on real testnet4.
 #
 # CAVEAT: this is NOT a full BOLT-2 splice end-to-end.  SuperScalar's

--- a/tools/test_testnet4_ts_htlc_fc.sh
+++ b/tools/test_testnet4_ts_htlc_fc.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Self-respawn in own session so systemd-logind cleanup on SSH session end
+# doesn't kill us mid-run (lesson from 2026-05-18 dual #112/#189 deaths).
+# Skip if already respawned or if running interactively (stdin is a tty).
+if [ -z "${_SS_TESTNET4_DETACHED:-}" ] && [ ! -t 0 ]; then
+    export _SS_TESTNET4_DETACHED=1
+    exec setsid "$0" "$@"
+fi
+
 # test_testnet4_ts_htlc_fc.sh — TS-HTLC-FC (#112): force-close with HTLC pending
 # on testnet4 using --test-htlc-force-close.
 #

--- a/tools/test_testnet4_ts_ptlc_basic.sh
+++ b/tools/test_testnet4_ts_ptlc_basic.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Self-respawn in own session so systemd-logind cleanup on SSH session end
+# doesn't kill us mid-run (lesson from 2026-05-18 dual #112/#189 deaths).
+# Skip if already respawned or if running interactively (stdin is a tty).
+if [ -z "${_SS_TESTNET4_DETACHED:-}" ] && [ ! -t 0 ]; then
+    export _SS_TESTNET4_DETACHED=1
+    exec setsid "$0" "$@"
+fi
+
 # test_testnet4_ts_ptlc_basic.sh — TS-PTLC-BASIC (#107, SF-W-PTLC Phase 3a)
 # on testnet4 using --test-ptlc-basic.
 #


### PR DESCRIPTION
Modern systemd-logind kills child processes when the SSH session that spawned them logs out, even with nohup, because cleanup uses cgroups.

On 2026-05-18, both **TS-HTLC-FC (#112)** and **TS-N64-PS-LIFECYCLE (#189)** long-runners died at 09:46:04 UTC (same second) when an SSH session logged out mid-run, losing 4h17m of progress on both. Journal showed multiple \`systemd-logind: Session NNNNN logged out\` events around that time.

## Fix

Each testnet4 runner script self-respawns under \`setsid\` at entry, so it becomes its own session leader (PID==PGID==SID, PPID=1) and is invisible to the spawning SSH session.

Skips the respawn if:
- already respawned via the \`_SS_TESTNET4_DETACHED\` env guard
- running interactively (stdin is a tty — operator wants to see output)

5 runners patched: \`ts_htlc_fc\`, \`n64_ps_lifecycle\`, \`passive_reorg_observer\`, \`splice\`, \`ts_ptlc_basic\`.

## Verified

\`bash -n\` syntax check passes on all 5. Behavior verified manually on \`ts_htlc_fc\` relaunch this morning — PID=PGID=SID=1843123 confirmed via \`ps -o pid,ppid,pgid,sid\`.

Tracks internal task SF-RUNNER-SETSID. Memory rule: \`feedback_testnet4_setsid_required\`.

No behavior change for already-running tests; only affects new launches.