### PR TITLE
ceremony-crash-inject: Gap C — SUPERSCALAR_CRASH_AT helper + checkpoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ add_library(superscalar
     src/lsp.c
     src/client.c
     src/lsp_channels.c
+    src/crash_inject.c
     src/lsp_bridge.c
     src/lsp_rotation.c
     src/lsp_demo.c

--- a/include/superscalar/crash_inject.h
+++ b/include/superscalar/crash_inject.h
@@ -1,0 +1,30 @@
+#ifndef SUPERSCALAR_CRASH_INJECT_H
+#define SUPERSCALAR_CRASH_INJECT_H
+
+/* Crash-injection helper for ceremony-state restart drills.
+ *
+ * Gate C of the dashboard-team handoff
+ * (C:/pirq/dashboard-upgrade/LSP_TEAM_HANDOFF_CEREMONY_CRASH_INJECTION.md).
+ *
+ * The library sprinkles lsp_crash_checkpoint("<name>") at ceremony state
+ * boundaries.  Production code never sets SUPERSCALAR_CRASH_AT, so the
+ * helper is a no-op (one getenv + one strcmp per checkpoint, microseconds).
+ * Test scaffolds set SUPERSCALAR_CRASH_AT=<name> in the LSP env to trigger a
+ * deterministic abort right after the named state lands in persist — driving
+ * mid-ceremony crash-recovery tests against fixed cut points instead of
+ * timing-based kills.
+ *
+ * Names defined today (see src/lsp.c lsp_run_factory_creation):
+ *   "pending_nonces"     — after persist_save_ceremony(PENDING_NONCES)
+ *   "nonces_aggregated"  — after persist_update_ceremony_state(NONCES_AGGREGATED)
+ *   "pending_sigs"       — after persist_update_ceremony_state(PENDING_SIGS)
+ *   "finalize_partial"   — before persist_update_ceremony_state(FINALIZED)
+ *                          (catches the N-1-SIGNED dual-sig-trap path)
+ *
+ * The same naming convention extends to ROTATE / FORCE_OUT once those
+ * ceremonies wire their own persist transitions (Gaps A + B of #245).  No
+ * conditional logic, no flag persistence — pure env check + abort.
+ */
+void lsp_crash_checkpoint(const char *name);
+
+#endif /* SUPERSCALAR_CRASH_INJECT_H */

--- a/src/crash_inject.c
+++ b/src/crash_inject.c
@@ -1,0 +1,16 @@
+#include "superscalar/crash_inject.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void lsp_crash_checkpoint(const char *name) {
+    const char *target = getenv("SUPERSCALAR_CRASH_AT");
+    if (!target || !name) return;
+    if (strcmp(target, name) != 0) return;
+    fprintf(stderr,
+            "lsp_crash_checkpoint: HIT '%s' — aborting per SUPERSCALAR_CRASH_AT\n",
+            name);
+    fflush(stderr);
+    abort();
+}

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -3,6 +3,7 @@
 #include "superscalar/lsps.h"
 #include "superscalar/persist.h"
 #include "superscalar/sha256.h"
+#include "superscalar/crash_inject.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -427,6 +428,7 @@ int lsp_run_factory_creation(lsp_t *lsp,
         } else {
             cer_persisted = 1;
         }
+        lsp_crash_checkpoint("pending_nonces");
     }
 
     /* Send FACTORY_PROPOSE to all clients */
@@ -841,6 +843,7 @@ int lsp_run_factory_creation(lsp_t *lsp,
                                                 agg_nonce_ser, NULL, NULL, 0, 0);
         }
     }
+    lsp_crash_checkpoint("nonces_aggregated");
 
     /* Finalize distribution TX signing session (separate from tree nodes) */
     if (has_dist_tx && f->dist_tx_ready) {
@@ -897,6 +900,7 @@ int lsp_run_factory_creation(lsp_t *lsp,
             fprintf(stderr, "LSP: persist_update_ceremony_state(PENDING_SIGS) failed\n");
         }
     }
+    lsp_crash_checkpoint("pending_sigs");
 
     /* Collect PSIG_BUNDLEs from all clients (parallel select) */
     {
@@ -1044,6 +1048,7 @@ int lsp_run_factory_creation(lsp_t *lsp,
        the final signature (root node) and the broadcast txid (the funding
        TXID — already broadcast by the caller before this ceremony started;
        the wallet team treats it as the authoritative on-chain anchor). */
+    lsp_crash_checkpoint("finalize_partial");
     if (cer_persisted) {
         if (!persist_update_ceremony_state(lsp->db, cer_id,
                                             PERSIST_CEREMONY_STATE_FINALIZED)) {


### PR DESCRIPTION
## Summary
Per dashboard-team handoff (`C:/pirq/dashboard-upgrade/LSP_TEAM_HANDOFF_CEREMONY_CRASH_INJECTION.md` §1 "Gap C: do this first"). Tiny, self-contained crash-injection helper that unblocks deterministic mid-ceremony restart drills.

## What ships
- `include/superscalar/crash_inject.h` — declares `void lsp_crash_checkpoint(const char *name);`
- `src/crash_inject.c` — 12-line implementation:
  ```c
  void lsp_crash_checkpoint(const char *name) {
      const char *target = getenv("SUPERSCALAR_CRASH_AT");
      if (!target || !name) return;
      if (strcmp(target, name) != 0) return;
      fprintf(stderr, "lsp_crash_checkpoint: HIT '%s' — aborting per SUPERSCALAR_CRASH_AT\n", name);
      fflush(stderr);
      abort();
  }
  ```
- `CMakeLists.txt` — adds `src/crash_inject.c` to `SUPERSCALAR_SRCS`
- `src/lsp.c` — 4 checkpoint calls in `lsp_run_factory_creation`:
  - `"pending_nonces"` after `persist_save_ceremony(PENDING_NONCES)` (~line 430)
  - `"nonces_aggregated"` after `persist_update_ceremony_state(NONCES_AGGREGATED)` (~line 845)
  - `"pending_sigs"` after `persist_update_ceremony_state(PENDING_SIGS)` (~line 902)
  - `"finalize_partial"` before `persist_update_ceremony_state(FINALIZED)` (~line 1050)

## Production impact
**Zero.** Production code never sets `SUPERSCALAR_CRASH_AT`. The helper is `getenv + strcmp` — microseconds per checkpoint, no side effects.

## What this unblocks
- Gaps A/B of #245 (ROTATE / FORCE_OUT wiring) — when those ceremonies land their `persist_save_ceremony(type=ROTATE)` etc., they can add `lsp_crash_checkpoint("rotate_pending_sigs")` etc.
- Gap D of #245 — `tools/test_regtest_crash_at_every_phase.sh` can drive `SUPERSCALAR_CRASH_AT=<phase>` per cell
- #250 SF-CHEAT-ROLLOVER — the rollover cheat needs to position the LSP at a specific ROTATE phase deterministically; SUPERSCALAR_CRASH_AT lets the test fire the LSP exactly at the cheat point

## Test plan
- [x] Build clean on regtest VPS
- [x] `nm build/superscalar_lsp | grep lsp_crash_checkpoint` resolves: `000000000008cce0 T lsp_crash_checkpoint`
- [x] `--help` works (production no-op verified)
- [ ] Once Gaps A+B land + test scaffold (#245 Gap D) lands, run the full 8-cell matrix on regtest

Refs: tracker SF-CRASH-INJECT-WIRE (#245).