### PR TITLE
fix(cheat-engine): PR #293 verdict — require actual WT defense evidence

### DIFF
--- a/tools/test_regtest_cheat_daemon_leaf_multistate.sh
+++ b/tools/test_regtest_cheat_daemon_leaf_multistate.sh
@@ -161,7 +161,7 @@ ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
     --db "$LSP_DB" \
     --demo --cheat-daemon-leaf $SIDE --advance-count $ADVANCE_COUNT \
     "${CHEAT_STATE_ARG[@]}" \
-    --lsp-balance-pct 100 \
+    --lsp-balance-pct 50 \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!
 PIDS+=($LSP_PID)

--- a/tools/test_regtest_cheat_leaf_multistate.sh
+++ b/tools/test_regtest_cheat_leaf_multistate.sh
@@ -116,7 +116,7 @@ ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
     --wallet $MINER_WALLET --db "$LSP_DB" \
     --demo --test-leaf-advance --cheat-leaf $SIDE --advance-count $ADVANCE_COUNT \
     "${CHEAT_STATE_ARG[@]}" \
-    --lsp-balance-pct 100 \
+    --lsp-balance-pct 50 \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!; PIDS+=($LSP_PID)
 
@@ -179,28 +179,38 @@ else
 fi
 echo
 echo "=== Final result ==="
-if grep -q "LEAF ADVANCE TEST PASSED" "$LSP_LOG" 2>/dev/null; then
-    ENTRIES=$(sqlite3 "$LSP_DB" "SELECT count(*) FROM ps_leaf_chains;" 2>/dev/null)
-    # F1+F7: if Tier B fired during the advance loop, chain_pos resets to 0
-    # for the new epoch and subsequent advances collide on the PRIMARY KEY
-    # (factory_id, leaf_node_idx, chain_pos), so DB entries cap at the peak
-    # pre-rollover count, not ADVANCE_COUNT.  Detect this and use a peak-aware
-    # assertion: require at least 2 entries (proof advances happened) AND that
-    # the LSP logged "Tier B" — semantically the defense is intact.
-    TIER_B_FIRED=$(grep -c "leaf 0 exhausted, root advanced" "$LSP_LOG" 2>/dev/null || true)
-    TIER_B_FIRED="${TIER_B_FIRED:-0}"
-    if [ "${ENTRIES:-0}" -ge "$ADVANCE_COUNT" ]; then
-        echo "  PASS: multi-state advance + WT defense (ps_leaf_chains=$ENTRIES entries, expected >=$ADVANCE_COUNT)"
-        exit 0
-    elif [ "$TIER_B_FIRED" -ge 1 ] && [ "${ENTRIES:-0}" -ge 2 ]; then
-        echo "  PASS: multi-state advance + WT defense (Tier B fired mid-test; ps_leaf_chains=$ENTRIES, capped by chain_pos reset on rollover — defense semantics intact)"
-        exit 0
-    else
-        echo "  FAIL: only $ENTRIES chain entries persisted, expected >=$ADVANCE_COUNT (Tier B fired: $TIER_B_FIRED)"
-        exit 1
-    fi
+# Tighter PASS criterion (library-team feedback on PR #293 verdict logic):
+# We REQUIRE evidence that the WT actually defended — not just that the
+# stale broadcast was unspendable for unrelated reasons.  Three signals,
+# at least one required:
+#   1. watchtower_check returned >= 1 (LSP log)
+#   2. breach_detections has at least one row tagged poison/penalty
+#   3. broadcast_log has a row whose source contains 'poison' or 'penalty'
+# A "Tier B made stale unspendable" by itself is NOT a defense — it's an
+# unrelated state-machine intervention.  Counting it as PASS produces
+# false-positives on a broken WT.
+WT_CHECK_FIRED=$(grep -cE "watchtower_check returned: [1-9]" "$LSP_LOG" 2>/dev/null || echo 0)
+WT_CHECK_FIRED="${WT_CHECK_FIRED:-0}"
+BREACH_ROWS=$(sqlite3 "$LSP_DB" "SELECT count(*) FROM breach_detections WHERE response_action LIKE '%poison%' OR response_action LIKE '%penalty%';" 2>/dev/null || echo 0)
+BREACH_ROWS="${BREACH_ROWS:-0}"
+POISON_BROADCASTS=$(sqlite3 "$LSP_DB" "SELECT count(*) FROM broadcast_log WHERE source LIKE '%poison%' OR source LIKE '%penalty%';" 2>/dev/null || echo 0)
+POISON_BROADCASTS="${POISON_BROADCASTS:-0}"
+
+if grep -q "LEAF ADVANCE TEST PASSED" "$LSP_LOG" 2>/dev/null && \
+   ( [ "$WT_CHECK_FIRED" -ge 1 ] || [ "$BREACH_ROWS" -ge 1 ] || [ "$POISON_BROADCASTS" -ge 1 ] ); then
+    ENTRIES=$(sqlite3 "$LSP_DB" "SELECT count(*) FROM ps_leaf_chains;" 2>/dev/null || echo 0)
+    echo "  PASS: WT defense fired (watchtower_check>=1=$WT_CHECK_FIRED, breach_rows=$BREACH_ROWS, poison_broadcasts=$POISON_BROADCASTS), ps_leaf_chains=$ENTRIES"
+    exit 0
 else
