### PR TITLE
feat(lsp): native Prometheus metrics endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ add_library(superscalar
     src/bolt8.c
     src/bolt8_server.c
     src/lsp_wellknown.c
+    src/prometheus_exporter.c
     src/gossip.c
     src/gossip_store.c
     src/mpp.c
@@ -333,6 +334,7 @@ add_executable(test_superscalar
     tests/test_bolt9_features.c
     tests/test_reorg.c
     tests/test_cli_arity.c
+    tests/test_prometheus.c
 )
 target_include_directories(test_superscalar PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
 target_include_directories(test_superscalar PRIVATE ${cjson_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ add_library(superscalar
     src/bech32m.c
     src/bolt8.c
     src/bolt8_server.c
+    src/http_util.c
     src/lsp_wellknown.c
     src/prometheus_exporter.c
     src/gossip.c

--- a/include/superscalar/http_util_internal.h
+++ b/include/superscalar/http_util_internal.h
@@ -1,0 +1,24 @@
+/*
+ * http_util_internal.h - minimal HTTP I/O helpers shared between
+ * src/lsp_wellknown.c and src/prometheus_exporter.c.
+ *
+ * Internal header (not part of the public include/superscalar/ API):
+ * just enough to remove the byte-identical copies of read_line/write_all
+ * that those two HTTP servers had carried.  If a third HTTP endpoint
+ * appears, it should use these helpers too.
+ */
+
+#ifndef SUPERSCALAR_HTTP_UTIL_INTERNAL_H
+#define SUPERSCALAR_HTTP_UTIL_INTERNAL_H
+
+#include <stddef.h>
+
+/* Read one CRLF- or LF-terminated line from fd into buf (NUL-terminated,
+   line terminator stripped).  Returns 0 on EOF or read() error. */
+int http_util_read_line(int fd, char *buf, size_t cap);
+
+/* Write all len bytes of buf to fd.  Returns 0 on partial-write or
+   write() error, 1 on success. */
+int http_util_write_all(int fd, const char *buf, size_t len);
+
+#endif /* SUPERSCALAR_HTTP_UTIL_INTERNAL_H */

--- a/include/superscalar/prometheus.h
+++ b/include/superscalar/prometheus.h
@@ -1,0 +1,85 @@
+/*
+ * prometheus.h - native Prometheus /metrics exporter for superscalar_lsp.
+ *
+ * Exposes a minimal HTTP/1.0 server on a configurable port that serves
+ * Prometheus text-format metrics scraped from the LSP runtime state and
+ * the persist (SQLite) forensic tables (signing_rounds, breach_detections,
+ * reorg_events, broadcast_log).
+ *
+ * Design: a background fork serves the endpoint, similar in spirit to
+ * lsp_wellknown_serve_fork.  The exporter opens the SQLite file
+ * read-only per scrape from the cached path so the live LSP process is
+ * unaffected by concurrent reads.
+ *
+ * Usage (LSP side):
+ *   prometheus_cfg_t cfg = { .db_path = ..., .start_time = ..., ... };
+ *   prometheus_serve_fork(&cfg, 9100);
+ *
+ * Metrics exposed (Prometheus text format):
+ *   superscalar_lsp_uptime_seconds (gauge)
+ *   superscalar_lsp_factories_total{state="..."} (gauge)
+ *   superscalar_lsp_clients_connected (gauge)
+ *   superscalar_lsp_signing_round_total{ceremony_type="..."} (counter)
+ *   superscalar_lsp_signing_round_duration_seconds_sum (counter)
+ *   superscalar_lsp_signing_round_duration_seconds_count (counter)
+ *   superscalar_lsp_breaches_detected_total (counter)
+ *   superscalar_lsp_reorg_events_total{severity="..."} (counter)
+ *   superscalar_lsp_penalty_broadcasts_total (counter)
+ */
+
+#ifndef SUPERSCALAR_PROMETHEUS_H
+#define SUPERSCALAR_PROMETHEUS_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
+
+/*
+ * Configuration passed to the exporter at fork time.  The struct is
+ * copied into the child via fork inheritance; pointed-to strings must
+ * remain live for the lifetime of the LSP process.
+ */
+typedef struct {
+    /* Path to the SQLite db (forensic tables).  May be NULL: in that
+       case DB-derived metrics are emitted as 0 with a HELP comment. */
+    const char *db_path;
+
+    /* Process start time in seconds since epoch.  Used to compute uptime. */
+    time_t start_time;
+
+    /* Pointer to a volatile size_t that the LSP main loop updates
+       whenever a client connects/disconnects.  May be NULL (omits
+       superscalar_lsp_clients_connected). */
+    const volatile size_t *n_clients_connected;
+} prometheus_cfg_t;
+
+/*
+ * Build the Prometheus text-format body into buf.  Returns bytes written
+ * (excluding NUL terminator), or 0 on error.  Caller-supplied buffer must
+ * be at least 8 KiB to comfortably hold the full output.
+ */
+size_t prometheus_build_body(const prometheus_cfg_t *cfg,
+                              char *buf, size_t buf_cap);
+
+/*
+ * Handle one HTTP connection: read the GET request on fd, write the
+ * /metrics response (200 + text body for GET /metrics, 404 otherwise).
+ * Closes fd when done.  Callable with a socketpair fd for unit testing.
+ */
+void prometheus_handle_connection(int fd, const prometheus_cfg_t *cfg);
+
+/*
+ * Fork a background process that accepts HTTP connections on tcp_port
+ * and serves the /metrics endpoint.  Returns 1 in the parent on success,
+ * 0 on error.  The child runs indefinitely; the parent continues.
+ *
+ * Note: the child inherits a copy of *cfg.  db_path is opened read-only
+ * per request, so DB updates by the parent are visible to scrapes.
+ * Live counters (clients_connected) are read through the volatile
+ * pointer in *cfg, which after fork points to the child's stale copy
+ * of parent memory; for v1 the in-DB counters are authoritative and
+ * the live client count is best-effort only.
+ */
+int prometheus_serve_fork(const prometheus_cfg_t *cfg, uint16_t tcp_port);
+
+#endif /* SUPERSCALAR_PROMETHEUS_H */

--- a/src/http_util.c
+++ b/src/http_util.c
@@ -1,0 +1,37 @@
+/*
+ * http_util.c - implementation of http_util_internal.h shared helpers.
+ *
+ * One-byte-at-a-time read_line is fine for tiny HTTP request lines
+ * (request line + a handful of headers).  Both callers parse only the
+ * request-line and discard the rest, so a fancier buffered reader is
+ * not justified.
+ */
+
+#include "superscalar/http_util_internal.h"
+
+#include <unistd.h>
+#include <sys/types.h>
+
+int http_util_read_line(int fd, char *buf, size_t cap) {
+    if (cap == 0) return 0;
+    size_t i = 0;
+    while (i < cap - 1) {
+        char c;
+        ssize_t n = read(fd, &c, 1);
+        if (n <= 0) return 0;
+        if (c == '\n') break;
+        if (c != '\r') buf[i++] = c;
+    }
+    buf[i] = '\0';
+    return 1;
+}
+
+int http_util_write_all(int fd, const char *buf, size_t len) {
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = write(fd, buf + sent, len - sent);
+        if (n <= 0) return 0;
+        sent += (size_t)n;
+    }
+    return 1;
+}

--- a/src/lsp_wellknown.c
+++ b/src/lsp_wellknown.c
@@ -6,6 +6,7 @@
  */
 
 #include "superscalar/lsp_wellknown.h"
+#include "superscalar/http_util_internal.h"
 #include <cJSON.h>
 
 #include <stdio.h>
@@ -119,30 +120,6 @@ cleanup:
 
 /* --- HTTP connection handler --- */
 
-/* Read one line from fd (strips \r\n). Returns 0 on EOF/error. */
-static int read_line(int fd, char *buf, size_t cap) {
-    size_t i = 0;
-    while (i < cap - 1) {
-        char c;
-        ssize_t n = read(fd, &c, 1);
-        if (n <= 0) return 0;
-        if (c == '\n') break;
-        if (c != '\r') buf[i++] = c;
-    }
-    buf[i] = '\0';
-    return 1;
-}
-
-/* Write all bytes to fd */
-static int write_all(int fd, const char *buf, size_t len) {
-    size_t sent = 0;
-    while (sent < len) {
-        ssize_t n = write(fd, buf + sent, len - sent);
-        if (n <= 0) return 0;
-        sent += (size_t)n;
-    }
-    return 1;
-}
 
 void lsp_wellknown_handle_connection(int fd,
                                       const lsp_wellknown_cfg_t *cfg) {
@@ -153,14 +130,14 @@ void lsp_wellknown_handle_connection(int fd,
 
     /* Read request line: "GET /path HTTP/1.x" */
     char req_line[512];
-    if (!read_line(fd, req_line, sizeof(req_line))) {
+    if (!http_util_read_line(fd, req_line, sizeof(req_line))) {
         close(fd);
         return;
     }
 
     /* Drain headers */
     char header_line[512];
-    while (read_line(fd, header_line, sizeof(header_line))) {
+    while (http_util_read_line(fd, header_line, sizeof(header_line))) {
         if (header_line[0] == '\0') break;  /* blank line = end of headers */
     }
 
@@ -172,7 +149,7 @@ void lsp_wellknown_handle_connection(int fd,
         const char *resp405 =
             "HTTP/1.0 405 Method Not Allowed\r\n"
             "Content-Length: 0\r\n\r\n";
-        write_all(fd, resp405, strlen(resp405));
+        http_util_write_all(fd, resp405, strlen(resp405));
         close(fd);
         return;
     }
@@ -181,7 +158,7 @@ void lsp_wellknown_handle_connection(int fd,
         const char *resp404 =
             "HTTP/1.0 404 Not Found\r\n"
             "Content-Length: 0\r\n\r\n";
-        write_all(fd, resp404, strlen(resp404));
+        http_util_write_all(fd, resp404, strlen(resp404));
         close(fd);
         return;
     }
@@ -193,7 +170,7 @@ void lsp_wellknown_handle_connection(int fd,
         const char *resp500 =
             "HTTP/1.0 500 Internal Server Error\r\n"
             "Content-Length: 0\r\n\r\n";
-        write_all(fd, resp500, strlen(resp500));
+        http_util_write_all(fd, resp500, strlen(resp500));
         close(fd);
         return;
     }
@@ -209,8 +186,8 @@ void lsp_wellknown_handle_connection(int fd,
         close(fd);
         return;
     }
-    write_all(fd, header, (size_t)header_len);
-    write_all(fd, body, body_len);
+    http_util_write_all(fd, header, (size_t)header_len);
+    http_util_write_all(fd, body, body_len);
     close(fd);
 }
 
@@ -253,7 +230,7 @@ int lsp_wellknown_fetch_http_port(const char *domain, uint16_t tcp_port,
         "Host: %s\r\n"
         "Connection: close\r\n\r\n",
         domain);
-    if (req_len <= 0 || !write_all(fd, req, (size_t)req_len)) {
+    if (req_len <= 0 || !http_util_write_all(fd, req, (size_t)req_len)) {
         close(fd);
         return 0;
     }

--- a/src/prometheus_exporter.c
+++ b/src/prometheus_exporter.c
@@ -1,0 +1,480 @@
+/*
+ * prometheus_exporter.c - native Prometheus /metrics exporter.
+ *
+ * Implements the API declared in superscalar/prometheus.h.  Modelled on
+ * src/lsp_wellknown.c (same fork-per-connection accept loop, same HTTP/1.0
+ * request parsing); the only meaningful difference is the response body,
+ * which is Prometheus text format scraped from runtime counters and from
+ * the SQLite forensic tables.
+ *
+ * No new external dependencies - uses only libc, POSIX sockets, and the
+ * already-linked sqlite3.  DB queries open a fresh sqlite3_open_v2 with
+ * SQLITE_OPEN_READONLY per scrape so the live LSP process is unaffected.
+ */
+
+#include "superscalar/prometheus.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <signal.h>
+#include <time.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <sqlite3.h>
+
+/* ------------------------------------------------------------------ */
+/* IO helpers (copied from lsp_wellknown.c to avoid coupling)         */
+/* ------------------------------------------------------------------ */
+
+static int read_line(int fd, char *buf, size_t cap) {
+    size_t i = 0;
+    while (i < cap - 1) {
+        char c;
+        ssize_t n = read(fd, &c, 1);
+        if (n <= 0) return 0;
+        if (c == '\n') break;
+        if (c != '\r') buf[i++] = c;
+    }
+    buf[i] = '\0';
+    return 1;
+}
+
+static int write_all(int fd, const char *buf, size_t len) {
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = write(fd, buf + sent, len - sent);
+        if (n <= 0) return 0;
+        sent += (size_t)n;
+    }
+    return 1;
+}
+
+/* Bounded append helper. Returns new offset (or buf_cap on overflow). */
+static size_t append_str(char *buf, size_t buf_cap, size_t off,
+                          const char *s) {
+    if (off >= buf_cap) return buf_cap;
+    size_t remain = buf_cap - off - 1;
+    size_t len = strlen(s);
+    if (len > remain) len = remain;
+    memcpy(buf + off, s, len);
+    buf[off + len] = '\0';
+    return off + len;
+}
+
+static size_t append_fmt(char *buf, size_t buf_cap, size_t off,
+                          const char *fmt, ...) {
+    if (off >= buf_cap) return buf_cap;
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(buf + off, buf_cap - off, fmt, ap);
+    va_end(ap);
+    if (n < 0) return off;
+    if ((size_t)n >= buf_cap - off) return buf_cap;
+    return off + (size_t)n;
+}
+
+/* ------------------------------------------------------------------ */
+/* DB queries (read-only)                                              */
+/* ------------------------------------------------------------------ */
+
+/* Sanitize a SQLite TEXT value into a Prometheus label-safe token.
+   Allows alphanumeric and underscore, replaces other chars with
+   underscore.  Caps at 32 chars.  Empty input becomes "unknown". */
+static void sanitize_label(const char *in, char *out, size_t out_cap) {
+    if (!out || out_cap == 0) return;
+    if (!in || !*in) {
+        snprintf(out, out_cap, "unknown");
+        return;
+    }
+    size_t j = 0;
+    for (size_t i = 0; in[i] && j + 1 < out_cap && j < 32; i++) {
+        char c = in[i];
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || c == '_')
+            out[j++] = c;
+        else
+            out[j++] = '_';
+    }
+    out[j] = '\0';
+    if (j == 0) snprintf(out, out_cap, "unknown");
+}
+
+/* Emit factories_total grouped by state. */
+static size_t emit_factories(sqlite3 *db, char *buf, size_t buf_cap,
+                              size_t off) {
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_factories_total Number of factories by state.\n"
+        "# TYPE superscalar_lsp_factories_total gauge\n");
+    if (!db) {
+        off = append_str(buf, buf_cap, off,
+            "superscalar_lsp_factories_total{state=\"unknown\"} 0\n");
+        return off;
+    }
+    sqlite3_stmt *stmt = NULL;
+    const char *sql =
+        "SELECT COALESCE(state,'unknown') AS s, COUNT(*) FROM factories "
+        "GROUP BY s;";
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        off = append_str(buf, buf_cap, off,
+            "superscalar_lsp_factories_total{state=\"unknown\"} 0\n");
+        return off;
+    }
+    int rows = 0;
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const unsigned char *state = sqlite3_column_text(stmt, 0);
+        int count = sqlite3_column_int(stmt, 1);
+        char label[40];
+        sanitize_label((const char *)state, label, sizeof(label));
+        off = append_fmt(buf, buf_cap, off,
+            "superscalar_lsp_factories_total{state=\"%s\"} %d\n",
+            label, count);
+        rows++;
+    }
+    sqlite3_finalize(stmt);
+    if (rows == 0)
+        off = append_str(buf, buf_cap, off,
+            "superscalar_lsp_factories_total{state=\"unknown\"} 0\n");
+    return off;
+}
+
+static size_t emit_signing_rounds(sqlite3 *db, char *buf, size_t buf_cap,
+                                    size_t off) {
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_signing_round_total Total signing rounds by ceremony type.\n"
+        "# TYPE superscalar_lsp_signing_round_total counter\n");
+    if (!db) {
+        off = append_str(buf, buf_cap, off,
+            "superscalar_lsp_signing_round_total{ceremony_type=\"unknown\"} 0\n");
+    } else {
+        sqlite3_stmt *stmt = NULL;
+        const char *sql =
+            "SELECT COALESCE(ceremony_type,'unknown') AS c, COUNT(*) "
+            "FROM signing_rounds GROUP BY c;";
+        if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+            int rows = 0;
+            while (sqlite3_step(stmt) == SQLITE_ROW) {
+                const unsigned char *ct = sqlite3_column_text(stmt, 0);
+                int count = sqlite3_column_int(stmt, 1);
+                char label[40];
+                sanitize_label((const char *)ct, label, sizeof(label));
+                off = append_fmt(buf, buf_cap, off,
+                    "superscalar_lsp_signing_round_total{ceremony_type=\"%s\"} %d\n",
+                    label, count);
+                rows++;
+            }
+            sqlite3_finalize(stmt);
+            if (rows == 0)
+                off = append_str(buf, buf_cap, off,
+                    "superscalar_lsp_signing_round_total{ceremony_type=\"unknown\"} 0\n");
+        } else {
+            off = append_str(buf, buf_cap, off,
+                "superscalar_lsp_signing_round_total{ceremony_type=\"unknown\"} 0\n");
+        }
+    }
+
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_signing_round_duration_seconds Total time spent in completed signing rounds.\n"
+        "# TYPE superscalar_lsp_signing_round_duration_seconds_sum counter\n"
+        "# TYPE superscalar_lsp_signing_round_duration_seconds_count counter\n");
+    long long sum_s = 0;
+    long long count_n = 0;
+    if (db) {
+        sqlite3_stmt *stmt = NULL;
+        const char *sql =
+            "SELECT COALESCE(SUM(completed_at - started_at), 0), COUNT(*) "
+            "FROM signing_rounds "
+            "WHERE completed_at IS NOT NULL AND started_at IS NOT NULL "
+            "  AND completed_at >= started_at;";
+        if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+            if (sqlite3_step(stmt) == SQLITE_ROW) {
+                sum_s = sqlite3_column_int64(stmt, 0);
+                count_n = sqlite3_column_int64(stmt, 1);
+            }
+            sqlite3_finalize(stmt);
+        }
+    }
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_signing_round_duration_seconds_sum %lld\n", sum_s);
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_signing_round_duration_seconds_count %lld\n",
+        count_n);
+    return off;
+}
+
+static size_t emit_breaches(sqlite3 *db, char *buf, size_t buf_cap,
+                              size_t off) {
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_breaches_detected_total Total breach (revoked-commit) detections.\n"
+        "# TYPE superscalar_lsp_breaches_detected_total counter\n");
+    long long n = 0;
+    if (db) {
+        sqlite3_stmt *stmt = NULL;
+        if (sqlite3_prepare_v2(db,
+                "SELECT COUNT(*) FROM breach_detections;",
+                -1, &stmt, NULL) == SQLITE_OK) {
+            if (sqlite3_step(stmt) == SQLITE_ROW)
+                n = sqlite3_column_int64(stmt, 0);
+            sqlite3_finalize(stmt);
+        }
+    }
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_breaches_detected_total %lld\n", n);
+    return off;
+}
+
+/* Reorg severity derivation:
+     n_entries_reset == 0 AND depth <= 0  -> info
+     n_entries_reset 1..5 AND depth <= 2  -> warn
+     anything deeper                       -> critical
+   depth = old_tip - new_tip (positive on rollback). */
+static size_t emit_reorgs(sqlite3 *db, char *buf, size_t buf_cap,
+                            size_t off) {
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_reorg_events_total Total reorg events by derived severity.\n"
+        "# TYPE superscalar_lsp_reorg_events_total counter\n");
+    long long info_n = 0, warn_n = 0, crit_n = 0;
+    if (db) {
+        sqlite3_stmt *stmt = NULL;
+        const char *sql =
+            "SELECT n_entries_reset, (old_tip - new_tip) AS depth "
+            "FROM reorg_events;";
+        if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) == SQLITE_OK) {
+            while (sqlite3_step(stmt) == SQLITE_ROW) {
+                int n_reset = sqlite3_column_int(stmt, 0);
+                int depth   = sqlite3_column_int(stmt, 1);
+                if (n_reset == 0 && depth <= 0) info_n++;
+                else if (n_reset <= 5 && depth <= 2) warn_n++;
+                else crit_n++;
+            }
+            sqlite3_finalize(stmt);
+        }
+    }
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_reorg_events_total{severity=\"info\"} %lld\n",
+        info_n);
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_reorg_events_total{severity=\"warn\"} %lld\n",
+        warn_n);
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_reorg_events_total{severity=\"critical\"} %lld\n",
+        crit_n);
+    return off;
+}
+
+static size_t emit_penalty_broadcasts(sqlite3 *db, char *buf, size_t buf_cap,
+                                        size_t off) {
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_penalty_broadcasts_total Total penalty TX broadcasts logged.\n"
+        "# TYPE superscalar_lsp_penalty_broadcasts_total counter\n");
+    long long n = 0;
+    if (db) {
+        sqlite3_stmt *stmt = NULL;
+        if (sqlite3_prepare_v2(db,
+                "SELECT COUNT(*) FROM broadcast_log WHERE source = 'penalty';",
+                -1, &stmt, NULL) == SQLITE_OK) {
+            if (sqlite3_step(stmt) == SQLITE_ROW)
+                n = sqlite3_column_int64(stmt, 0);
+            sqlite3_finalize(stmt);
+        }
+    }
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_penalty_broadcasts_total %lld\n", n);
+    return off;
+}
+
+/* ------------------------------------------------------------------ */
+/* Body builder                                                        */
+/* ------------------------------------------------------------------ */
+
+size_t prometheus_build_body(const prometheus_cfg_t *cfg,
+                              char *buf, size_t buf_cap) {
+    if (!cfg || !buf || buf_cap < 256) return 0;
+    size_t off = 0;
+
+    time_t now = time(NULL);
+    long long uptime = (long long)(now - cfg->start_time);
+    if (uptime < 0) uptime = 0;
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_uptime_seconds Seconds since LSP process start.\n"
+        "# TYPE superscalar_lsp_uptime_seconds gauge\n");
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_uptime_seconds %lld\n", uptime);
+
+    off = append_str(buf, buf_cap, off,
+        "# HELP superscalar_lsp_clients_connected Currently connected native clients.\n"
+        "# TYPE superscalar_lsp_clients_connected gauge\n");
+    long long n_conn = 0;
+    if (cfg->n_clients_connected)
+        n_conn = (long long)(*cfg->n_clients_connected);
+    off = append_fmt(buf, buf_cap, off,
+        "superscalar_lsp_clients_connected %lld\n", n_conn);
+
+    sqlite3 *db = NULL;
+    if (cfg->db_path) {
+        int rc = sqlite3_open_v2(cfg->db_path, &db,
+                                   SQLITE_OPEN_READONLY, NULL);
+        if (rc != SQLITE_OK) {
+            if (db) sqlite3_close(db);
+            db = NULL;
+        }
+    }
+
+    off = emit_factories(db, buf, buf_cap, off);
+    off = emit_signing_rounds(db, buf, buf_cap, off);
+    off = emit_breaches(db, buf, buf_cap, off);
+    off = emit_reorgs(db, buf, buf_cap, off);
+    off = emit_penalty_broadcasts(db, buf, buf_cap, off);
+
+    if (db) sqlite3_close(db);
+
+    return off;
+}
+
+/* ------------------------------------------------------------------ */
+/* HTTP connection handler                                             */
+/* ------------------------------------------------------------------ */
+
+void prometheus_handle_connection(int fd, const prometheus_cfg_t *cfg) {
+    if (fd < 0 || !cfg) {
+        if (fd >= 0) close(fd);
+        return;
+    }
+
+    char req_line[512];
+    if (!read_line(fd, req_line, sizeof(req_line))) {
+        close(fd);
+        return;
+    }
+
+    char header_line[512];
+    while (read_line(fd, header_line, sizeof(header_line))) {
+        if (header_line[0] == '\0') break;
+    }
+
+    char method[8] = {0}, path[256] = {0};
+    sscanf(req_line, "%7s %255s", method, path);
+
+    if (strcmp(method, "GET") != 0) {
+        const char *resp =
+            "HTTP/1.0 405 Method Not Allowed\r\n"
+            "Content-Length: 0\r\n\r\n";
+        write_all(fd, resp, strlen(resp));
+        close(fd);
+        return;
+    }
+
+    if (strcmp(path, "/metrics") != 0 && strcmp(path, "/") != 0) {
+        const char *resp =
+            "HTTP/1.0 404 Not Found\r\n"
+            "Content-Length: 0\r\n\r\n";
+        write_all(fd, resp, strlen(resp));
+        close(fd);
+        return;
+    }
+
+    static char body[16384];
+    size_t body_len = prometheus_build_body(cfg, body, sizeof(body));
+    if (body_len == 0) {
+        const char *resp =
+            "HTTP/1.0 500 Internal Server Error\r\n"
+            "Content-Length: 0\r\n\r\n";
+        write_all(fd, resp, strlen(resp));
+        close(fd);
+        return;
+    }
+
+    char header[256];
+    int header_len = snprintf(header, sizeof(header),
+        "HTTP/1.0 200 OK\r\n"
+        "Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n"
+        "Content-Length: %zu\r\n\r\n",
+        body_len);
+    if (header_len <= 0) {
+        close(fd);
+        return;
+    }
+    write_all(fd, header, (size_t)header_len);
+    write_all(fd, body, body_len);
+    close(fd);
+}
+
+/* ------------------------------------------------------------------ */
+/* Background server (fork-based, mirrors lsp_wellknown_serve_fork)    */
+/* ------------------------------------------------------------------ */
+
+int prometheus_serve_fork(const prometheus_cfg_t *cfg, uint16_t tcp_port) {
+    if (!cfg || tcp_port == 0) return 0;
+
+    int srv = socket(AF_INET6, SOCK_STREAM, 0);
+    if (srv < 0) {
+        srv = socket(AF_INET, SOCK_STREAM, 0);
+        if (srv < 0) return 0;
+    }
+
+    int one = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in6 addr6;
+    memset(&addr6, 0, sizeof(addr6));
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_port   = htons(tcp_port);
+    addr6.sin6_addr   = in6addr_any;
+
+    if (bind(srv, (struct sockaddr *)&addr6, sizeof(addr6)) != 0) {
+        close(srv);
+        srv = socket(AF_INET, SOCK_STREAM, 0);
+        if (srv < 0) return 0;
+        setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+        struct sockaddr_in addr4;
+        memset(&addr4, 0, sizeof(addr4));
+        addr4.sin_family      = AF_INET;
+        addr4.sin_port        = htons(tcp_port);
+        addr4.sin_addr.s_addr = INADDR_ANY;
+        if (bind(srv, (struct sockaddr *)&addr4, sizeof(addr4)) != 0) {
+            close(srv);
+            return 0;
+        }
+    }
+
+    if (listen(srv, 16) != 0) {
+        close(srv);
+        return 0;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(srv);
+        return 0;
+    }
+
+    if (pid > 0) {
+        close(srv);
+        return 1;
+    }
+
+    signal(SIGCHLD, SIG_IGN);
+
+    while (1) {
+        int conn = accept(srv, NULL, NULL);
+        if (conn < 0) {
+            if (errno == EINTR) continue;
+            break;
+        }
+        pid_t cpid = fork();
+        if (cpid == 0) {
+            close(srv);
+            prometheus_handle_connection(conn, cfg);
+            _exit(0);
+        }
+        close(conn);
+    }
+    close(srv);
+    _exit(0);
+}

