### PR TITLE
htlc_commit: reject update_fee that would strand HTLC sweep outputs

### DIFF
--- a/src/htlc_commit.c
+++ b/src/htlc_commit.c
@@ -349,7 +349,47 @@ int htlc_commit_recv_update_fee(channel_t *ch,
     uint32_t feerate = get_u32(msg + 34); /* after type(2) + channel_id(32) */
     if (feerate < feerate_floor || feerate > feerate_ceiling) return 0;
 
-    ch->fee_rate_sat_per_kvb = (uint64_t)feerate * 4; /* sat/kw -> sat/kvb */
+    /* Dust-race defense (SF-CHEAT-DUST-RACE): a peer-proposed feerate that's
+       in-bounds can still strand funds. The accepted feerate is later used to
+       compute per-HTLC sweep fees (channel.c:1730, 2177, 2326). If the sweep
+       fee at the new rate would push any active HTLC's sweep output below
+       dust, refuse the update — otherwise the counterparty can force-close
+       leaving us unable to claim. */
+    uint64_t new_kvb = (uint64_t)feerate * 4;
+    uint64_t htlc_sweep_fee = (new_kvb * 180 + 999) / 1000;
+    uint64_t htlc_safe_floor = htlc_sweep_fee + CHANNEL_DUST_LIMIT_SATS;
+    for (size_t i = 0; i < ch->n_htlcs; i++) {
+        if (ch->htlcs[i].state != HTLC_STATE_ACTIVE) continue;
+        if (ch->htlcs[i].amount_sats < CHANNEL_DUST_LIMIT_SATS) continue; /* already trimmed */
+        if (ch->htlcs[i].amount_sats < htlc_safe_floor) {
+            fprintf(stderr,
+                    "htlc_commit_recv_update_fee: REJECT feerate %u sat/kw — "
+                    "HTLC[%zu] amount=%llu sats would yield sweep amount below dust "
+                    "(sweep_fee=%llu, dust=%u)\n",
+                    feerate, i,
+                    (unsigned long long)ch->htlcs[i].amount_sats,
+                    (unsigned long long)htlc_sweep_fee,
+                    CHANNEL_DUST_LIMIT_SATS);
+            return 0;
+        }
+    }
+    for (size_t i = 0; i < ch->n_ptlcs; i++) {
+        if (ch->ptlcs[i].state != PTLC_STATE_ACTIVE) continue;
+        if (ch->ptlcs[i].amount_sats < CHANNEL_DUST_LIMIT_SATS) continue;
+        if (ch->ptlcs[i].amount_sats < htlc_safe_floor) {
+            fprintf(stderr,
+                    "htlc_commit_recv_update_fee: REJECT feerate %u sat/kw — "
+                    "PTLC[%zu] amount=%llu sats would yield sweep amount below dust "
+                    "(sweep_fee=%llu, dust=%u)\n",
+                    feerate, i,
+                    (unsigned long long)ch->ptlcs[i].amount_sats,
+                    (unsigned long long)htlc_sweep_fee,
+                    CHANNEL_DUST_LIMIT_SATS);
+            return 0;
+        }
+    }
+
+    ch->fee_rate_sat_per_kvb = new_kvb;
     return 1;
 }
 

--- a/tests/test_htlc_commit.c
+++ b/tests/test_htlc_commit.c
@@ -16,6 +16,12 @@
  * HC13: test_htlc_commit_recv_update_fee_accepts   — valid feerate accepted
  * HC14: test_htlc_commit_recv_update_fee_rejects_low  — below floor rejected
  * HC15: test_htlc_commit_recv_update_fee_rejects_high — above ceiling rejected
+ * HC16: test_htlc_commit_recv_update_fee_dust_race_rejects — abusive feerate
+ *                                                       rejected when active HTLC
+ *                                                       would become unsweepable
+ * HC17: test_htlc_commit_recv_update_fee_dust_race_accepts_large — safe-but-high
+ *                                                       feerate accepted when
+ *                                                       HTLC value is sufficient
  */
 
 #include "superscalar/htlc_commit.h"
@@ -701,6 +707,100 @@ int test_htlc_commit_recv_update_fee_rejects_high(void) {
                                       BOLT2_UPDATE_FEE_FLOOR,
                                       BOLT2_UPDATE_FEE_CEILING);
     ASSERT(ok == 1, "feerate exactly at ceiling accepted");
