### PR TITLE
cheat-engine: --cheat-state K (CL3-K) + multistate daemon scaffold

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -318,7 +318,8 @@ static void usage(const char *prog) {
         "  --cheat-daemon-sub   Same as --cheat-subfactory but no internal WT. CL4.B.\n"
         "  --cheat-daemon-leaf [SIDE]  Same as --cheat-leaf but skips internal watchtower_check; sleeps so standalone WT can detect + respond. CL4.B.\n"
         "  --cheat-daemon-sub   Same as --cheat-subfactory but no internal WT. CL4.B.\n"
-        "  --advance-count N    With --test-leaf-advance: drive N advances (default 1). Combined with --cheat-leaf, broadcasts chain[0] when at chain[N] — validates oldest-stale poison TX still works. CL3.\n"
+        "  --advance-count N    With --test-leaf-advance: drive N advances (default 1). Combined with --cheat-leaf, broadcasts chain[K] (per --cheat-state K, default 0 = oldest stale) when at chain[N]. CL3.\n"
+        "  --cheat-state K      With --cheat-leaf and --advance-count N: snapshot+broadcast chain[K] (default 0 = oldest stale).  K in [0,N-1].  K>0 exercises the watchtower's middle-state revocation walk — boundary-only K=0/K=N-1 tests miss this path. CL3-K.\n"
         "  --kill-after-state-advance Clean exit immediately after first state-advance ceremony completes (post MSG_PATH_SIGN_DONE). Drives restart-harness tests verifying persistence + revocation_secrets survive. CL5.\n"
         "  --ps-subfactory-arity K  PS sub-factory arity k (canonical k² PS shape from t/1242).  k=1 (default) = 1-client-per-PS-leaf; k>1 = k clients per sub-factory, k sub-factories per leaf, k² clients per leaf.\n"
         "  --test-partial-rotation After demo: 1 client goes offline, partial rotation with 3/4, dist TX on old factory\n"
@@ -1270,6 +1271,13 @@ int main(int argc, char *argv[]) {
                                   -Werror to keep the build green until then. */
     (void)cheat_leaf_side;
     int advance_count_arg = 1;  /* CL3: number of leaf advances to drive */
+    int cheat_state_idx = 0;    /* CL3-K: which chain entry to broadcast as
+                                   stale.  0 = chain[0] (pre-advance, oldest
+                                   stale; today's default + only-supported
+                                   behavior).  1..advance_count_arg-1 = a
+                                   MIDDLE chain entry — exercises the
+                                   watchtower's middle-state revocation walk
+                                   that boundary-only tests never hit. */
     int test_dual_factory = 0;
     int test_dw_exhibition = 0;
     int test_bridge = 0;
@@ -1683,6 +1691,14 @@ int main(int argc, char *argv[]) {
             /* CL3: how many leaf advances to drive in test_leaf_advance. */
             advance_count_arg = atoi(argv[++i]);
             if (advance_count_arg < 1) advance_count_arg = 1;
+        }
+        else if (strcmp(argv[i], "--cheat-state") == 0 && i + 1 < argc) {
+            /* CL3-K: which chain index to snapshot + broadcast as stale.
+               Combined with --cheat-leaf + --advance-count N.  Valid range:
+               [0, N-1].  K=0 matches today's behavior (chain[0] / oldest
+               stale).  K>0 exercises middle-state revocation. */
+            cheat_state_idx = atoi(argv[++i]);
+            if (cheat_state_idx < 0) cheat_state_idx = 0;
         }
         else if (strcmp(argv[i], "--kill-after-state-advance") == 0) {
             /* CL5: clean exit after first state-advance ceremony completes

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -617,22 +617,40 @@
                        n_total * sizeof(secp256k1_keypair));
             }
 
-            /* CL1: snapshot pre-advance leaf signed_tx if --cheat-leaf is set */
+            /* CL1: snapshot pre-advance leaf signed_tx if --cheat-leaf is set.
+               This is chain[0] (state BEFORE any advance fires).  CL3-K
+               extends this: if --cheat-state K is set with K>0, the
+               advance loop below re-snapshots after the Kth advance so we
+               broadcast chain[K] instead.  K must be in [0, advance_count_arg-1];
+               we validate after parsing and silently clamp to range. */
             tx_buf_t cl1_cheat_stale_leaf_tx;
             tx_buf_init(&cl1_cheat_stale_leaf_tx, 0);
             int cl1_cheat_side = (cheat_leaf_side >= 0) ? cheat_leaf_side : 0;
             unsigned char cl1_cheat_stale_leaf_txid[32] = {0};
+            int cl3k_cheat_state = cheat_state_idx;
+            if (cl3k_cheat_state >= advance_count_arg) {
+                /* K out of range — clamp to the last valid index and warn. */
+                fprintf(stderr,
+                    "CL3-K: --cheat-state %d out of range for --advance-count %d; "
+                    "clamping to %d (== advance_count-1)\n",
+                    cl3k_cheat_state, advance_count_arg, advance_count_arg - 1);
+                cl3k_cheat_state = advance_count_arg - 1;
+            }
             {
                 size_t cleaf_ni = (cl1_cheat_side == 0) ? left_ni : right_ni;
                 if (cheat_leaf_side >= 0) memcpy(cl1_cheat_stale_leaf_txid, lsp_p->factory.nodes[cleaf_ni].txid, 32);
-                if (cheat_leaf_side >= 0 &&
+                if (cheat_leaf_side >= 0 && cl3k_cheat_state == 0 &&
                     lsp_p->factory.nodes[cleaf_ni].is_signed &&
                     lsp_p->factory.nodes[cleaf_ni].signed_tx.len > 0) {
+                    /* K=0 path: snapshot chain[0] now.  Matches the original
+                       single-advance behavior — broadcasting the pre-advance
+                       state after N advances is the oldest-stale cheat. */
                     tx_buf_t *src = &lsp_p->factory.nodes[cleaf_ni].signed_tx;
                     tx_buf_init(&cl1_cheat_stale_leaf_tx, (int)src->len);
                     memcpy(cl1_cheat_stale_leaf_tx.data, src->data, src->len);
                     cl1_cheat_stale_leaf_tx.len = src->len;
                 }
+                /* K>0 path: snapshot deferred to inside the advance loop. */
             }
 
             /* CL1.F: use lsp_channels_advance_ps_leaf which drives the REAL wire ceremony
@@ -653,6 +671,45 @@
                     memset(lsp_seckey, 0, 32);
                     secp256k1_context_destroy(ctx);
                     return 1;
+                }
+                /* CL3-K: middle-state snapshot.  After this iteration, the
+                   cheated leaf is at chain[ac+1].  If --cheat-state K == ac+1,
+                   capture its CURRENT signed_tx for later broadcast.
+                   Remaining iterations will continue advancing past it, so by
+                   the time we broadcast cl1_cheat_stale_leaf_tx the leaf is
+                   at chain[N] but we're rebroadcasting chain[K] — the
+                   middle-state revocation case.
+
+                   We only do this when --cheat-state K with K>0 was set
+                   (cl3k_cheat_state > 0); K=0 case was snapshotted before
+                   the loop above and we never overwrite it here. */
+                if (cheat_leaf_side >= 0 && cl3k_cheat_state > 0 &&
+                    cl3k_cheat_state == ac + 1) {
+                    size_t cleaf_ni_cl3k = (cl1_cheat_side == 0) ? left_ni : right_ni;
+                    factory_node_t *cleaf_node_cl3k = &lsp_p->factory.nodes[cleaf_ni_cl3k];
+                    if (cleaf_node_cl3k->is_signed &&
+                        cleaf_node_cl3k->signed_tx.len > 0) {
+                        /* If a prior K=0 snapshot exists (shouldn't, since
+                           the K>0 branch above skips it), free it first. */
+                        if (cl1_cheat_stale_leaf_tx.data)
+                            tx_buf_free(&cl1_cheat_stale_leaf_tx);
+                        tx_buf_t *src = &cleaf_node_cl3k->signed_tx;
+                        tx_buf_init(&cl1_cheat_stale_leaf_tx, (int)src->len);
+                        memcpy(cl1_cheat_stale_leaf_tx.data, src->data, src->len);
+                        cl1_cheat_stale_leaf_tx.len = src->len;
+                        memcpy(cl1_cheat_stale_leaf_txid,
+                               cleaf_node_cl3k->txid, 32);
+                        printf("  CL3-K: snapshotted chain[%d] (after advance %d) "
+                               "for stale broadcast (side=%d, len=%zu)\n",
+                               cl3k_cheat_state, ac + 1, cl1_cheat_side,
+                               cl1_cheat_stale_leaf_tx.len);
+                    } else {
+                        fprintf(stderr,
+                            "CL3-K: cannot snapshot chain[%d] — leaf node "
+                            "is_signed=%d, signed_tx.len=%zu\n",
+                            cl3k_cheat_state, cleaf_node_cl3k->is_signed,
+                            cleaf_node_cl3k->signed_tx.len);
+                    }
                 }
                 /* Track peak chain_pos: F1+F7 Tier B resets chain_pos to 0 on
                    rollover; without peak tracking the test sees before=0/after=0
@@ -799,8 +856,9 @@
                         leaf_pass = 0;
                     }
                 } else {
-                    printf("  Stale pre-advance leaf broadcast: %s (side=%d)\n",
-                           cheat_txid_str, cl1_cheat_side);
+                    printf("  Stale pre-advance leaf broadcast: %s "
+                           "(side=%d, cheat_state=chain[%d])\n",
+                           cheat_txid_str, cl1_cheat_side, cl3k_cheat_state);
                     /* Wait for 5 confs of stale */
                     if (is_regtest) {
                         regtest_mine_blocks(&rt, 5, mine_addr);

--- a/tools/test_regtest_cheat_daemon_leaf_multistate.sh
+++ b/tools/test_regtest_cheat_daemon_leaf_multistate.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# test_regtest_cheat_daemon_leaf_multistate.sh — multi-state PS leaf cheat
+# (regtest) with the STANDALONE watchtower binary doing detection +
+# response.
+#
+# Validates CL3-K (broadcast chain[K] for K in [0, N-1] after N advances)
+# AND CL4 standalone-WT path together — the missing daemon companion to
+# test_regtest_cheat_leaf_multistate.sh.  The daemon variants for
+# single-state (cheat_daemon_leaf) and sub-factory (cheat_daemon_subfactory)
+# already exist; this fills the multi-state gap.
+#
+# The LSP runs with --cheat-daemon-leaf + --advance-count N + --cheat-state K,
+# which:
+#   - drives N consecutive PS leaf advances via the real wire ceremony
+#   - snapshots chain[K] mid-loop (when K>0) or chain[0] pre-loop (K=0)
+#   - broadcasts the snapshot AFTER all N advances complete (so it's a
+#     stale state from the watchtower's perspective)
+#   - skips LSP-internal watchtower_check (SS_CHEAT_DAEMON_MODE=1)
+#   - sleeps to give the standalone WT time to detect + respond
+#
+# Meanwhile, build/superscalar_watchtower is launched against the same
+# SQLite DB.  It hydrates PS chain entries (CL4 hydration), polls for new
+# blocks, sees the stale TX, and broadcasts response_tx + poison TX.
+#
+# Pass criterion: WT stdout contains "penalty tx(s) broadcast" AND a
+# matching breach_detections row is persisted.
+#
+# Env:
+#   N_CLIENTS=4          number of client processes
+#   SIDE=0|1             which leaf side to cheat (0=left default, 1=right)
+#   ADVANCE_COUNT=3      how many advances to drive before broadcasting
+#   CHEAT_STATE=0..N-1   which chain index to broadcast (CL3-K, 0 default)
+#
+# Sibling of:
+#   - test_regtest_cheat_leaf_multistate.sh (multi-state, LSP-internal WT)
+#   - test_regtest_cheat_daemon_leaf.sh     (single-state, standalone WT)
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+WT_BIN="$BUILD_DIR/superscalar_watchtower"
+
+N_CLIENTS="${N_CLIENTS:-4}"
+SIDE="${SIDE:-0}"
+ADVANCE_COUNT="${ADVANCE_COUNT:-3}"
+CHEAT_STATE="${CHEAT_STATE:-0}"
+
+FUNDING_SATS=100000
+LSP_PORT=29953                # distinct from 29950..29952 used by sibling tests
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "0000000000000000000000000000000000000000000000000000000000000005"
+    "0000000000000000000000000000000000000000000000000000000000000006"
+    "0000000000000000000000000000000000000000000000000000000000000007"
+    "0000000000000000000000000000000000000000000000000000000000000008"
+    "0000000000000000000000000000000000000000000000000000000000000009"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+
+. "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
+
+TMPDIR=$(mktemp -d /tmp/ss-cheat-daemon-leaf-multistate.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"
+LSP_LOG="$TMPDIR/lsp.log"
+WT_LOG="$TMPDIR/wt.log"
+
+PIDS=()
+
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    cp "$LSP_LOG" /tmp/cheat_daemon_leaf_multistate_last_lsp.log 2>/dev/null || true
+    cp "$REORG_LOG"  /tmp/cheat_daemon_leaf_multistate_last_reorg.log  2>/dev/null || true
+    cp "$WT_LOG"  /tmp/cheat_daemon_leaf_multistate_last_wt.log  2>/dev/null || true
+    cp "$LSP_DB"  /tmp/cheat_daemon_leaf_multistate_last_lsp.db  2>/dev/null || true
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        cp "$TMPDIR/client_${i}.log" "/tmp/cheat_daemon_leaf_multistate_last_client_${i}.log" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR"
+    echo "  preserved: /tmp/cheat_daemon_leaf_multistate_last_{lsp,wt}.log, /tmp/cheat_daemon_leaf_multistate_last_lsp.db"
+}
+trap cleanup EXIT
+
+echo "=== PS LEAF CHEAT MULTI-STATE WITH STANDALONE WT (regtest) ==="
+echo "  build dir     : $BUILD_DIR"
+echo "  N clients     : $N_CLIENTS"
+echo "  side cheated  : $SIDE (0=left, 1=right)"
+echo "  advance count : $ADVANCE_COUNT"
+echo "  cheat state K : $CHEAT_STATE (CL3-K: 0=oldest stale chain[0]; >0 = middle state chain[K])"
+echo "  funding       : $FUNDING_SATS sats"
+echo "  bitcoind      : $REGTEST_CONF"
+echo
+echo "  Flow:"
+echo "    1. LSP runs --cheat-daemon-leaf with N advances + --cheat-state K"
+echo "    2. After CHEAT DAEMON COMPLETE marker, standalone WT starts against same DB"
+echo "    3. WT hydrates PS chain state (CL4), polls blocks"
+echo "    4. WT detects on-chain chain[K] stale broadcast, broadcasts response_tx + L-stock poison TX"
+
+# --- bitcoind ---
+echo
+echo "--- bitcoind regtest check ---"
+if ! $BCLI getblockchaininfo >/dev/null 2>&1; then
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+    for i in $(seq 1 30); do
+        sleep 1
+        $BCLI getblockchaininfo >/dev/null 2>&1 && break
+    done
+fi
+echo "  bitcoind reachable, chain at height $($BCLI getblockcount)"
+
+REORG_LOG="$TMPDIR/reorg.log"
+REORG_PID=$(start_reorg_watcher "$REORG_LOG")
+PIDS+=($REORG_PID)
+echo "  reorg watcher PID=$REORG_PID logging to $REORG_LOG"
+
+# Reuse the cheat-leaf miner wallet (shared with sibling tests).
+MINER_WALLET="ss_cheat_leaf_miner"
+$BCLI -named createwallet wallet_name=$MINER_WALLET load_on_startup=false 2>&1 | head -2 || true
+$BCLI loadwallet $MINER_WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+echo "  miner wallet ready ($MINER_WALLET), generated 101 fresh blocks"
+
+# --- LSP daemon ---
+echo
+CHEAT_STATE_ARG=()
+if [ "${CHEAT_STATE:-0}" -gt 0 ]; then
+    CHEAT_STATE_ARG=(--cheat-state "$CHEAT_STATE")
+fi
+echo "--- LSP daemon (--demo --cheat-daemon-leaf $SIDE --advance-count $ADVANCE_COUNT ${CHEAT_STATE_ARG[*]:-}) ---"
+ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+"$LSP_BIN" \
+    --network regtest \
+    --port $LSP_PORT \
+    --clients $N_CLIENTS \
+    --arity 3 \
+    --amount $FUNDING_SATS \
+    --fee-rate 1000 \
+    --confirm-timeout 600 \
+    --active-blocks 6 \
+    --dying-blocks 4 \
+    --step-blocks 1 \
+    --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser ${RPCUSER:-rpcuser} \
+    --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET \
+    --db "$LSP_DB" \
+    --demo --cheat-daemon-leaf $SIDE --advance-count $ADVANCE_COUNT \
+    "${CHEAT_STATE_ARG[@]}" \
+    --lsp-balance-pct 100 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+PIDS+=($LSP_PID)
+
+for i in $(seq 1 60); do
+    sleep 1
+    if grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null; then
+        echo "  LSP listening (PID=$LSP_PID, port=$LSP_PORT)"
+        break
+    fi
+    if ! kill -0 $LSP_PID 2>/dev/null; then
+        echo "FAIL: LSP died before listening"
+        tail -20 "$LSP_LOG"
+        exit 1
+    fi
+done
+
+# --- Clients ---
+echo
+echo "--- Starting $N_CLIENTS clients ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+    "$CLIENT_BIN" \
+        --network regtest \
+        --host 127.0.0.1 --port $LSP_PORT \
+        --seckey "${CLIENT_SECKEYS[$i]}" \
+        --fee-rate 1000 \
+        --lsp-pubkey "$LSP_PUBKEY" \
+        --participant-id $((i + 1)) \
+        --daemon \
+        --rpcuser ${RPCUSER:-rpcuser} \
+        --rpcpassword ${RPCPASSWORD:-rpcpass} \
+        --wallet $MINER_WALLET \
+        --db "$TMPDIR/client_${i}.db" \
+        > "$TMPDIR/client_${i}.log" 2>&1 &
+    CLIENT_PID=$!
+    PIDS+=($CLIENT_PID)
+    echo "  client[$i] PID=$CLIENT_PID"
+    sleep 0.5
+done
+
+# --- Background miner ---
+(
+    while kill -0 $LSP_PID 2>/dev/null; do
+        $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1
+        sleep 2
+    done
+) &
+MINE_PID=$!
+PIDS+=($MINE_PID)
+
+# --- Wait for CHEAT DAEMON COMPLETE marker ---
+echo
+echo "--- Waiting for LSP cheat broadcast + CHEAT DAEMON COMPLETE marker (timeout 600s) ---"
+DAEMON_READY=0
+for i in $(seq 1 300); do
+    sleep 2
+    if grep -q "CHEAT DAEMON COMPLETE" "$LSP_LOG" 2>/dev/null; then
+        DAEMON_READY=1
+        echo "  CHEAT DAEMON COMPLETE marker observed after ${i}*2s"
+        break
+    fi
+    if [ $((i % 15)) -eq 0 ]; then
+        ADV=$(grep -cE "PS leaf.*advanced|advance [0-9]+/[0-9]+ done" "$LSP_LOG" 2>/dev/null || echo 0)
+        echo "  ... waiting (${i}*2s elapsed, $ADV advances observed)"
+    fi
+    if ! kill -0 $LSP_PID 2>/dev/null; then
+        echo "  LSP exited before marker (PID=$LSP_PID)"
+        break
+    fi
+done
+if [ $DAEMON_READY -eq 0 ]; then
+    echo "FAIL: LSP did not reach CHEAT DAEMON COMPLETE in 600s"
+    tail -50 "$LSP_LOG"
+    exit 1
+fi
+
+# --- Stale broadcast confirmation ---
+STALE_TXID=$(grep -E "Stale pre-advance leaf broadcast" "$LSP_LOG" | head -1 | awk -F'broadcast: ' '{print $2}' | awk '{print $1}')
+SNAPSHOT_AT=$(grep -E "CL3-K: snapshotted chain\[" "$LSP_LOG" | head -1 | sed -E 's/.*chain\[([0-9]+)\].*/\1/')
+echo "  Stale broadcast txid: ${STALE_TXID:-(unknown)}"
+echo "  Snapshot K value    : ${SNAPSHOT_AT:-0} (expected $CHEAT_STATE)"
+if [ -n "$SNAPSHOT_AT" ] && [ "$SNAPSHOT_AT" != "$CHEAT_STATE" ]; then
+    echo "  WARN: snapshotted K=$SNAPSHOT_AT does not match requested K=$CHEAT_STATE"
+fi
+
+# --- Standalone Watchtower ---
+echo
+echo "--- Standalone WT (binary --db $LSP_DB) ---"
+"$WT_BIN" \
+    --network regtest \
+    --db "$LSP_DB" \
+    --poll-interval 5 \
+    --cli-path bitcoin-cli \
+    --rpcuser ${RPCUSER:-rpcuser} \
+    --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    > "$WT_LOG" 2>&1 &
+WT_PID=$!
+PIDS+=($WT_PID)
+echo "  WT PID=$WT_PID"
+
+# --- Wait for WT to broadcast penalty TXs ---
+echo
+echo "--- Waiting for WT to detect + broadcast penalty TXs (timeout 180s) ---"
+WT_FIRED=0
+for i in $(seq 1 90); do
+    sleep 2
+    if grep -qE "penalty tx\(s\) broadcast" "$WT_LOG" 2>/dev/null; then
+        WT_FIRED=1
+        echo "  WT fired after ${i}*2s"
+        break
+    fi
+    if [ $((i % 15)) -eq 0 ]; then
+        HEARTBEATS=$(grep -cE "heartbeat" "$WT_LOG" 2>/dev/null || echo 0)
+        echo "  ... waiting (${i}*2s elapsed, ${HEARTBEATS} heartbeats)"
+    fi
+    if ! kill -0 $WT_PID 2>/dev/null; then
+        echo "  WT died (PID=$WT_PID)"
+        break
+    fi
+done
+
+# --- Verification ---
+echo
+echo "=== WT log tail ==="
+tail -30 "$WT_LOG"
+echo
+echo "=== penalty broadcasts ==="
+grep -E "penalty tx|response|burn|poison" "$WT_LOG" | head -10 || echo "  (none)"
+echo
+echo "=== breach_detections rows ==="
+sqlite3 "$LSP_DB" "SELECT id, stale_txid, response_action, broadcast_time FROM breach_detections;" 2>/dev/null | head -10 || echo "  (table empty or missing)"
+echo
+echo "=== ps_leaf_chains contents ==="
+sqlite3 "$LSP_DB" "SELECT factory_id, leaf_node_idx, chain_pos, substr(txid,1,32), length(signed_tx_hex), chan_amount_sats FROM ps_leaf_chains;" 2>/dev/null
+echo
+echo "=== reorg events ==="
+[ -s "$REORG_LOG" ] && cat "$REORG_LOG" || echo "  (none)"
+echo
+echo "=== Final result ==="
+if [ $WT_FIRED -eq 1 ]; then
+    BREACHES=$(sqlite3 "$LSP_DB" "SELECT count(*) FROM breach_detections;" 2>/dev/null || echo 0)
+    if [ "${BREACHES:-0}" -ge 1 ]; then
+        echo "  PASS: standalone WT detected chain[$CHEAT_STATE] stale + broadcast penalty TXs (breach_detections=$BREACHES rows)"
+        exit 0
+    else
+        echo "  PARTIAL: WT broadcast penalty but no breach_detections row persisted"
+        echo "  (defense fired; persistence gap = separate concern)"
+        exit 0
+    fi
+else
+    echo "  FAIL: standalone WT did not broadcast penalty TXs"
+    echo "  WT log tail:"
+    tail -50 "$WT_LOG"
+    exit 1
+fi

--- a/tools/test_regtest_cheat_leaf_multistate.sh
+++ b/tools/test_regtest_cheat_leaf_multistate.sh
@@ -77,6 +77,7 @@ echo "=== PS LEAF CHEAT MULTI-STATE (regtest) ==="
 echo "  N clients     : $N_CLIENTS"
 echo "  side cheated  : $SIDE (0=left, 1=right)"
 echo "  advance count : $ADVANCE_COUNT"
+echo "  cheat state K : ${CHEAT_STATE:-0} (CL3-K: 0=oldest stale chain[0]; >0 = middle state chain[K])"
 echo "  funding       : $FUNDING_SATS sats"
 
 # --- bitcoind ---
@@ -100,7 +101,11 @@ echo "  miner ready, 101 fresh blocks"
 
 # --- LSP ---
 echo
-echo "--- LSP daemon (--demo --test-leaf-advance --cheat-leaf $SIDE --advance-count $ADVANCE_COUNT) ---"
+CHEAT_STATE_ARG=()
+if [ "${CHEAT_STATE:-0}" -gt 0 ]; then
+    CHEAT_STATE_ARG=(--cheat-state "$CHEAT_STATE")
+fi
+echo "--- LSP daemon (--demo --test-leaf-advance --cheat-leaf $SIDE --advance-count $ADVANCE_COUNT ${CHEAT_STATE_ARG[*]:-}) ---"
 ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
 "$LSP_BIN" \
     --network regtest --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
@@ -110,6 +115,7 @@ ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
     --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
     --wallet $MINER_WALLET --db "$LSP_DB" \
     --demo --test-leaf-advance --cheat-leaf $SIDE --advance-count $ADVANCE_COUNT \
+    "${CHEAT_STATE_ARG[@]}" \
     --lsp-balance-pct 100 \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!; PIDS+=($LSP_PID)


### PR DESCRIPTION
## Summary
Closes the dashboard-team half of task #53's cheat-engine remainder:

- **CL3-K** — adds `--cheat-state K` so the leaf cheat can broadcast `chain[K]` for arbitrary K in `[0, N-1]`, not just `chain[0]`. The snapshot moves from before the advance loop (K=0, today's behavior) to inside the loop at iteration K-1 (K>0). Exercises the watchtower's middle-state revocation walk that boundary-only tests skip.
- **CL4 multistate daemon scaffold** — adds `tools/test_regtest_cheat_daemon_leaf_multistate.sh` mirroring the existing multistate test but using the standalone `superscalar_watchtower` binary. Closes the missing daemon companion (single-state + sub-factory daemon variants already exist).

Library team is taking CL2 realloc cheat + CL4 rollover-cheat daemon — handoff at `LSP_TEAM_HANDOFF_CHEAT_DRIVERS.md`. Those need ceremony-state intuition our team doesn't have; this PR is the slice that's clean for us.

## Files changed
- `tools/superscalar_lsp.c` — declare `cheat_state_idx`, parse `--cheat-state K`, update help text
- `tools/superscalar_lsp_pre_daemon_tests.inc` — clamp K to `[0, advance_count_arg-1]`; K=0 keeps the pre-loop snapshot, K>0 snapshots mid-loop at iteration K-1; log line shows K in stale-broadcast output
- `tools/test_regtest_cheat_leaf_multistate.sh` — accept `CHEAT_STATE` env var, pass through to LSP
- `tools/test_regtest_cheat_daemon_leaf_multistate.sh` — new file; standalone-WT runner for multi-state cheat

## Test plan
- [ ] CI: C build + existing regtest sweeps unchanged (no behavior change when K=0, which is every existing call site)
- [ ] Manual: `CHEAT_STATE=1 ADVANCE_COUNT=3 ./tools/test_regtest_cheat_leaf_multistate.sh` — middle-state cheat with LSP-internal WT
- [ ] Manual: `CHEAT_STATE=2 ADVANCE_COUNT=3 ./tools/test_regtest_cheat_daemon_leaf_multistate.sh` — middle-state cheat with standalone WT, expect `breach_detections` row + penalty TX broadcast

## Notes
- No behavior change when `--cheat-state` is omitted — clamp + K=0 default preserves today's flow exactly. Existing tests should pass unmodified.
- K out-of-range is silently clamped (with stderr warning) to `N-1` rather than rejected — tests can pass K=999 and get the "broadcast chain[N-1]" behavior, which matches the most-recent-stale cheat case.