### PR TITLE
fix(wt): register pre-realloc leaf as stale-watch target (closes #258)

### DIFF
--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3358,6 +3358,42 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
 
+    /* Step 11b: register the OLD (pre-realloc) leaf state with the
+       watchtower as a stale-broadcast target.  Without this, a malicious
+       LSP can force-close + broadcast the pre-realloc leaf TX and the WT
+       has no entry to match the on-chain spend against.  Mirror the
+       leaf-advance pattern at line ~2785 — registers (OLD txid → NEW
+       signed_tx as response + poison TX).  Surfaced by SF-WT-REALLOC-DETECT-GAP
+       (#258), reproduced end-to-end by tools/test_regtest_cheat_realloc.sh. */
+    if (mgr->watchtower && realloc_had_signed && node->is_signed &&
+        node->signed_tx.len > 0) {
+        uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+        size_t n_leaf_ch = 0;
+        for (size_t cc = 0; cc < mgr->n_channels; cc++) {
+            size_t c_node;
+            uint32_t c_vout;
+            if (!factory_client_to_leaf(f, cc, &c_node, &c_vout)) continue;
+            if (c_node == node_idx)
+                leaf_ch_ids[n_leaf_ch++] = (uint32_t)cc;
+        }
+        const unsigned char *poison_data = NULL;
+        size_t poison_len = 0;
+        if (realloc_poison_prepared &&
+            node->poison_is_signed && node->poison_signed_tx.len > 0) {
+            poison_data = node->poison_signed_tx.data;
+            poison_len = node->poison_signed_tx.len;
+        }
+        watchtower_watch_factory_node_with_channels(mgr->watchtower,
+            (uint32_t)node_idx, realloc_old_leaf_txid,
+            node->signed_tx.data, node->signed_tx.len,
+            poison_data, poison_len,
+            leaf_ch_ids, n_leaf_ch);
+        printf("LSP realloc: watchtower registered OLD leaf %zu txid as stale "
+               "(response_tx=%zub, poison=%s, %zu channels)\n",
+               node_idx, (size_t)node->signed_tx.len,
+               poison_data ? "yes" : "no", n_leaf_ch);
+    }
+
     /* Step 12: Update channel amounts in lsp_channel_entry_t.
 
        Generic mapping: each client owns the leaf output at the vout


### PR DESCRIPTION
## Summary
Closes SF-WT-REALLOC-DETECT-GAP (#258). Real defense-path bug surfaced by [PR #295's end-to-end cheat-realloc test](https://github.com/8144225309/SuperScalar/pull/295#issuecomment-4495648743).

## The bug
After the CL2 cheat-realloc PR landed the test infrastructure (snapshot pre-realloc tx + broadcast tree + broadcast stale + WT-check), the end-to-end run on regtest produced:

```
CL2 CHEAT-REALLOC: parent tree on-chain; broadcasting revoked pre-realloc leaf
CL2 CHEAT-REALLOC: revoked tx broadcast txid=c595332e95f382e4...
CL2 CHEAT-REALLOC: watchtower did NOT detect revoked broadcast (defense MISS)
```

The cheat broadcast confirmed on chain, but `watchtower_check` returned 0. **No penalty TX fired.** In production this means a malicious LSP can force-close + broadcast the pre-realloc leaf state to claim the higher pre-realloc L-stock allocation, and the watchtower has no recourse.

## Root cause
`lsp_realloc_leaf` (src/lsp_channels.c:3046) prepared a poison TX at realloc time for the NEW state's response. But it never registered the OLD (pre-realloc) leaf state with the watchtower as a stale-broadcast target.

The WT therefore had no entry to match the on-chain spend against. The leaf-advance path at lines 2785-2798 already does this correctly — proven by `--cheat-leaf` regtest tests passing — but the realloc path was missing the equivalent call.

## The fix
After `factory_session_complete_node` finalizes the new state (step 11 of `lsp_realloc_leaf`), call `watchtower_watch_factory_node_with_channels` with:
- `parent_txid` = `realloc_old_leaf_txid` (already snapshotted at step 0)
- `response_tx` = `node->signed_tx` (the new post-realloc state)
- `poison_tx` = `node->poison_signed_tx` (if prepared in step 3)
- `channel_ids` = clients on this leaf

Mirrors the identical pattern at `lsp_channels.c:2785-2798` used by leaf-advance.

## Test plan
- [ ] Cherry-pick onto PR #295's branch and run `tools/test_regtest_cheat_realloc.sh` — expected: `CL2 CHEAT-REALLOC: BREACH DETECTED!` + `LEAF REALLOC TEST: PASS`
- [ ] Build clean on all CI targets
- [ ] No regression on existing `--cheat-leaf` tests (the registration call is now made in TWO paths; the existing leaf-advance one is untouched)

This closes the cheat-engine loop for realloc. Combined with PR #295 (CL2 driver + scaffold), realloc adversarial defense is now end-to-end testable on regtest.

Refs: tracker SF-WT-REALLOC-DETECT-GAP (#258), PR #295 (CL2 cheat-realloc).