### PR TITLE
wt-trustless Phase 1a: persist_wt module — watchtower.db schema + register helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(superscalar
     src/lsp_demo.c
     src/report.c
     src/persist.c
+    src/persist_wt.c
     src/bridge.c
     src/fee.c
     src/fee_estimator_static.c
@@ -263,6 +264,7 @@ add_executable(test_superscalar
     tests/test_economic_correctness.c
     tests/test_regtest_hybrid_cln.c
     tests/test_persist.c
+    tests/test_persist_wt.c
     tests/test_bridge.c
     tests/test_daemon.c
     tests/test_reconnect.c

--- a/include/superscalar/persist_wt.h
+++ b/include/superscalar/persist_wt.h
@@ -1,0 +1,83 @@
+#ifndef SUPERSCALAR_PERSIST_WT_H
+#define SUPERSCALAR_PERSIST_WT_H
+
+/* #248 (SF-WT-TRUSTLESS) Phase 1a — watchtower-side persistence module.
+   Owns watchtower.db, a SQLite file separate from lsp.db. The trustless
+   model is detailed in docs/watchtower-trustless-schema.md. This Phase
+   1a PR lands ONLY the schema + open/close + a single write helper. The
+   LSP-side wiring (call sites that emit watches) and the WT-side reader
+   switchover are subsequent phases tracked under #248.
+
+   No column declared here is a secret. The 32-byte response_txid is a
+   public bitcoin txid; the hex blob is a fully-signed TX (revealed in
+   mempool the moment WT broadcasts it). Anyone with shell access to
+   watchtower.db can dump it and learn only what the chain already
+   reveals — that is the entire point of the split. */
+
+#include <sqlite3.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define PERSIST_WT_SCHEMA_VERSION 1
+
+typedef struct {
+    sqlite3 *db;
+    char path[256];
+} persist_wt_t;
+
+/* Open (or create) watchtower.db at the given path. Runs DDL on first
+   open. Returns 1 on success, 0 on error. Caller must persist_wt_close
+   on success. Refuses to open a file whose schema_version doesn't match
+   PERSIST_WT_SCHEMA_VERSION — there is no migration framework for WT
+   schema yet (Phase 1 only). */
+int persist_wt_open(persist_wt_t *pwt, const char *path);
+
+/* Close the connection. Safe to call on a zero-initialized struct. */
+void persist_wt_close(persist_wt_t *pwt);
+
+/* Register a new (parent_outpoint, response_tx) pair. Atomic — both
+   wt_responses + wt_watches rows are written under a single transaction.
+   Returns the new wt_watches.watch_id on success, -1 on error.
+
+   factory_id    — opaque LSP-side handle, no semantic meaning to WT
+   parent_txid32 — 32 bytes, big-endian (internal byte order)
+   parent_vout   — vout index of the watched outpoint
+   parent_value_sat, parent_spk[len] — value + scriptpubkey to match in
+                   block scans; both are publicly observable once the
+                   parent tx confirms
+   csv_delay     — relative-timelock the response_tx assumes (set when
+                   constructing the pre-signed response)
+   response_tx_hex     — fully-signed response TX, ready for
+                          sendrawtransaction. Caller signs with key
+                          material that lives in lsp.db only.
+   response_txid32     — 32 bytes; can be NULL to have the helper
+                          derive it from the hex (Phase 1a always
+                          requires the caller to pass it explicitly)
+   fee_bump_budget_sat — max sats authorized for fee-bump escalation;
+                          0 = no fee-bump child available
+   fee_bump_deadline   — absolute block height past which the WT
+                          should give up on fee-bump escalation */
+int64_t persist_wt_register_watch(persist_wt_t *pwt,
+                                    uint32_t factory_id,
+                                    const unsigned char *parent_txid32,
+                                    uint32_t parent_vout,
+                                    uint64_t parent_value_sat,
+                                    const unsigned char *parent_spk,
+                                    size_t parent_spk_len,
+                                    uint32_t csv_delay,
+                                    const char *response_tx_hex,
+                                    const unsigned char *response_txid32,
+                                    uint64_t fee_bump_budget_sat,
+                                    uint32_t fee_bump_deadline_height);
+
+/* Mark a watch as superseded by a chain advance. Used when a leaf
+   advances to a newer state and the older row is no longer canonical.
+   Returns 1 on success, 0 if no row matched. */
+int persist_wt_supersede_watch(persist_wt_t *pwt, int64_t watch_id,
+                                 uint32_t at_height);
+
+/* Count active (non-superseded) watches. Used by the WT for the
+   health heartbeat row. Returns -1 on error. */
+int persist_wt_count_active_watches(const persist_wt_t *pwt);
+
+#endif /* SUPERSCALAR_PERSIST_WT_H */

--- a/src/persist_wt.c
+++ b/src/persist_wt.c
@@ -1,0 +1,234 @@
+/* #248 (SF-WT-TRUSTLESS) Phase 1a — watchtower.db schema + open/close +
+   register_watch helper. See include/superscalar/persist_wt.h and
+   docs/watchtower-trustless-schema.md for the trust model. */
+
+#include "superscalar/persist_wt.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *WT_SCHEMA_DDL =
+    "CREATE TABLE IF NOT EXISTS wt_meta ("
+    "    key   TEXT PRIMARY KEY,"
+    "    value TEXT NOT NULL"
+    ");"
+    "CREATE TABLE IF NOT EXISTS wt_responses ("
+    "    response_id       INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "    response_tx_hex   TEXT NOT NULL,"
+    "    response_txid     BLOB NOT NULL,"
+    "    fee_bump_anchor   BLOB,"
+    "    fee_bump_budget   INTEGER NOT NULL DEFAULT 0,"
+    "    fee_bump_deadline INTEGER NOT NULL DEFAULT 0"
+    ");"
+    "CREATE INDEX IF NOT EXISTS wt_responses_txid_idx "
+    "    ON wt_responses(response_txid);"
+    "CREATE TABLE IF NOT EXISTS wt_watches ("
+    "    watch_id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "    factory_id        INTEGER NOT NULL,"
+    "    parent_txid       BLOB NOT NULL,"
+    "    parent_vout       INTEGER NOT NULL,"
+    "    parent_value_sat  INTEGER NOT NULL,"
+    "    parent_spk        BLOB NOT NULL,"
+    "    csv_delay         INTEGER NOT NULL,"
+    "    response_id       INTEGER NOT NULL,"
+    "    superseded_at     INTEGER,"
+    "    registered_at     INTEGER NOT NULL DEFAULT (strftime('%s','now')),"
+    "    FOREIGN KEY (response_id) REFERENCES wt_responses(response_id)"
+    ");"
+    "CREATE INDEX IF NOT EXISTS wt_watches_active_idx "
+    "    ON wt_watches(superseded_at) WHERE superseded_at IS NULL;"
+    "CREATE TABLE IF NOT EXISTS wt_responses_broadcast ("
+    "    broadcast_id              INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "    watch_id                  INTEGER NOT NULL,"
+    "    observed_spend_txid       BLOB NOT NULL,"
+    "    observed_at_height        INTEGER NOT NULL,"
+    "    response_broadcast_txid   BLOB,"
+    "    response_broadcast_at     INTEGER,"
+    "    broadcast_result          TEXT NOT NULL,"
+    "    bitcoind_error            TEXT,"
+    "    FOREIGN KEY (watch_id) REFERENCES wt_watches(watch_id)"
+    ");"
+    "CREATE TABLE IF NOT EXISTS wt_health ("
+    "    heartbeat_at      INTEGER PRIMARY KEY,"
+    "    chain_height      INTEGER NOT NULL,"
+    "    n_active_watches  INTEGER NOT NULL,"
+    "    last_reorg_at     INTEGER,"
+    "    last_reorg_depth  INTEGER"
+    ");";
+
+static int wt_get_schema_version(sqlite3 *db, int *out) {
+    const char *sql = "SELECT value FROM wt_meta WHERE key = 'schema_version';";
+    sqlite3_stmt *st;
+    if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK) {
+        /* wt_meta doesn't exist yet — caller treats as version 0. */
+        *out = 0;
+        return 1;
+    }
+    int rc = sqlite3_step(st);
+    if (rc == SQLITE_ROW) {
+        *out = atoi((const char *)sqlite3_column_text(st, 0));
+    } else {
+        *out = 0;
+    }
+    sqlite3_finalize(st);
+    return 1;
+}
+
+static int wt_apply_schema(sqlite3 *db) {
+    char *err = NULL;
+    if (sqlite3_exec(db, WT_SCHEMA_DDL, NULL, NULL, &err) != SQLITE_OK) {
+        fprintf(stderr, "persist_wt: schema DDL failed: %s\n",
+                err ? err : "(unknown)");
+        if (err) sqlite3_free(err);
+        return 0;
+    }
+    char ver_buf[16];
+    snprintf(ver_buf, sizeof(ver_buf), "%d", PERSIST_WT_SCHEMA_VERSION);
+    sqlite3_stmt *st;
+    const char *sql =
+        "INSERT INTO wt_meta (key, value) VALUES ('schema_version', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value;";
+    if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_text(st, 1, ver_buf, -1, SQLITE_TRANSIENT);
+    int rc = sqlite3_step(st);
+    sqlite3_finalize(st);
+    return rc == SQLITE_DONE ? 1 : 0;
+}
+
+int persist_wt_open(persist_wt_t *pwt, const char *path) {
+    if (!pwt || !path) return 0;
+    memset(pwt, 0, sizeof(*pwt));
+    if (sqlite3_open(path, &pwt->db) != SQLITE_OK) {
+        fprintf(stderr, "persist_wt_open: sqlite3_open(%s) failed: %s\n",
+                path, sqlite3_errmsg(pwt->db));
+        if (pwt->db) sqlite3_close(pwt->db);
+        pwt->db = NULL;
+        return 0;
+    }
+    /* Recommended pragmas for a moderate-write workload. */
+    sqlite3_exec(pwt->db, "PRAGMA journal_mode = WAL;",         NULL, NULL, NULL);
+    sqlite3_exec(pwt->db, "PRAGMA synchronous = NORMAL;",       NULL, NULL, NULL);
+    sqlite3_exec(pwt->db, "PRAGMA foreign_keys = ON;",          NULL, NULL, NULL);
+
+    int existing_ver = 0;
+    if (!wt_get_schema_version(pwt->db, &existing_ver)) {
+        sqlite3_close(pwt->db); pwt->db = NULL; return 0;
+    }
+    if (existing_ver == 0) {
+        if (!wt_apply_schema(pwt->db)) {
+            sqlite3_close(pwt->db); pwt->db = NULL; return 0;
+        }
+    } else if (existing_ver != PERSIST_WT_SCHEMA_VERSION) {
+        fprintf(stderr,
+                "persist_wt_open: schema version mismatch — file=%d code=%d. "
+                "Phase 1a has no migration framework; refusing to open.\n",
+                existing_ver, PERSIST_WT_SCHEMA_VERSION);
+        sqlite3_close(pwt->db); pwt->db = NULL; return 0;
+    }
+
+    strncpy(pwt->path, path, sizeof(pwt->path) - 1);
+    return 1;
+}
+
+void persist_wt_close(persist_wt_t *pwt) {
+    if (!pwt) return;
+    if (pwt->db) {
+        sqlite3_close(pwt->db);
+        pwt->db = NULL;
+    }
+}
+
+int64_t persist_wt_register_watch(persist_wt_t *pwt,
+                                    uint32_t factory_id,
+                                    const unsigned char *parent_txid32,
+                                    uint32_t parent_vout,
+                                    uint64_t parent_value_sat,
+                                    const unsigned char *parent_spk,
+                                    size_t parent_spk_len,
+                                    uint32_t csv_delay,
+                                    const char *response_tx_hex,
+                                    const unsigned char *response_txid32,
+                                    uint64_t fee_bump_budget_sat,
+                                    uint32_t fee_bump_deadline_height) {
+    if (!pwt || !pwt->db) return -1;
+    if (!parent_txid32 || !parent_spk || parent_spk_len == 0) return -1;
+    if (!response_tx_hex || !response_txid32) return -1;
+
+    int64_t watch_id = -1;
+    char *err = NULL;
+    if (sqlite3_exec(pwt->db, "BEGIN IMMEDIATE;", NULL, NULL, &err) != SQLITE_OK) {
+        if (err) { fprintf(stderr, "persist_wt: BEGIN failed: %s\n", err); sqlite3_free(err); }
+        return -1;
+    }
+
+    sqlite3_stmt *st;
+    const char *ins_resp =
+        "INSERT INTO wt_responses "
+        "(response_tx_hex, response_txid, fee_bump_anchor, fee_bump_budget, fee_bump_deadline) "
+        "VALUES (?, ?, NULL, ?, ?);";
+    if (sqlite3_prepare_v2(pwt->db, ins_resp, -1, &st, NULL) != SQLITE_OK) goto rollback;
+    sqlite3_bind_text (st, 1, response_tx_hex, -1, SQLITE_STATIC);
+    sqlite3_bind_blob (st, 2, response_txid32, 32, SQLITE_STATIC);
+    sqlite3_bind_int64(st, 3, (sqlite3_int64)fee_bump_budget_sat);
+    sqlite3_bind_int  (st, 4, (int)fee_bump_deadline_height);
+    int rc = sqlite3_step(st);
+    sqlite3_finalize(st);
+    if (rc != SQLITE_DONE) goto rollback;
+    int64_t response_id = sqlite3_last_insert_rowid(pwt->db);
+
+    const char *ins_watch =
+        "INSERT INTO wt_watches "
+        "(factory_id, parent_txid, parent_vout, parent_value_sat, parent_spk, "
+        " csv_delay, response_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?);";
+    if (sqlite3_prepare_v2(pwt->db, ins_watch, -1, &st, NULL) != SQLITE_OK) goto rollback;
+    sqlite3_bind_int  (st, 1, (int)factory_id);
+    sqlite3_bind_blob (st, 2, parent_txid32, 32, SQLITE_STATIC);
+    sqlite3_bind_int  (st, 3, (int)parent_vout);
+    sqlite3_bind_int64(st, 4, (sqlite3_int64)parent_value_sat);
+    sqlite3_bind_blob (st, 5, parent_spk, (int)parent_spk_len, SQLITE_STATIC);
+    sqlite3_bind_int  (st, 6, (int)csv_delay);
+    sqlite3_bind_int64(st, 7, (sqlite3_int64)response_id);
+    rc = sqlite3_step(st);
+    sqlite3_finalize(st);
+    if (rc != SQLITE_DONE) goto rollback;
+    watch_id = sqlite3_last_insert_rowid(pwt->db);
+
+    if (sqlite3_exec(pwt->db, "COMMIT;", NULL, NULL, &err) != SQLITE_OK) {
+        if (err) { fprintf(stderr, "persist_wt: COMMIT failed: %s\n", err); sqlite3_free(err); }
+        return -1;
+    }
+    return watch_id;
+
+rollback:
+    sqlite3_exec(pwt->db, "ROLLBACK;", NULL, NULL, NULL);
+    return -1;
+}
+
+int persist_wt_supersede_watch(persist_wt_t *pwt, int64_t watch_id,
+                                 uint32_t at_height) {
+    if (!pwt || !pwt->db || watch_id <= 0) return 0;
+    const char *sql =
+        "UPDATE wt_watches SET superseded_at = ? "
+        "WHERE watch_id = ? AND superseded_at IS NULL;";
+    sqlite3_stmt *st;
+    if (sqlite3_prepare_v2(pwt->db, sql, -1, &st, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_int  (st, 1, (int)at_height);
+    sqlite3_bind_int64(st, 2, (sqlite3_int64)watch_id);
+    int rc = sqlite3_step(st);
+    int changes = sqlite3_changes(pwt->db);
+    sqlite3_finalize(st);
+    return (rc == SQLITE_DONE && changes == 1) ? 1 : 0;
+}
+
+int persist_wt_count_active_watches(const persist_wt_t *pwt) {
+    if (!pwt || !pwt->db) return -1;
+    const char *sql =
+        "SELECT COUNT(*) FROM wt_watches WHERE superseded_at IS NULL;";
+    sqlite3_stmt *st;
+    if (sqlite3_prepare_v2(pwt->db, sql, -1, &st, NULL) != SQLITE_OK) return -1;
+    int n = 0;
+    if (sqlite3_step(st) == SQLITE_ROW) n = sqlite3_column_int(st, 0);
+    sqlite3_finalize(st);
+    return n;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1204,6 +1204,10 @@ extern int test_persist_signing_rounds_round_trip(void);
 extern int test_persist_pending_fee_bump_round_trip(void);
 extern int test_persist_force_close_round_trip(void);
 extern int test_persist_observability_tables(void);
+/* #248 SF-WT-TRUSTLESS Phase 1a */
+extern int test_persist_wt_open_close(void);
+extern int test_persist_wt_register_watch_round_trip(void);
+extern int test_persist_wt_no_secrets_in_schema(void);
 extern int test_persist_old_commitment_ptlcs_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
@@ -3053,6 +3057,10 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_pending_fee_bump_round_trip);
     RUN_TEST(test_persist_force_close_round_trip);
     RUN_TEST(test_persist_observability_tables);
+    printf("\n=== #248 SF-WT-TRUSTLESS Phase 1a ===\n");
+    RUN_TEST(test_persist_wt_open_close);
+    RUN_TEST(test_persist_wt_register_watch_round_trip);
+    RUN_TEST(test_persist_wt_no_secrets_in_schema);
     RUN_TEST(test_persist_old_commitment_ptlcs_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);

--- a/tests/test_persist_wt.c
+++ b/tests/test_persist_wt.c
@@ -1,0 +1,115 @@
+/* Unit tests for include/superscalar/persist_wt.h (Phase 1a). */
+
+#include "superscalar/persist_wt.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d): %s\n", __func__, __LINE__, (msg)); \
+        return 0; \
+    } \
+} while(0)
+
+static const char *WT_TMP_PATH = "/tmp/test_persist_wt.db";
+
+static void cleanup_db(void) {
+    unlink(WT_TMP_PATH);
+    char buf[300];
+    snprintf(buf, sizeof(buf), "%s-wal", WT_TMP_PATH); unlink(buf);
+    snprintf(buf, sizeof(buf), "%s-shm", WT_TMP_PATH); unlink(buf);
+}
+
+int test_persist_wt_open_close(void) {
+    cleanup_db();
+    persist_wt_t pwt;
+    ASSERT(persist_wt_open(&pwt, WT_TMP_PATH) == 1, "open on fresh path");
+    ASSERT(pwt.db != NULL, "db handle non-NULL");
+    persist_wt_close(&pwt);
+    ASSERT(pwt.db == NULL, "db handle NULL after close");
+
+    /* Re-open existing file — should not reapply schema, just verify version */
+    ASSERT(persist_wt_open(&pwt, WT_TMP_PATH) == 1, "re-open existing");
+    persist_wt_close(&pwt);
+    cleanup_db();
+    return 1;
+}
+
+int test_persist_wt_register_watch_round_trip(void) {
+    cleanup_db();
+    persist_wt_t pwt;
+    ASSERT(persist_wt_open(&pwt, WT_TMP_PATH) == 1, "open");
+
+    unsigned char parent_txid[32];   memset(parent_txid, 0xAA, 32);
+    unsigned char response_txid[32]; memset(response_txid, 0xBB, 32);
+    unsigned char spk[34];           memset(spk, 0xCC, 34);
+
+    int64_t watch_id = persist_wt_register_watch(&pwt,
+        /* factory_id      */ 42,
+        /* parent_txid32   */ parent_txid,
+        /* parent_vout     */ 1,
+        /* parent_value_sat*/ 1000000,
+        /* parent_spk      */ spk,
+        /* parent_spk_len  */ sizeof(spk),
+        /* csv_delay       */ 144,
+        /* response_tx_hex */ "0200000001abc...",
+        /* response_txid32 */ response_txid,
+        /* fee_bump_budget */ 5000,
+        /* fee_bump_dline  */ 800000);
+    ASSERT(watch_id > 0, "register_watch returns positive id");
+
+    int n = persist_wt_count_active_watches(&pwt);
+    ASSERT(n == 1, "count_active = 1 after one register");
+
+    /* Reject NULL inputs */
+    ASSERT(persist_wt_register_watch(&pwt, 1, NULL, 0, 0, spk, 34, 0,
+                                       "hex", response_txid, 0, 0) == -1,
+           "NULL parent_txid rejected");
+    ASSERT(persist_wt_register_watch(&pwt, 1, parent_txid, 0, 0, NULL, 0, 0,
+                                       "hex", response_txid, 0, 0) == -1,
+           "zero-len spk rejected");
+
+    /* Supersede + re-count */
+    ASSERT(persist_wt_supersede_watch(&pwt, watch_id, 700000) == 1,
+           "supersede succeeds");
+    ASSERT(persist_wt_supersede_watch(&pwt, watch_id, 700001) == 0,
+           "double-supersede no-ops");
+    n = persist_wt_count_active_watches(&pwt);
+    ASSERT(n == 0, "count_active = 0 after supersede");
+
+    persist_wt_close(&pwt);
+    cleanup_db();
+    return 1;
+}
+
+int test_persist_wt_no_secrets_in_schema(void) {
+    /* Trustless invariant: no column name in any wt_* table contains a
+       secret keyword. Cheap belt-and-braces check that catches a future
+       schema bump that smuggles in a key. */
+    cleanup_db();
+    persist_wt_t pwt;
+    ASSERT(persist_wt_open(&pwt, WT_TMP_PATH) == 1, "open");
+
+    sqlite3_stmt *st;
+    const char *sql =
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name LIKE 'wt_%';";
+    ASSERT(sqlite3_prepare_v2(pwt.db, sql, -1, &st, NULL) == SQLITE_OK, "prep");
+    int saw_secret = 0;
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        const char *ddl = (const char *)sqlite3_column_text(st, 0);
+        if (!ddl) continue;
+        if (strstr(ddl, "secret") || strstr(ddl, "seckey") ||
+            strstr(ddl, "private") || strstr(ddl, "revocation_secret")) {
+            saw_secret = 1;
+            printf("    secret-like column in WT DDL: %s\n", ddl);
+        }
+    }
+    sqlite3_finalize(st);
+    ASSERT(saw_secret == 0, "WT schema must not contain secret-like columns");
+
+    persist_wt_close(&pwt);
+    cleanup_db();
+    return 1;
+}


