### PR TITLE
fix(ps): guard lsp_advance_leaf against k>=2 sub-factory PS (#269)

### DIFF
--- a/docs/testnet4-phase5/shape-3e-N4-ARITY3-K2/runner.sh
+++ b/docs/testnet4-phase5/shape-3e-N4-ARITY3-K2/runner.sh
@@ -60,7 +60,13 @@ LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
 case "$VARIANT" in
     V1) DEMO_FLAGS="--demo" ;;
     V2) DEMO_FLAGS="--demo --force-close" ;;
-    V3) DEMO_FLAGS="--demo --test-ps-advance" ;;
+    V3) # alias to V4 per #269: leaf-advance has no meaning for k>=2 sub-factory PS.
+        # Per docs/ps-subfactories.md spec Phase 2, dynamic state extension on
+        # k>=2 PS shapes goes through lsp_subfactory_chain_advance, not the
+        # legacy leaf-advance path. Redirect V3 -> V4 here so the canonical
+        # "advance the chain" test on these shapes exercises the correct ceremony.
+        echo "  NOTE: V3 (--test-ps-advance) on k>=2 PS shape redirects to V4 (--test-subfactory-advance)" >&2
+        DEMO_FLAGS="--demo --test-subfactory-advance" ;;
     V4) DEMO_FLAGS="--demo --test-subfactory-advance" ;;
     *)  echo "FAIL: unknown VARIANT=$VARIANT (V1|V2|V3|V4)" >&2; exit 2 ;;
 esac

--- a/docs/testnet4-phase5/shape-3epp-N16-ARITY3-K2/runner.sh
+++ b/docs/testnet4-phase5/shape-3epp-N16-ARITY3-K2/runner.sh
@@ -39,7 +39,13 @@ LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
 
 case "$VARIANT" in
     V2) DEMO_FLAGS="--demo --force-close" ;;
-    V3) DEMO_FLAGS="--demo --test-ps-advance" ;;
+    V3) # alias to V4 per #269: leaf-advance has no meaning for k>=2 sub-factory PS.
+        # Per docs/ps-subfactories.md spec Phase 2, dynamic state extension on
+        # k>=2 PS shapes goes through lsp_subfactory_chain_advance, not the
+        # legacy leaf-advance path. Redirect V3 -> V4 here so the canonical
+        # "advance the chain" test on these shapes exercises the correct ceremony.
+        echo "  NOTE: V3 (--test-ps-advance) on k>=2 PS shape redirects to V4 (--test-subfactory-advance)" >&2
+        DEMO_FLAGS="--demo --test-subfactory-advance" ;;
     V4) DEMO_FLAGS="--demo --test-subfactory-advance" ;;
     *)  echo "FAIL: unknown VARIANT=$VARIANT (V2|V3|V4)" >&2; exit 2 ;;
 esac

--- a/docs/testnet4-phase5/shape-3f-N64-ARITY24-K2-STATIC1/runner.sh
+++ b/docs/testnet4-phase5/shape-3f-N64-ARITY24-K2-STATIC1/runner.sh
@@ -41,7 +41,13 @@ LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
 case "$VARIANT" in
     V1) DEMO_FLAGS="--demo" ;;
     V2) DEMO_FLAGS="--demo --force-close" ;;
-    V3) DEMO_FLAGS="--demo --test-ps-advance" ;;
+    V3) # alias to V4 per #269: leaf-advance has no meaning for k>=2 sub-factory PS.
+        # Per docs/ps-subfactories.md spec Phase 2, dynamic state extension on
+        # k>=2 PS shapes goes through lsp_subfactory_chain_advance, not the
+        # legacy leaf-advance path. Redirect V3 -> V4 here so the canonical
+        # "advance the chain" test on these shapes exercises the correct ceremony.
+        echo "  NOTE: V3 (--test-ps-advance) on k>=2 PS shape redirects to V4 (--test-subfactory-advance)" >&2
+        DEMO_FLAGS="--demo --test-subfactory-advance" ;;
     V4) DEMO_FLAGS="--demo --test-subfactory-advance" ;;
     V5) DEMO_FLAGS="--demo --breach-test" ;;
     V6) DEMO_FLAGS="--demo --force-close" ;;  # operator kills LSP mid-flight externally

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1571,6 +1571,25 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
     if (f->leaf_arity != FACTORY_ARITY_1 && f->leaf_arity != FACTORY_ARITY_PS) return 1;
     if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) return 0;
 
