### PR TITLE
feat(musig): Phase 1b — wire opcodes for reversed per-leaf advance flow (greenfield, no behavior change)

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -142,6 +142,15 @@
    surface based on reason. */
 #define MSG_CEREMONY_ABORT      0x79
 
+/* MuSig2 stateless redesign Phase 1b (#271 / MUSIG_NONCE_REDESIGN_MEMO §3.1).
+   Reversed per-leaf-advance round 2 flow.  Sent only when both peers have
+   negotiated --musig-stateless support (Phase 1a flag).  The legacy
+   PROPOSE -> PSIG -> DONE path (opcodes 0x58/0x59/0x5A) continues to
+   work for non-stateless peers. */
+#define MSG_LEAF_ADVANCE_CLIENT_PUBNONCE  0x7A  /* Client -> LSP: client_pubnonce only (no psig yet) */
+#define MSG_LEAF_ADVANCE_LSP_RESPONSE     0x7B  /* LSP -> Client: lsp_pubnonce + lsp_psig (atomic generate + sign on LSP) */
+#define MSG_LEAF_ADVANCE_FINAL            0x7C  /* Client -> LSP: final aggregated sig (optional confirmation for LSP records) */
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -430,6 +439,21 @@ int wire_parse_ceremony_abort(const cJSON *json,
                                 unsigned char ceremony_id[8],
                                 unsigned char *out_reason,
                                 char **out_reason_text);
+
+/* Phase 1b per MUSIG_NONCE_REDESIGN_MEMO §3.1 stateless-signer flow. */
+cJSON *wire_build_leaf_advance_client_pubnonce(const unsigned char client_pubnonce[66]);
+int    wire_parse_leaf_advance_client_pubnonce(const cJSON *json,
+                                                  unsigned char out_client_pubnonce[66]);
+
+cJSON *wire_build_leaf_advance_lsp_response(const unsigned char lsp_pubnonce[66],
+                                              const unsigned char lsp_psig[32]);
+int    wire_parse_leaf_advance_lsp_response(const cJSON *json,
+                                              unsigned char out_lsp_pubnonce[66],
+                                              unsigned char out_lsp_psig[32]);
+
+cJSON *wire_build_leaf_advance_final(const unsigned char final_sig[64]);
+int    wire_parse_leaf_advance_final(const cJSON *json,
+                                       unsigned char out_final_sig[64]);
 
 /* LSP → Bridge: BRIDGE_HELLO_ACK {} */
 cJSON *wire_build_bridge_hello_ack(void);

--- a/src/wire.c
+++ b/src/wire.c
@@ -1091,6 +1091,51 @@ int wire_parse_ceremony_abort(const cJSON *json,
     return 1;
 }
 
+cJSON *wire_build_leaf_advance_client_pubnonce(const unsigned char client_pubnonce[66]) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    wire_json_add_hex(j, "client_pubnonce", client_pubnonce, 66);
+    return j;
+}
+
+int wire_parse_leaf_advance_client_pubnonce(const cJSON *json,
+                                              unsigned char out_client_pubnonce[66]) {
+    if (!json || !out_client_pubnonce) return 0;
+    return wire_json_get_hex(json, "client_pubnonce", out_client_pubnonce, 66) == 66;
+}
+
+cJSON *wire_build_leaf_advance_lsp_response(const unsigned char lsp_pubnonce[66],
+                                              const unsigned char lsp_psig[32]) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    wire_json_add_hex(j, "lsp_pubnonce", lsp_pubnonce, 66);
+    wire_json_add_hex(j, "lsp_psig", lsp_psig, 32);
+    return j;
+}
+
+int wire_parse_leaf_advance_lsp_response(const cJSON *json,
+                                           unsigned char out_lsp_pubnonce[66],
+                                           unsigned char out_lsp_psig[32]) {
+    if (!json || !out_lsp_pubnonce || !out_lsp_psig) return 0;
+    if (wire_json_get_hex(json, "lsp_pubnonce", out_lsp_pubnonce, 66) != 66) return 0;
+    if (wire_json_get_hex(json, "lsp_psig", out_lsp_psig, 32) != 32) return 0;
+    return 1;
+}
+
+cJSON *wire_build_leaf_advance_final(const unsigned char final_sig[64]) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    wire_json_add_hex(j, "final_sig", final_sig, 64);
+    return j;
+}
+
+int wire_parse_leaf_advance_final(const cJSON *json,
+                                    unsigned char out_final_sig[64]) {
+    if (!json || !out_final_sig) return 0;
+    return wire_json_get_hex(json, "final_sig", out_final_sig, 64) == 64;
+}
+
+
 cJSON *wire_build_bridge_hello_ack(void) {
     return cJSON_CreateObject();
 }


### PR DESCRIPTION
## Summary

Phase 1b of the MuSig2 stateless-signer redesign (#271). Greenfield wire codec for the reversed round-2 flow per `MUSIG_NONCE_REDESIGN_MEMO §3.1`. **NO behavior change** — new opcodes have no handlers yet. Phase 1c will wire them into the alternate `lsp_advance_leaf` / `client_handle_leaf_advance` code path gated by `SS_MUSIG_STATELESS` (the env var registered in Phase 1a PR #321).

## Three new opcodes

| Opcode | Direction | Payload |
|---|---|---|
| `0x7A MSG_LEAF_ADVANCE_CLIENT_PUBNONCE` | Client → LSP | `client_pubnonce[66]` only (no psig yet — client doesn't have aggnonce until LSP responds) |
| `0x7B MSG_LEAF_ADVANCE_LSP_RESPONSE` | LSP → Client | `lsp_pubnonce[66]` + `lsp_psig[32]` (LSP atomically generates + aggregates + signs in ONE message — zero secnonce lifetime across wait) |
| `0x7C MSG_LEAF_ADVANCE_FINAL` | Client → LSP | `final_sig[64]` (optional confirmation for LSP records) |

## What stays the same

- `0x58 MSG_LEAF_ADVANCE_PROPOSE` — legacy initiation message; LSP still uses this for "advance now" intent (the nonce field may become optional in Phase 1c)
- `0x59 MSG_LEAF_ADVANCE_PSIG` — legacy single-message client response; old-path only
- `0x5A MSG_LEAF_ADVANCE_DONE` — terminal completion message; both paths use it

## Phase 1 progress

| Phase | Status | What landed |
|---|---|---|
| 1a (#321 merged) | ✅ | `MSG_CEREMONY_ABORT` + `--musig-stateless` flag + reason enum |
| **1b (this PR)** | **opening** | **Wire opcodes for reversed flow** |
| 1c | next | Actual code paths wiring the new opcodes behind the flag |
| 1d | future | Same pattern for Tier B + sub-factory advance ceremonies |

## Test plan

- [x] Build clean
- [x] 1472/1472 unit tests pass
- [x] Wire builders/parsers use the standard `wire_json_add_hex` / `wire_json_get_hex` helpers consistent with the rest of the codec
- [ ] Phase 1c: actual code-path integration + unit test for round-trip of new opcodes

Closes the Phase 1b portion of task #271 (master MuSig redesign #261).

## References

- `MUSIG_NONCE_REDESIGN_MEMO.md` §3.1 (happy-path flow)
- `docs/musig-stateless-audit.md` §3a (current per-leaf advance shape — already 3-message, only direction needs reversing)
- PR #321 (Phase 1a — opcode + flag groundwork)