+
+    return 1;
+}
+
+/* ================================================================== */
+/* HC16 — dust-race rejection: abusive feerate would strand small HTLC */
+/* ================================================================== */
+
+int test_htlc_commit_recv_update_fee_dust_race_rejects(void) {
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    /* Small active HTLC (5000 sats). At ceiling 100000 sat/kw,
+       sweep fee = (400000*180+999)/1000 = 72000 sats. The HTLC sweep
+       output would be 5000 - 72000 < 0 → unsweepable. Must reject. */
+    htlc_t htlcs[1];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = 5000;
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 1;
+
+    unsigned char msg[38];
+    memset(msg, 0, sizeof(msg));
+    wr16(msg, BOLT2_UPDATE_FEE);
+    wr32(msg + 34, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "abusive feerate rejected (HTLC would become unsweepable)");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000,
+           "fee_rate unchanged on dust-race rejection");
+
+    /* Sub-dust HTLCs are already trimmed — they shouldn't block fee updates */
+    htlcs[0].amount_sats = 200;  /* below CHANNEL_DUST_LIMIT_SATS = 546 */
+    ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                      BOLT2_UPDATE_FEE_FLOOR,
+                                      BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 1, "already-trimmed sub-dust HTLC does not block fee update");
+
+    return 1;
+}
+
+/* ================================================================== */
+/* HC17 — dust-race acceptance: safe-but-high feerate ok when HTLC big */
+/* ================================================================== */
+
+int test_htlc_commit_recv_update_fee_dust_race_accepts_large(void) {
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    /* Active HTLC of 200k sats. At ceiling, sweep fee = 72000 sats,
+       sweep amount = 200000 - 72000 = 128000 > dust → accept. */
+    htlc_t htlcs[1];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = 200000;
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 1;
+
+    unsigned char msg[38];
+    memset(msg, 0, sizeof(msg));
+    wr16(msg, BOLT2_UPDATE_FEE);
+    wr32(msg + 34, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 1, "safe-but-high feerate accepted with sufficient HTLC value");
+    ASSERT(ch.fee_rate_sat_per_kvb == (uint64_t)BOLT2_UPDATE_FEE_CEILING * 4,
+           "fee_rate updated on dust-race acceptance");
+
+    /* PTLC counterpart: also blocks if small */
+    ch.fee_rate_sat_per_kvb = 1000;
+    ch.n_htlcs = 0;
+    ptlc_t ptlcs[1];
+    memset(ptlcs, 0, sizeof(ptlcs));
+    ptlcs[0].state = PTLC_STATE_ACTIVE;
+    ptlcs[0].direction = PTLC_OFFERED;
+    ptlcs[0].amount_sats = 5000;
+    ch.ptlcs = ptlcs;
+    ch.n_ptlcs = 1;
+
+    ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                      BOLT2_UPDATE_FEE_FLOOR,
+                                      BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "abusive feerate rejected (PTLC would become unsweepable)");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000,
+           "fee_rate unchanged on PTLC dust-race rejection");
 
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -913,6 +913,8 @@ extern int test_htlc_commit_update_fee_layout(void);
 extern int test_htlc_commit_recv_update_fee_accepts(void);
 extern int test_htlc_commit_recv_update_fee_rejects_low(void);
 extern int test_htlc_commit_recv_update_fee_rejects_high(void);
+extern int test_htlc_commit_recv_update_fee_dust_race_rejects(void);
+extern int test_htlc_commit_recv_update_fee_dust_race_accepts_large(void);
 /* PR #21 Phase 3: CLTV watchdog */
 extern int test_cltv_watchdog_default_delta(void);
 extern int test_cltv_watchdog_no_htlcs(void);
@@ -2775,6 +2777,8 @@ static void run_unit_tests(void) {
     RUN_TEST(test_htlc_commit_recv_update_fee_accepts);
     RUN_TEST(test_htlc_commit_recv_update_fee_rejects_low);
     RUN_TEST(test_htlc_commit_recv_update_fee_rejects_high);
+    RUN_TEST(test_htlc_commit_recv_update_fee_dust_race_rejects);
+    RUN_TEST(test_htlc_commit_recv_update_fee_dust_race_accepts_large);
     printf("\n=== PR #21 Phase 3: CLTV Watchdog ===\n");
     RUN_TEST(test_cltv_watchdog_default_delta);
     RUN_TEST(test_cltv_watchdog_no_htlcs);


### PR DESCRIPTION
## Summary
- `htlc_commit_recv_update_fee` previously only checked the BOLT-2 floor/ceiling and silently applied any in-bounds feerate to `ch->fee_rate_sat_per_kvb`. That feerate flows into HTLC sweep / penalty tx fee math (`channel.c:1730`, `2177`, `2326`). At the ceiling (100000 sat/kw → 400000 sat/kvb) the per-HTLC sweep fee is ~72000 sats — any active HTLC smaller than ~72546 sats would yield a sub-dust sweep output and be unclaimable on a hostile force-close.
- Adds a dust-impact check: refuse the update if any active HTLC or PTLC would become unsweepable at the proposed feerate. Sub-dust HTLCs that are already trimmed at commit time are ignored.
- New tests HC16 / HC17 cover the rejection and acceptance paths plus PTLC parity, and confirm `fee_rate_sat_per_kvb` is left untouched when the proposal is refused.

## Test plan
- [ ] `superscalar_test_runner` clean on VPS — HC1–HC17 all pass, no regression in existing HTLC/PTLC suites
- [ ] Spot-check regtest end-to-end: existing HTLC tests (`tests/test_regtest_ts_htlc_fc.sh` family) still pass under the new validation (no false positives at typical channel sizes)