+    /* Per docs/ps-subfactories.md (canonical t/1242 PS spec): with k>=2 sub-
+       factory PS, the leaf is static after factory creation. Dynamic state
+       lives in the SUB-FACTORY chain TXs and is extended via
+       lsp_subfactory_chain_advance (Phase 2 of the spec). The leaf-level
+       wire ceremony (MSG_LEAF_ADVANCE_PROPOSE/PSIG) was designed for the
+       legacy 1-client-per-leaf PS shape (k=1, n_signers=2) and silently
+       fails on k>=2 (where the leaf has k^2+1 signers but the wire flow
+       only collects 2 nonces). Refuse the misuse with a clear error.
+       (#269 PS_ADVANCE quorum collapse fix.) */
+    if (f->leaf_arity == FACTORY_ARITY_PS && f->ps_subfactory_arity >= 2) {
+        fprintf(stderr,
+                "lsp_advance_leaf: refused -- k=%u sub-factory PS has no "
+                "leaf-level dynamic operation. Use lsp_subfactory_chain_advance "
+                "instead (--test-subfactory-advance). "
+                "Per docs/ps-subfactories.md spec Phase 2.\n",
+                f->ps_subfactory_arity);
+        return 0;
+    }
+
     /* C3 (Tier 1): journal the ceremony at start; success-update at the
        final return below.  Error returns leave the row in flight for the
        startup sweep to mark aborted_crash. */

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -307,7 +307,7 @@ static void usage(const char *prog) {
         "  --test-full-settlement  After demo: force-close tree, broadcast ALL commitment TXs, verify cross-leaf balances\n"
         "  --test-bad-terms    Offer 0 bps profit share; PASSES if client rejects (use with --min-profit-bps on client)\n"
         "  --test-dw-advance   After demo: advance DW counter, re-sign tree, force-close (shows nSequence decrease)\n"
-        "  --test-ps-advance   After demo: advance all PS leaves (chain_pos 0->1), verify amounts, force-close\n"
+        "  --test-ps-advance   After demo (LEGACY 1-client-per-leaf only; for k>=2 sub-factory PS use --test-subfactory-advance): advance all PS leaves (chain_pos 0->1), verify amounts, force-close\n"
         "  --test-leaf-advance After demo: advance left leaf only, force-close (proves per-leaf independence)\n"
         "  --test-tier-b-rollover After demo: drive states_per_layer+1 leaf-0 advances to trigger root rollover; verify Tier B ceremony (Gap B+F)\n"
         "  --test-subfactory-advance After demo: drive a sub-factory chain extension via lsp_subfactory_chain_advance (requires --arity 3 --ps-subfactory-arity K, K>1)\n"


### PR DESCRIPTION
## Summary

Closes #269 — PS_ADVANCE quorum collapse on k≥2 sub-factory PS shapes (3e / 3epp / 3f).

**Root cause** (verified against `docs/ps-subfactories.md` + ZmnSCPxj's t/1242 spec):

For k≥2 PS sub-factory shapes, the LEAF is static after factory creation. Dynamic state extension lives in the SUB-FACTORY chain TXs and is driven by `lsp_subfactory_chain_advance` (Phase 2 of the spec). The legacy `lsp_advance_leaf` path was designed for 1-client-per-leaf PS (k=1, n_signers=2) and silently ran the 2-party wire flow on a k²+1-signer leaf when mis-called. MuSig finalize failed at 2/(k²+1) → client 0 EOF-disconnects → PS_ADVANCE TEST FAILED.

**Diagnosis** (3e V3c on testnet4):
- LSP: `expected LEAF_ADVANCE_PSIG from client 0, got 0x00`
- Client: `musig_session_finalize_nonces failed (n_signers=5, nonces_collected=2, has_taptree=1)`

## Three changes

1. **`src/lsp_channels.c:1568`** — `lsp_advance_leaf` adds a guard for `ps_subfactory_arity >= 2`. Refuses with a clear stderr message pointing to `lsp_subfactory_chain_advance`.

2. **`docs/testnet4-phase5/shape-3{e,epp,f}/runner.sh`** — V3 variant now aliases to V4 (`--test-subfactory-advance`) with a deprecation NOTE. Existing operator workflows that say `VARIANT=V3` still exercise the correct ceremony for k≥2 shapes.

3. **`tools/superscalar_lsp.c`** — `--test-ps-advance` CLI help flagged as LEGACY (k=1 only); operators directed to `--test-subfactory-advance` for k≥2.

## What confirms the fix is right

The sub-factory chain-extension regtest tests (`test_regtest_k{2..6}_subfactory_breach.sh`, `test_regtest_subfactory_chain_advance_multi.sh`) **all PASSed in today's sweep** — confirming `lsp_subfactory_chain_advance` is the working multi-party ceremony for these shapes.

## Test plan

- [x] Build clean (`cmake --build build-release`)
- [x] **1472/1472 unit tests pass**
- [x] Existing k²-subfactory regtest tests still PASS (already PASSed before this patch — guard is additive)
- [ ] End-to-end on testnet4: relaunch shape-3e VARIANT=V3 (now redirected to V4) and verify the sub-factory ceremony completes

Closes task #269.
