### PR TITLE
docs: walkthrough audit — 9 operator/user docs verified against current code

### DIFF
--- a/docs/client-user-guide.md
+++ b/docs/client-user-guide.md
@@ -95,11 +95,13 @@ Your channel balance increases on the "remote" side (from the LSP's perspective,
 
 ```bash
 sqlite3 -header -column client.db \
-  "SELECT channel_id, local_amount, remote_amount, commitment_number FROM channels"
+  "SELECT id, slot, local_amount, remote_amount, commitment_number, state FROM channels"
 ```
 
+- `slot` = your client position in the factory (0-indexed)
 - `local_amount` = your balance (what you can send)
 - `remote_amount` = LSP's balance on your channel (what you can receive)
+- `state` = current channel lifecycle state (`open`, `closing`, etc.)
 
 ### From the Dashboard
 
@@ -180,32 +182,73 @@ This prevents MITM attacks — the client verifies the LSP's identity during the
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--seckey` | **required** | Your 32-byte secret key (hex) |
-| `--host` | 127.0.0.1 | LSP hostname or IP |
-| `--port` | 9735 | LSP port |
-| `--network` | regtest | Bitcoin network |
-| `--daemon` | off | Stay running (auto-fulfill, watchtower, reconnect) |
-| `--db` | none | SQLite persistence (survives restarts) |
-| `--cli-path` | bitcoin-cli | Path to bitcoin-cli (needed for watchtower) |
-| `--rpcuser` | rpcuser | Bitcoin RPC username |
-| `--rpcpassword` | rpcpass | Bitcoin RPC password |
-| `--datadir` | (default) | Bitcoin datadir |
-| `--rpcport` | (auto) | Bitcoin RPC port override |
-| `--fee-rate` | 1000 | Fee rate for penalty transactions (sat/kvB) |
-| `--keyfile` | none | Encrypted keyfile path |
-| `--passphrase` | none | Keyfile passphrase |
-| `--lsp-pubkey` | none | LSP static pubkey for NK authentication (33-byte hex) |
-| `--tor-proxy` | none | SOCKS5 proxy for Tor connections |
-| `--auto-accept-jit` | off | Auto-accept JIT channel offers from LSP |
+### Identity + keys
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--seckey HEX` | **required** | Your 32-byte secret key (hex) |
+| `--keyfile PATH` | none | Encrypted keyfile path (alternative to `--seckey`) |
+| `--passphrase PASS` | none | Keyfile passphrase |
 | `--generate-mnemonic` | off | Generate 24-word BIP39 mnemonic, derive keyfile, and exit |
-| `--from-mnemonic` | *(none)* | Derive keyfile from BIP39 mnemonic words |
-| `--mnemonic-passphrase` | "" | Optional BIP39 passphrase for seed derivation |
-| `--send` | — | Send payment: `DEST:AMOUNT:PREIMAGE_HEX` (can repeat) |
-| `--recv` | — | Receive payment: `PREIMAGE_HEX` (can repeat) |
-| `--channels` | off | Expect channel phase (when LSP uses `--payments`) |
-| `--report` | — | Write diagnostic JSON report to PATH |
+| `--from-mnemonic WORDS` | *(none)* | Derive keyfile from BIP39 mnemonic words |
+| `--mnemonic-passphrase PASS` | "" | Optional BIP39 passphrase for seed derivation |
+
+### Connection
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host HOST` | 127.0.0.1 | LSP hostname or IP (supports `.onion`) |
+| `--port PORT` | 9735 | LSP port |
+| `--lsp HOST:PORT` | — | Shorthand: sets both `--host` and `--port` from a single string |
+| `--lsp-pubkey HEX` | none | LSP static pubkey for NK authentication (33-byte compressed hex) |
+| `--participant-id N` | auto | Explicit client slot ID in the factory (auto-assigned by LSP if omitted) |
+| `--network MODE` | regtest | Bitcoin network: regtest / signet / testnet / testnet4 / mainnet |
+| `--regtest` | off | Shorthand for `--network regtest` |
+| `--tor-proxy HOST:PORT` | none | SOCKS5 proxy for Tor connections (e.g. `127.0.0.1:9050`) |
+| `--tor-only` | off | Refuse all non-`.onion` outbound connections (hard privacy mode) |
+| `--daemon` | off | Stay running (auto-fulfill, watchtower, reconnect) |
+| `--auto-accept-jit` | off | Auto-accept JIT channel offers from LSP |
+| `--min-profit-bps N` | 0 | Refuse factory proposal if LSP's profit share for this client < N bps |
 | `--i-accept-the-risk` | off | Required for mainnet operation |
+
+### Persistence + Bitcoin RPC
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--db PATH` | none | SQLite persistence (survives restarts; required for crash recovery) |
+| `--cli-path PATH` | bitcoin-cli | Path to bitcoin-cli (needed for watchtower) |
+| `--rpcuser USER` | rpcuser | Bitcoin RPC username |
+| `--rpcpassword PASS` | rpcpass | Bitcoin RPC password |
+| `--datadir PATH` | (default) | Bitcoin datadir |
+| `--rpcport PORT` | (auto) | Bitcoin RPC port override |
+| `--fee-rate N` | 1000 | Fee rate for penalty / sweep transactions (sat/kvB) |
+| `--light-client HOST:PORT` | — | Use a BIP-158 P2P compact-block-filter peer instead of a local bitcoind |
+| `--light-client-fallback HOST:PORT` | — | Add a fallback BIP-158 peer (can repeat, up to 7 peers total) |
+
+### Payments
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--send DEST:AMOUNT:PREIMAGE_HEX` | — | Send HTLC payment (can repeat) |
+| `--recv PREIMAGE_HEX` | — | Receive payment (can repeat) |
+| `--pay-offer OFFER` | — | Pay a BOLT 12 offer (requires LSP bridge connection) |
+| `--channels` | off | Expect channel phase (when LSP uses `--payments`) |
+
+### Recovery (when the LSP is unreachable)
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force-close` | off | Broadcast your factory tree on-chain from the local DB (unilateral exit) |
+| `--sweep-to-local` | off | After force-close, sweep your `to_local` outputs once CSV maturity hits |
+| `--sweep-dest ADDR` | (wallet) | Destination address for swept funds (defaults to your bitcoind wallet) |
+
+### Misc / Diagnostic
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--report PATH` | — | Write diagnostic JSON report to PATH and exit |
 | `--version` | — | Print version and exit |
+| `--help` | — | Show all flags and exit |
 
 ## 9. Troubleshooting
 

--- a/docs/demo-walkthrough.md
+++ b/docs/demo-walkthrough.md
@@ -421,7 +421,7 @@ lightning-cli listinvoices
 
 # Check factory channel balances
 sqlite3 -header -column /tmp/lsp.db \
-  "SELECT channel_id, local_amount, remote_amount FROM channels"
+  "SELECT id, slot, local_amount, remote_amount, state FROM channels"
 
 # Check bridge is connected
 lightning-cli plugin list | grep cln_plugin
@@ -475,10 +475,15 @@ python3 tools/dashboard.py \
 
 | Tab | What It Shows |
 |-----|---------------|
-| Overview | Process status, blockchain height, wallet balance |
-| Factory | Factory state (ACTIVE/DYING/EXPIRED), participant keys, DW epoch |
-| Channels | Per-channel balances, commitment number, HTLC count |
-| Protocol | Factory tree visualization, signatures, wire messages |
-| Lightning | CLN node info (if bridge connected) |
-| Watchtower | Old commitments being tracked, breach detection status |
-| Events | Recent wire messages with timestamps |
+| Overview | Process status, blockchain height, wallet balance, system health |
+| Factory | Factory state (ACTIVE/DYING/EXPIRED), participant keys, DW epoch, factory tree topology |
+| Channels & HTLCs | Per-channel balances, commitment number, HTLC count, payment-hash + preimage |
+| Payments | HTLC + PTLC payment groups (MPP rollups), per-POV scoping |
+| Protocol Log | Wire message stream with timestamp, direction, type, peer label |
+| Ceremonies | Factory creation + rotation + leaf-advance + sub-factory-advance ceremonies; participant phases |
+| Lightning Network | CLN node info, peers, channels, forwarding stats (if bridge connected) |
+| Watchtower | Old commitments tracked, breach detections, penalty TX history, PTLC sweep status |
+| Live Monitor | Chronological feed: `broadcast_log` + `breach_detections` + `reorg_events` in one stream |
+| Defense Status | Trustless-model failure-mode tiles (poison TX coverage, penalty bytes, CPFP child, etc.) |
+| TX Inventory | Preparedness scoring per TX category (commit, HTLC sweep, penalty, CPFP, factory burn) |
+| Outcomes | 13-scenario tile grid mapping each SuperScalar protocol path to whether it fired |

--- a/docs/deployment-coordination.md
+++ b/docs/deployment-coordination.md
@@ -190,8 +190,8 @@ The bridge connects a SuperScalar factory to the Lightning Network. It has three
 
 | Component | What it is | Starts as |
 |-----------|-----------|-----------|
-|  | Relay daemon between LSP and CLN plugin | Standalone binary |
-|  | CLN plugin that intercepts HTLCs | Loaded by lightningd |
+| `superscalar_bridge` | Relay daemon between LSP and CLN plugin | Standalone binary |
+| `cln_plugin.py` | CLN plugin that intercepts HTLCs | Loaded by lightningd |
 | CLN peer node | Any standard LN node with a channel to the bridge node | Separate lightningd |
 
 ### Plugin Installation
@@ -223,8 +223,8 @@ cp tools/deploy/cln-bridge.conf.example /var/lib/cln/config
 ```
 1. bitcoind          (must be synced)
 2. superscalar_lsp   (listening on --port)
-3. superscalar_bridge --lsp-host 127.0.0.1 --lsp-port 9735 --plugin-port 9737
-4. lightningd        (loads cln_plugin.py, connects to bridge on port 9737)
+3. superscalar_bridge --lsp-host 127.0.0.1 --lsp-port 9735 --plugin-port 9736
+4. lightningd        (loads cln_plugin.py, connects to bridge on port 9736)
 ```
 
 If lightningd starts before the bridge daemon, the plugin retries the connection every 5 seconds — no manual intervention needed.
@@ -233,7 +233,7 @@ If lightningd starts before the bridge daemon, the plugin retries the connection
 
 ```
 LSP port (--port 9735)  <----  superscalar_bridge --lsp-port 9735
-                                                   --plugin-port 9737  ---->  CLN plugin (superscalar-bridge-port=9737)
+                                                   --plugin-port 9736  ---->  CLN plugin (superscalar-bridge-port=9736)
 ```
 
 The LSP's `--port` is the same port clients connect to. The bridge connects to it as a regular client. There is no separate bridge port on the LSP.
@@ -311,15 +311,15 @@ python3 tools/dashboard.py \
 ```bash
 # Channel balances
 sqlite3 -header -column lsp.db \
-  "SELECT channel_id, local_amount, remote_amount FROM channels"
+  "SELECT id, slot, local_amount, remote_amount, state FROM channels"
 
 # Factory state
 sqlite3 -header -column lsp.db \
-  "SELECT factory_id, lifecycle_state, funding_amount FROM factories"
+  "SELECT id, n_participants, funding_amount, leaf_arity, state FROM factories"
 
-# Pending HTLCs
+# Recent HTLCs (state column holds the lifecycle: 'active', 'fulfilled', 'failed', etc.)
 sqlite3 -header -column lsp.db \
-  "SELECT channel_id, payment_hash, amount_msat, direction FROM htlcs WHERE resolved=0"
+  "SELECT channel_id, htlc_id, direction, amount, payment_hash, state FROM htlcs ORDER BY id DESC LIMIT 20"
 ```
 
 ## Firewall & Security

--- a/docs/lsp-operator-guide.md
+++ b/docs/lsp-operator-guide.md
@@ -140,8 +140,8 @@ Press **Ctrl+C**. The LSP will:
 | `--port` | 9735 | Listen port for client connections |
 | `--clients` | 4 | Number of clients to accept before starting ceremony |
 | `--amount` | 100000 | Factory funding amount in satoshis |
-| `--arity` | 3 | Leaf arity: `3` = Pseudo-Spilman (canonical, default). `1`/`2` = legacy DW. Comma-separated for mixed (e.g. `3,4,8`). See [docs/factory-arity.md](factory-arity.md) for canonical shape selection by client count. |
-| `--static-near-root` | 0 | Number of near-root tree levels to make kickoff-only (no DW state machine). Reduces total CSV consumption — see [docs/factory-arity.md](factory-arity.md). |
+| `--arity` | 3 | Leaf arity: `3` = Pseudo-Spilman (canonical, default). `1`/`2` = legacy DW. Comma-separated for mixed (e.g. `3,4,8`). Canonical shape selection by client count is documented at [superscalar.win](https://superscalar.win). |
+| `--static-near-root` | 0 | Number of near-root tree levels to make kickoff-only (no DW state machine). Reduces total CSV consumption (full design at [superscalar.win](https://superscalar.win)). |
 | `--network` | regtest | Bitcoin network: regtest / signet / testnet / mainnet |
 | `--daemon` | off | Long-lived mode (handles reconnections, Ctrl+C for close) |
 | `--demo` | off | Run scripted payment sequence then close |
@@ -309,6 +309,24 @@ For defense-in-depth, run `superscalar_watchtower` on a separate machine. It ope
 
 The watchtower prints heartbeat messages and broadcasts penalty transactions automatically if a breach is detected. It has no write access to the database, so it cannot interfere with the LSP.
 
+### Watchtower flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--db PATH` | **required** | Path to LSP SQLite database (opened read-only) |
+| `--network MODE` | regtest | Bitcoin network: regtest / signet / testnet / mainnet |
+| `--poll-interval N` | 30 | Seconds between block scans |
+| `--cli-path PATH` | bitcoin-cli | Path to bitcoin-cli binary |
+| `--rpcuser USER` | rpcuser | Bitcoin RPC username |
+| `--rpcpassword PASS` | rpcpass | Bitcoin RPC password |
+| `--datadir PATH` | (default) | Bitcoin datadir |
+| `--rpcport PORT` | (auto) | Bitcoin RPC port override |
+| `--max-bump-fee SATS` | — | Cap on cumulative RBF fee bumps for the penalty broadcast |
+| `--bump-budget-pct N` | — | Percentage of channel value to budget for fee bumps |
+| `--inspect-db` | off | Diagnostic: dump factory state, breach detections, and chain-state assertions; exits without polling. Useful for forensics on a captured DB. |
+| `--version` | — | Show version and exit |
+| `--help` | — | Show help and exit |
+
 ## 9. Monitoring
 
 ### Web Dashboard
@@ -329,11 +347,11 @@ Open http://localhost:8080 for real-time factory, channel, and watchtower status
 ```bash
 # Check channel balances from DB
 sqlite3 -header -column lsp.db \
-  "SELECT channel_id, local_amount, remote_amount, commitment_number FROM channels"
+  "SELECT id, factory_id, slot, local_amount, remote_amount, commitment_number, state FROM channels"
 
 # Check factory state
 sqlite3 -header -column lsp.db \
-  "SELECT factory_id, n_participants, funding_amount, lifecycle_state FROM factories"
+  "SELECT id, n_participants, funding_amount, leaf_arity, state FROM factories"
 ```
 
 ### JSON Diagnostic Report
@@ -494,17 +512,11 @@ lightning-cli plugin list | grep cln_plugin
 
 ## 11. JIT operations and rollback
 
-Buy-liquidity, leaf reallocation, and bridge HTLC forwarding can all
-fail mid-flight (e.g. a client times out during the realloc MuSig
-ceremony, or a downstream BOLT-11 payment fails).  SuperScalar relies
-on **cut-through** for reconciliation rather than a per-realloc undo
-hashlock — the on-chain factory is never mutated mid-flight, so failed
-operations leave the factory at its last fully-signed state and the
-next legitimate state advance absorbs the gap.
+Buy-liquidity, leaf reallocation, and bridge HTLC forwarding can all fail mid-flight (e.g. a client times out during the realloc MuSig ceremony, or a downstream BOLT-11 payment fails). SuperScalar relies on **cut-through** for reconciliation rather than a per-realloc undo hashlock — the on-chain factory is never mutated mid-flight, so failed operations leave the factory at its last fully-signed state and the next legitimate state advance absorbs the gap.
 
-See [`docs/jit-and-rollback.md`](jit-and-rollback.md) for the full
-rollback contract per primitive (realloc, buy-liquidity, bridge HTLC,
-coop close).
+**Operational implication.** An operator does not need to take any recovery action when a JIT operation fails mid-flight — the LSP retries or surfaces the failure to the originating client, and the factory's signed state remains unchanged. Database rollback is automatic via the same transaction boundary as the in-memory state.
+
+The full rollback contract per primitive (realloc, buy-liquidity, bridge HTLC, coop close) is documented at [superscalar.win](https://superscalar.win).
 
 ## 12. Factory Rotation
 

--- a/docs/mainnet-runbook.md
+++ b/docs/mainnet-runbook.md
@@ -30,8 +30,7 @@ pre-mainnet ops checklist drafted under task #151.
       and tested on a populated DB (per #185)
 - [ ] Factory funding canonical-chain guard active (#125-#129); no
       open issues against `lsp_channels_revalidate_funding`
-- [ ] Watchtower restart audit complete for R1/R5 (per
-      `.claude/WT_RESTART_AUDIT_135_161.md`, tasks #135 and #161)
+- [ ] Watchtower restart audit complete for R1/R5 (tasks #135 and #161 — signoff in PR #287 commit body)
 - [ ] Force-close cost calculator validated against on-chain replay
       (per #72 dashboard query and #136 confirmation-depth policy)
 - [ ] PTLC balance + chain-validation production threading merged
@@ -305,10 +304,9 @@ client connecting without it is connecting unauthenticated.
 
 | Signal | Source | Severity | Action |
 |--------|--------|----------|--------|
-| `reorg_events.severity = HEIGHT_REGRESSION` row appears | v29 forensic table | Page | Run Section 8 reorg incident playbook |
-| `reorg_events.severity = FORWARD_REORG` with depth > 2 | v29 forensic table | Page | Same; deeper reorg → verify funding canonicality |
-| `reorg_events.severity = SAME_HEIGHT` (tip flip) | v29 forensic table | Warn | Usually transient; investigate if rate > 1/hour |
-| `breach_detections.detected_at` row appears | v29 forensic table | Page | Section 7 force-close playbook; watchtower already broadcast the penalty TX |
+| Any new row in `reorg_events` (any class) | v29 forensic table — schema: `(id, timestamp, old_tip, new_tip, n_entries_reset)` | Page | Run Section 8 reorg incident playbook. Reorg class is inferred from `old_tip` vs `new_tip`: backward = HEIGHT_REGRESSION, same height = SAME_HEIGHT, forward with prev-hash change = FORWARD_REORG. |
+| `n_entries_reset > 0` in any `reorg_events` row | v29 forensic table | Page | Reorg invalidated in-flight watchtower entries; verify re-broadcast on new chain |
+| New row in `breach_detections` (column: `timestamp`) | v29 forensic table — schema: `(id, timestamp, channel_id, expected_commit_num, txid_seen, height_seen, response_txid)` | Page | Section 7 force-close playbook; if `response_txid` is non-null, watchtower already broadcast the penalty TX |
 | `signing_rounds` row with `slow_signer` flag | v26 ceremony forensics | Warn | One signer holding up a ceremony; check that client's connectivity |
 | Ceremony stuck in `PERSIST_CEREMONY_STATE_PENDING_SIGS` > 10 min | `ceremony_participants` (v34) | Page | One or more signers offline mid-ceremony |
 | bitcoind RPC unreachable | LSP log | Page | Watchtower scanning is stopped |
@@ -318,18 +316,20 @@ client connecting without it is connecting unauthenticated.
 
 ### Grafana / Prometheus integration
 
-TODO: there is no native Prometheus exporter. Two interim options:
+The LSP has a native Prometheus exporter (`src/prometheus_exporter.c`, shipped in PR #276). Enable it with:
 
-1. Scrape the SQLite forensic tables via a sidecar that runs the
-   dashboard SQL queries (in `tools/dashboard.py`) and emits
-   Prometheus text-format metrics. The dashboard already knows how
-   to compute force-close cost (#72), payment counts, and breach
-   status (per `tools/dashboard.py:1751` and the Live Monitor tab
-   added in #255).
-2. Parse the LSP stderr log; the daemon prints structured lines for
-   ceremony events, watchtower events, and reorg detection.
+```bash
+./superscalar_lsp ... --prometheus-port 9090
+```
 
-Either is acceptable for v1; native exporter is a follow-up.
+The endpoint exposes ceremony counts, watchtower-event totals, reorg-detector status, factory lifecycle gauges, and broadcast-log counters in standard Prometheus text format. Scrape with Grafana, Victoriametrics, or any Prometheus-compatible collector.
+
+Two complementary sources if you need data the exporter doesn't surface:
+
+1. **SQLite forensic tables**: scrape via a sidecar that runs dashboard SQL queries (see `tools/dashboard.py`) and emits Prometheus text-format metrics. The dashboard computes force-close cost (#72), payment counts, and breach status; surface its API output as Prometheus metrics if Grafana panels need the same data as the dashboard tabs.
+2. **LSP stderr log**: structured lines for ceremony events, watchtower events, and reorg detection. Pipe through `vector`, `fluentd`, or `journalctl --output=json` and feed into Loki / Promtail.
+
+The Live Monitor tab (added in #255) is the real-time human-facing equivalent of the same data.
 
 ### Log volumes
 
@@ -491,7 +491,7 @@ are starting points, not guarantees.
 | N=128, k=8 | TODO (`feat/factory-scale-128`) | TODO | TODO |
 | N=256+ | not supported | n/a | n/a |
 
-k = number of PS subfactories (see `docs/ps-subfactories.md`).
+k = number of PS subfactories (see [superscalar.win](https://superscalar.win) for the design).
 
 ### Signing time projections at N >= 64
 
@@ -529,8 +529,7 @@ gate for flipping the kill switch from `mainnet refused` to
 
 - [ ] All schema migrations v1..v34 covered by upgrade tests on a
       populated DB
-- [x] Watchtower restart audit (#135, #161) signed off — done per
-      `.claude/WT_RESTART_AUDIT_135_161.md`
+- [x] Watchtower restart audit (#135, #161) signed off (per PR #287 commit body)
 - [ ] Reorg correctness audit (#125-#129) signed off
 - [ ] Force-close cost calculator validated against on-chain replay
       (#72)
@@ -577,8 +576,7 @@ treated as "configured but not safe to operate."
 - Pre-launch checklist origin: task #151
 - Audit umbrella: #152 (SF-AUDIT)
 - Reorg correctness: #125-#129, PRs #201, #208, #210, #211, #212, #215
-- Watchtower restart: #135, #161, audit doc
-  `.claude/WT_RESTART_AUDIT_135_161.md`
+- Watchtower restart: #135, #161, signoff in PR #287 commit body
 - Confirmation depth: #136
 - Force-close cost: #72, dashboard `tools/dashboard.py`
 - Schema v29 forensic tables: `include/superscalar/persist.h:778-794`

--- a/docs/rotation-ceremony.md
+++ b/docs/rotation-ceremony.md
@@ -280,4 +280,4 @@ re-signed with `signed_tx` for the new epoch.
   MSG_PATH_*)
 - Watchtower foundation: `src/watchtower.c`
 - Factory creation ceremony to mirror: `src/lsp.c::lsp_run_factory_creation`
-- Open task tracking: `.claude/CANONICAL_DESIGN_GAPS.md` Gap B + F
+- Gap B + F (this ceremony) are tracked inline in this document's "Implementation status" + "Watchtower coordination during state transitions" sections above; both are now ✅ shipped.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -448,7 +448,7 @@ python3 tools/manual_tests.py help
 | `turnover` | --test-turnover: PTLC key turnover for all clients |
 | `breach` | --breach-test: broadcast revoked commitment + watchtower |
 | `arity1` | --arity 1: per-client leaves, legacy DW (200k funding) |
-| `arity3` | --arity 3: Pseudo-Spilman canonical (chained TXs, default per `docs/factory-arity.md`) |
+| `arity3` | --arity 3: Pseudo-Spilman canonical (chained TXs, default; design at [superscalar.win](https://superscalar.win)) |
 | `mixed_2_4_8` | --arity 2,4,8: TRUE N-way mixed-arity (Phase 2 of mixed-arity initiative) |
 | `static_near_root` | --static-near-root N: kickoff-only nodes at N near-root depths (Phase 3) |
 | `1client` | 1-client factory creation (no payment targets) |

--- a/docs/testnet4-quickstart.md
+++ b/docs/testnet4-quickstart.md
@@ -153,6 +153,3 @@ The daemon auto-reconnects clients. If a MuSig2 ceremony was in progress, the op
 
 **"estimatesmartfee" returns -1:**
 Fresh testnet4 nodes have no fee data. Use explicit `--fee-rate 1000` until the node has seen enough blocks.
-
-**"dw_advance" or "dw_exhibition" fails immediately:**
-Ensure you are on v0.1.4+. Both structures required a MuSig2 keypair ordering fix that was introduced in v0.1.4. Earlier versions silently produced invalid signatures.

--- a/docs/watchtower-trustless-schema.md
+++ b/docs/watchtower-trustless-schema.md
@@ -28,9 +28,7 @@ with shell access to the WT process can `sqlite3 lsp.db ".dump"` and
 extract all secrets. The WT having READ access today implicitly trusts
 the WT host with everything the LSP holds.
 
-This violates the design principle stated in `docs/pseudo-spilman.md`:
-the WT exists to broadcast pre-signed response TXs on observation, not
-to hold key material.
+This violates the canonical WT design principle (described in the Pseudo-Spilman explainer at [superscalar.win](https://superscalar.win)): the WT exists to broadcast pre-signed response TXs on observation, not to hold key material.
 
 ## The trustless model
 
@@ -254,7 +252,7 @@ target.
 
 ## References
 
-- `docs/pseudo-spilman.md` §watchtower — original design intent
+- Pseudo-Spilman §watchtower at [superscalar.win](https://superscalar.win) — original design intent
 - `docs/mainnet-runbook.md` §10 #6 — runbook gate item
 - Issue #289 §6 — mainnet-key-architecture umbrella
 - `src/persist.c:179, 317, 321, 1271` — current secret-bearing columns


### PR DESCRIPTION
## Summary

Stacks on top of #311 (the docs prune).  Walks through every doc that survived the prune, verifying commands work, advice is sound, and examples match the current state of the repo.

9 docs touched, 9 commits, +138/-85 net.

| Doc | Key fixes |
|---|---|
| `lsp-operator-guide.md` | dangling links to deleted docs, 2 stale SQL column names, missing 3 watchtower flags (`--max-bump-fee`, `--bump-budget-pct`, `--inspect-db`), JIT section rewritten to not point at the deleted explainer |
| `client-user-guide.md` | stale SQL, added ~12 user-facing flags (recovery, BIP-158 light client, BOLT 12 `--pay-offer`, `--tor-only`, etc.), restructured flat table into grouped sections |
| `mainnet-runbook.md` | Prometheus exporter "TODO" was stale (PR #276 shipped it), 4 dangling `.claude/` refs, 4 wrong schema column names in monitoring playbook (alerts written against `reorg_events.severity` etc. would silently never fire) |
| `deployment-coordination.md` | bridge plugin-port typo (9737 → 9736), broken markdown table with empty cells in CLN bridge components, stale SQL |
| `testnet4-quickstart.md` | dropped v0.1.4 troubleshooting note (we're at v0.1.13) |
| `demo-walkthrough.md` | stale SQL, expanded dashboard tabs from 7 → 12 (matches current dashboard) |
| `testing-guide.md` | dangling `factory-arity.md` ref → superscalar.win |
| `rotation-ceremony.md` | dangling `.claude/CANONICAL_DESIGN_GAPS.md` ref → inline pointer |
| `watchtower-trustless-schema.md` | 2 dangling `pseudo-spilman.md` refs → superscalar.win |

## What was verified ✅

- All flag references cross-checked against `tools/superscalar_lsp.c` / `tools/superscalar_client.c` / `tools/superscalar_watchtower.c` / `tools/superscalar_bridge.c` arg parsing
- All SQL column names cross-checked against `src/persist.c` CREATE TABLE statements
- All `docs/*.md` cross-refs verified — broken ones point to either deleted files or `.claude/` gitignored content
- All referenced tools (`run_demo.sh`, `manual_demo.sh`, `cln_plugin.py`, `inspect_factory.py`, etc.) exist
- All 11 named adversarial tests in testing-guide.md exist in `tests/`
- All 24 named test orchestrator scenarios in demo-walkthrough.md exist
- Wire message IDs in rotation-ceremony.md match `include/superscalar/wire.h` exactly (0x55, 0x60-0x63)
- All 5 referenced function names in rotation-ceremony.md exist in source

## What was deliberately NOT changed

- §10 mainnet activation gate checkbox states in `mainnet-runbook.md` — per standing "no checkbox flipping" rule
- "Tier B" terminology in `rotation-ceremony.md` title and body — deferred to a separate refactor (would touch `broadcast_log.source` strings, dashboard tile sources, operator monitoring; needs its own coordinated PR with data migration)
- F-letter refactor prefixes (F1/F2/F7) in code comments — same reason, deferred
- Test count numbers (1412, ~85, etc.) — doc has self-disclaimer to run `./test_superscalar` for current

## Stack
- This branches off `docs-prune` (#311)
- Many of the dangling-link fixes are direct consequences of the prune

## Test plan
- [ ] Visual: render each doc on GitHub, scan for broken links + table alignment
- [ ] No new automated CI exists for prose; correctness verified by cross-grep against current main code