### PR TITLE
fix(testnet4): make runner --fee-rate operator-tunable via FEE_RATE env

### DIFF
--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -31,6 +31,10 @@ set -euo pipefail
 source "$(dirname "$0")/test_diag_lib.sh"
 
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+# Fee rate in sat/kvB. Default 1000 = 1 sat/vB = testnet4 wallet mintxfee floor.
+# Lower (e.g. FEE_RATE=100 = 0.1 sat/vB) when running sat-recovery sweeps
+# against a bitcoind that has -mintxfee lowered in bitcoin.conf.
+FEE_RATE="${FEE_RATE:-1000}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 
@@ -80,7 +84,7 @@ nohup "$LSP_BIN" \
     --amount "$AMOUNT" \
     --active-blocks 50 --dying-blocks 20 \
     --step-blocks 5 --states-per-layer 2 \
-    --fee-rate 1100 --lsp-balance-pct 100 \
+    --fee-rate "$FEE_RATE" --lsp-balance-pct 100 \
     --confirm-timeout 86400 \
     --max-conn-rate 400 --max-handshakes 80 \
     --seckey "$LSP_SECKEY" \
@@ -104,7 +108,7 @@ for i in $(seq 1 $N_CLIENTS); do
     SK=$(printf '%064x' $((i + 1)))  # 0x02 .. 0x41
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK" --fee-rate 1100 --lsp-balance-pct 100 \
+        --seckey "$SK" --fee-rate "$FEE_RATE" --lsp-balance-pct 100 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id $i \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK:60:4}.db" \

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -36,6 +36,10 @@ set -euo pipefail
 source "$(dirname "$0")/test_diag_lib.sh"
 
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+# Fee rate in sat/kvB. Default 1000 = 1 sat/vB = testnet4 wallet mintxfee floor.
+# Lower (e.g. FEE_RATE=100 = 0.1 sat/vB) when running sat-recovery sweeps
+# against a bitcoind that has -mintxfee lowered in bitcoin.conf.
+FEE_RATE="${FEE_RATE:-1000}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 
@@ -76,7 +80,7 @@ nohup "$LSP_BIN" \
     --clients "$N_CLIENTS" --arity 1 --amount "$AMOUNT" \
     --active-blocks 50 --dying-blocks 20 \
     --step-blocks 5 --states-per-layer 2 \
-    --fee-rate 1100 --lsp-balance-pct 100 \
+    --fee-rate "$FEE_RATE" --lsp-balance-pct 100 \
     --confirm-timeout 86400 \
     --seckey 0000000000000000000000000000000000000000000000000000000000000001 \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
@@ -94,7 +98,7 @@ done
 
 nohup "$CLIENT_BIN" \
     --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-    --seckey "$CLIENT_SECKEY" --fee-rate 1100 --lsp-balance-pct 100 \
+    --seckey "$CLIENT_SECKEY" --fee-rate "$FEE_RATE" --lsp-balance-pct 100 \
     --lsp-pubkey "$LSP_PUBKEY" --participant-id 1 \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c0.db" \

--- a/tools/test_testnet4_ts_htlc_fc.sh
+++ b/tools/test_testnet4_ts_htlc_fc.sh
@@ -21,6 +21,10 @@ set -euo pipefail
 source "$(dirname "$0")/test_diag_lib.sh"
 
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+# Fee rate in sat/kvB. Default 1000 = 1 sat/vB = testnet4 wallet mintxfee floor.
+# Lower (e.g. FEE_RATE=100 = 0.1 sat/vB) when running sat-recovery sweeps
+# against a bitcoind that has -mintxfee lowered in bitcoin.conf.
+FEE_RATE="${FEE_RATE:-1000}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 
@@ -61,7 +65,7 @@ nohup "$LSP_BIN" \
     --network "$NETWORK" --port "$PORT" \
     --demo --test-htlc-force-close \
     --clients "$N_CLIENTS" --arity "$ARITY" \
