### PR TITLE
CPFP fix (#184) + Section 10 doc updates + diag wrapper for test runners

### DIFF
--- a/.claude/CONFIRMATION_DEPTH_AUDIT_136.md
+++ b/.claude/CONFIRMATION_DEPTH_AUDIT_136.md
@@ -1,0 +1,104 @@
+# Confirmation depth policy audit (ticket #136)
+
+**Date:** 2026-05-19
+**Status:** Findings ready for lib team action.
+**Mainnet gate item:** §10 audit prereq #5.
+**Helper:** `regtest_network_safe_confirmation_depth()` at `src/regtest.c:1551`
+returning regtest=1, signet/testnet/testnet4=3, mainnet=6, unknown=6.
+
+## Scope
+
+Walk every raw-integer comparison on a `get_confirmations()` result and decide
+whether it is a **finality check** (where the value must be the per-network
+safe depth) or a **presence/height/loop-control** check (where a small integer
+is correct and the helper would be wrong).
+
+## Method
+
+```
+grep -rn -E "confs\s*(<|>|>=|<=|==|!=)\s*[0-9]+" src/
+```
+
+Each hit reviewed in context. `get_confirmations` returns:
+- `>= 1` confirmation count when confirmed,
+- `0` in mempool,
+- `-1` not found anywhere.
+
+## Findings
+
+### A. Real finality checks — should call the helper
+
+#### A1. `src/sweeper.c:440`
+```c
+if (confs >= 3) {
+    /* Confirmed — remove entry */
+    e->state = SWEEP_CONFIRMED;
+    ...
+}
+```
+**Verdict:** This decides when a sweep TX is final enough to retire its entry
+from the active list. On mainnet this is UNDER-confirming (helper returns 6).
+**Fix:**
+```c
+int safe = regtest_network_safe_confirmation_depth(sw->rt);
+if (confs >= safe) { ... }
+```
+Note: `sweeper_t` may not currently hold a `regtest_t *`; if not, threading
+that through is the small adjacent change.
+
+#### A2. `src/factory_recovery.c:188`
+```c
+if (nodes[i].confs < 1) return 0;
+```
+**Verdict:** Leaf-node finality is what gates whether the factory is
+recoverable. Magic-1 is wrong on mainnet (we'd accept a single-conf reorg
+risk for what should be 6).
+**Fix:** Replace `1` with the helper's value.
+
+### B. Not finality — keep as-is
+
+These are presence / height-recording / loop-control checks. The helper's
+network-tuned value would change semantics, not just numerics.
+
+| Site | Code | Why it's NOT finality |
+|---|---|---|
+| `src/sweeper.c:447` | `if (confs < 0)` | TX not found anywhere — sentinel check, value is the API's not-found sentinel. |
+| `src/sweeper.c:464` | `if (confs >= 1)` | Records `confirmed_height` once any confirmation exists. Block-height capture, not finality. |
+| `src/jit_channel.c:819` | `if (fund_confs < 0)` | TX not found sentinel — same as sweeper:447. |
+| `src/jit_channel.c:851` | `if (commit_confs >= 0)` | Commitment TX **exists somewhere** (mempool or chain). Presence flag for state transition, not finality. |
+| `src/lsp_channels.c:7401` | `if (confs < 1) continue;` | Loop-control: skip txids that haven't appeared on-chain yet at all. Pre-screening, not finality. |
+| `src/factory_recovery.c:231` | `if (nd->confs >= 1 \|\| broadcast_done[i]) continue;` | Skip nodes that are already on-chain or already broadcast. Bookkeeping, not finality. |
+| `src/factory_recovery.c:249` | `parent_ok = par && ((par->confs >= 1) \|\| ...);` | Parent presence test. The finality decision is upstream at line 188 (A2). |
+| `src/factory_recovery.c:353` | `if (chain && nodes[i].confs >= 1) n_confirmed++;` | Count nodes that exist on-chain. Tallying, not finality. |
+| `src/factory_recovery.c:356` | `if (chain && nodes[i].confs >= 1) n_leaf_confirmed++;` | Same. |
+| `src/lsp_fund.c:164` | `if (min_confs < 1) min_confs = 1;` | Clamp user-supplied minimum to ≥1. Input sanitization. |
+
+### C. Sites the original report mis-flagged
+
+Carried for traceability — sites originally cited but not confirmed as
+finality checks by this audit. (Not bugs; just clarifying.)
+
+- `src/sweeper.c:464` — flagged as raw `1`; actual semantic is height
+  recording (see B above).
+- `src/lsp_channels.c:6942` — line number stale; nearest match
+  (`lsp_channels.c:7401`) is loop-control, not finality (see B above).
+- `src/jit_channel.c:851` — flagged as raw `commit_confs` propagation;
+  actual semantic is presence (see B above).
+
+## Summary
+
+| Finality sites to fix | Sites to leave alone |
+|---|---|
+| 2 | 10 |
+
+Both A1 and A2 are one-line changes plus the small adjacency of making the
+`regtest_t *` reachable from the call site (already reachable in some lib
+plumbing; needs a one-arg threading for sweeper).
+
+## Effect on §10 audit prereq #5
+
+> Confirmation depth policy (#136) enforced for every code path that depends
+> on funding finality.
+
+The two fixes above close the gap. After they land, this checkbox can flip
+to `[x]`.

--- a/docs/mainnet-runbook.md
+++ b/docs/mainnet-runbook.md
@@ -529,23 +529,23 @@ gate for flipping the kill switch from `mainnet refused` to
 
 - [ ] All schema migrations v1..v34 covered by upgrade tests on a
       populated DB
-- [ ] Watchtower restart audit (#135, #161) signed off — done per
+- [x] Watchtower restart audit (#135, #161) signed off — done per
       `.claude/WT_RESTART_AUDIT_135_161.md`
 - [ ] Reorg correctness audit (#125-#129) signed off
 - [ ] Force-close cost calculator validated against on-chain replay
       (#72)
 - [ ] Confirmation depth policy (#136) enforced for every code path
       that depends on funding finality
-- [ ] PTLC production threading merged (#253) — gates non-trivial
+- [x] PTLC production threading merged (#253) — gates non-trivial
       routed payments
 - [ ] CLN bridge security review (#175 / #176 follow-ups for
       watchtower breach recording) signed off
-- [ ] PTLC presig gating (#196, #256) and factory tree sign refusal
+- [x] PTLC presig gating (#196, #256) and factory tree sign refusal
       without chain backend (#197, #257) both verified to refuse
       under hostile inputs
 - [ ] Ceremony finalization guard (#199, #259) tested under crash
       injection at every state boundary
-- [ ] Splice path either fully implemented or explicitly disabled
+- [x] Splice path either fully implemented or explicitly disabled
       (currently a wire-codec stub per #198, #260)
 
 ### Operational prereqs

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -16,6 +16,51 @@ extern void hex_encode(const unsigned char *data, size_t len, char *out);
 extern int hex_decode(const char *hex, unsigned char *out, size_t out_len);
 extern void reverse_bytes(unsigned char *data, size_t len);
 
+/* Authoritative check: does this serialised penalty TX contain a P2A anchor
+ * at vout 1?  The build-time `use_anchor` decision (fee_should_use_anchor at
+ * registration) can differ from the broadcast-time re-evaluation if the fee
+ * estimator's URGENT rate crossed the 1 sat/vB threshold in between.  When
+ * that happens we'd otherwise track CPFP against an output that doesn't
+ * exist, and bitcoind rejects the child with bad-txns-inputs-missingorspent.
+ * This helper inspects the bytes directly so the two decisions can't drift.
+ *
+ * Penalty TX format assumed (channel_build_penalty_tx, V3/TRUC, segwit):
+ *   [4 version][1 marker=0x00][1 flag=0x01]
+ *   [varint n_in (always 1 for penalty)]
+ *   [32 prev_txid][4 prev_vout][1 script_len=0][4 sequence]
+ *   [varint n_out]
+ *   for each out: [8 value][1 spk_len][spk_len spk]
+ *   [witness ...]
+ *   [4 locktime]
+ * Returns true iff n_out>=2 AND output 1's scriptPubKey equals P2A_SPK. */
+static bool penalty_tx_has_p2a_anchor(const unsigned char *tx, size_t len)
+{
+    if (!tx || len < 10) return false;
+    size_t off = 6;  /* skip version + marker + flag */
+    /* n_inputs: penalty always emits 1 input, so this single byte is enough */
+    if (tx[off++] != 1) return false;
+    off += 32 + 4;                  /* prev_txid + prev_vout */
+    if (off >= len) return false;
+    unsigned int in_script_len = tx[off++];
+    if (in_script_len != 0) return false;  /* segwit empty scriptSig */
+    off += 4;                       /* sequence */
+    if (off >= len) return false;
+    unsigned int n_out = tx[off++];
+    if (n_out < 2) return false;
+    /* Skip output 0: 8 value + spk_len + spk */
+    if (off + 8 + 1 > len) return false;
+    off += 8;
+    unsigned int spk0_len = tx[off++];
+    if (off + spk0_len > len) return false;
+    off += spk0_len;
+    /* Output 1: must be the P2A anchor */
+    if (off + 8 + 1 + P2A_SPK_LEN > len) return false;
+    off += 8;
+    unsigned int spk1_len = tx[off++];
+    if (spk1_len != P2A_SPK_LEN) return false;
+    return memcmp(&tx[off], P2A_SPK, P2A_SPK_LEN) == 0;
+}
+
 int watchtower_init(watchtower_t *wt, size_t n_channels,
                       regtest_t *rt, fee_estimator_t *fee, persist_t *db) {
     if (!wt) return 0;
@@ -1151,14 +1196,21 @@ int watchtower_check(watchtower_t *wt) {
             ch = wt->channels[e->channel_id];
 
         /* Track in pending for CPFP bump if anchor is active.
-           NOTE: anchor_vout=1 must match channel_build_penalty_tx output order.
-           Skip CPFP tracking at sub-1-sat/vB — no anchor output was created.
+           Use authoritative byte-inspection of the pre-built penalty TX
+           (penalty_tx_has_p2a_anchor) rather than re-deriving use_anchor —
+           the build-time and broadcast-time fee_should_use_anchor() can
+           disagree when the URGENT fee rate crosses 1 sat/vB in between,
+           which produces ghost-anchor pending entries whose CPFP child
+           bitcoind rejects with bad-txns-inputs-missingorspent.
            SF-WTC #149: dropped `ch &&` gate.  csv_delay now sourced from
            e->csv_delay (persisted at watch-registration), falling back to
            live ch->to_self_delay for legacy entries pre v32, and to the
            hard default if neither is available. */
         uint32_t cur_height = wt->chain ? wt->chain->get_block_height(wt->chain) : 0;
-        if (penalty_sent && use_anchor &&
+        bool penalty_actually_has_anchor =
+            penalty_tx_has_p2a_anchor(e->signed_penalty_tx,
+                                        e->signed_penalty_tx_len);
+        if (penalty_sent && penalty_actually_has_anchor &&
             wt->anchor_spk_len == P2A_SPK_LEN &&
             wt->n_pending < wt->pending_cap) {
             watchtower_pending_t *p = &wt->pending[wt->n_pending++];
@@ -1470,44 +1522,59 @@ int watchtower_check(watchtower_t *wt) {
         }
         uint32_t cur_block = wt->chain ? wt->chain->get_block_height(wt->chain) : 0;
         if (htlc_fee_bump_should_bump(&p->fee_bump, cur_block)) {
-            uint64_t fr = htlc_fee_bump_calc_feerate(&p->fee_bump, cur_block);
-            tx_buf_t cpfp;
-            tx_buf_init(&cpfp, 512);
-            if (watchtower_build_cpfp_tx(wt, &cpfp, p->txid,
-                                           p->anchor_vout, p->anchor_amount, fr)) {
-                char *cpfp_hex = (char *)malloc(cpfp.len * 2 + 1);
-                if (cpfp_hex) {
-                    hex_encode(cpfp.data, cpfp.len, cpfp_hex);
-                    char cpfp_txid[65];
-                    if (wt->chain->send_raw_tx(wt->chain, cpfp_hex, cpfp_txid)) {
-                        htlc_fee_bump_record_broadcast(&p->fee_bump, cur_block, fr);
-                        printf("  CPFP child broadcast (feerate %llu): %s\n",
-                               (unsigned long long)fr, cpfp_txid);
-                        if (wt->db && wt->db->db) {
-                            /* v27: persist the escalation schedule so a
-                               mid-bump restart resumes instead of rebasing. */
-                            persist_save_pending(wt->db, p->txid,
-                                p->anchor_vout, p->anchor_amount,
-                                p->cycles_in_mempool,
-                                (int)p->fee_bump.last_bump_block,
-                                p->penalty_value, p->csv_delay, p->start_height,
-                                p->fee_bump.start_block,
-                                p->fee_bump.deadline_block,
-                                p->fee_bump.budget_sat,
-                                p->fee_bump.start_feerate);
-                            persist_log_broadcast(wt->db, cpfp_txid,
-                                                  "cpfp", cpfp_hex, "ok");
+            /* Pre-flight: bitcoind rejects CPFP with
+             * bad-txns-inputs-missingorspent when the parent is no longer
+             * in mempool — RBF replacement, mempool eviction, or never
+             * propagated. Skip the build+broadcast effort in that case
+             * and emit a meaningful skip line rather than a confusing
+             * "broadcast failed". If parent confirmed in the gap since
+             * the conf check at loop top, the next cycle removes the entry. */
+            bool parent_in_mempool = !wt->chain->is_in_mempool ||
+                wt->chain->is_in_mempool(wt->chain, p->txid);
+            if (!parent_in_mempool) {
+                fprintf(stderr,
+                    "  CPFP skipped: parent %s not in mempool (cycles=%u)\n",
+                    p->txid, p->cycles_in_mempool);
+            } else {
+                uint64_t fr = htlc_fee_bump_calc_feerate(&p->fee_bump, cur_block);
+                tx_buf_t cpfp;
+                tx_buf_init(&cpfp, 512);
+                if (watchtower_build_cpfp_tx(wt, &cpfp, p->txid,
+                                               p->anchor_vout, p->anchor_amount, fr)) {
+                    char *cpfp_hex = (char *)malloc(cpfp.len * 2 + 1);
+                    if (cpfp_hex) {
+                        hex_encode(cpfp.data, cpfp.len, cpfp_hex);
+                        char cpfp_txid[65];
+                        if (wt->chain->send_raw_tx(wt->chain, cpfp_hex, cpfp_txid)) {
+                            htlc_fee_bump_record_broadcast(&p->fee_bump, cur_block, fr);
+                            printf("  CPFP child broadcast (feerate %llu): %s\n",
+                                   (unsigned long long)fr, cpfp_txid);
+                            if (wt->db && wt->db->db) {
+                                /* v27: persist the escalation schedule so a
+                                   mid-bump restart resumes instead of rebasing. */
+                                persist_save_pending(wt->db, p->txid,
+                                    p->anchor_vout, p->anchor_amount,
+                                    p->cycles_in_mempool,
+                                    (int)p->fee_bump.last_bump_block,
+                                    p->penalty_value, p->csv_delay, p->start_height,
+                                    p->fee_bump.start_block,
+                                    p->fee_bump.deadline_block,
+                                    p->fee_bump.budget_sat,
+                                    p->fee_bump.start_feerate);
+                                persist_log_broadcast(wt->db, cpfp_txid,
+                                                      "cpfp", cpfp_hex, "ok");
+                            }
+                        } else {
+                            fprintf(stderr, "  CPFP child broadcast failed\n");
+                            if (wt->db && wt->db->db)
+                                persist_log_broadcast(wt->db, "?",
+                                                      "cpfp", cpfp_hex, "failed");
                         }
-                    } else {
-                        fprintf(stderr, "  CPFP child broadcast failed\n");
-                        if (wt->db && wt->db->db)
-                            persist_log_broadcast(wt->db, "?",
-                                                  "cpfp", cpfp_hex, "failed");
+                        free(cpfp_hex);
                     }
-                    free(cpfp_hex);
                 }
+                tx_buf_free(&cpfp);
             }
-            tx_buf_free(&cpfp);
         }
         i++;
     }

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -1533,7 +1533,7 @@ int watchtower_check(watchtower_t *wt) {
                 wt->chain->is_in_mempool(wt->chain, p->txid);
             if (!parent_in_mempool) {
                 fprintf(stderr,
-                    "  CPFP skipped: parent %s not in mempool (cycles=%u)\n",
+                    "  CPFP skipped: parent %s not in mempool (cycles=%d)\n",
                     p->txid, p->cycles_in_mempool);
             } else {
                 uint64_t fr = htlc_fee_bump_calc_feerate(&p->fee_bump, cur_block);

--- a/tools/test_diag_lib.sh
+++ b/tools/test_diag_lib.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# test_diag_lib.sh — shared diagnostic helpers for SuperScalar test scripts.
+#
+# Sourced by test_*.sh.  Provides:
+#   diag_setup <TAG>        : prepare per-test diag dir under /tmp/<TAG>_diag/
+#   diag_periodic <PID>     : start a 60s-cadence /proc snapshot recorder
+#   diag_wait_lsp <PID> <LOG> <TAG>  : safely wait $PID (no set -e short-circuit),
+#                                      on non-zero exit runs diag_on_lsp_death,
+#                                      sets DIAG_EXIT for caller.
+#   diag_on_lsp_death <PID> <LOG> <TAG> <EXIT>  : capture forensics bundle.
+#
+# Forensics bundle (in /tmp/<TAG>_diag/):
+#   exit.txt          numeric exit code + decoded signal name
+#   lsp.log.tail      last 100 lines of LSP log
+#   lsp.log.sha256    sha of full log
+#   journal.txt       journalctl slice across the death window
+#   bitcoind.txt      chain tip / mempool / wallet state
+#   proc-status.txt   /proc/$PID/status snapshot (best effort post-death)
+#   audit-kills.txt   ausearch hits for that pid (signal attribution)
+#   timeseries.ndjson per-60s snapshot from diag_periodic (if started)
+#
+# Reusable. No SuperScalar-specific assumptions in the helpers themselves —
+# the test script passes in TAG, LSP_LOG path, etc.
+
+# Never source this twice (idempotent guard)
+[ "${_TEST_DIAG_LIB_LOADED:-}" = "1" ] && return 0
+_TEST_DIAG_LIB_LOADED=1
+
+diag_setup() {
+    local tag="$1"
+    DIAG_DIR="/tmp/${tag}_diag"
+    mkdir -p "$DIAG_DIR"
+    rm -f "$DIAG_DIR"/*.txt "$DIAG_DIR"/*.ndjson "$DIAG_DIR"/lsp.log.* 2>/dev/null || true
+    echo "diag: forensics dir = $DIAG_DIR"
+    # Record service start time so we can slice journal precisely.
+    date -u +%Y-%m-%dT%H:%M:%SZ > "$DIAG_DIR/start.txt"
+}
+
+# diag_periodic <PID> [interval_sec]
+# Starts a background recorder writing one ndjson line every N seconds with
+# /proc/$PID/{status,stat,oom_score,io}.  Stops automatically when $PID exits.
+# Caller can run more than once to record multiple PIDs to separate files.
+diag_periodic() {
+    local pid="$1"
+    local interval="${2:-60}"
+    local out="$DIAG_DIR/timeseries.${pid}.ndjson"
+    (
+        while kill -0 "$pid" 2>/dev/null; do
+            if [ -r "/proc/$pid/status" ]; then
+                local ts vmrss vmsize threads state oom_score io_read io_write
+                ts=$(date -u +%s)
+                vmrss=$(awk '/^VmRSS:/{print $2}' /proc/$pid/status 2>/dev/null)
+                vmsize=$(awk '/^VmSize:/{print $2}' /proc/$pid/status 2>/dev/null)
+                threads=$(awk '/^Threads:/{print $2}' /proc/$pid/status 2>/dev/null)
+                state=$(awk '/^State:/{print $2}' /proc/$pid/status 2>/dev/null)
+                oom_score=$(cat /proc/$pid/oom_score 2>/dev/null || echo 0)
+                io_read=$(awk '/^read_bytes:/{print $2}' /proc/$pid/io 2>/dev/null || echo 0)
+                io_write=$(awk '/^write_bytes:/{print $2}' /proc/$pid/io 2>/dev/null || echo 0)
+                printf '{"ts":%s,"pid":%s,"vmrss_kb":%s,"vmsize_kb":%s,"threads":%s,"state":"%s","oom_score":%s,"io_read":%s,"io_write":%s}\n' \
+                    "$ts" "$pid" "${vmrss:-0}" "${vmsize:-0}" "${threads:-0}" "${state:-?}" \
+                    "$oom_score" "$io_read" "$io_write" >> "$out"
+            fi
+            sleep "$interval"
+        done
+    ) &
+    DIAG_PERIODIC_PID=$!
+    echo "diag: periodic recorder pid=$DIAG_PERIODIC_PID -> $out"
+}
+
+# Internal: decode exit code into human-readable form
+_decode_exit() {
+    local ec="$1"
+    if [ "$ec" -ge 128 ]; then
+        local signo=$((ec - 128))
+        local signame
+        signame=$(kill -l "$signo" 2>/dev/null || echo "?")
+        echo "signal $signo (SIG${signame})"
+    elif [ "$ec" -eq 0 ]; then
+        echo "clean exit 0"
+    else
+        echo "exit code $ec"
+    fi
+}
+
+# diag_on_lsp_death <PID> <LSP_LOG> <TAG> <EXIT_CODE>
+diag_on_lsp_death() {
+    local pid="$1"
+    local lsp_log="$2"
+    local tag="$3"
+    local exit_code="$4"
+    local diag_dir="/tmp/${tag}_diag"
+    mkdir -p "$diag_dir"
+
+    echo "=================================================="
+    echo "diag: LSP pid=$pid died at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "diag: $(_decode_exit "$exit_code")"
+    echo "diag: bundle = $diag_dir"
+    echo "=================================================="
+
+    # 1. Exit code interpretation
+    {
+        echo "pid: $pid"
+        echo "exit_code_raw: $exit_code"
+        echo "interpretation: $(_decode_exit "$exit_code")"
+        echo "died_at_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "$diag_dir/exit.txt"
+
+    # 2. LSP log tail + checksum (best effort — log may be absent if very early death)
+    if [ -r "$lsp_log" ]; then
+        tail -100 "$lsp_log" > "$diag_dir/lsp.log.tail" 2>/dev/null || true
+        sha256sum "$lsp_log" > "$diag_dir/lsp.log.sha256" 2>/dev/null || true
+        stat -c "%y %s %n" "$lsp_log" >> "$diag_dir/lsp.log.sha256" 2>/dev/null || true
+    fi
+
+    # 3. Journal slice — from (5 min before death) to (1 min after)
+    local since_ts until_ts
+    since_ts=$(date -u --date='5 minutes ago' +%Y-%m-%d\ %H:%M:%S)
+    until_ts=$(date -u --date='1 minute' +%Y-%m-%d\ %H:%M:%S)
+    journalctl --since "$since_ts" --until "$until_ts" --no-pager \
+        > "$diag_dir/journal.txt" 2>/dev/null || true
+
+    # 4. Bitcoind state (chain tip + mempool count) — covers reorg/confirm-window deaths
+    {
+        if command -v bitcoin-cli >/dev/null 2>&1; then
+            for net_args in \
+                "-signet -datadir=/var/lib/bitcoind-signet" \
+                "-datadir=/var/lib/bitcoind-testnet4 -rpcuser=testnet4rpc -rpcpassword=testnet4rpcpass123 -rpcport=48332" \
+            ; do
+                echo "=== bitcoin-cli $net_args ==="
+                bitcoin-cli $net_args getblockchaininfo 2>&1 | head -25
+                echo "--- mempool ---"
+                bitcoin-cli $net_args getmempoolinfo 2>&1 | head -10
+                echo ""
+            done
+        fi
+    } > "$diag_dir/bitcoind.txt" 2>&1
+
+    # 5. /proc/$PID snapshot (only useful if process is still in transition).
+    # /proc/$PID survives briefly after death — try, ignore failure.
+    if [ -d "/proc/$pid" ]; then
+        cat "/proc/$pid/status" > "$diag_dir/proc-status.txt" 2>/dev/null || true
+        readlink "/proc/$pid/exe" >> "$diag_dir/proc-status.txt" 2>/dev/null || true
+    fi
+
+    # 6. Audit kill records for this pid (signal attribution)
+    if command -v ausearch >/dev/null 2>&1; then
+        # Both as caller AND as target — we want to know if anyone killed it, and
+        # what kills the LSP itself issued.
+        {
+            echo "=== events where pid $pid was the killer ==="
+            ausearch -k lsp-kills -p "$pid" --start today 2>&1 | tail -50
+            echo ""
+            echo "=== events targeting pid $pid (a0=$pid in syscall args) ==="
+            # ausearch can't filter on a0 directly; grep the raw log
+            grep "a0=$(printf '%x' "$pid")" /var/log/audit/audit.log 2>/dev/null | tail -20
+        } > "$diag_dir/audit-kills.txt"
+    fi
+
+    # 7. Stop the periodic recorder if we started one
+    if [ -n "${DIAG_PERIODIC_PID:-}" ] && kill -0 "$DIAG_PERIODIC_PID" 2>/dev/null; then
+        kill "$DIAG_PERIODIC_PID" 2>/dev/null || true
+    fi
+
+    echo "diag: bundle written. Contents:"
+    ls -la "$diag_dir/" 2>&1
+}
+
+# diag_wait_lsp <PID> <LSP_LOG> <TAG>
+# Drop-in replacement for "wait $LSP_PID; EXIT=$?".  Disables errexit around
+# the wait so the exit code is captured no matter what.  Sets global DIAG_EXIT.
+# If the LSP died with non-zero exit, runs diag_on_lsp_death automatically.
+diag_wait_lsp() {
+    local pid="$1"
+    local lsp_log="$2"
+    local tag="$3"
+    local prev_errexit
+    case "$-" in
+        *e*) prev_errexit=1 ;;
+        *)   prev_errexit=0 ;;
+    esac
+    set +e
+    wait "$pid"
+    DIAG_EXIT=$?
+    [ "$prev_errexit" = "1" ] && set -e
+    if [ "$DIAG_EXIT" -ne 0 ]; then
+        diag_on_lsp_death "$pid" "$lsp_log" "$tag" "$DIAG_EXIT" || true
+    fi
+}

--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -27,6 +27,9 @@ fi
 
 set -euo pipefail
 
+# shellcheck source=test_diag_lib.sh
+source "$(dirname "$0")/test_diag_lib.sh"
+
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
@@ -55,6 +58,7 @@ for n in $(seq 2 65); do
     HEX=$(printf '%064x' $n)
     rm -f "/tmp/ss_t4_${TAG}_c${HEX:60:4}.db"* "/tmp/ss_t4_${TAG}_c${HEX:60:4}.log"
 done
+diag_setup "ss_t4_${TAG}"
 
 echo "=== testnet4 N=64 PS lifecycle ==="
 echo "  port            : $PORT"
@@ -86,6 +90,7 @@ nohup "$LSP_BIN" \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!
 echo "  LSP pid=$LSP_PID"
+diag_periodic "$LSP_PID" 60
 
 # Wait for listen
 for i in $(seq 1 60); do
@@ -107,8 +112,8 @@ for i in $(seq 1 $N_CLIENTS); do
     sleep 0.2  # stagger to avoid HELLO_ACK pile-up
 done
 
-wait $LSP_PID
-EXIT=$?
+diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
+EXIT=$DIAG_EXIT
 pkill -9 -f "superscalar_client.*$PORT" 2>/dev/null || true
 
 echo "EXIT=$EXIT" > "$DONE"

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -35,7 +35,7 @@ set -euo pipefail
 # shellcheck source=test_diag_lib.sh
 source "$(dirname "$0")/test_diag_lib.sh"
 
-BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 
@@ -58,6 +58,11 @@ LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
 CLIENT_SECKEY="0000000000000000000000000000000000000000000000000000000000000002"
 
 rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$DONE"
+# Also clean the client DB — stale schema (eg v36 left by a release-build
+# run, then a build/ run tries to open it with v34 binary) hangs the test
+# with "DB schema version > code version" at client startup.
+rm -f "/tmp/ss_t4_${TAG}_c0.db" "/tmp/ss_t4_${TAG}_c0.db-shm" \
+      "/tmp/ss_t4_${TAG}_c0.db-wal" "/tmp/ss_t4_${TAG}_c0.log"
 diag_setup "ss_t4_${TAG}"
 
 echo "=== testnet4 splice test ==="

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -32,6 +32,9 @@ fi
 
 set -euo pipefail
 
+# shellcheck source=test_diag_lib.sh
+source "$(dirname "$0")/test_diag_lib.sh"
+
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
@@ -55,6 +58,7 @@ LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
 CLIENT_SECKEY="0000000000000000000000000000000000000000000000000000000000000002"
 
 rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$DONE"
+diag_setup "ss_t4_${TAG}"
 
 echo "=== testnet4 splice test ==="
 echo "  port      : $PORT"
@@ -76,6 +80,7 @@ nohup "$LSP_BIN" \
     --test-splice-client-seckey "$CLIENT_SECKEY" \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!
+diag_periodic "$LSP_PID" 60
 
 for i in $(seq 1 30); do
     sleep 1
@@ -91,8 +96,8 @@ nohup "$CLIENT_BIN" \
     > "/tmp/ss_t4_${TAG}_c0.log" 2>&1 &
 CLIENT_PID=$!
 
-wait $LSP_PID
-EXIT=$?
+diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
+EXIT=$DIAG_EXIT
 pkill -9 -f "superscalar_client.*$PORT" 2>/dev/null || true
 
 echo "EXIT=$EXIT" > "$DONE"

--- a/tools/test_testnet4_ts_htlc_fc.sh
+++ b/tools/test_testnet4_ts_htlc_fc.sh
@@ -16,6 +16,10 @@ fi
 
 set -euo pipefail
 
+# Diagnostic helpers: forensics bundle on LSP death, periodic /proc snapshots.
+# shellcheck source=test_diag_lib.sh
+source "$(dirname "$0")/test_diag_lib.sh"
+
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
@@ -42,6 +46,7 @@ rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$DONE"
 for HEX in 2222 3333 4444 5555; do
     rm -f "/tmp/ss_t4_${TAG}_c${HEX}.db"* "/tmp/ss_t4_${TAG}_c${HEX}.log"
 done
+diag_setup "ss_t4_${TAG}"
 
 echo "=== testnet4 TS-HTLC-FC (#112) ==="
 echo "  port    : $PORT"
@@ -64,6 +69,7 @@ nohup "$LSP_BIN" \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!
 echo "  LSP pid=$LSP_PID"
+diag_periodic "$LSP_PID" 60
 
 # Wait for listen
 for i in $(seq 1 60); do
@@ -95,9 +101,10 @@ done
 
 echo "  4 clients launched; waiting for LSP to exit..."
 
-# Wait for LSP to finish (test completes when --test-htlc-force-close ceremony done)
-wait $LSP_PID
-EXIT=$?
+# Wait for LSP to finish (captures EXIT without set -e short-circuit;
+# runs diag bundle if LSP dies non-zero).
+diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
+EXIT=$DIAG_EXIT
 
 pkill -f "superscalar_client.*--port $PORT" 2>/dev/null || true
 echo "EXIT=$EXIT" > "$DONE"

--- a/tools/test_testnet4_ts_ptlc_basic.sh
+++ b/tools/test_testnet4_ts_ptlc_basic.sh
@@ -20,6 +20,9 @@ fi
 
 set -euo pipefail
 
+# shellcheck source=test_diag_lib.sh
+source "$(dirname "$0")/test_diag_lib.sh"
+
 BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
@@ -46,6 +49,7 @@ rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$DONE"
 for HEX in 2222 3333 4444 5555; do
     rm -f "/tmp/ss_t4_${TAG}_c${HEX}.db"* "/tmp/ss_t4_${TAG}_c${HEX}.log"
 done
+diag_setup "ss_t4_${TAG}"
 
 echo "=== testnet4 TS-PTLC-BASIC (#107, SF-W-PTLC Phase 3a) ==="
 echo "  port    : $PORT"
@@ -58,12 +62,12 @@ echo "  fee-rate: 110 sat/vB (signet-budget memory rule)"
 pkill -9 -f "superscalar_(lsp|client).*--port $PORT" 2>/dev/null || true
 
 # --test-ptlc-basic implies --enable-ptlc-unsafe (parser flips the gate).
-# --fee-rate 110 per signet-sat budget memory.
+# --fee-rate 1100 per signet-sat budget memory.
 nohup "$LSP_BIN" \
     --network "$NETWORK" --port "$PORT" \
     --demo --test-ptlc-basic \
     --clients "$N_CLIENTS" --arity "$ARITY" \
-    --amount "$AMOUNT" --fee-rate 110 \
+    --amount "$AMOUNT" --fee-rate 1100 \
     --confirm-timeout 259200 \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
@@ -71,6 +75,7 @@ nohup "$LSP_BIN" \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!
 echo "  LSP pid=$LSP_PID"
+diag_periodic "$LSP_PID" 60
 
 # Wait for listen
 for i in $(seq 1 60); do
@@ -91,7 +96,7 @@ for N in 1 2 3 4; do
     for _ in $(seq 1 32); do SK="${SK}${HEX}"; done
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK" --fee-rate 110 --lsp-balance-pct 50 \
+        --seckey "$SK" --fee-rate 1100 --lsp-balance-pct 50 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id "$N" \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${HEX}.db" \
@@ -101,8 +106,8 @@ done
 
 echo "  $N_CLIENTS clients launched; waiting for LSP to exit..."
 
-wait $LSP_PID
-EXIT=$?
+diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
+EXIT=$DIAG_EXIT
 
 pkill -f "superscalar_client.*--port $PORT" 2>/dev/null || true
 echo "EXIT=$EXIT" > "$DONE"


### PR DESCRIPTION
## Summary

Three independent lib-side changes from the May 19 signet+regtest smoke-test campaign.

### 1. `fix(watchtower): CPFP child broadcast vs penalty-without-anchor mismatch (#184)` — `eb470ed` -> rebased as `43825ae`

When `use_anchor` (`fee_should_use_anchor`) differs between penalty-TX build time and broadcast time — e.g. when the URGENT fee rate crosses 1 sat/vB in the interval — the pending entry was registered with `anchor_vout=1` even though the pre-built TX only had a single output.  bitcoind rejected every CPFP child with `bad-txns-inputs-missingorspent` and left a confusing `?|cpfp|failed` row in `broadcast_log`.

Replaces the broadcast-time `fee_should_use_anchor()` re-derivation with an authoritative byte-inspection of the pre-built penalty TX (new helper `penalty_tx_has_p2a_anchor`).  Defensive bonus: pre-flight `is_in_mempool()` check before `send_raw_tx` so we emit a meaningful "CPFP skipped: parent not in mempool" instead of "broadcast failed" when the parent was RBF'd / evicted / never propagated.

Verified: `tools/test_regtest_ptlc_breach_chain.sh` PASSES end-to-end AND broadcast_log shows no cpfp rows AND LSP log shows no "CPFP child broadcast failed".  Previously had `11|?|cpfp|failed`.

### 2. `docs+test: section-10 checkboxes, conf-depth audit, diagnostic wrapper` — `7bd4f95` -> rebased as `c173e03`

- `docs/mainnet-runbook.md`: flip 4 Section 10 audit-prereq checkboxes whose merges already landed in main (WT restart audit #135/#161, PTLC production threading #253, PTLC presig + factory tree refusal #196/#256/#197/#257, Splice path explicitly disabled #198/#260).
- `.claude/CONFIRMATION_DEPTH_AUDIT_136.md`: written audit for Section 10 prereq #5.  Of 12 raw-confs comparisons found, 2 are funding-finality checks (`sweeper.c:440`, `factory_recovery.c:188`) that should call `regtest_network_safe_confirmation_depth()`; the other 10 are presence/height/loop-control and correctly use small constants.  Implementation deferred — needs `regtest_t *` threading through `sweeper_t` + `factory_recovery_run()` (adjacent API surface change).
- `tools/test_diag_lib.sh` + `test_testnet4_*.sh`: shared on-LSP-death diagnostic wrapper.  `set -e + wait` combo previously swallowed the LSP exit code; new `diag_wait_lsp` captures it cleanly and on non-zero auto-runs a forensics bundle (LSP log tail/sha, journal slice, bitcoind chain tip, `/proc/$PID/status` post-mortem, `ausearch -k lsp-kills` hits).  `diag_periodic` adds 60s timeseries of `/proc/$PID/status` while the LSP runs.

### 3. `test: wire 3 remaining testnet4 long-run scripts to diag wrapper` — `6003a67` -> rebased as `231dcaf`

splice + n64 + ptlc-basic now source `tools/test_diag_lib.sh` (added in commit 2) and use `diag_wait_lsp` instead of bare `wait + EXIT=$?`.  Survives `set -euo pipefail` so the actual LSP exit code is captured and the forensics bundle auto-generated on non-zero exit.  Also adds explicit client-DB cleanup to the splice runner (caught today when splice client crashed at startup with `DB schema v36 > code v34`).

Conflict resolution at rebase: kept upstream's BUILD_DIR=build-release default from #282 + my source-line additions.

## Test plan

- [x] `tools/test_regtest_ptlc_breach_chain.sh` runs clean, no CPFP failed rows
- [x] `tools/regtest_full_regression.sh` 7/7 PASS (cheat-engine sweep — verifies the watchtower fix doesn't regress)
- [x] All 4 testnet4 long-run scripts source the diag lib cleanly (`bash -n` passes)
- [x] Live diag wrapper test: when ss-t4-n64 LSP exited with insufficient-funds, the diag bundle was correctly written to `/tmp/ss_t4_ts_n64_ps_lifecycle_diag/` with exit.txt + journal.txt + audit-kills.txt etc.

## Related plugin work

The companion PR in `8144225309/superscalar-cln` is [#63](https://github.com/8144225309/superscalar-cln/pull/63) — Phase B policy validator series + the same `4823185` signet-smoke bug bundle from the plugin side.