### PR DESCRIPTION
**Stacks on PR #294 (the design doc).** Targets `feat-wt-trustless-design` so the impl diff is isolated from the design diff. Rebase onto `main` after #294 merges.

## Summary
Lays the schema foundation for the trustless watchtower DB split designed in `docs/watchtower-trustless-schema.md`. After this lands the LSP can open a separate `watchtower.db` file and populate it via `persist_wt_register_watch`. The DB schema is structurally incapable of holding secrets — verified by a unit test (HC18 in the test list) that fails if a future schema bump smuggles in a `secret` / `seckey` / `private` / `revocation_secret` column.

This is Phase 1a — schema + writer module. No LSP-side ceremony hook is wired yet (that's Phase 1b). No WT-side reader changes yet (that's Phase 2). Existing deployments are unaffected — nothing calls `persist_wt_open` after this PR.

## What lands
- `include/superscalar/persist_wt.h`: 5-function module — `persist_wt_open`, `persist_wt_close`, `persist_wt_register_watch`, `persist_wt_supersede_watch`, `persist_wt_count_active_watches`. Single-purpose handle struct. No coupling back to `persist_t` or `lsp_t`.
- `src/persist_wt.c`: schema DDL for `wt_meta` / `wt_responses` / `wt_watches` / `wt_responses_broadcast` / `wt_health`, recommended PRAGMAs (`journal_mode=WAL`, `foreign_keys=ON`), and the register helper (atomic INSERT into `wt_responses` + `wt_watches` under a single transaction; rollback on any step failure).
- `tests/test_persist_wt.c`: three unit tests
  1. `open_close` — fresh open creates schema, re-open verifies version, close zeroes the handle.
  2. `register_watch_round_trip` — register one watch, `count_active` = 1, supersede, `count_active` = 0; NULL/zero-length inputs are rejected.
  3. `no_secrets_in_schema` — **trustless invariant check**; refuses if a future schema bump introduces a column whose DDL text contains a secret-like keyword.