-    --amount "$AMOUNT" --fee-rate 1100 \
+    --amount "$AMOUNT" --fee-rate "$FEE_RATE" \
     --confirm-timeout 259200 \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
@@ -91,7 +95,7 @@ for N in 1 2 3 4; do
     for _ in $(seq 1 32); do SK_FULL="${SK_FULL}${SK}"; done
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK_FULL" --fee-rate 1100 --lsp-balance-pct 50 \
+        --seckey "$SK_FULL" --fee-rate "$FEE_RATE" --lsp-balance-pct 50 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id "$N" \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK}${SK}.db" \

--- a/tools/test_testnet4_ts_ptlc_basic.sh
+++ b/tools/test_testnet4_ts_ptlc_basic.sh
@@ -24,6 +24,10 @@ set -euo pipefail
 source "$(dirname "$0")/test_diag_lib.sh"
 
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+# Fee rate in sat/kvB. Default 1000 = 1 sat/vB = testnet4 wallet mintxfee floor.
+# Lower (e.g. FEE_RATE=100 = 0.1 sat/vB) when running sat-recovery sweeps
+# against a bitcoind that has -mintxfee lowered in bitcoin.conf.
+FEE_RATE="${FEE_RATE:-1000}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 
@@ -62,12 +66,12 @@ echo "  fee-rate: 110 sat/vB (signet-budget memory rule)"
 pkill -9 -f "superscalar_(lsp|client).*--port $PORT" 2>/dev/null || true
 
 # --test-ptlc-basic implies --enable-ptlc-unsafe (parser flips the gate).
-# --fee-rate 1100 per signet-sat budget memory.
+# --fee-rate "$FEE_RATE" per signet-sat budget memory.
 nohup "$LSP_BIN" \
     --network "$NETWORK" --port "$PORT" \
     --demo --test-ptlc-basic \
     --clients "$N_CLIENTS" --arity "$ARITY" \
-    --amount "$AMOUNT" --fee-rate 1100 \
+    --amount "$AMOUNT" --fee-rate "$FEE_RATE" \
     --confirm-timeout 259200 \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
@@ -96,7 +100,7 @@ for N in 1 2 3 4; do
     for _ in $(seq 1 32); do SK="${SK}${HEX}"; done
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK" --fee-rate 1100 --lsp-balance-pct 50 \
+        --seckey "$SK" --fee-rate "$FEE_RATE" --lsp-balance-pct 50 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id "$N" \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${HEX}.db" \


### PR DESCRIPTION
## Summary

Refactor 4 testnet4 runners to honor `FEE_RATE` env var (default 1000 sat/kvB = 1 sat/vB) instead of hardcoding `--fee-rate`.

```bash
# default 1 sat/vB (matches testnet4 wallet mintxfee floor)
bash tools/test_testnet4_ts_htlc_fc.sh

# cheap sweep at 0.1 sat/vB (requires -mintxfee=0.00000100 in bitcoin.conf)
FEE_RATE=100 bash tools/test_testnet4_ts_htlc_fc.sh
```

## Why

- ptlc-basic was hardcoded to 110 sat/kvB which the testnet4 wallet rejected at funding (-6 below mintxfee floor)
- Others were at 1100 — 10% above the floor, wasteful
- Operator-driven runs need to dial down to 0.1 sat/vB when consolidating stranded sats from prior tests; hardcoding blocks that

## testnet4 fee reference

| Knob | Value | sat/vB |
|------|-------|--------|
| minrelaytxfee | 100 sat/kvB | 0.1 |
| mempoolminfee | 100 sat/kvB | 0.1 |
| wallet mintxfee (default) | 1000 sat/kvB | 1.0 |

## Test plan
- [x] All 4 runners default to FEE_RATE=1000 (sendtoaddress passes)
- [x] FEE_RATE override propagates to both LSP and client --fee-rate args