### PR TITLE
test scaffolding: deterministic basepoints + runner diagnostics

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2,6 +2,7 @@
 #include "superscalar/tapscript.h"
 #include "superscalar/fee_estimator.h"
 #include "superscalar/persist.h"
+#include "superscalar/noise.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -11,6 +12,7 @@
 
 #include "superscalar/sha256.h"
 extern void reverse_bytes(unsigned char *, size_t);
+extern int hex_decode(const char *hex, unsigned char *out, size_t out_len);
 
 /* ---- Key derivation (BOLT #3) ---- */
 
@@ -399,16 +401,74 @@ void channel_set_remote_basepoints(channel_t *ch,
 #define BASEPOINT_DIAG 0
 #endif
 
+/* When SUPERSCALAR_TEST_SEED is set in the environment, derive the four
+   basepoint secrets deterministically via HMAC-SHA256 instead of /dev/urandom.
+   This lets test scaffolds recover access to factory outputs after a DB wipe
+   by re-seeding from a stored hex.  Production leaves the env var unset and
+   falls through to the random path.
+
+   Domain separation:
+     key   = test_seed
+     data  = local_funding_secret(32) || channel_counter_be32(4) || role
+     role  ∈ {"payment", "delayed", "revocation", "htlc"}
+   The local_funding_secret discriminates LSP vs client (their static seckeys
+   already differ).  The per-process counter discriminates channels created
+   with the same funding secret in sequence. */
 int channel_generate_random_basepoints(channel_t *ch) {
     unsigned char ps[32], ds[32], rs[32], hs[32];
-    if (!channel_read_random_bytes(ps, 32) || !channel_read_random_bytes(ds, 32) ||
-        !channel_read_random_bytes(rs, 32) || !channel_read_random_bytes(hs, 32)) {
-        return 0;
+    int seeded = 0;
+
+    const char *test_seed_hex = getenv("SUPERSCALAR_TEST_SEED");
+    if (test_seed_hex && *test_seed_hex) {
+        size_t hex_len = strlen(test_seed_hex);
+        if (hex_len == 0 || hex_len > 128 || (hex_len & 1)) {
+            fprintf(stderr,
+                    "WARN SUPERSCALAR_TEST_SEED invalid length %zu — using /dev/urandom\n",
+                    hex_len);
+        } else {
+            unsigned char seed[64];
+            int n = hex_decode(test_seed_hex, seed, sizeof(seed));
+            if (n <= 0) {
+                fprintf(stderr,
+                        "WARN SUPERSCALAR_TEST_SEED invalid hex — using /dev/urandom\n");
+            } else {
+                static uint32_t s_test_chan_counter = 0;
+                uint32_t idx = s_test_chan_counter++;
+                unsigned char info[32 + 4 + 16];
+                memcpy(info, ch->local_funding_secret, 32);
+                info[32] = (unsigned char)((idx >> 24) & 0xff);
+                info[33] = (unsigned char)((idx >> 16) & 0xff);
+                info[34] = (unsigned char)((idx >> 8) & 0xff);
+                info[35] = (unsigned char)(idx & 0xff);
+                static const char *const roles[4] = {
+                    "payment", "delayed", "revocation", "htlc" };
+                unsigned char *outs[4] = { ps, ds, rs, hs };
+                for (int r = 0; r < 4; r++) {
+                    size_t rl = strlen(roles[r]);
+                    memcpy(info + 36, roles[r], rl);
+                    hmac_sha256(outs[r], seed, (size_t)n, info, 36 + rl);
+                }
+                memset(seed, 0, sizeof(seed));
+                memset(info, 0, sizeof(info));
+                fprintf(stderr,
+                        "DIAG basepoint: derived from SUPERSCALAR_TEST_SEED channel_idx=%u\n",
+                        (unsigned)idx);
+                seeded = 1;
+            }
+        }
+    }
+
+    if (!seeded) {
+        if (!channel_read_random_bytes(ps, 32) || !channel_read_random_bytes(ds, 32) ||
+            !channel_read_random_bytes(rs, 32) || !channel_read_random_bytes(hs, 32)) {
+            return 0;
+        }
     }
 
 #if BASEPOINT_DIAG
-    fprintf(stderr, "DIAG basepoint: generated random (pay=%02x%02x..., delay=%02x%02x..., "
+    fprintf(stderr, "DIAG basepoint: generated %s (pay=%02x%02x..., delay=%02x%02x..., "
             "revoc=%02x%02x..., htlc=%02x%02x...)\n",
+            seeded ? "deterministic" : "random",
             ps[0], ps[1], ds[0], ds[1], rs[0], rs[1], hs[0], hs[1]);
 #endif
 

--- a/tools/test_diag_lib.sh
+++ b/tools/test_diag_lib.sh
@@ -30,10 +30,38 @@ diag_setup() {
     local tag="$1"
     DIAG_DIR="/tmp/${tag}_diag"
     mkdir -p "$DIAG_DIR"
-    rm -f "$DIAG_DIR"/*.txt "$DIAG_DIR"/*.ndjson "$DIAG_DIR"/lsp.log.* 2>/dev/null || true
+    rm -f "$DIAG_DIR"/*.txt "$DIAG_DIR"/*.ndjson "$DIAG_DIR"/lsp.log.* \
+          "$DIAG_DIR"/*.stderr "$DIAG_DIR"/predeath_* "$DIAG_DIR"/core.* 2>/dev/null || true
     echo "diag: forensics dir = $DIAG_DIR"
     # Record service start time so we can slice journal precisely.
     date -u +%Y-%m-%dT%H:%M:%SZ > "$DIAG_DIR/start.txt"
+}
+
+# diag_enable_core_dumps
+# Lifts the RLIMIT_CORE soft limit and points the kernel core-pattern (best
+# effort — needs root for sysctl) at DIAG_DIR so a SIGSEGV/SIGABRT leaves
+# a usable core file in the forensics bundle.
+diag_enable_core_dumps() {
+    ulimit -c unlimited 2>/dev/null || true
+    if [ -w /proc/sys/kernel/core_pattern ] 2>/dev/null; then
+        echo "${DIAG_DIR}/core.%e.%p.%t" > /proc/sys/kernel/core_pattern 2>/dev/null || true
+    fi
+    # core_uses_pid keeps the %p in the name if pattern wasn't writable
+    [ -w /proc/sys/kernel/core_uses_pid ] && \
+        echo 1 > /proc/sys/kernel/core_uses_pid 2>/dev/null || true
+    {
+        echo "ulimit_c: $(ulimit -c 2>/dev/null)"
+        echo "core_pattern: $(cat /proc/sys/kernel/core_pattern 2>/dev/null)"
+        echo "core_uses_pid: $(cat /proc/sys/kernel/core_uses_pid 2>/dev/null)"
+    } > "$DIAG_DIR/core_config.txt"
+    echo "diag: core dumps -> $DIAG_DIR/core.* (ulimit_c=$(ulimit -c 2>/dev/null))"
+}
+
+# diag_stderr_path <name>
+# Returns a per-name stderr path under DIAG_DIR.  Use like:
+#   "$BIN" args > "$LOG" 2> "$(diag_stderr_path lsp)" &
+diag_stderr_path() {
+    echo "${DIAG_DIR:-/tmp}/$1.stderr"
 }
 
 # diag_periodic <PID> [interval_sec]
@@ -44,6 +72,7 @@ diag_periodic() {
     local pid="$1"
     local interval="${2:-60}"
     local out="$DIAG_DIR/timeseries.${pid}.ndjson"
+    local snap="$DIAG_DIR/predeath_${pid}"  # rotating snapshot prefix
     (
         while kill -0 "$pid" 2>/dev/null; do
             if [ -r "/proc/$pid/status" ]; then
@@ -59,12 +88,26 @@ diag_periodic() {
                 printf '{"ts":%s,"pid":%s,"vmrss_kb":%s,"vmsize_kb":%s,"threads":%s,"state":"%s","oom_score":%s,"io_read":%s,"io_write":%s}\n' \
                     "$ts" "$pid" "${vmrss:-0}" "${vmsize:-0}" "${threads:-0}" "${state:-?}" \
                     "$oom_score" "$io_read" "$io_write" >> "$out"
+
+                # Rotating predeath snapshot: overwrites each interval so the
+                # post-death handler always has a recent /proc capture even if
+                # the kernel reaped the process between death and handler run.
+                cat /proc/$pid/status > "${snap}_status.txt" 2>/dev/null || true
+                cat /proc/$pid/stat   > "${snap}_stat.txt"   2>/dev/null || true
+                readlink /proc/$pid/exe > "${snap}_exe.txt"  2>/dev/null || true
+                # The last few lines of any file referenced via /proc/$pid/fd
+                # would be too much; track just the open-fd count as a smoke
+                # signal for fd leaks.
+                if [ -d "/proc/$pid/fd" ]; then
+                    ls /proc/$pid/fd 2>/dev/null | wc -l > "${snap}_nfd.txt" || true
+                fi
+                date -u +%Y-%m-%dT%H:%M:%SZ > "${snap}_ts.txt"
             fi
             sleep "$interval"
         done
     ) &
     DIAG_PERIODIC_PID=$!
-    echo "diag: periodic recorder pid=$DIAG_PERIODIC_PID -> $out"
+    echo "diag: periodic recorder pid=$DIAG_PERIODIC_PID -> $out (predeath snapshots: ${snap}_*)"
 }
 
 # Internal: decode exit code into human-readable form
@@ -141,6 +184,33 @@ diag_on_lsp_death() {
         cat "/proc/$pid/status" > "$diag_dir/proc-status.txt" 2>/dev/null || true
         readlink "/proc/$pid/exe" >> "$diag_dir/proc-status.txt" 2>/dev/null || true
     fi
+
+    # 5b. Predeath snapshot — last /proc capture written by diag_periodic.
+    # Lives independently of post-death /proc reaping; safe to rely on.
+    {
+        for f in "${diag_dir}/predeath_${pid}_"*; do
+            [ -r "$f" ] || continue
+            echo "=== ${f##*/} ==="
+            cat "$f" 2>/dev/null
+            echo
+        done
+    } > "$diag_dir/predeath.txt" 2>&1
+
+    # 5c. Separated stderr tail — useful when the LSP log captures stdout-only
+    # diagnostics but the death cause is a stderr-only assertion / glibc abort.
+    local stderr_path="${diag_dir}/lsp.stderr"
+    if [ -r "$stderr_path" ]; then
+        tail -200 "$stderr_path" > "$diag_dir/lsp.stderr.tail" 2>/dev/null || true
+    fi
+
+    # 5d. Core file — if ulimit + core_pattern were set up at boot, a SIGSEGV/
+    # SIGABRT/SIGBUS leaves a core in DIAG_DIR.  Match by pid OR by name pattern.
+    {
+        ls -la "$diag_dir/core."* 2>/dev/null
+        # Default kernel pattern may dump in CWD; check there too.
+        find /tmp -maxdepth 2 -name "core.*${pid}*" -newer "$diag_dir/start.txt" 2>/dev/null
+        find . -maxdepth 1 -name "core.*${pid}*" 2>/dev/null
+    } > "$diag_dir/core_files.txt" 2>&1
 
     # 6. Audit kill records for this pid (signal attribution)
     if command -v ausearch >/dev/null 2>&1; then

--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -59,6 +59,7 @@ for n in $(seq 2 65); do
     rm -f "/tmp/ss_t4_${TAG}_c${HEX:60:4}.db"* "/tmp/ss_t4_${TAG}_c${HEX:60:4}.log"
 done
 diag_setup "ss_t4_${TAG}"
+diag_enable_core_dumps
 
 echo "=== testnet4 N=64 PS lifecycle ==="
 echo "  port            : $PORT"
@@ -87,7 +88,7 @@ nohup "$LSP_BIN" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
     --demo --force-close \
-    > "$LSP_LOG" 2>&1 &
+    > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!
 echo "  LSP pid=$LSP_PID"
 diag_periodic "$LSP_PID" 60
@@ -108,7 +109,7 @@ for i in $(seq 1 $N_CLIENTS); do
         --lsp-pubkey "$LSP_PUBKEY" --participant-id $i \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK:60:4}.db" \
-        > "/tmp/ss_t4_${TAG}_c${SK:60:4}.log" 2>&1 &
+        > "/tmp/ss_t4_${TAG}_c${SK:60:4}.log" 2> "$(diag_stderr_path client${i})" &
     sleep 0.2  # stagger to avoid HELLO_ACK pile-up
 done
 

--- a/tools/test_testnet4_splice.sh
+++ b/tools/test_testnet4_splice.sh
@@ -64,6 +64,7 @@ rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$DONE"
 rm -f "/tmp/ss_t4_${TAG}_c0.db" "/tmp/ss_t4_${TAG}_c0.db-shm" \
       "/tmp/ss_t4_${TAG}_c0.db-wal" "/tmp/ss_t4_${TAG}_c0.log"
 diag_setup "ss_t4_${TAG}"
+diag_enable_core_dumps
 
 echo "=== testnet4 splice test ==="
 echo "  port      : $PORT"
@@ -83,7 +84,7 @@ nohup "$LSP_BIN" \
     --wallet "$WALLET" --db "$LSP_DB" \
     --demo --test-splice \
     --test-splice-client-seckey "$CLIENT_SECKEY" \
-    > "$LSP_LOG" 2>&1 &
+    > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!
 diag_periodic "$LSP_PID" 60
 
@@ -98,7 +99,7 @@ nohup "$CLIENT_BIN" \
     --lsp-pubkey "$LSP_PUBKEY" --participant-id 1 \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c0.db" \
-    > "/tmp/ss_t4_${TAG}_c0.log" 2>&1 &
+    > "/tmp/ss_t4_${TAG}_c0.log" 2> "$(diag_stderr_path client0)" &
 CLIENT_PID=$!
 
 diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"

--- a/tools/test_testnet4_ts_htlc_fc.sh
+++ b/tools/test_testnet4_ts_htlc_fc.sh
@@ -47,6 +47,7 @@ for HEX in 2222 3333 4444 5555; do
     rm -f "/tmp/ss_t4_${TAG}_c${HEX}.db"* "/tmp/ss_t4_${TAG}_c${HEX}.log"
 done
 diag_setup "ss_t4_${TAG}"
+diag_enable_core_dumps
 
 echo "=== testnet4 TS-HTLC-FC (#112) ==="
 echo "  port    : $PORT"
@@ -66,7 +67,7 @@ nohup "$LSP_BIN" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
-    > "$LSP_LOG" 2>&1 &
+    > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!
 echo "  LSP pid=$LSP_PID"
 diag_periodic "$LSP_PID" 60
@@ -95,7 +96,7 @@ for N in 1 2 3 4; do
         --lsp-pubkey "$LSP_PUBKEY" --participant-id "$N" \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK}${SK}.db" \
-        > "/tmp/ss_t4_${TAG}_c${SK}${SK}.log" 2>&1 &
+        > "/tmp/ss_t4_${TAG}_c${SK}${SK}.log" 2> "$(diag_stderr_path client${N})" &
     sleep 0.5
 done
 

--- a/tools/test_testnet4_ts_ptlc_basic.sh
+++ b/tools/test_testnet4_ts_ptlc_basic.sh
@@ -50,6 +50,7 @@ for HEX in 2222 3333 4444 5555; do
     rm -f "/tmp/ss_t4_${TAG}_c${HEX}.db"* "/tmp/ss_t4_${TAG}_c${HEX}.log"
 done
 diag_setup "ss_t4_${TAG}"
+diag_enable_core_dumps
 
 echo "=== testnet4 TS-PTLC-BASIC (#107, SF-W-PTLC Phase 3a) ==="
 echo "  port    : $PORT"
@@ -72,7 +73,7 @@ nohup "$LSP_BIN" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
-    > "$LSP_LOG" 2>&1 &
+    > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!
 echo "  LSP pid=$LSP_PID"
 diag_periodic "$LSP_PID" 60
@@ -100,7 +101,7 @@ for N in 1 2 3 4; do
         --lsp-pubkey "$LSP_PUBKEY" --participant-id "$N" \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${HEX}.db" \
-        > "/tmp/ss_t4_${TAG}_c${HEX}.log" 2>&1 &
+        > "/tmp/ss_t4_${TAG}_c${HEX}.log" 2> "$(diag_stderr_path client${N})" &
     sleep 0.5
 done
 


### PR DESCRIPTION
Two test-scaffold improvements that came out of the post-#228 review. Both production-safe: no behaviour change unless a new env var is set, or a new diag helper is called.

## 1. `src/channel.c` — deterministic basepoints (gated)

`channel_generate_random_basepoints` now checks `SUPERSCALAR_TEST_SEED`. When set + valid hex:

  key  = test_seed (hex-decoded, up to 64 bytes)
  data = local_funding_secret(32) || channel_counter_be32(4) || role
  role in {payment, delayed, revocation, htlc}
  out  = HMAC-SHA256(key, data)

The four basepoint secrets are derived from one HMAC each, then fed into the existing `channel_set_local_basepoints` / `channel_set_local_htlc_basepoint` path. Memory of the seed is wiped before return.

`local_funding_secret` discriminates LSP vs client (their static seckeys already differ); a per-process counter discriminates sequential channels under the same funding secret.

Invalid length / invalid hex → warn + fall through to the existing `/dev/urandom` path.

**Production unchanged.** With `SUPERSCALAR_TEST_SEED` unset, the code takes the same `channel_read_random_bytes` path it always has.

Motivation: test scaffolds wipe DBs between runs. Without a way to recover basepoints from a stored seed we permanently lose access to factory outputs from the previous run.

Validated:
- `test_superscalar` with env unset: 1467/1467 passed (same as main).
- `test_superscalar` with env set: 1467/1467 passed; 96 \"DIAG basepoint: derived from SUPERSCALAR_TEST_SEED\" emissions confirm the seeded path fires.

## 2. `tools/test_diag_lib.sh` + runners — runner diagnostics (#229)

New helpers:
- `diag_enable_core_dumps`: lifts `ulimit -c`, points `/proc/sys/kernel/core_pattern` at `DIAG_DIR` (best-effort, needs root). Cores land in the forensics bundle.
- `diag_stderr_path <name>`: returns `DIAG_DIR/<name>.stderr`. Runners now use `> \"\$LOG\" 2> \"\$(diag_stderr_path lsp)\"` to keep stderr-only assertions / glibc aborts on a separate stream from the formatted run log.
- `diag_periodic` now also rotates a per-interval predeath snapshot (status, stat, exe, nfd, ts). Survives kernel reap of the dead PID.
- `diag_on_lsp_death` harvests the predeath snapshot, tails the stderr stream, and inventories any matching `core.*`.

Wired into the four active testnet4 runners: `test_testnet4_ts_htlc_fc.sh`, `test_testnet4_ts_ptlc_basic.sh`, `test_testnet4_splice.sh`, `test_testnet4_n64_ps_lifecycle.sh`. Passive reorg observer intentionally untouched — it's not a test driver.

## Test plan
- [x] Release build clean on Linux (VPS)
- [x] Unit tests 1467/1467 pass with env unset (no regression)
- [x] Unit tests 1467/1467 pass with `SUPERSCALAR_TEST_SEED=deadbeef`; deterministic path observed
- [x] `bash -n` clean on all five touched scripts
- [ ] Next testnet4 run will exercise the diag bundle end-to-end (will report on first long-runner)