### PR TITLE
fix(testnet4): default runner BUILD_DIR to build-release

### DIFF
--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -27,7 +27,7 @@ fi
 
 set -euo pipefail
 
-BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 

--- a/tools/test_testnet4_passive_reorg_observer.sh
+++ b/tools/test_testnet4_passive_reorg_observer.sh
@@ -26,7 +26,7 @@ fi
 
 set -uo pipefail
 
-BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 WT_BIN="$BUILD_DIR/superscalar_watchtower"
 WT_LOG="${WT_LOG:-/tmp/passive_reorg_observer.log}"
 WT_DB="${1:-}"


### PR DESCRIPTION
## Summary

- Flip default BUILD_DIR in two testnet4 runner scripts from `/root/SuperScalar/build` (ASan) to `/root/SuperScalar/build-release`.
- Affects `tools/test_testnet4_n64_ps_lifecycle.sh` and `tools/test_testnet4_passive_reorg_observer.sh`.

## Why

ASan-instrumented binaries die silently under long RPC polling against `bitcoind` (documented in earlier #138 investigation). The other testnet4 runner scripts already default to `build-release`; these two were inconsistent and recently caught us when both long-runners came up under ASan and risked a silent death several hours into the run. The override path (`BUILD_DIR=/root/SuperScalar/build bash …`) still works for short diagnostic runs.

## Test plan
- [x] `grep -n BUILD_DIR tools/test_testnet4_*.sh` — all default to `build-release`
- [x] Manual override `BUILD_DIR=/root/SuperScalar/build bash …` still resolves the older path
- [x] Diff is two single-line changes, no functional refactor