-    echo "  FAIL: LEAF ADVANCE TEST did not PASSED"
+    if grep -q "LEAF ADVANCE TEST PASSED" "$LSP_LOG" 2>/dev/null; then
+        TIER_B_FIRED=$(grep -c "leaf 0 exhausted, root advanced" "$LSP_LOG" 2>/dev/null || echo 0)
+        TIER_B_FIRED="${TIER_B_FIRED:-0}"
+        echo "  FAIL: LSP reported PASSED but no WT defense evidence (watchtower_check=$WT_CHECK_FIRED, breach_rows=$BREACH_ROWS, poison_broadcasts=$POISON_BROADCASTS, Tier_B=$TIER_B_FIRED)"
+        echo "  Tier B making stale unspendable is NOT a WT defense — it's an unrelated rollover; failing the test rather than papering over it."
+    else
+        echo "  FAIL: LEAF ADVANCE TEST did not PASSED"
+    fi
+    echo "  LSP log tail:"
     tail -30 "$LSP_LOG"
     exit 1
 fi


### PR DESCRIPTION
## Summary
Closes SF-PR293-VERDICT-FIX (#253). Library-team fix for the two scaffold issues I identified on PR #293 during the test run pass.

This is a small, surgical follow-up to PR #293 — does not touch the C-side CL3-K work, just the runner scaffolds.

## Fixes

**1. Default `--lsp-balance-pct 50` (was 100)**
With 100, clients have 0 sats. The `--demo` payment path fails (`add_htlc on sender failed`), LSP exits before the cheat marker, and the runner times out 600s waiting. 50 lets demo payments actually run.

**2. Tighten PASS criterion in `test_regtest_cheat_leaf_multistate.sh`**

Old logic:
```
LEAF ADVANCE TEST PASSED  AND  (entries>=advance_count  OR  (Tier_B_fired AND entries>=2))
```

New logic:
```
LEAF ADVANCE TEST PASSED  AND  ANY-OF:
  (a) watchtower_check returned >= 1   (LSP log)
  (b) breach_detections row with poison/penalty response_action
  (c) broadcast_log row with poison/penalty source
```

A "Tier B made stale unspendable" event by itself is **not** a WT defense — it's an unrelated rollover side-effect. Counting it as PASS produces false-positives: a broken WT that never fires would still pass the old criterion. The new criterion requires positive evidence that the WT actually defended.

If the test reaches `LEAF ADVANCE TEST PASSED` but none of (a), (b), (c) fired, we now report FAIL with diagnostic counts:
```
FAIL: LSP reported PASSED but no WT defense evidence (watchtower_check=0, breach_rows=0, poison_broadcasts=0, Tier_B=1)
Tier B making stale unspendable is NOT a WT defense — it's an unrelated rollover
```

## Daemon variant
`test_regtest_cheat_daemon_leaf_multistate.sh` was already correctly gated on `WT_FIRED` + `breach_detections` for the verdict — only the `--lsp-balance-pct` fix applies there.

## Test plan
- [x] `bash -n` clean on both runners
- [ ] Re-run both tests on regtest (post-merge by dashboard team or library team) — expected outcome now distinguishes real WT defense from Tier B coincidence
- [ ] If real defense fails to fire on either runner, that's outcome 3 (real bug) — file as separate task

Refs: tracker SF-PR293-VERDICT-FIX (#253), source critique on PR #293 ([comment](https://github.com/8144225309/SuperScalar/pull/293#issuecomment-4494921107)).