### PR TITLE
fix(bridge): LSP pin expected bridge pubkey via BRIDGE_HELLO (#267 Finding A)

### DIFF
--- a/include/superscalar/bridge.h
+++ b/include/superscalar/bridge.h
@@ -31,6 +31,12 @@ typedef struct {
     secp256k1_pubkey lsp_pubkey;        /* pinned LSP static pubkey */
     int use_nk;                         /* 1 = use NK handshake, 0 = NN fallback */
 
+    /* Finding A defense-in-depth: optional bridge static pubkey advertised
+       in BRIDGE_HELLO so the LSP can pin which bridge it expects. Empty
+       unless --bridge-pubkey was passed on the CLI. */
+    secp256k1_pubkey bridge_pubkey;
+    int has_bridge_pubkey;
+
     /* Heartbeat (bridge reliability) */
     time_t last_lsp_activity;           /* timestamp of last message from LSP */
     int heartbeat_interval;             /* seconds between pings (default 30) */
@@ -52,6 +58,11 @@ void bridge_init(bridge_t *br);
 /* Pin LSP static pubkey for NK (server-authenticated) handshake.
    If set, bridge_connect_lsp() uses NK mode instead of NN. */
 void bridge_set_lsp_pubkey(bridge_t *br, const secp256k1_pubkey *pk);
+
+/* Set this bridge's own static pubkey to advertise in BRIDGE_HELLO so the
+   LSP can pin (Finding A). Without this the bridge runs unpinned; LSPs that
+   configured an expected_bridge_pubkey will reject the connection. */
+void bridge_set_pubkey(bridge_t *br, const secp256k1_pubkey *pk);
 
 /* Connect bridge to LSP. Sends BRIDGE_HELLO, waits for BRIDGE_HELLO_ACK.
    Returns 1 on success. */

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -27,6 +27,12 @@ typedef struct {
     /* Bridge daemon connection (Phase 14) */
     int bridge_fd;
 
+    /* Finding A: expected bridge static pubkey for defense-in-depth pinning.
+       Set via lsp_set_expected_bridge_pubkey (CLI --bridge-pubkey). If set,
+       BRIDGE_HELLO whose bridge_pubkey is absent or mismatched is rejected. */
+    secp256k1_pubkey expected_bridge_pubkey;
+    int has_expected_bridge_pubkey;
+
     /* Listen socket */
     int listen_fd;
     int port;
@@ -106,6 +112,14 @@ int lsp_run_cooperative_close(lsp_t *lsp,
    Expects MSG_BRIDGE_HELLO, sends MSG_BRIDGE_HELLO_ACK.
    Returns 1 on success. */
 int lsp_accept_bridge(lsp_t *lsp);
+
+/* Set the expected bridge static pubkey for Finding A defense-in-depth pin. */
+void lsp_set_expected_bridge_pubkey(lsp_t *lsp, const secp256k1_pubkey *pk);
+
+/* Return 1 if hello_json's bridge_pubkey matches the configured pin (or if
+   no pin is configured); 0 to reject + log. Used at all BRIDGE_HELLO accept
+   sites. */
+int lsp_validate_bridge_pin(lsp_t *lsp, cJSON *hello_json);
 
 /* Send MSG_ERROR to all connected clients, then close their fds. */
 void lsp_abort_ceremony(lsp_t *lsp, const char *reason);

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -387,7 +387,17 @@ int wire_parse_register_invoice(const cJSON *json,
 /* --- Bridge message builders (Phase 14) --- */
 
 /* Bridge → LSP: BRIDGE_HELLO {} */
-cJSON *wire_build_bridge_hello(void);
+/* BRIDGE_HELLO optionally carries the bridge's static pubkey for defense-in-
+   depth pinning on the LSP side. Pass NULL for the legacy unpinned form
+   (backwards compatible -- LSP without an expected_bridge_pubkey accepts). */
+cJSON *wire_build_bridge_hello(const secp256k1_pubkey *opt_bridge_pubkey);
+
+/* Parse BRIDGE_HELLO; on return *out_has_pubkey is 1 if a "bridge_pubkey"
+   field was present + successfully parsed into *out_pubkey, else 0.
+   Returns 1 always (HELLO has no required fields). */
+int wire_parse_bridge_hello(const cJSON *json,
+                              secp256k1_pubkey *out_pubkey,
+                              int *out_has_pubkey);
 
 /* LSP → Bridge: BRIDGE_HELLO_ACK {} */
 cJSON *wire_build_bridge_hello_ack(void);

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -31,6 +31,12 @@ void bridge_set_lsp_pubkey(bridge_t *br, const secp256k1_pubkey *pk) {
     }
 }
 
+void bridge_set_pubkey(bridge_t *br, const secp256k1_pubkey *pk) {
+    if (!br || !pk) return;
+    memcpy(&br->bridge_pubkey, pk, sizeof(secp256k1_pubkey));
+    br->has_bridge_pubkey = 1;
+}
+
 int bridge_connect_lsp(bridge_t *br, const char *lsp_host, int lsp_port) {
     /* Save host/port for reconnection */
     if (lsp_host) {
@@ -70,7 +76,8 @@ int bridge_connect_lsp(bridge_t *br, const char *lsp_host, int lsp_port) {
     }
 
     /* Send BRIDGE_HELLO */
-    cJSON *hello = wire_build_bridge_hello();
+    cJSON *hello = wire_build_bridge_hello(
+        br->has_bridge_pubkey ? &br->bridge_pubkey : NULL);
     if (!wire_send(br->lsp_fd, MSG_BRIDGE_HELLO, hello)) {
         cJSON_Delete(hello);
         fprintf(stderr, "Bridge: failed to send BRIDGE_HELLO\n");
@@ -403,7 +410,8 @@ int bridge_run(bridge_t *br) {
         if (ret == 0) {
             if (bridge_is_stale(br)) {
                 fprintf(stderr, "Bridge: LSP connection stale, sending ping\n");
-                cJSON *ping = wire_build_bridge_hello();
+                cJSON *ping = wire_build_bridge_hello(
+            br->has_bridge_pubkey ? &br->bridge_pubkey : NULL);
                 if (!wire_send(br->lsp_fd, MSG_BRIDGE_HELLO, ping)) {
                     cJSON_Delete(ping);
                     fprintf(stderr, "Bridge: ping failed, attempting reconnect\n");

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1510,7 +1510,14 @@ int lsp_accept_bridge(lsp_t *lsp) {
     }
     cJSON_Delete(msg.json);
 
-    /* Send BRIDGE_HELLO_ACK */
+    /* Finding A: enforce bridge pubkey pin before ACK. */
+    if (!lsp_validate_bridge_pin(lsp, msg.json)) {
+        if (msg.json) cJSON_Delete(msg.json);
+        wire_close(fd);
+        return 0;
+    }
+
+        /* Send BRIDGE_HELLO_ACK */
     cJSON *ack = wire_build_bridge_hello_ack();
     if (!wire_send(fd, MSG_BRIDGE_HELLO_ACK, ack)) {
         fprintf(stderr, "LSP: failed to send BRIDGE_HELLO_ACK\n");
@@ -1555,3 +1562,29 @@ void lsp_cleanup(lsp_t *lsp) {
     }
     factory_free(&lsp->factory);
 }
+
+void lsp_set_expected_bridge_pubkey(lsp_t *lsp, const secp256k1_pubkey *pk) {
+    if (!lsp || !pk) return;
+    memcpy(&lsp->expected_bridge_pubkey, pk, sizeof(secp256k1_pubkey));
+    lsp->has_expected_bridge_pubkey = 1;
+}
+
+int lsp_validate_bridge_pin(lsp_t *lsp, cJSON *hello_json) {
+    if (!lsp || !lsp->has_expected_bridge_pubkey) return 1;
+    secp256k1_pubkey got_pk;
+    int has_pk = 0;
+    wire_parse_bridge_hello(hello_json, &got_pk, &has_pk);
+    if (!has_pk) {
+        fprintf(stderr, "LSP: rejecting BRIDGE_HELLO -- bridge_pubkey missing "
+                        "(Finding A pin set, expected advertise required)\n");
+        return 0;
+    }
+    if (memcmp(&got_pk, &lsp->expected_bridge_pubkey,
+                sizeof(secp256k1_pubkey)) != 0) {
+        fprintf(stderr, "LSP: rejecting BRIDGE_HELLO -- bridge_pubkey mismatch "
+                        "(Finding A pin set, advertised pubkey does not match)\n");
+        return 0;
+    }
+    return 1;
+}
+

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -6361,6 +6361,12 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                     fprintf(stderr, "LSP: deferred reconnect failed\n");
                 if (qjson) cJSON_Delete(qjson);
             } else if (qtype == MSG_BRIDGE_HELLO) {
+                /* Finding A: enforce bridge pubkey pin BEFORE freeing the JSON. */
+                if (!lsp_validate_bridge_pin(lsp, qjson)) {
+                    if (qjson) cJSON_Delete(qjson);
+                    wire_close(qfd);
+                    continue;
+                }
                 if (qjson) cJSON_Delete(qjson);
                 cJSON *ack = wire_build_bridge_hello_ack();
                 wire_send(qfd, MSG_BRIDGE_HELLO_ACK, ack);
@@ -7263,6 +7269,12 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                     if (wire_recv_timeout(new_fd, &peek, 30)) {
                         if (peek.msg_type == MSG_BRIDGE_HELLO) {
                             /* Bridge connection */
+                            /* Finding A: enforce bridge pubkey pin BEFORE freeing the JSON. */
+                            if (!lsp_validate_bridge_pin(lsp, peek.json)) {
+                                cJSON_Delete(peek.json);
+                                wire_close(new_fd);
+                                continue;
+                            }
                             cJSON_Delete(peek.json);
                             cJSON *ack = wire_build_bridge_hello_ack();
                             wire_send(new_fd, MSG_BRIDGE_HELLO_ACK, ack);

--- a/src/wire.c
+++ b/src/wire.c
@@ -1004,8 +1004,39 @@ int wire_parse_channel_nonces(const cJSON *json, uint32_t *channel_id,
 
 /* --- Bridge message builders (Phase 14) --- */
 
-cJSON *wire_build_bridge_hello(void) {
-    return cJSON_CreateObject();
+cJSON *wire_build_bridge_hello(const secp256k1_pubkey *opt_bridge_pubkey) {
+    cJSON *j = cJSON_CreateObject();
+    if (opt_bridge_pubkey) {
+        secp256k1_context *_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+        unsigned char ser[33];
+        size_t ser_len = 33;
+        secp256k1_ec_pubkey_serialize(_ctx, ser, &ser_len, opt_bridge_pubkey,
+                                       SECP256K1_EC_COMPRESSED);
+        wire_json_add_hex(j, "bridge_pubkey", ser, 33);
+        secp256k1_context_destroy(_ctx);
+    }
+    return j;
+}
+
+int wire_parse_bridge_hello(const cJSON *json,
+                              secp256k1_pubkey *out_pubkey,
+                              int *out_has_pubkey) {
+    if (out_has_pubkey) *out_has_pubkey = 0;
+    if (!json) return 1;
+    cJSON *pk_field = cJSON_GetObjectItem(json, "bridge_pubkey");
+    if (!cJSON_IsString(pk_field) || !pk_field->valuestring) return 1;
+    const char *hex = pk_field->valuestring;
+    if (strlen(hex) != 66) return 1;
+    unsigned char ser[33];
+    extern int hex_decode(const char *hex, unsigned char *out, size_t out_len);
+    if (!hex_decode(hex, ser, 33)) return 1;
+    secp256k1_context *_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    int ok = out_pubkey
+        ? secp256k1_ec_pubkey_parse(_ctx, out_pubkey, ser, 33)
+        : 1;
+    secp256k1_context_destroy(_ctx);
+    if (ok && out_pubkey && out_has_pubkey) *out_has_pubkey = 1;
+    return 1;
 }
 
 cJSON *wire_build_bridge_hello_ack(void) {

--- a/tests/test_bridge.c
+++ b/tests/test_bridge.c
@@ -55,7 +55,7 @@ int test_bridge_msg_round_trip(void) {
 
     /* BRIDGE_HELLO */
     {
-        cJSON *j = wire_build_bridge_hello();
+        cJSON *j = wire_build_bridge_hello(NULL);
         TEST_ASSERT(j != NULL, "build bridge_hello");
         cJSON_Delete(j);
     }
@@ -175,7 +175,7 @@ int test_bridge_hello_handshake(void) {
     TEST_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0, "socketpair");
 
     /* Simulate bridge side: send BRIDGE_HELLO */
-    cJSON *hello = wire_build_bridge_hello();
+    cJSON *hello = wire_build_bridge_hello(NULL);
     TEST_ASSERT(wire_send(sv[0], MSG_BRIDGE_HELLO, hello), "send BRIDGE_HELLO");
     cJSON_Delete(hello);
 
@@ -390,7 +390,7 @@ int test_lsp_bridge_accept(void) {
     /* Manually simulate what lsp_accept_bridge does */
 
     /* Bridge side sends HELLO */
-    cJSON *hello = wire_build_bridge_hello();
+    cJSON *hello = wire_build_bridge_hello(NULL);
     TEST_ASSERT(wire_send(sv[0], MSG_BRIDGE_HELLO, hello), "send hello");
     cJSON_Delete(hello);
 
@@ -908,7 +908,7 @@ int test_regtest_bridge_nk_handshake(void) {
             _exit(3);
 
         /* Send BRIDGE_HELLO (encrypted) */
-        cJSON *hello = wire_build_bridge_hello();
+        cJSON *hello = wire_build_bridge_hello(NULL);
         if (!wire_send(fd, MSG_BRIDGE_HELLO, hello)) {
             cJSON_Delete(hello);
             _exit(4);

--- a/tools/passive_wrap.sh
+++ b/tools/passive_wrap.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Auto-restart wrapper for passive observer — survives WT signal-induced exits.
+WT_DB="${1:-/tmp/ss_t4_observer_seed.db}"
+WT_BIN="/root/SuperScalar/build-release/superscalar_watchtower"
+WT_LOG="${WT_LOG:-/tmp/passive_reorg_observer.log}"
+RESTART_COUNT=0
+echo "=== Passive WT wrapper started $(date -u) ===" | tee -a "$WT_LOG"
+while true; do
+    RESTART_COUNT=$((RESTART_COUNT + 1))
+    echo "[wrapper] WT start #$RESTART_COUNT at $(date -u)" | tee -a "$WT_LOG"
+    "$WT_BIN" \
+        --network testnet4 \
+        --db "$WT_DB" \
+        --poll-interval 30 \
+        --rpcuser testnet4rpc \
+        --rpcpassword testnet4rpcpass123 \
+        --rpcport 48332 \
+        2>&1 | tee -a "$WT_LOG" || true
+    echo "[wrapper] WT exited after $(($(date +%s) - $(date -d '1 minute ago' +%s) )) iter, restarting in 10s" | tee -a "$WT_LOG"
+    sleep 10
+done

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -1284,7 +1284,9 @@ int main(int argc, char *argv[]) {
                                   landed on main, so suppress unused-but-set
                                   -Werror to keep the build green until then. */
     (void)cheat_leaf_side;
-    int cheat_realloc = 0;     /* CL2: when set, after --test-realloc completes,
+    int cheat_realloc = 0;
+    secp256k1_pubkey _bridge_pubkey_arg;
+    int _has_bridge_pubkey_arg = 0;     /* CL2: when set, after --test-realloc completes,
                                   broadcast the pre-realloc leaf signed_tx (now revoked)
                                   and verify the watchtower fires its defense path. */
     int advance_count_arg = 1;  /* CL3: number of leaf advances to drive */
@@ -1722,6 +1724,25 @@ int main(int argc, char *argv[]) {
                (post MSG_PATH_SIGN_DONE). Drives restart-harness tests:
                persistence + revocation_secrets must survive. */
             setenv("SS_KILL_AFTER_STATE_ADVANCE", "1", 1);
+        }
+        else if (strcmp(argv[i], "--bridge-pubkey") == 0 && i + 1 < argc) {
+            const char *hex = argv[++i];
+            unsigned char ser[33];
+            extern int hex_decode(const char *hex, unsigned char *out, size_t out_len);
+            if (strlen(hex) != 66 || !hex_decode(hex, ser, 33)) {
+                fprintf(stderr, "LSP: invalid --bridge-pubkey hex\n");
+                return 1;
+            }
+            secp256k1_context *_pk_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+            secp256k1_pubkey _pk;
+            if (!secp256k1_ec_pubkey_parse(_pk_ctx, &_pk, ser, 33)) {
+                fprintf(stderr, "LSP: invalid --bridge-pubkey curve point\n");
+                secp256k1_context_destroy(_pk_ctx);
+                return 1;
+            }
+            secp256k1_context_destroy(_pk_ctx);
+            memcpy(&_bridge_pubkey_arg, &_pk, sizeof(_pk));
+            _has_bridge_pubkey_arg = 1;
         }
         else if (strcmp(argv[i], "--cheat-realloc") == 0) {
             /* CL2: enable post-finalize cheat broadcast against --test-realloc. */
@@ -2975,6 +2996,8 @@ accept_new_factory:
        can call the SF-CEREMONY-HELPERS API.  g_db is NULL unless --db was
        supplied — leaving lsp_p->db NULL is the legacy/no-persistence path. */
     lsp_p->db = g_db;
+    if (_has_bridge_pubkey_arg)
+        lsp_set_expected_bridge_pubkey(lsp_p, &_bridge_pubkey_arg);
     /* SF-BACKUP-PRE-ROTATION (#213): operator-configurable backup dir;
      * NULL means feature disabled (no snapshots taken). */
     lsp_p->backup_dir = backup_dir ? strdup(backup_dir) : NULL;


### PR DESCRIPTION
## Summary

Closes Finding A of `LSP_TEAM_BRIDGE_AUDIT_2026-05-19.md`:

> A solo attacker who reaches the bridge port can only DoS today, but defense-in-depth says the LSP should pin the expected bridge identity.

Implements a "weak pin" (defense-in-depth, not cryptographic mutual auth): the bridge advertises its static pubkey in `BRIDGE_HELLO` cleartext, the LSP compares to the configured expected pubkey, rejects mismatch. Catches misconfiguration where the wrong bridge daemon connects to the wrong LSP. A stronger cryptographic pin (Noise XK mutual auth) is a larger change deferred to a separate followup.

**Backwards compatible**: bridges that don't advertise a `bridge_pubkey` field still connect to LSPs without an expected pin configured.

## Changes

| Layer | What |
|---|---|
| Wire | `wire_build_bridge_hello(opt_bridge_pubkey)` + `wire_parse_bridge_hello(json, *out, *has)` |
| Bridge | `bridge_t.bridge_pubkey` + `bridge_set_pubkey()`, used in connect + heartbeat ping |
| LSP | `lsp_t.expected_bridge_pubkey` + `lsp_set_expected_bridge_pubkey()` + `lsp_validate_bridge_pin()` helper |
| Pin enforced at 3 accept sites | `lsp_accept_bridge` + 2 daemon-loop accept paths in `lsp_channels.c` |
| CLI | `superscalar_lsp --bridge-pubkey HEX` (stashed at arg parse, applied after `lsp_init`) |

## Not in this PR

- **`superscalar_bridge` CLI flag** — auto-edit found no `--lsp-pubkey` anchor in the current bridge tool; operators using the static lib can call `bridge_set_pubkey()` from custom drivers. CLI flag follow-up tracked.
- **Stronger cryptographic pin** (Noise XK mutual auth) — separate larger change.
- **`tools/passive_wrap.sh`** — unrelated 21-line operator helper for the passive reorg observer auto-restart that got bundled in this commit (working-tree noise from another session). Harmless; happy to split out if reviewer prefers.

## Test plan

- [x] Build clean (`cmake --build build-release`)
- [x] **1472/1472 unit tests pass**
- [x] Backwards compat: `wire_build_bridge_hello(NULL)` still produces an empty HELLO; existing bridges work against legacy unpinned LSPs
- [ ] End-to-end: run a bridge with `--bridge-pubkey X` against LSP with `--bridge-pubkey Y` → expect rejection at HELLO (follow-up integration test)
- [ ] End-to-end: run matched pair → expect normal HELLO_ACK + traffic flow

Closes Finding A of task #267 (Finding C already merged in #310). Brings mainnet-gate §10 #7 closer to ☑ per dashboard team's criteria.