--- a/src/prometheus_exporter.c
+++ b/src/prometheus_exporter.c
@@ -13,6 +13,7 @@
  */
 
 #include "superscalar/prometheus.h"
+#include "superscalar/http_util_internal.h"
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -28,33 +29,6 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <sqlite3.h>
-
-/* ------------------------------------------------------------------ */
-/* IO helpers (copied from lsp_wellknown.c to avoid coupling)         */
-/* ------------------------------------------------------------------ */
-
-static int read_line(int fd, char *buf, size_t cap) {
-    size_t i = 0;
-    while (i < cap - 1) {
-        char c;
-        ssize_t n = read(fd, &c, 1);
-        if (n <= 0) return 0;
-        if (c == '\n') break;
-        if (c != '\r') buf[i++] = c;
-    }
-    buf[i] = '\0';
-    return 1;
-}
-
-static int write_all(int fd, const char *buf, size_t len) {
-    size_t sent = 0;
-    while (sent < len) {
-        ssize_t n = write(fd, buf + sent, len - sent);
-        if (n <= 0) return 0;
-        sent += (size_t)n;
-    }
-    return 1;
-}
 
 /* Bounded append helper. Returns new offset (or buf_cap on overflow). */
 static size_t append_str(char *buf, size_t buf_cap, size_t off,
@@ -348,13 +322,13 @@ void prometheus_handle_connection(int fd, const prometheus_cfg_t *cfg) {
     }
 
     char req_line[512];
-    if (!read_line(fd, req_line, sizeof(req_line))) {
+    if (!http_util_read_line(fd, req_line, sizeof(req_line))) {
         close(fd);
         return;
     }
 
     char header_line[512];
-    while (read_line(fd, header_line, sizeof(header_line))) {
+    while (http_util_read_line(fd, header_line, sizeof(header_line))) {
         if (header_line[0] == '\0') break;
     }
 
@@ -365,7 +339,7 @@ void prometheus_handle_connection(int fd, const prometheus_cfg_t *cfg) {
         const char *resp =
             "HTTP/1.0 405 Method Not Allowed\r\n"
             "Content-Length: 0\r\n\r\n";
-        write_all(fd, resp, strlen(resp));
+        http_util_write_all(fd, resp, strlen(resp));
         close(fd);
         return;
     }
@@ -374,7 +348,7 @@ void prometheus_handle_connection(int fd, const prometheus_cfg_t *cfg) {
         const char *resp =
             "HTTP/1.0 404 Not Found\r\n"
             "Content-Length: 0\r\n\r\n";
-        write_all(fd, resp, strlen(resp));
+        http_util_write_all(fd, resp, strlen(resp));
         close(fd);
         return;
     }
@@ -385,7 +359,7 @@ void prometheus_handle_connection(int fd, const prometheus_cfg_t *cfg) {
         const char *resp =
             "HTTP/1.0 500 Internal Server Error\r\n"
             "Content-Length: 0\r\n\r\n";
-        write_all(fd, resp, strlen(resp));
+        http_util_write_all(fd, resp, strlen(resp));
         close(fd);
         return;
     }
@@ -400,8 +374,8 @@ void prometheus_handle_connection(int fd, const prometheus_cfg_t *cfg) {
         close(fd);
         return;
     }
-    write_all(fd, header, (size_t)header_len);
-    write_all(fd, body, body_len);
+    http_util_write_all(fd, header, (size_t)header_len);
+    http_util_write_all(fd, body, body_len);
     close(fd);
 }
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1265,6 +1265,12 @@ extern int test_cli_shape_uniform_arity2_n64_rejected(void);
 extern int test_cli_shape_mixed_248_n64_passes(void);
 extern int test_cli_shape_mixed_248_static2_n128_passes(void);
 extern int test_cli_shape_regtest_step10_always_passes(void);
+/* SF-PROMETHEUS-EXPORTER: native /metrics endpoint */
+extern int test_prometheus_build_body_contains_all_metrics(void);
+extern int test_prometheus_handle_connection_metrics(void);
+extern int test_prometheus_handle_connection_404(void);
+extern int test_prometheus_handle_connection_405(void);
+extern int test_prometheus_client_counter(void);
 
 /* Phase 16: Reconnection */
 extern int test_reconnect_wire(void);
@@ -3103,6 +3109,13 @@ static void run_unit_tests(void) {
     RUN_TEST(test_cli_shape_mixed_248_n64_passes);
     RUN_TEST(test_cli_shape_mixed_248_static2_n128_passes);
     RUN_TEST(test_cli_shape_regtest_step10_always_passes);
+
+    printf("\n=== Prometheus Exporter ===\n");
+    RUN_TEST(test_prometheus_build_body_contains_all_metrics);
+    RUN_TEST(test_prometheus_handle_connection_metrics);
+    RUN_TEST(test_prometheus_handle_connection_404);
+    RUN_TEST(test_prometheus_handle_connection_405);
+    RUN_TEST(test_prometheus_client_counter);
 
     printf("\n=== Reconnection (Phase 16) ===\n");
     RUN_TEST(test_reconnect_wire);

--- a/tests/test_prometheus.c
+++ b/tests/test_prometheus.c
@@ -1,0 +1,183 @@
+/*
+ * test_prometheus.c - unit tests for the native Prometheus exporter.
+ *
+ * Verifies:
+ *   - prometheus_build_body returns a non-zero length and emits the
+ *     expected metric names with proper HELP/TYPE preambles.
+ *   - The body is well-formed Prometheus text format (no NULs, each
+ *     metric line ends in \n, and label values are quoted).
+ *   - prometheus_handle_connection over a socketpair returns
+ *     "HTTP/1.0 200 OK" with the metric body when GET /metrics is sent.
+ *   - It returns 404 for unknown paths and 405 for non-GET methods.
+ *
+ * No external dependencies: socketpair gives us a portable in-process
+ * bidirectional channel that exercises the same read_line/write_all
+ * paths as a real TCP scrape.
+ */
+
+#include "superscalar/prometheus.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d): %s\n", __func__, __LINE__, (msg)); \
+        return 0; \
+    } \
+} while(0)
+
+/* P1: body builder emits expected metric names and TYPE comments. */
+int test_prometheus_build_body_contains_all_metrics(void) {
+    prometheus_cfg_t cfg = {
+        .db_path = NULL,            /* DB-less path: emits zero rows */
+        .start_time = time(NULL) - 42,  /* uptime ~42s */
+        .n_clients_connected = NULL,
+    };
+    char buf[8192];
+    size_t n = prometheus_build_body(&cfg, buf, sizeof(buf));
+    ASSERT(n > 0, "body length > 0");
+    ASSERT(n < sizeof(buf), "body fits in buffer");
+    buf[n] = '\0';
+
+    /* Required metric names */
+    ASSERT(strstr(buf, "superscalar_lsp_uptime_seconds") != NULL,
+           "uptime_seconds present");
+    ASSERT(strstr(buf, "superscalar_lsp_factories_total") != NULL,
+           "factories_total present");
+    ASSERT(strstr(buf, "superscalar_lsp_clients_connected") != NULL,
+           "clients_connected present");
+    ASSERT(strstr(buf, "superscalar_lsp_signing_round_total") != NULL,
+           "signing_round_total present");
+    ASSERT(strstr(buf, "superscalar_lsp_signing_round_duration_seconds_sum")
+           != NULL, "duration_sum present");
+    ASSERT(strstr(buf, "superscalar_lsp_signing_round_duration_seconds_count")
+           != NULL, "duration_count present");
+    ASSERT(strstr(buf, "superscalar_lsp_breaches_detected_total") != NULL,
+           "breaches_detected present");
+    ASSERT(strstr(buf, "superscalar_lsp_reorg_events_total") != NULL,
+           "reorg_events_total present");
+    ASSERT(strstr(buf, "superscalar_lsp_penalty_broadcasts_total") != NULL,
+           "penalty_broadcasts present");
+
+    /* HELP and TYPE comments */
+    ASSERT(strstr(buf, "# HELP superscalar_lsp_uptime_seconds") != NULL,
+           "uptime HELP comment");
+    ASSERT(strstr(buf, "# TYPE superscalar_lsp_uptime_seconds gauge") != NULL,
+           "uptime TYPE gauge");
+    ASSERT(strstr(buf, "# TYPE superscalar_lsp_breaches_detected_total counter")
+           != NULL, "breaches TYPE counter");
+
+    /* No NUL embedded mid-body */
+    ASSERT(strlen(buf) == n, "no embedded NUL bytes");
+
+    return 1;
+}
+
+/* P2: HTTP handler over socketpair returns 200 OK with body for GET /metrics. */
+int test_prometheus_handle_connection_metrics(void) {
+    int sv[2];
+    ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0, "socketpair");
+
+    prometheus_cfg_t cfg = {
+        .db_path = NULL,
+        .start_time = time(NULL) - 5,
+        .n_clients_connected = NULL,
+    };
+
+    /* Send GET /metrics request on sv[0] */
+    const char *req = "GET /metrics HTTP/1.0\r\nHost: x\r\n\r\n";
+    ssize_t w = write(sv[0], req, strlen(req));
+    ASSERT(w == (ssize_t)strlen(req), "write request");
+
+    /* Server side processes sv[1] */
+    prometheus_handle_connection(sv[1], &cfg);
+
+    /* Read response from sv[0] */
+    char resp[16384];
+    ssize_t total = 0, n;
+    while (total < (ssize_t)sizeof(resp) - 1 &&
+           (n = read(sv[0], resp + total, sizeof(resp) - 1 - total)) > 0)
+        total += n;
+    resp[total] = '\0';
+    close(sv[0]);
+
+    ASSERT(total > 0, "response has bytes");
+    ASSERT(strncmp(resp, "HTTP/1.0 200 OK", 15) == 0, "200 OK status");
+    ASSERT(strstr(resp, "Content-Type: text/plain") != NULL,
+           "text/plain content-type");
+    ASSERT(strstr(resp, "superscalar_lsp_uptime_seconds") != NULL,
+           "body contains uptime metric");
+
+    return 1;
+}
+
+/* P3: unknown path returns 404. */
+int test_prometheus_handle_connection_404(void) {
+    int sv[2];
+    ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0, "socketpair");
+
+    prometheus_cfg_t cfg = {
+        .db_path = NULL,
+        .start_time = time(NULL),
+        .n_clients_connected = NULL,
+    };
+
+    const char *req = "GET /not-metrics HTTP/1.0\r\nHost: x\r\n\r\n";
+    write(sv[0], req, strlen(req));
+    prometheus_handle_connection(sv[1], &cfg);
+
+    char resp[1024];
+    ssize_t n = read(sv[0], resp, sizeof(resp) - 1);
+    if (n < 0) n = 0;
+    resp[n] = '\0';
+    close(sv[0]);
+    ASSERT(strncmp(resp, "HTTP/1.0 404", 12) == 0, "404 status");
+    return 1;
+}
+
+/* P4: non-GET method returns 405. */
+int test_prometheus_handle_connection_405(void) {
+    int sv[2];
+    ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0, "socketpair");
+
+    prometheus_cfg_t cfg = {
+        .db_path = NULL,
+        .start_time = time(NULL),
+        .n_clients_connected = NULL,
+    };
+
+    const char *req = "POST /metrics HTTP/1.0\r\nHost: x\r\n\r\n";
+    write(sv[0], req, strlen(req));
+    prometheus_handle_connection(sv[1], &cfg);
+
+    char resp[1024];
+    ssize_t n = read(sv[0], resp, sizeof(resp) - 1);
+    if (n < 0) n = 0;
+    resp[n] = '\0';
+    close(sv[0]);
+    ASSERT(strncmp(resp, "HTTP/1.0 405", 12) == 0, "405 status");
+    return 1;
+}
+
+/* P5: live client counter is reflected. */
+int test_prometheus_client_counter(void) {
+    volatile size_t n_clients = 7;
+    prometheus_cfg_t cfg = {
+        .db_path = NULL,
+        .start_time = time(NULL),
+        .n_clients_connected = &n_clients,
+    };
+    char buf[8192];
+    size_t n = prometheus_build_body(&cfg, buf, sizeof(buf));
+    ASSERT(n > 0, "body length > 0");
+    buf[n] = '\0';
+    ASSERT(strstr(buf, "superscalar_lsp_clients_connected 7") != NULL,
+           "clients=7 reflected");
+    return 1;
+}

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -33,6 +33,7 @@
 #include "superscalar/splice.h"
 #include "superscalar/musig.h"
 #include "superscalar/lsp_wellknown.h"
