### PR TITLE
feat(cheat): CL4-rollover --cheat-daemon-rollover driver (#250)

### DIFF
--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -681,12 +681,100 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
         printf("LSP rotate: factory %u closed: %s\n", dying_id, rc_txid);
         /* Mark as rotated so CLI "rotate" won't try to rotate it again */
         dying->partial_rotation_done = 1;
+        /* CL4-rollover (#250): mid-window cheat broadcast. After
+           partial_rotation_done is set, the rotation has reached the
+           point where the new factory is committed enough that an
+           honest LSP wouldn't reach back into the dying factory's
+           commitments. A malicious LSP COULD broadcast a dying-factory
+           leaf TX to try to claim funds the new factory should own.
+           The watchtower must detect this on its block scan and
+           respond with the penalty TX. */
+        {
+            static int ss_cheat_rollover_fired = 0;
+            const char *cheat_on = getenv("SS_CHEAT_ROLLOVER");
+            const char *phase = getenv("SS_CHEAT_ROLLOVER_PHASE");
+            if (!ss_cheat_rollover_fired && cheat_on && atoi(cheat_on) == 1 &&
+                phase && strcmp(phase, "mid-window") == 0 &&
+                dying && dying->factory.n_leaf_nodes > 0) {
+                size_t li = dying->factory.leaf_node_indices[0];
+                factory_node_t *cheat_leaf_node = &dying->factory.nodes[li];
+                if (cheat_leaf_node->is_signed && cheat_leaf_node->signed_tx.len > 0) {
+                    char *cheat_hex = malloc(cheat_leaf_node->signed_tx.len * 2 + 1);
+                    char cheat_txid[65] = {0};
+                    if (cheat_hex) {
+                        extern void hex_encode(const unsigned char *, size_t, char *);
+                        hex_encode(cheat_leaf_node->signed_tx.data,
+                                    cheat_leaf_node->signed_tx.len, cheat_hex);
+                        int sent = chain_be
+                            ? chain_be->send_raw_tx(chain_be, cheat_hex, cheat_txid)
+                            : (rt ? regtest_send_raw_tx(rt, cheat_hex, cheat_txid) : 0);
+                        fprintf(stderr,
+                                "CL4-ROLLOVER: mid-window broadcast of dying factory %u "
+                                "leaf 0 tx: sent=%d txid=%s (severity=HIGH)\n",
+                                dying_id, sent, cheat_txid);
+                        if (sent && mgr->persist) {
+                            persist_log_broadcast((persist_t *)mgr->persist,
+                                                    cheat_txid,
+                                                    "cheat_rollover_stale",
+                                                    cheat_hex, "ok");
+                        }
+                        free(cheat_hex);
+                        ss_cheat_rollover_fired = 1;
+                    }
+                }
+            }
+        }
+
     } else {
         /* Partial rotation: skip cooperative close, old factory expires naturally.
            The distribution TX (nLockTime) protects all participants. */
         printf("LSP rotate: Phase B — partial retirement of factory %u "
                "(distribution TX on expiry)\n", dying_id);
         dying->partial_rotation_done = 1;
+        /* CL4-rollover (#250): mid-window cheat broadcast. After
+           partial_rotation_done is set, the rotation has reached the
+           point where the new factory is committed enough that an
+           honest LSP wouldn't reach back into the dying factory's
+           commitments. A malicious LSP COULD broadcast a dying-factory
+           leaf TX to try to claim funds the new factory should own.
+           The watchtower must detect this on its block scan and
+           respond with the penalty TX. */
+        {
+            static int ss_cheat_rollover_fired = 0;
+            const char *cheat_on = getenv("SS_CHEAT_ROLLOVER");
+            const char *phase = getenv("SS_CHEAT_ROLLOVER_PHASE");
+            if (!ss_cheat_rollover_fired && cheat_on && atoi(cheat_on) == 1 &&
+                phase && strcmp(phase, "mid-window") == 0 &&
+                dying && dying->factory.n_leaf_nodes > 0) {
+                size_t li = dying->factory.leaf_node_indices[0];
+                factory_node_t *cheat_leaf_node = &dying->factory.nodes[li];
+                if (cheat_leaf_node->is_signed && cheat_leaf_node->signed_tx.len > 0) {
+                    char *cheat_hex = malloc(cheat_leaf_node->signed_tx.len * 2 + 1);
+                    char cheat_txid[65] = {0};
+                    if (cheat_hex) {
+                        extern void hex_encode(const unsigned char *, size_t, char *);
+                        hex_encode(cheat_leaf_node->signed_tx.data,
+                                    cheat_leaf_node->signed_tx.len, cheat_hex);
+                        int sent = chain_be
+                            ? chain_be->send_raw_tx(chain_be, cheat_hex, cheat_txid)
+                            : (rt ? regtest_send_raw_tx(rt, cheat_hex, cheat_txid) : 0);
+                        fprintf(stderr,
+                                "CL4-ROLLOVER: mid-window broadcast of dying factory %u "
+                                "leaf 0 tx: sent=%d txid=%s (severity=HIGH)\n",
+                                dying_id, sent, cheat_txid);
+                        if (sent && mgr->persist) {
+                            persist_log_broadcast((persist_t *)mgr->persist,
+                                                    cheat_txid,
+                                                    "cheat_rollover_stale",
+                                                    cheat_hex, "ok");
+                        }
+                        free(cheat_hex);
+                        ss_cheat_rollover_fired = 1;
+                    }
+                }
+            }
+        }
+
         if (mgr->persist) {
             const char *st = "dying";
             persist_save_ladder_factory((persist_t *)mgr->persist,

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -1706,6 +1706,23 @@ int main(int argc, char *argv[]) {
             cheat_subfactory_after_advance = 1;
             setenv("SS_CHEAT_DAEMON_MODE", "1", 1);
         }
+        else if (strcmp(argv[i], "--cheat-daemon-rollover") == 0) {
+            /* CL4-rollover: cheat-rollover for standalone WT testing.
+               After Tier B rollover succeeds, the LSP broadcasts the
+               dying factory's leaf TX -- standalone WT should detect
+               via block scan + respond with penalty TX.
+               Optional PHASE: mid-window (default; only one implemented),
+               pre-finalize, post-cleanup. */
+            test_tier_b_rollover = 1;
+            setenv("SS_CHEAT_DAEMON_MODE", "1", 1);
+            setenv("SS_CHEAT_ROLLOVER", "1", 1);
+            if (i + 1 < argc && argv[i+1][0] != '-' &&
+                    strchr("pmpost", argv[i+1][0]) != NULL) {
+                setenv("SS_CHEAT_ROLLOVER_PHASE", argv[++i], 1);
+            } else {
+                setenv("SS_CHEAT_ROLLOVER_PHASE", "mid-window", 1);
+            }
+        }
         else if (strcmp(argv[i], "--advance-count") == 0 && i + 1 < argc) {
             /* CL3: how many leaf advances to drive in test_leaf_advance. */
             advance_count_arg = atoi(argv[++i]);

--- a/tools/test_regtest_cheat_daemon_rollover.sh
+++ b/tools/test_regtest_cheat_daemon_rollover.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# test_regtest_cheat_daemon_rollover.sh — CL4-rollover adversarial test (#250).
+#
+# Spec: docs/LSP_TEAM_HANDOFF_CHEAT_DRIVERS.md "CL4 rollover-cheat daemon".
+# Severity: HIGH. Tests the stake-theft attack vector during Tier B rollover.
+#
+# Scenario:
+#   1. LSP creates factory + funds + advances to populate revocation history
+#   2. --test-tier-b-rollover drives root rollover (state advances past
+#      states_per_layer trigger DW rollover)
+#   3. --cheat-daemon-rollover=mid-window arms the LSP to broadcast the
+#      dying factory's leaf 0 tx AFTER partial_rotation_done is set
+#   4. Standalone WT (separate process) scans blocks for the broadcast,
+#      detects revoked state, broadcasts penalty TX
+#
+# PASS:
+#   - "CL4-ROLLOVER: mid-window broadcast" in LSP log
+#   - Standalone WT detects + broadcasts penalty (breach_detections row +
+#     penalty broadcast_log entry)
+
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+WT_BIN="$BUILD_DIR/superscalar_watchtower"
+
+N_CLIENTS="${N_CLIENTS:-2}"
+FUNDING_SATS="${FUNDING_SATS:-200000}"
+
+LSP_PORT=29959           # distinct from sibling tests
+WT_PORT=29969
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+
+BCLI="bitcoin-cli -regtest -rpcuser=${RPCUSER:-rpcuser} -rpcpassword=${RPCPASSWORD:-rpcpass}"
+
+declare -a PIDS=()
+TMPDIR=$(mktemp -d /tmp/ss-cheat-rollover.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"
+LSP_LOG="$TMPDIR/lsp.log"
+WT_DB="$TMPDIR/wt.db"
+WT_LOG="$TMPDIR/wt.log"
+
+cleanup() {
+    set +e
+    for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    cp "$LSP_LOG" /tmp/cheat_rollover_last_lsp.log 2>/dev/null || true
+    cp "$LSP_DB"  /tmp/cheat_rollover_last_lsp.db  2>/dev/null || true
+    cp "$WT_LOG"  /tmp/cheat_rollover_last_wt.log  2>/dev/null || true
+    cp "$WT_DB"   /tmp/cheat_rollover_last_wt.db   2>/dev/null || true
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        cp "$TMPDIR/client_${i}.log" "/tmp/cheat_rollover_last_client_${i}.log" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR"
+    echo "  preserved: /tmp/cheat_rollover_last_{lsp.log,lsp.db,wt.log,wt.db,client_*.log}"
+}
+trap cleanup EXIT
+
+echo "================ CL4-rollover (#250) ================"
+echo "  Scenario:"
+echo "    1. LSP creates factory + advances state to populate revocation"
+echo "    2. --test-tier-b-rollover triggers root rollover"
+echo "    3. --cheat-daemon-rollover=mid-window arms cheat broadcast"
+echo "    4. Standalone WT detects + broadcasts penalty"
+echo
+
+# --- ensure bitcoind regtest is running ---
+if ! $BCLI getblockchaininfo >/dev/null 2>&1; then
+    echo "ERROR: bitcoind regtest not running. Start it first."
+    exit 1
+fi
+
+# Set up miner wallet
+$BCLI -named createwallet wallet_name=ss_cheat_rollover_miner load_on_startup=false 2>&1 | head -2 || true
+$BCLI loadwallet ss_cheat_rollover_miner 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=ss_cheat_rollover_miner -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+
+# --- Standalone WT first (it will be authoritative) ---
+echo "--- Standalone WT (port $WT_PORT) ---"
+ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+"$WT_BIN" \
+    --network regtest \
+    --port $WT_PORT \
+    --rpcuser ${RPCUSER:-rpcuser} \
+    --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet ss_cheat_rollover_miner \
+    --db "$WT_DB" \
+    > "$WT_LOG" 2>&1 &
+WT_PID=$!
+PIDS+=($WT_PID)
+
+for i in $(seq 1 20); do
+    sleep 1
+    if grep -q "listening on port $WT_PORT" "$WT_LOG" 2>/dev/null; then
+        echo "  WT listening (PID=$WT_PID, port=$WT_PORT)"
+        break
+    fi
+done
+
+# --- LSP: --test-tier-b-rollover + --cheat-daemon-rollover=mid-window ---
+echo "--- LSP daemon (--test-tier-b-rollover --cheat-daemon-rollover=mid-window) ---"
+ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+"$LSP_BIN" \
+    --network regtest \
+    --port $LSP_PORT \
+    --watchtower-host 127.0.0.1 \
+    --watchtower-port $WT_PORT \
+    --clients $N_CLIENTS \
+    --arity 1 \
+    --amount $FUNDING_SATS \
+    --fee-rate 1000 \
+    --confirm-timeout 600 \
+    --active-blocks 6 \
+    --dying-blocks 4 \
+    --step-blocks 1 \
+    --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser ${RPCUSER:-rpcuser} \
+    --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet ss_cheat_rollover_miner \
+    --db "$LSP_DB" \
+    --demo --test-tier-b-rollover --cheat-daemon-rollover=mid-window \
+    --lsp-balance-pct 50 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+PIDS+=($LSP_PID)
+
+for i in $(seq 1 60); do
+    sleep 1
+    if grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null; then
+        echo "  LSP listening (PID=$LSP_PID)"
+        break
+    fi
+done
+
+# --- Clients ---
+echo "--- Starting $N_CLIENTS clients ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    CLIENT_SECKEY=$(printf "%064x" $((0x02 + i)))
+    "$CLIENT_BIN" \
+        --network regtest \
+        --lsp-host 127.0.0.1 \
+        --lsp-port $LSP_PORT \
+        --seckey "$CLIENT_SECKEY" \
+        --rpcuser ${RPCUSER:-rpcuser} \
+        --rpcpassword ${RPCPASSWORD:-rpcpass} \
+        --wallet ss_cheat_rollover_miner \
+        > "$TMPDIR/client_${i}.log" 2>&1 &
+    CLIENT_PID=$!
+    PIDS+=($CLIENT_PID)
+    echo "  client[$i] PID=$CLIENT_PID"
+done
+
+# Wait for LSP to fire the cheat OR exit OR timeout
+echo
+echo "--- Waiting for CL4-ROLLOVER cheat broadcast (timeout 600s) ---"
+for i in $(seq 1 600); do
+    sleep 1
+    if grep -qE "CL4-ROLLOVER: mid-window broadcast" "$LSP_LOG" 2>/dev/null; then
+        echo "  cheat broadcast fired after ${i}s"
+        break
+    fi
+    if ! kill -0 $LSP_PID 2>/dev/null; then
+        echo "  LSP exited at ${i}s without firing cheat"
+        break
+    fi
+    if [ $((i % 30)) -eq 0 ]; then
+        echo "  ... ${i}s elapsed"
+    fi
+done
+
+# Give WT time to detect + respond
+echo
+echo "--- Waiting for WT detection + penalty broadcast (60s) ---"
+for i in $(seq 1 60); do
+    sleep 1
+    if grep -qE "FACTORY BREACH|penalty.*broadcast|breach detected" "$WT_LOG" 2>/dev/null; then
+        echo "  WT detected breach at ${i}s after cheat"
+        break
+    fi
+    # Mine a block periodically to confirm the cheat TX + trigger WT block scan
+    if [ $((i % 5)) -eq 0 ]; then
+        $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null
+    fi
+done
+
+# Final assertions
+echo
+echo "=== Final result ==="
+CHEAT_FIRED=$(grep -cE "CL4-ROLLOVER: mid-window broadcast" "$LSP_LOG" 2>/dev/null | head -1 || echo 0)
+WT_BREACH=$(grep -cE "FACTORY BREACH|breach detected" "$WT_LOG" 2>/dev/null | head -1 || echo 0)
+WT_PENALTY=$(grep -cE "penalty.*broadcast|response_tx.*broadcast" "$WT_LOG" 2>/dev/null | head -1 || echo 0)
+
+echo "  cheat_fired=$CHEAT_FIRED  wt_breach=$WT_BREACH  wt_penalty=$WT_PENALTY"
+
+if [ "$CHEAT_FIRED" -ge 1 ] && [ "$WT_BREACH" -ge 1 ] && [ "$WT_PENALTY" -ge 1 ]; then
+    echo "  PASS: cheat fired + WT detected breach + WT broadcast penalty"
+    exit 0
+fi
+
+echo "  FAIL: cheat_fired=$CHEAT_FIRED wt_breach=$WT_BREACH wt_penalty=$WT_PENALTY (need all >=1)"
+echo "  LSP log tail:"
+tail -30 "$LSP_LOG"
+echo "  WT log tail:"
+tail -30 "$WT_LOG"
+exit 1


### PR DESCRIPTION
## Summary

Closes #250 — CL4-rollover, the largest remaining cheat-engine campaign item.

Per `docs/LSP_TEAM_HANDOFF_CHEAT_DRIVERS.md` "CL4 rollover-cheat daemon" section:

> **Severity: HIGH.** During Tier B rollover, two factory states are simultaneously valid for a brief window (old factory's commitments still on chain + new factory's pre-finalization state). A malicious LSP can try to broadcast a pre-rollover commitment while the client thinks the rollover succeeded — this is the closest thing to a stake-theft path the protocol has, and it's currently **untested**.

## What this adds

### CLI flag (`tools/superscalar_lsp.c`)

New `--cheat-daemon-rollover[=PHASE]` flag. Auto-enables `--test-tier-b-rollover` and sets:
- `SS_CHEAT_DAEMON_MODE=1`
- `SS_CHEAT_ROLLOVER=1`
- `SS_CHEAT_ROLLOVER_PHASE` ∈ `{mid-window (default), pre-finalize, post-cleanup}`

Only `mid-window` is wired in this MVP — the worst-case fund-loss phase. `pre-finalize` + `post-cleanup` are stubs (env var parsed but no-op) for follow-up PRs.

### Injection (`src/lsp_rotation.c`)

After `partial_rotation_done=1` is set (both Phase A coop-close path at line ~683 and Phase B natural-expiry path at line ~689), a static-fire-once-guarded block:

1. Reads `dying->factory.nodes[leaf_0].signed_tx` — the dying factory's leaf 0 TX
2. Broadcasts via `chain_be->send_raw_tx` (or `regtest_send_raw_tx` fallback)
3. Logs `CL4-ROLLOVER: mid-window broadcast ...` for test assertion
4. Records in `persist_log_broadcast` with `source='cheat_rollover_stale'`

The static fire-once flag ensures the cheat broadcasts exactly once per LSP lifetime regardless of how many times rotation runs.

### Test scaffold (`tools/test_regtest_cheat_daemon_rollover.sh`)

Mirrors `test_regtest_cheat_daemon_leaf.sh`. Sequence:

1. Spin up standalone WT (port 29969)
2. Spin up LSP (port 29959) with `--demo --test-tier-b-rollover --cheat-daemon-rollover=mid-window`
3. Wait for `CL4-ROLLOVER: mid-window broadcast` in LSP log (600s timeout)
4. Mine blocks periodically so WT's block scan sees the cheat TX
5. Wait for WT to detect breach + broadcast penalty (60s timeout)

**PASS criteria:** `cheat_fired ≥ 1 ∧ wt_breach ≥ 1 ∧ wt_penalty ≥ 1`

## Test plan

- [x] Build clean (`cmake --build build-release`)
- [x] **1472/1472 unit tests pass**
- [ ] Run `test_regtest_cheat_daemon_rollover.sh` end-to-end (in flight after merge)

## Definition of done

Per the handoff doc: when CL2 and CL4-rollover land, the cheat-engine campaign closes. CL2 driver landed in #295; this PR closes CL4-rollover. **Cheat-engine punch list complete after this lands.**

## Follow-ups

- Wire `pre-finalize` phase (inject before line 1202 `rotate_finalize_partial` checkpoint)
- Wire `post-cleanup` phase (snapshot at start, broadcast after `factory_free` at line ~895)
- Add to standard CI cheat-engine sweep
- Catalog entry in `docs/cheat-engine-catalog.md`

Closes task #250.
