### PR TITLE
phase5 runners: emit on-chain events from broadcast_log + multi-format grep

### DIFF
--- a/docs/testnet4-phase5/shape-3a-N8-ARITY3/runner.sh
+++ b/docs/testnet4-phase5/shape-3a-N8-ARITY3/runner.sh
@@ -113,10 +113,7 @@ done
 diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
 EXIT=$DIAG_EXIT
 
-emit ""
-emit "## On-chain events"
-grep -oE "(funding|tree_node_[0-9]+|FORCE CLOSE|cooperative close).*txid=[a-f0-9]+" "$LSP_LOG" | sort -u >> "$EVIDENCE" || true
-emit ""
+diag_emit_onchain_events "$LSP_DB" "$LSP_LOG" "$EVIDENCE"
 emit "## Log assertions"
 for m in "shape ewt =" "PS leaf" "TEST PASSED" "TEST FAILED"; do
     H=$(grep -E "$m" "$LSP_LOG" | head -1 || true)

--- a/docs/testnet4-phase5/shape-3b-N8-ARITY34-STATIC1/runner.sh
+++ b/docs/testnet4-phase5/shape-3b-N8-ARITY34-STATIC1/runner.sh
@@ -113,10 +113,7 @@ done
 diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
 EXIT=$DIAG_EXIT
 
-emit ""
-emit "## On-chain events"
-grep -oE "(funding|tree_node_[0-9]+|FORCE CLOSE|cooperative close).*txid=[a-f0-9]+" "$LSP_LOG" | sort -u >> "$EVIDENCE" || true
-emit ""
+diag_emit_onchain_events "$LSP_DB" "$LSP_LOG" "$EVIDENCE"
 emit "## Log assertions"
 for m in "shape ewt =" "static-near-root" "is_static_only" "TEST PASSED" "TEST FAILED"; do
     H=$(grep -E "$m" "$LSP_LOG" | head -1 || true)

--- a/docs/testnet4-phase5/shape-3e-N4-ARITY3-K2/runner.sh
+++ b/docs/testnet4-phase5/shape-3e-N4-ARITY3-K2/runner.sh
@@ -157,15 +157,8 @@ done
 diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
 EXIT=$DIAG_EXIT
 
-# --- harvest on-chain evidence from log ---
-emit ""
-emit "## On-chain events"
-emit "| Event | TXID | grep marker |"
-emit "|---|---|---|"
-grep -oE "factory funding.* txid=[a-f0-9]+" "$LSP_LOG" | head -1 | sed 's/.*txid=/| funding | /; s/$/ | /' >> "$EVIDENCE" || true
-grep -oE "tree_node_[0-9]+ broadcast OK.*txid=[a-f0-9]+" "$LSP_LOG" | sed 's/.*tree_node_/| tree_node_/; s/.broadcast OK.*txid=/ | /; s/$/ | /' >> "$EVIDENCE" || true
-grep -oE "subfactory.* chain_len=[0-9]+.*txid=[a-f0-9]+" "$LSP_LOG" | sed 's/^/| subfactory | /; s/$/ | /' >> "$EVIDENCE" || true
-grep -oE "FORCE CLOSE.*txid=[a-f0-9]+" "$LSP_LOG" | sed 's/^/| force-close | /; s/$/ | /' >> "$EVIDENCE" || true
+# --- harvest on-chain evidence (broadcast_log + log-grep fallback) ---
+diag_emit_onchain_events "$LSP_DB" "$LSP_LOG" "$EVIDENCE"
 
 # --- harvest log assertions ---
 emit ""

--- a/docs/testnet4-phase5/shape-3epp-N16-ARITY3-K2/runner.sh
+++ b/docs/testnet4-phase5/shape-3epp-N16-ARITY3-K2/runner.sh
@@ -115,10 +115,7 @@ done
 diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
 EXIT=$DIAG_EXIT
 
-emit ""
-emit "## On-chain events"
-grep -oE "(funding|tree_node_[0-9]+|subfactory.*chain_len|FORCE CLOSE|cooperative close).*txid=[a-f0-9]+" "$LSP_LOG" | sort -u >> "$EVIDENCE" || true
-emit ""
+diag_emit_onchain_events "$LSP_DB" "$LSP_LOG" "$EVIDENCE"
 emit "## Log assertions"
 for m in "shape ewt =" "k²=" "sub-factory" "PS sub-factory" "MSG_SUBFACTORY_DONE" "persist: ps_subfactory_chain" "TEST PASSED" "TEST FAILED"; do
     H=$(grep -E "$m" "$LSP_LOG" | head -1 || true)

--- a/docs/testnet4-phase5/shape-3f-N64-ARITY24-K2-STATIC1/runner.sh
+++ b/docs/testnet4-phase5/shape-3f-N64-ARITY24-K2-STATIC1/runner.sh
@@ -119,10 +119,7 @@ done
 diag_wait_lsp "$LSP_PID" "$LSP_LOG" "ss_t4_${TAG}"
 EXIT=$DIAG_EXIT
 
