### PR TITLE
fix(testnet4): lower runner --fee-rate to 1000 sat/kvB (1 sat/vB)

### DIFF
--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -76,7 +76,7 @@ nohup "$LSP_BIN" \
     --amount "$AMOUNT" \
     --active-blocks 50 --dying-blocks 20 \
     --step-blocks 5 --states-per-layer 2 \
-    --fee-rate 1100 --lsp-balance-pct 100 \
+    --fee-rate 1000 --lsp-balance-pct 100 \
     --confirm-timeout 86400 \
     --max-conn-rate 400 --max-handshakes 80 \
     --seckey "$LSP_SECKEY" \
@@ -99,7 +99,7 @@ for i in $(seq 1 $N_CLIENTS); do
     SK=$(printf '%064x' $((i + 1)))  # 0x02 .. 0x41
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK" --fee-rate 1100 --lsp-balance-pct 100 \
+        --seckey "$SK" --fee-rate 1000 --lsp-balance-pct 100 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id $i \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK:60:4}.db" \

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -67,7 +67,7 @@ nohup "$LSP_BIN" \
     --clients "$N_CLIENTS" --arity 1 --amount "$AMOUNT" \
     --active-blocks 50 --dying-blocks 20 \
     --step-blocks 5 --states-per-layer 2 \
-    --fee-rate 1100 --lsp-balance-pct 100 \
+    --fee-rate 1000 --lsp-balance-pct 100 \
     --confirm-timeout 86400 \
     --seckey 0000000000000000000000000000000000000000000000000000000000000001 \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
@@ -84,7 +84,7 @@ done
 
 nohup "$CLIENT_BIN" \
     --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-    --seckey "$CLIENT_SECKEY" --fee-rate 1100 --lsp-balance-pct 100 \
+    --seckey "$CLIENT_SECKEY" --fee-rate 1000 --lsp-balance-pct 100 \
     --lsp-pubkey "$LSP_PUBKEY" --participant-id 1 \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c0.db" \

--- a/tools/test_testnet4_ts_htlc_fc.sh
+++ b/tools/test_testnet4_ts_htlc_fc.sh
@@ -56,7 +56,7 @@ nohup "$LSP_BIN" \
     --network "$NETWORK" --port "$PORT" \
     --demo --test-htlc-force-close \
     --clients "$N_CLIENTS" --arity "$ARITY" \
-    --amount "$AMOUNT" --fee-rate 1100 \
+    --amount "$AMOUNT" --fee-rate 1000 \
     --confirm-timeout 259200 \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
@@ -85,7 +85,7 @@ for N in 1 2 3 4; do
     for _ in $(seq 1 32); do SK_FULL="${SK_FULL}${SK}"; done
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK_FULL" --fee-rate 1100 --lsp-balance-pct 50 \
+        --seckey "$SK_FULL" --fee-rate 1000 --lsp-balance-pct 50 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id "$N" \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK}${SK}.db" \

--- a/tools/test_testnet4_ts_ptlc_basic.sh
+++ b/tools/test_testnet4_ts_ptlc_basic.sh
@@ -53,17 +53,17 @@ echo "  wallet  : $WALLET"
 echo "  N       : $N_CLIENTS"
 echo "  amount  : $AMOUNT sats"
 echo "  binary  : build-release (per #138 ASan-stability rule)"
-echo "  fee-rate: 110 sat/vB (signet-budget memory rule)"
+echo "  fee-rate: 1 sat/vB (testnet4 wallet mintxfee floor)"
 
 pkill -9 -f "superscalar_(lsp|client).*--port $PORT" 2>/dev/null || true
 
 # --test-ptlc-basic implies --enable-ptlc-unsafe (parser flips the gate).
-# --fee-rate 110 per signet-sat budget memory.
+# --fee-rate 1000 per signet-sat budget memory.
 nohup "$LSP_BIN" \
     --network "$NETWORK" --port "$PORT" \
     --demo --test-ptlc-basic \
     --clients "$N_CLIENTS" --arity "$ARITY" \
-    --amount "$AMOUNT" --fee-rate 110 \
+    --amount "$AMOUNT" --fee-rate 1000 \
     --confirm-timeout 259200 \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
@@ -91,7 +91,7 @@ for N in 1 2 3 4; do
     for _ in $(seq 1 32); do SK="${SK}${HEX}"; done
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK" --fee-rate 110 --lsp-balance-pct 50 \
+        --seckey "$SK" --fee-rate 1000 --lsp-balance-pct 50 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id "$N" \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${HEX}.db" \


### PR DESCRIPTION
## Summary

- Drop testnet4 runner `--fee-rate` from 1100 → 1000 sat/kvB (= 1 sat/vB exactly, the wallet `mintxfee` floor).
- ptlc-basic was at 110 (a signet-budget value) which the testnet4 wallet rejected at funding — now 1000.

## Why

testnet4 network `minrelaytxfee` is 100 sat/kvB (= 0.1 sat/vB), so the chain has lots of headroom. But Bitcoin Core's default wallet `mintxfee` is 1000 sat/kvB — that's the binding floor for `sendtoaddress`. The runners were spending ~10% more than necessary on every funding TX; ptlc-basic was rejected wholesale by the wallet.

## Test plan
- [x] All `tools/test_testnet4_*.sh` runners now default to `--fee-rate 1000`
- [x] ptlc-basic relaunched manually today with the patch and progressed to `=== PTLC BASIC TEST PASSED ===`