### PR TITLE
fix(tests): harden cheat_realloc.sh integer comparison (#268 partial)

### DIFF
--- a/tools/test_regtest_cheat_realloc.sh
+++ b/tools/test_regtest_cheat_realloc.sh
@@ -202,10 +202,11 @@ echo "=== Final result ==="
 # Earlier criterion only checked watchtower_check() which misses the case
 # where detection fires in the main loop before the scaffold's explicit
 # check.
-BREACH_DETECTED=$(grep -cE "FACTORY BREACH on node|CL2 CHEAT-REALLOC: BREACH DETECTED" "$LSP_LOG" 2>/dev/null || echo 0)
-BREACH_DETECTED="${BREACH_DETECTED:-0}"
-POISON_BROADCAST=$(grep -cE "L-stock burn tx broadcast|poison TX broadcast|penalty.*broadcast" "$LSP_LOG" 2>/dev/null || echo 0)
-POISON_BROADCAST="${POISON_BROADCAST:-0}"
+# Use `grep | wc -l` to guarantee a single integer (grep -c with || echo can
+# yield a "0\n0" two-line value that breaks the integer comparison below;
+# the wc-l form is bullet-proof regardless of grep's stderr/exit behavior).
+BREACH_DETECTED=$(grep -E "FACTORY BREACH on node|CL2 CHEAT-REALLOC: BREACH DETECTED" "$LSP_LOG" 2>/dev/null | wc -l)
+POISON_BROADCAST=$(grep -E "L-stock burn tx broadcast|poison TX broadcast|penalty.*broadcast" "$LSP_LOG" 2>/dev/null | wc -l)
 
 if [ "$BREACH_DETECTED" -ge 1 ] && [ "$POISON_BROADCAST" -ge 1 ]; then
     echo "  PASS: WT detected breach (FACTORY BREACH x$BREACH_DETECTED) + broadcast poison (x$POISON_BROADCAST)"


### PR DESCRIPTION
﻿## Summary

Partial fix for #268.

Fix the bash arithmetic crash in `test_regtest_cheat_realloc.sh:210`:

```
tools/test_regtest_cheat_realloc.sh: line 210: [: 0
0: integer expression expected
  FAIL: BREACH_DETECTED=0
0 POISON_BROADCAST=0
0
```

`BREACH_DETECTED` had a literal newline in its value, breaking the integer test. Root cause: `grep -c | || echo 0` pattern can yield a `"0\n0"` two-line value when both grep and the echo fallback both output. Replaced with the robust `grep ... | wc -l` form — always exactly one integer regardless of grep behavior.

## What this does NOT fix

The LSP-side issue under #268 — where `--cheat-realloc` neither snapshots nor broadcasts the stale leaf TX — is still open. The snapshot block at `superscalar_lsp_post_daemon_tests.inc:1048` silently skips. Diagnostic printf experiments couldn't reach the conditional. Needs focused trace session.

This PR ships the script-crash fix (so the script no longer dies with bash syntax error) and unblocks running the test cleanly to observe the deeper LSP-side issue.

## Test plan

- [x] Bash `wc -l` form produces a single integer in all states
- [x] Existing other regtest scripts unaffected (only this script changed)
- [ ] Re-run regtest sweep to confirm cheat_realloc still FAILs with the LSP-side issue but no longer crashes the script