-emit ""
-emit "## On-chain events"
-grep -oE "(funding|tree_node_[0-9]+|subfactory.*chain_len|FORCE CLOSE|cooperative close|breach|response).*txid=[a-f0-9]+" "$LSP_LOG" | sort -u >> "$EVIDENCE" || true
-emit ""
+diag_emit_onchain_events "$LSP_DB" "$LSP_LOG" "$EVIDENCE"
 emit "## Log assertions"
 for m in "shape ewt =" "static-near-root" "k²=" "sub-factory" "MSG_SUBFACTORY_DONE" "persist: ps_subfactory_chain" "watchtower: registered subfactory" "TEST PASSED" "TEST FAILED"; do
     H=$(grep -E "$m" "$LSP_LOG" | head -1 || true)

--- a/tools/test_diag_lib.sh
+++ b/tools/test_diag_lib.sh
@@ -212,3 +212,37 @@ diag_wait_lsp() {
         diag_on_lsp_death "$pid" "$lsp_log" "$tag" "$DIAG_EXIT" || true
     fi
 }
+
+# diag_emit_onchain_events <LSP_DB> <LSP_LOG> <EVIDENCE_FILE>
+#
+# Phase 5 runners' shared "## On-chain events" section emitter. Replaces the
+# previous per-runner grep that missed half the LSP's log formats (txid=
+# vs. txid: vs. bare confirmed: <hex>). Prefers a sqlite3 dump of the
+# broadcast_log table (the LSP's authoritative record); falls back to a
+# log grep that matches both txid=<hex> and txid: <hex> patterns so older
+# ceremonies that pre-date the broadcast_log journal still get captured.
+#
+# Writes a markdown table to the evidence file. Safe to call when LSP_DB
+# is absent (legacy runners), in which case only the grep fallback runs.
+diag_emit_onchain_events() {
+    local lsp_db="$1"
+    local lsp_log="$2"
+    local evidence="$3"
+    {
+        printf '\n## On-chain events\n\n'
+        printf '| source | txid | result |\n'
+        printf '|---|---|---|\n'
+    } >> "$evidence"
+    if [ -f "$lsp_db" ]; then
+        sqlite3 -separator '|' "$lsp_db" \
+            "SELECT source, txid, result FROM broadcast_log ORDER BY id;" \
+            2>/dev/null \
+            | awk -F'|' 'NF>=2 { printf "| %s | %s | %s |\n", $1, $2, $3 }' \
+            >> "$evidence" || true
+    fi
+    # Fallback grep catches anything broadcast_log missed. Matches both
+    # `txid=<hex>` (tree_node broadcasts) and `txid: <hex>` (cooperative
+    # close success line).
+    grep -oE "(funding|tree_node_[0-9]+|FORCE CLOSE|cooperative close|subfactory|breach|response)[^[:space:]]*[[:space:]]+txid[:=][[:space:]]*[a-f0-9]+" \
+        "$lsp_log" 2>/dev/null | sort -u >> "$evidence" || true
+}


### PR DESCRIPTION
Stacks on the Phase 5 scaffold PR (feat-testnet4-phase5-scaffold). Rebase onto main after that lands.

## Summary
The "## On-chain events" section is empty in every Phase 5 V1-results.md / V2-results.md file we PASSED today (3a V1, 3b V1, 3e V2). Cause: each per-shape runner had its own ad-hoc grep that matched only `txid=<hex>`, but the LSP also logs `txid: <hex>` (cooperative_close path) and several runners' patterns were stricter than needed. Heading printed, body empty.

This consolidates the extraction into a shared helper `diag_emit_onchain_events` in `tools/test_diag_lib.sh`. It prefers a sqlite3 SELECT from `broadcast_log` (the LSP's authoritative journal — gives `source`, `txid`, `result` in one query) and falls back to a multi-format regex that matches both `txid=` and `txid: ` for legacy ceremonies that pre-date the journal.

All five per-shape runners (3a, 3b, 3e, 3epp, 3f) now call the helper instead of their divergent greps. Net diff is **+34 helper LOC, -25 LOC of repeated grep**.

## Behaviour delta
- Empty "On-chain events" sections will populate on the next PASS for each shape
- Already-recorded results.md (3a V1, 3b V1, 3e V2) can be backfilled from `/tmp/ss_t4_phase5_*.db` with the same sqlite3 query — no runner needs to re-run
- No behaviour change on FAIL — the helper still fires; if the DB is missing it just emits the table header

## Test plan
- [ ] One next Phase 5 V2 run (3a V2, 3b V2, 3epp V2, or 3f V1 — all currently in-flight) lands and populates the on-chain events table correctly
- [ ] Backfill the three already-PASSED results.md files to capture the txids