### PR TITLE
fix(testnet4-phase5): runner scripts --- --lsp-balance-pct 50 on LSP + tighter pgrep

### DIFF
--- a/docs/testnet4-phase5/shape-3a-N8-ARITY3/runner.sh
+++ b/docs/testnet4-phase5/shape-3a-N8-ARITY3/runner.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-if pgrep -f "superscalar_lsp.*--port ${PORT:-9951}" >/dev/null 2>&1; then
+if (for pid in $(pgrep -f "/superscalar_lsp.*--port ${PORT:-9951}" 2>/dev/null); do [ "$(cat /proc/$pid/comm 2>/dev/null)" = "superscalar_lsp" ] && echo found && break; done | grep -q found); then
     echo "REFUSE: another superscalar_lsp is on port ${PORT:-9951}." >&2
     exit 3
 fi
@@ -74,6 +74,7 @@ nohup "$LSP_BIN" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
+    --lsp-balance-pct 50 \
     $DEMO_FLAGS \
     > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!

--- a/docs/testnet4-phase5/shape-3b-N8-ARITY34-STATIC1/runner.sh
+++ b/docs/testnet4-phase5/shape-3b-N8-ARITY34-STATIC1/runner.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-if pgrep -f "superscalar_lsp.*--port ${PORT:-9952}" >/dev/null 2>&1; then
+if (for pid in $(pgrep -f "/superscalar_lsp.*--port ${PORT:-9952}" 2>/dev/null); do [ "$(cat /proc/$pid/comm 2>/dev/null)" = "superscalar_lsp" ] && echo found && break; done | grep -q found); then
     echo "REFUSE: another superscalar_lsp is on port ${PORT:-9952}." >&2
     exit 3
 fi
@@ -74,6 +74,7 @@ nohup "$LSP_BIN" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
+    --lsp-balance-pct 50 \
     $DEMO_FLAGS \
     > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!

--- a/docs/testnet4-phase5/shape-3e-N4-ARITY3-K2/runner.sh
+++ b/docs/testnet4-phase5/shape-3e-N4-ARITY3-K2/runner.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 # Refuse to run if another LSP is already on our port (avoid the foot-gun where
 # a second invocation pkills the first one's LSP).
-if pgrep -f "superscalar_lsp.*--port ${PORT:-9950}" >/dev/null 2>&1; then
+if (for pid in $(pgrep -f "/superscalar_lsp.*--port ${PORT:-9950}" 2>/dev/null); do [ "$(cat /proc/$pid/comm 2>/dev/null)" = "superscalar_lsp" ] && echo found && break; done | grep -q found); then
     echo "REFUSE: another superscalar_lsp is on port ${PORT:-9950}." >&2
     echo "        pkill it manually if it is stale, or set PORT=<other> for this run." >&2
     exit 3
@@ -109,6 +109,7 @@ nohup "$LSP_BIN" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
+    --lsp-balance-pct 50 \
     $DEMO_FLAGS \
     > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!

--- a/docs/testnet4-phase5/shape-3epp-N16-ARITY3-K2/runner.sh
+++ b/docs/testnet4-phase5/shape-3epp-N16-ARITY3-K2/runner.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-if pgrep -f "superscalar_lsp.*--port ${PORT:-9953}" >/dev/null 2>&1; then
+if (for pid in $(pgrep -f "/superscalar_lsp.*--port ${PORT:-9953}" 2>/dev/null); do [ "$(cat /proc/$pid/comm 2>/dev/null)" = "superscalar_lsp" ] && echo found && break; done | grep -q found); then
     echo "REFUSE: another superscalar_lsp is on port ${PORT:-9953}." >&2
     exit 3
 fi
@@ -76,6 +76,7 @@ nohup "$LSP_BIN" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
+    --lsp-balance-pct 50 \
     $DEMO_FLAGS \
     > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!

--- a/docs/testnet4-phase5/shape-3f-N64-ARITY24-K2-STATIC1/runner.sh
+++ b/docs/testnet4-phase5/shape-3f-N64-ARITY24-K2-STATIC1/runner.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-if pgrep -f "superscalar_lsp.*--port ${PORT:-9954}" >/dev/null 2>&1; then
+if (for pid in $(pgrep -f "/superscalar_lsp.*--port ${PORT:-9954}" 2>/dev/null); do [ "$(cat /proc/$pid/comm 2>/dev/null)" = "superscalar_lsp" ] && echo found && break; done | grep -q found); then
     echo "REFUSE: another superscalar_lsp is on port ${PORT:-9954}." >&2
     exit 3
 fi
@@ -80,6 +80,7 @@ nohup "$LSP_BIN" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
     --wallet "$WALLET" --db "$LSP_DB" \
+    --lsp-balance-pct 50 \
     $DEMO_FLAGS \
     > "$LSP_LOG" 2> "$(diag_stderr_path lsp)" &
 LSP_PID=$!


### PR DESCRIPTION
## Summary

Two related fixes to all 5 phase5 shape runners (3a, 3b, 3e, 3epp, 3f):

### 1. Add `--lsp-balance-pct 50` to LSP cmdline

Clients were already getting `--lsp-balance-pct 50`; the LSP was inheriting the binary's default (100 = "LSP takes all") which left clients at 0 sats and silently failed the demo Payment 1 (`Client 1 → Client 2, 1000 sats`):

```
LSP: --demo with default --lsp-balance-pct 100 — clients will
     have 0 sats and any demo payment FROM a client will fail.
channel_add_htlc: refused — RECEIVED amount 1000 > remote_amount 0
```

V1 + V2 variants (`--demo` / `--demo --force-close`) survived this silently because their pass criteria didn't depend on demo state. V3 (`--test-ps-advance`) + V4 (`--test-subfactory-advance`) require clean post-demo channel coordination — without the flag, demo-cascade noise breaks the multi-signer ceremonies they exercise. Originally surfaced as 3e V3 PS_ADVANCE quorum failure on testnet4.

### 2. Tighten REFUSE pgrep so it only matches the actual binary

```diff
- pgrep -f "superscalar_lsp.*--port ${PORT}"
+ for pid in $(pgrep -f "/superscalar_lsp.*--port ${PORT}"); do
+     [ "$(cat /proc/$pid/comm)" = "superscalar_lsp" ] && echo found && break
+ done | grep -q found
```

Without this, any ssh diagnostic like `pgrep -af "/superscalar_lsp.*--port 9950"` would self-match and trip the REFUSE guard with a false positive.

## Scope

- No C-code path changes — pure runner-script hygiene
- All 5 shapes patched identically
- Already validated in practice (3e V3b on testnet4 launched cleanly with these patches before the conservation fix #305 was needed)

## Test plan

- [x] Patches applied to all 5 runner.sh files in `docs/testnet4-phase5/shape-*/`
- [x] All 5 still parse via `bash -n` (implicit in launching them)
- [ ] One-shot V2 run against a patched runner shows no `--lsp-balance-pct` warning + no REFUSE false-positive