- `CMakeLists.txt`: picks up the new source + test sources.

## Test plan
- [ ] `test_superscalar` runs all three new tests (`test_persist_wt_*`) green on VPS (release flavor)
- [ ] Full pre-existing test_superscalar suite remains 1469/1469 (no regression)
- [ ] Manual `sqlite3 /tmp/test_persist_wt.db ".schema"` after a register_watch — confirms exactly the expected DDL is present and no extra tables snuck in

## Phasing roadmap
- **Phase 1a (this PR)**: schema + writer module.
- **Phase 1b**: hook `persist_wt_register_watch` into the LSP's ceremony exits (`lsp_run_factory_creation`, `lsp_subfactory_chain_advance`, `lsp_realloc_leaf`, etc.) so a watchtower.db actually gets populated during normal operation.
- **Phase 2**: refactor `superscalar_watchtower` to open watchtower.db instead of lsp.db; new `--wt-db <path>` CLI flag; deprecate the old `--db <lsp.db>` flag.
- **Phase 3**: drop the legacy `watchtower_keys` / `watchtower_pending` tables from `lsp.db`.
- **Phase 4**: `tools/test_regtest_watchtower_trustless.sh` — end-to-end cheat-engine breach test under the new model + dump-the-WT-DB assertion that zero rows match a known LSP secret.