+#include "superscalar/prometheus.h"
 #include "superscalar/admin_rpc.h"
 #include "superscalar/cli_arity.h"
 #include <stdio.h>
@@ -1339,6 +1340,7 @@ int main(int argc, char *argv[]) {
     const char *create_offer_desc = NULL;  /* --create-offer DESCRIPTION */
     uint64_t create_offer_amount = 0;      /* optional amount_msat (0 = any) */
     uint16_t well_known_port = 0;          /* 0 = disabled; set with --well-known-port */
+    uint16_t prometheus_port = 0;         /* 0 = disabled; set with --prometheus-port */
     int use_clnbridge = 0;                 /* --clnbridge: use CLN bridge for inbound payments */
     char gossip_peers[1024] = "";          /* --gossip-peers HOST:PORT[,HOST:PORT,...] */
     uint16_t bolt8_listen_port = 0;        /* --bolt8-port N: BOLT #8 TCP accept port */
@@ -1835,6 +1837,8 @@ int main(int argc, char *argv[]) {
             create_offer_amount = (uint64_t)strtoull(argv[++i], NULL, 10);
         else if (strcmp(argv[i], "--well-known-port") == 0 && i + 1 < argc)
             well_known_port = (uint16_t)atoi(argv[++i]);
+        else if (strcmp(argv[i], "--prometheus-port") == 0 && i + 1 < argc)
+            prometheus_port = (uint16_t)atoi(argv[++i]);
         else if (strcmp(argv[i], "--clnbridge") == 0)
             use_clnbridge = 1;
         else if (strcmp(argv[i], "--gossip-peers") == 0 && i + 1 < argc) {
@@ -3126,6 +3130,21 @@ accept_new_factory:
                 fprintf(stderr,
                         "LSP: warning: well-known server on port %u failed\n",
                         (unsigned)well_known_port);
+        }
+
+        if (prometheus_port > 0) {
+            static prometheus_cfg_t prom_cfg;
+            prom_cfg.db_path = use_db ? db_path : NULL;
+            prom_cfg.start_time = time(NULL);
+            prom_cfg.n_clients_connected =
+                (g_lsp ? (const volatile size_t *)&g_lsp->n_clients : NULL);
+            if (prometheus_serve_fork(&prom_cfg, prometheus_port))
+                printf("LSP: Prometheus /metrics on port %u\n",
+                       (unsigned)prometheus_port);
+            else
+                fprintf(stderr,
+                        "LSP: warning: Prometheus server on port %u failed\n",
+                        (unsigned)prometheus_port);
         }
     }
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -1194,6 +1194,11 @@ int main(int argc, char *argv[]) {
     /* Line-buffered stdout/stderr so logs are visible in real time */
     setvbuf(stdout, NULL, _IOLBF, 0);
     setvbuf(stderr, NULL, _IOLBF, 0);
+    /* Process start time, captured before any other work — used for the
+       Prometheus uptime metric so it reflects true LSP-process lifetime
+       rather than the (later) time when --prometheus-port forks the
+       metrics server. */
+    time_t lsp_process_start_time = time(NULL);
 
     /* Ignore SIGPIPE — write() to dead client sockets returns EPIPE instead of killing us */
     signal(SIGPIPE, SIG_IGN);
@@ -3135,7 +3140,7 @@ accept_new_factory:
         if (prometheus_port > 0) {
             static prometheus_cfg_t prom_cfg;
             prom_cfg.db_path = use_db ? db_path : NULL;
-            prom_cfg.start_time = time(NULL);
+            prom_cfg.start_time = lsp_process_start_time;
             prom_cfg.n_clients_connected =
                 (g_lsp ? (const volatile size_t *)&g_lsp->n_clients : NULL);
             if (prometheus_serve_fork(&prom_cfg, prometheus_port))


### PR DESCRIPTION
Adds a native `/metrics` endpoint to `superscalar_lsp`, opt-in via `--prometheus-port N`.

Tracks internal task SF-PROMETHEUS-EXPORTER. Closes the TODO at `docs/mainnet-runbook.md:319-332` ("no native Prometheus exporter").

## Implementation

- New `src/prometheus_exporter.c` + `include/superscalar/prometheus.h`. Modelled on `src/lsp_wellknown.c`: same fork-per-connection accept loop, same HTTP/1.0 request parser. No new external dependencies.
- DB-derived metrics open the existing SQLite forensic file with `SQLITE_OPEN_READONLY` per scrape, so the live LSP writer is unaffected by concurrent reads.
- Live counters (`clients_connected`) are read through a volatile pointer to the in-memory `lsp->n_clients`. In-DB counters are authoritative; the live client count is best-effort across the post-`fork()` snapshot.

## Metrics

- `superscalar_lsp_uptime_seconds` (gauge)
- `superscalar_lsp_clients_connected` (gauge)
- `superscalar_lsp_factories_total{state="..."}` (gauge, from `factories`)
- `superscalar_lsp_signing_round_total{ceremony_type="..."}` (counter, from `signing_rounds`)
- `superscalar_lsp_signing_round_duration_seconds_{sum,count}` (basic summary across completed rounds)
- `superscalar_lsp_breaches_detected_total` (counter, from `breach_detections`)
- `superscalar_lsp_reorg_events_total{severity="info|warn|critical"}` (counter; severity derived from `n_entries_reset` and depth = `old_tip - new_tip`)
- `superscalar_lsp_penalty_broadcasts_total` (counter, from `broadcast_log WHERE source='penalty'`)

## CLI

- `--prometheus-port 9100` (default `0` = disabled)
- Server is launched once via `prometheus_serve_fork()` right after the existing well-known fork (`tools/superscalar_lsp.c`).

## Testing

- New `tests/test_prometheus.c`: 5 unit tests over socketpair fds
  - `test_prometheus_build_body_contains_all_metrics` — every expected metric name + HELP/TYPE preamble present.
  - `test_prometheus_handle_connection_metrics` — `GET /metrics` returns `HTTP/1.0 200 OK` with metric body.
  - `test_prometheus_handle_connection_404` — unknown path returns 404.
  - `test_prometheus_handle_connection_405` — non-GET returns 405.
  - `test_prometheus_client_counter` — volatile counter is reflected in the gauge value.
- Full suite: `1467/1467` unit tests pass under `build-release-prom` (Release).
- End-to-end smoke on regtest: launched `superscalar_lsp --prometheus-port 19100 --regtest`, `curl http://127.0.0.1:19100/metrics` returned valid Prometheus text-format with all nine metric families and well-formed HELP/TYPE preambles.

## Test plan

- [x] Unit suite green (1467/1467)
- [x] Prometheus-specific subset green (5/5)
- [x] Live `/metrics` scrape on regtest returns expected metric names
- [ ] Operator validation against a real Prometheus scrape (verify `text/plain; version=0.0.4` content-type is accepted by the collector)
