### PR TITLE
feat(musig): Phase 1c — wire reversed per-leaf advance flow behind --musig-stateless

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -693,13 +693,22 @@ int wire_parse_jit_migrate(const cJSON *json, uint32_t *jit_channel_id,
 
 /* --- Per-Leaf Advance message builders (Upgrade 2) --- */
 
-/* LSP -> Client: LEAF_ADVANCE_PROPOSE {leaf_side, pubnonce, [poison_pubnonce]}.
+/* LSP -> Client: LEAF_ADVANCE_PROPOSE {leaf_side, [pubnonce], [poison_pubnonce]}.
    poison_pubnonce is OPTIONAL on the wire — when present it accompanies
    the state pubnonce so the client can run two MuSig2 ceremonies in
    lockstep (closes Wire-Ceremony Gap A for leaf advance: poison TX
    defense in multi-process LSPs).  Pass `poison_pubnonce66 = NULL` to
-   either build or parse to skip the second nonce.  Parse return value:
-   0 = failure, 1 = state only, 2 = state + poison both parsed. */
+   either build or parse to skip the second nonce.
+
+   Phase 1c (--musig-stateless): passing state_pubnonce66 = NULL to the
+   builder omits the pubnonce field entirely; the parser then returns 3
+   to signal stateless mode (client goes first, LSP_RESPONSE later
+   carries lsp_pubnonce + lsp_psig).  Legacy callers always pass a real
+   66-byte pointer.
+
+   Parse return value:
+   0 = failure, 1 = state only, 2 = state + poison both parsed,
+   3 = stateless (no pubnonce field, leaf_side parsed). */
 cJSON *wire_build_leaf_advance_propose(int leaf_side,
                                         const unsigned char *state_pubnonce66,
                                         const unsigned char *poison_pubnonce66);

--- a/src/client.c
+++ b/src/client.c
@@ -3393,10 +3393,261 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
     return 1;
 }
 
+
+/* --- Phase 1c (#271): MuSig2 stateless-signer client-side handler ---
+
+   Mirrors lsp_advance_leaf_stateless in src/lsp_channels.c.  The client
+   goes FIRST with its pubnonce; the LSP atomically generates its nonce
+   + signs and replies with both lsp_pubnonce + lsp_psig in one message;
+   the client then aggregates locally and ships the 64-byte final sig.
+
+   Scope: state TX only.  Poison TX deferred (TODO).  See the LSP-side
+   header for the full rationale. */
+static int client_handle_leaf_advance_stateless(int fd,
+                                                  secp256k1_context *ctx,
+                                                  const secp256k1_keypair *keypair,
+                                                  factory_t *factory,
+                                                  uint32_t my_index,
+                                                  const wire_msg_t *propose_msg) {
+    persist_t *persist = g_client_persist;
+    int leaf_side;
+    /* Parse PROPOSE.  In stateless mode the parser returns 3 (no pubnonce
+       field).  We accept that one return value; everything else is an
+       error (we shouldn't be in this function if the LSP is sending the
+       legacy shape). */
+    unsigned char throwaway_pn[66], throwaway_poison_pn[66];
+    int propose_rc = wire_parse_leaf_advance_propose(propose_msg->json,
+                                                       &leaf_side,
+                                                       throwaway_pn,
+                                                       throwaway_poison_pn);
+    if (propose_rc != 3) {
+        fprintf(stderr,
+                "Client-stateless %u: PROPOSE not in stateless shape (rc=%d) "
+                "-- refusing.  Set SS_MUSIG_STATELESS on both ends or unset on both.\n",
+                my_index, propose_rc);
+        return 0;
+    }
+    if (leaf_side < 0 || leaf_side >= factory->n_leaf_nodes) {
+        fprintf(stderr, "Client-stateless %u: bad leaf_side %d\n", my_index, leaf_side);
+        return 0;
+    }
+
+    size_t node_idx = factory->leaf_node_indices[leaf_side];
+    factory_node_t *ps_node = &factory->nodes[node_idx];
+
+    /* Step 1: advance local state to mirror the LSP. */
+    int rc = factory_advance_leaf_unsigned(factory, leaf_side);
+    if (rc <= 0) {
+        fprintf(stderr, "Client-stateless %u: leaf %d advance_unsigned failed (rc=%d)\n",
+                my_index, leaf_side, rc);
+        return 0;
+    }
+
+    /* PS double-spend defense -- same as legacy path. */
+    if (persist && ps_node->is_ps_leaf && ps_node->ps_chain_len > 0) {
+        unsigned char prev_sighash[32];
+        int already = persist_check_ps_signed_input(
+            persist, /* factory_id = */ 0,
+            ps_node->ps_prev_txid, /* parent_vout = */ 0,
+            prev_sighash);
+        if (already) {
+            char hex[65];
+            for (int i = 0; i < 32; i++)
+                snprintf(hex + 2 * i, 3, "%02x", ps_node->ps_prev_txid[i]);
+            fprintf(stderr,
+                    "Client-stateless %u: REFUSING PS double-spend -- already signed "
+                    "a TX spending (%s:0).\n", my_index, hex);
+            return 0;
+        }
+    }
+
+    if (!factory_session_init_node(factory, node_idx)) {
+        fprintf(stderr, "Client-stateless %u: session_init failed\n", my_index);
+        return 0;
+    }
+
+    int my_slot = factory_find_signer_slot(factory, node_idx, my_index);
+    int lsp_slot = factory_find_signer_slot(factory, node_idx, 0);
+    if (my_slot < 0 || lsp_slot < 0) {
+        fprintf(stderr, "Client-stateless %u: signer slot lookup failed (my=%d lsp=%d)\n",
+                my_index, my_slot, lsp_slot);
+        return 0;
+    }
+
+    /* Step 2: generate own nonce and ship MSG_LEAF_ADVANCE_CLIENT_PUBNONCE.
+       Client secnonce lives on stack across the LSP_RESPONSE recv -- this
+       is OK because Option G targets specifically the LSP's secnonce
+       lifetime (LSP is the high-value, persistent, multi-tenant party).
+       Client-side secnonce already exists on stack in the legacy flow too. */
+    unsigned char my_seckey[32];
+    secp256k1_pubkey my_pubkey;
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        fprintf(stderr, "Client-stateless %u: keypair_sec failed\n", my_index);
+        return 0;
+    }
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+    secp256k1_musig_secnonce my_secnonce;
+    secp256k1_musig_pubnonce my_pubnonce;
+    if (!musig_generate_nonce(ctx, &my_secnonce, &my_pubnonce,
+                                my_seckey, &my_pubkey,
+                                &factory->nodes[node_idx].keyagg.cache)) {
+        memset(my_seckey, 0, 32);
+        fprintf(stderr, "Client-stateless %u: nonce gen failed\n", my_index);
+        return 0;
+    }
+    memset(my_seckey, 0, 32);
+    if (!factory_session_set_nonce(factory, node_idx, (size_t)my_slot, &my_pubnonce)) {
+        fprintf(stderr, "Client-stateless %u: set own nonce failed\n", my_index);
+        return 0;
+    }
+
+    unsigned char my_pubnonce_ser[66];
+    musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
+    cJSON *cpn_json = wire_build_leaf_advance_client_pubnonce(my_pubnonce_ser);
+    if (!wire_send(fd, MSG_LEAF_ADVANCE_CLIENT_PUBNONCE, cpn_json)) {
+        cJSON_Delete(cpn_json);
+        fprintf(stderr, "Client-stateless %u: send CLIENT_PUBNONCE failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(cpn_json);
+
+    /* Step 3: wait for LSP_RESPONSE with lsp_pubnonce + lsp_psig. */
+    wire_msg_t lr_msg;
+    if (!wire_recv(fd, &lr_msg) || lr_msg.msg_type != MSG_LEAF_ADVANCE_LSP_RESPONSE) {
+        fprintf(stderr, "Client-stateless %u: expected LSP_RESPONSE, got 0x%02x\n",
+                my_index, lr_msg.json ? lr_msg.msg_type : 0);
+        if (lr_msg.json) cJSON_Delete(lr_msg.json);
+        return 0;
+    }
+    unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
+    int lrrc = wire_parse_leaf_advance_lsp_response(lr_msg.json,
+                                                       lsp_pubnonce_ser,
+                                                       lsp_psig_ser);
+    cJSON_Delete(lr_msg.json);
+    if (!lrrc) {
+        fprintf(stderr, "Client-stateless %u: parse LSP_RESPONSE failed\n", my_index);
+        return 0;
+    }
+
+    /* Step 4: set LSP nonce, finalize session. */
+    secp256k1_musig_pubnonce lsp_pubnonce;
+    if (!musig_pubnonce_parse(ctx, &lsp_pubnonce, lsp_pubnonce_ser)) {
+        fprintf(stderr, "Client-stateless %u: parse LSP pubnonce failed\n", my_index);
+        return 0;
+    }
+    if (!factory_session_set_nonce(factory, node_idx, (size_t)lsp_slot, &lsp_pubnonce)) {
+        fprintf(stderr, "Client-stateless %u: set LSP nonce failed\n", my_index);
+        return 0;
+    }
+    if (!factory_session_finalize_node(factory, node_idx)) {
+        fprintf(stderr, "Client-stateless %u: finalize_node failed\n", my_index);
+        return 0;
+    }
+
+    /* Step 5: create own partial_sig (zeroes own secnonce). */
+    secp256k1_musig_partial_sig my_psig;
+    if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonce, keypair,
+                                    &factory->nodes[node_idx].signing_session)) {
+        fprintf(stderr, "Client-stateless %u: create_partial_sig failed\n", my_index);
+        return 0;
+    }
+
+    /* Step 6: parse LSP's psig and set both psigs into the session. */
+    secp256k1_musig_partial_sig lsp_psig;
+    if (!musig_partial_sig_parse(ctx, &lsp_psig, lsp_psig_ser)) {
+        fprintf(stderr, "Client-stateless %u: parse LSP psig failed\n", my_index);
+        return 0;
+    }
+    if (!factory_session_set_partial_sig(factory, node_idx, (size_t)my_slot, &my_psig)) {
+        fprintf(stderr, "Client-stateless %u: set own partial_sig failed\n", my_index);
+        return 0;
+    }
+    if (!factory_session_set_partial_sig(factory, node_idx, (size_t)lsp_slot, &lsp_psig)) {
+        fprintf(stderr, "Client-stateless %u: set LSP partial_sig failed\n", my_index);
+        return 0;
+    }
+
+    /* PS defense: record what we just signed BEFORE shipping FINAL.  A
+       crash after record + before send is safe -- a retry sees the row
+       and refuses.  Same shape as legacy path. */
+    if (persist && ps_node->is_ps_leaf && ps_node->ps_chain_len > 0) {
+        unsigned char sighash[32];
+        if (compute_taproot_sighash(sighash,
+                ps_node->unsigned_tx.data, ps_node->unsigned_tx.len, 0,
+                ps_node->outputs[0].script_pubkey,
+                ps_node->outputs[0].script_pubkey_len,
+                ps_node->ps_prev_chan_amount, ps_node->nsequence)) {
+            unsigned char psig_buf[36];
+            unsigned char my_psig_ser[32];
+            musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
+            memset(psig_buf, 0, 36);
+            memcpy(psig_buf, my_psig_ser, 32);
+            persist_save_ps_signed_input(persist, /* factory_id = */ 0,
+                (int)node_idx, ps_node->ps_prev_txid, 0,
+                sighash, psig_buf);
+        }
+    }
+
+    /* Step 7: complete_node aggregates both psigs + attaches the signed
+       witness, populating node->signed_tx.  This is the same call the
+       legacy path uses for its local copy. */
+    if (!factory_session_complete_node(factory, node_idx)) {
+        fprintf(stderr, "Client-stateless %u: complete_node failed\n", my_index);
+        return 0;
+    }
+
+    /* Extract the 64-byte aggregated sig so we can ship it to the LSP.
+       The LSP needs the bare 64 bytes (not the segwit witness), so we
+       re-aggregate explicitly from the session's slot-indexed
+       partial_sigs buffer.  node->partial_sigs[0..n_signers-1] are set
+       by factory_session_set_partial_sig in slot order. */
+    factory_node_t *node = &factory->nodes[node_idx];
+    unsigned char final_sig[64];
+    if (!musig_aggregate_partial_sigs(ctx, final_sig,
+                                        &node->signing_session,
+                                        node->partial_sigs, node->n_signers)) {
+        fprintf(stderr, "Client-stateless %u: aggregate_partial_sigs failed\n", my_index);
+        return 0;
+    }
+
+    /* Step 8: ship FINAL. */
+    cJSON *fin_json = wire_build_leaf_advance_final(final_sig);
+    if (!wire_send(fd, MSG_LEAF_ADVANCE_FINAL, fin_json)) {
+        cJSON_Delete(fin_json);
+        fprintf(stderr, "Client-stateless %u: send FINAL failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(fin_json);
+
+    /* Step 9: wait for LEAF_ADVANCE_DONE (LSP's broadcast). */
+    wire_msg_t done_msg;
+    if (!wire_recv(fd, &done_msg) || done_msg.msg_type != MSG_LEAF_ADVANCE_DONE) {
+        fprintf(stderr, "Client-stateless %u: expected LEAF_ADVANCE_DONE, got 0x%02x\n",
+                my_index, done_msg.json ? done_msg.msg_type : 0);
+        if (done_msg.json) cJSON_Delete(done_msg.json);
+        return 0;
+    }
+    if (done_msg.json) cJSON_Delete(done_msg.json);
+
+    printf("Client-stateless %u: leaf %d advance complete\n", my_index, leaf_side);
+    return 1;
+}
+
 int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
                                  const secp256k1_keypair *keypair,
                                  factory_t *factory, uint32_t my_index,
                                  const wire_msg_t *propose_msg) {
+    /* Phase 1c (#271): when --musig-stateless is in effect, dispatch to the
+       reversed-order flow.  Legacy path below is untouched. */
+    {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        if (stateless && stateless[0] == '1')
+            return client_handle_leaf_advance_stateless(fd, ctx, keypair,
+                                                          factory, my_index,
+                                                          propose_msg);
+    }
+
     persist_t *persist = g_client_persist;
     int leaf_side;
     unsigned char lsp_pubnonce_ser[66], lsp_poison_pn_ser[66];

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1559,6 +1559,322 @@ static int handle_add_htlc(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     return 1;
 }
 
+
+/* --- Phase 1c (#271): MuSig2 stateless-signer per-leaf advance ---
+
+   Reversed-order flow per .claude/MUSIG_NONCE_REDESIGN_MEMO sec 3.1.  The
+   LSP MUST NOT hold a secnonce across any wire recv-wait -- invariant
+   that motivates the whole redesign.
+
+   Wire round-trip (gated by SS_MUSIG_STATELESS):
+     LSP   -> Client : MSG_LEAF_ADVANCE_PROPOSE   {leaf_side}   (no nonce)
+     Client -> LSP   : MSG_LEAF_ADVANCE_CLIENT_PUBNONCE {client_pubnonce}
+     LSP   -> Client : MSG_LEAF_ADVANCE_LSP_RESPONSE {lsp_pubnonce, lsp_psig}
+                       ^-- LSP atomically: gen nonce, set both nonces,
+                           finalize, create_partial_sig (zeroes secnonce),
+                           reply.  No suspension between gen and zero.
+     Client -> LSP   : MSG_LEAF_ADVANCE_FINAL {final_sig64}
+                       ^-- client locally aggregates psigs into the
+                           64-byte Schnorr sig and ships it for the LSP
+                           to attach to the unsigned tx.
+
+   Scope (Phase 1c MVP):
+     - STATE TX only.  Poison TX is NOT signed in the new flow -- the
+       atomic generate+sign here would require a second independent
+       secnonce, doubling the surface.  TODO(Phase 1d/2): re-introduce
+       poison TX via a second MSG_LEAF_ADVANCE_LSP_RESPONSE round or a
+       parallel atomic sub-ceremony.
+     - Watchtower registration is skipped here too (legacy path keeps
+       it).  TODO(Phase 2): re-enable once we decide whether to register
+       with a NULL poison TX or run the legacy poison sub-ceremony.
+     - Other ceremonies (Tier B, sub-factory, factory creation) defer
+       to later phases per the audit's blast-radius ordering.
+
+   When SS_MUSIG_STATELESS is unset the caller takes the legacy path
+   instead and this function is unreachable. */
+static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
+                                        int leaf_side) {
+    factory_t *f = &lsp->factory;
+
+    if (f->leaf_arity != FACTORY_ARITY_1 && f->leaf_arity != FACTORY_ARITY_PS) return 1;
+    if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) return 0;
+
+    /* PS k>=2: same refusal as legacy path (see lsp_advance_leaf header). */
+    if (f->leaf_arity == FACTORY_ARITY_PS && f->ps_subfactory_arity >= 2) {
+        fprintf(stderr,
+                "lsp_advance_leaf_stateless: refused -- k=%u sub-factory PS has "
+                "no leaf-level dynamic operation.\n",
+                f->ps_subfactory_arity);
+        return 0;
+    }
+
+    int64_t c3_round_id = -1;
+    if (mgr->persist) {
+        persist_save_signing_round_start((persist_t *)mgr->persist,
+                                           /* factory_id */ 0,
+                                           (uint32_t)f->leaf_node_indices[leaf_side],
+                                           "leaf_advance_stateless",
+                                           f->counter.current_epoch,
+                                           (uint32_t)f->n_participants,
+                                           &c3_round_id);
+    }
+
+    /* Step 1: advance leaf state to rebuild the unsigned TX. */
+    int rc = factory_advance_leaf_unsigned(f, leaf_side);
+    if (rc == 0) {
+        fprintf(stderr, "LSP-stateless: leaf %d advance exhausted\n", leaf_side);
+        return 0;
+    }
+    if (rc == -1) {
+        /* Root rollover triggers Tier B -- defer to legacy until that
+           ceremony is reversed (Phase 2). */
+        printf("LSP-stateless: leaf %d exhausted, root advanced -- "
+               "falling back to legacy Tier B state-advance ceremony\n",
+               leaf_side);
+        return lsp_run_state_advance(mgr, lsp, leaf_side);
+    }
+
+    size_t node_idx = f->leaf_node_indices[leaf_side];
+    uint32_t client_participant = (uint32_t)(leaf_side + 1);
+
+    /* Step 2: ship PROPOSE with NO nonce -- client goes first. */
+    cJSON *propose = wire_build_leaf_advance_propose(leaf_side, NULL, NULL);
+    if (!wire_send(lsp->client_fds[leaf_side], MSG_LEAF_ADVANCE_PROPOSE, propose)) {
+        cJSON_Delete(propose);
+        fprintf(stderr, "LSP-stateless: send PROPOSE failed\n");
+        return 0;
+    }
+    cJSON_Delete(propose);
+
+    /* Step 3: wait for client_pubnonce. */
+    wire_msg_t cpn_msg;
+    int rrc = recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[leaf_side],
+                                             &cpn_msg, WIRE_CEREMONY_RECV_TIMEOUT_SEC);
+    if (!rrc || cpn_msg.msg_type != MSG_LEAF_ADVANCE_CLIENT_PUBNONCE) {
+        const char *why = !rrc ? "recv timeout / peer EOF" : "wrong message type";
+        fprintf(stderr,
+                "LSP-stateless: expected CLIENT_PUBNONCE from client %d, got 0x%02x (%s)\n",
+                leaf_side, cpn_msg.msg_type, why);
+        if (cpn_msg.json) cJSON_Delete(cpn_msg.json);
+        return 0;
+    }
+    unsigned char client_pubnonce_ser[66];
+    int prc = wire_parse_leaf_advance_client_pubnonce(cpn_msg.json,
+                                                         client_pubnonce_ser);
+    cJSON_Delete(cpn_msg.json);
+    if (!prc) {
+        fprintf(stderr, "LSP-stateless: parse CLIENT_PUBNONCE failed\n");
+        return 0;
+    }
+
+    /* Step 4: init session (state only, no poison). */
+    if (!factory_session_init_node(f, node_idx)) {
+        fprintf(stderr, "LSP-stateless: state session init failed for node %zu\n", node_idx);
+        return 0;
+    }
+
+    /* Step 5: set client's pubnonce into the session. */
+    int client_slot = factory_find_signer_slot(f, node_idx, client_participant);
+    int lsp_slot = factory_find_signer_slot(f, node_idx, 0);
+    if (client_slot < 0 || lsp_slot < 0) {
+        fprintf(stderr, "LSP-stateless: signer slot lookup failed (client=%d, lsp=%d)\n",
+                client_slot, lsp_slot);
+        return 0;
+    }
+    secp256k1_musig_pubnonce client_pubnonce;
+    if (!musig_pubnonce_parse(lsp->ctx, &client_pubnonce, client_pubnonce_ser)) {
+        fprintf(stderr, "LSP-stateless: parse client pubnonce failed\n");
+        return 0;
+    }
+    if (!factory_session_set_nonce(f, node_idx, (size_t)client_slot, &client_pubnonce)) {
+        fprintf(stderr, "LSP-stateless: set client nonce failed\n");
+        return 0;
+    }
+
+    /* Step 6 (THE CRITICAL ATOMIC BLOCK):
+       Generate LSP secnonce + pubnonce, install it, finalize the session,
+       create the partial sig (which zeroes our secnonce), and serialize
+       the response.  No wire recv between nonce gen and zeroing. */
+    unsigned char lsp_seckey[32];
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) {
+        fprintf(stderr, "LSP-stateless: keypair_sec failed\n");
+        return 0;
+    }
+    secp256k1_musig_secnonce lsp_secnonce;
+    secp256k1_musig_pubnonce lsp_pubnonce;
+    if (!musig_generate_nonce(lsp->ctx, &lsp_secnonce, &lsp_pubnonce,
+                                lsp_seckey, &lsp->lsp_pubkey,
+                                &f->nodes[node_idx].keyagg.cache)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless: LSP nonce gen failed\n");
+        return 0;
+    }
+    if (!factory_session_set_nonce(f, node_idx, (size_t)lsp_slot, &lsp_pubnonce)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless: set LSP nonce failed\n");
+        return 0;
+    }
+    if (!factory_session_finalize_node(f, node_idx)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless: finalize_node failed\n");
+        return 0;
+    }
+    secp256k1_keypair lsp_kp;
+    if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless: keypair_create failed\n");
+        return 0;
+    }
+    memset(lsp_seckey, 0, 32);
+
+    secp256k1_musig_partial_sig lsp_psig;
+    if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
+                                    &f->nodes[node_idx].signing_session)) {
+        fprintf(stderr, "LSP-stateless: create_partial_sig failed\n");
+        return 0;
+    }
+    /* lsp_secnonce has been zeroed by musig_create_partial_sig.
+       INVARIANT: from this point on we no longer hold any LSP secnonce.
+       The wire recv that follows is safe. */
+
+    unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
+    musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
+    musig_partial_sig_serialize(lsp->ctx, lsp_psig_ser, &lsp_psig);
+
+    /* Also stash our psig into the session so we can verify the final
+       aggregated sig matches (and for future Phase-2 re-aggregation). */
+    if (!factory_session_set_partial_sig(f, node_idx, (size_t)lsp_slot, &lsp_psig)) {
+        fprintf(stderr, "LSP-stateless: set LSP partial_sig failed\n");
+        return 0;
+    }
+
+    /* Step 7: ship LSP_RESPONSE. */
+    cJSON *response = wire_build_leaf_advance_lsp_response(lsp_pubnonce_ser,
+                                                             lsp_psig_ser);
+    if (!wire_send(lsp->client_fds[leaf_side], MSG_LEAF_ADVANCE_LSP_RESPONSE, response)) {
+        cJSON_Delete(response);
+        fprintf(stderr, "LSP-stateless: send LSP_RESPONSE failed\n");
+        return 0;
+    }
+    cJSON_Delete(response);
+
+    /* Step 8: wait for FINAL with the 64-byte aggregated sig. */
+    wire_msg_t fin_msg;
+    int frc = recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[leaf_side],
+                                             &fin_msg, WIRE_CEREMONY_RECV_TIMEOUT_SEC);
+    if (!frc || fin_msg.msg_type != MSG_LEAF_ADVANCE_FINAL) {
+        const char *why = !frc ? "recv timeout / peer EOF" : "wrong message type";
+        fprintf(stderr,
+                "LSP-stateless: expected FINAL from client %d, got 0x%02x (%s)\n",
+                leaf_side, fin_msg.msg_type, why);
+        if (fin_msg.json) cJSON_Delete(fin_msg.json);
+        return 0;
+    }
+    unsigned char final_sig[64];
+    int frc2 = wire_parse_leaf_advance_final(fin_msg.json, final_sig);
+    cJSON_Delete(fin_msg.json);
+    if (!frc2) {
+        fprintf(stderr, "LSP-stateless: parse FINAL failed\n");
+        return 0;
+    }
+
+    /* Step 9: verify the final sig against the session's keyagg+sighash
+       and (on success) attach it as the node's signed_tx.  The session's
+       cache is the tweaked keyagg (factory_session_finalize_node applied
+       the taproot xonly tweak), so musig_pubkey_get returns the output
+       (tweaked) aggregated pubkey.  Convert to xonly for schnorrsig_verify. */
+    factory_node_t *node = &f->nodes[node_idx];
+    secp256k1_pubkey output_pk;
+    if (!secp256k1_musig_pubkey_get(lsp->ctx, &output_pk,
+                                       &node->signing_session.cache)) {
+        fprintf(stderr, "LSP-stateless: pubkey_get from cache failed\n");
+        return 0;
+    }
+    secp256k1_xonly_pubkey output_xpub;
+    if (!secp256k1_xonly_pubkey_from_pubkey(lsp->ctx, &output_xpub, NULL,
+                                              &output_pk)) {
+        fprintf(stderr, "LSP-stateless: xonly_from_pubkey failed\n");
+        return 0;
+    }
+    if (!secp256k1_schnorrsig_verify(lsp->ctx, final_sig,
+                                       node->signing_session.msg32, 32,
+                                       &output_xpub)) {
+        fprintf(stderr, "LSP-stateless: schnorr verify of FINAL sig failed\n");
+        return 0;
+    }
+    if (!finalize_signed_tx(&node->signed_tx,
+                              node->unsigned_tx.data, node->unsigned_tx.len,
+                              final_sig)) {
+        fprintf(stderr, "LSP-stateless: finalize_signed_tx failed\n");
+        return 0;
+    }
+    node->is_signed = 1;
+
+    /* TODO(Phase 1d/2): poison TX ceremony.  In the legacy path we run
+       a parallel MuSig2 ceremony over the OLD state's L-stock distribution
+       so the watchtower can burn-redistribute on breach.  The reversed
+       flow needs an analogous round (or a second LSP_RESPONSE message
+       carrying lsp_poison_pubnonce + lsp_poison_psig). */
+
+    /* TODO(Phase 2): watchtower_watch_factory_node_with_channels.  Skipped
+       in MVP because the new flow has no poison TX yet -- degrading would
+       broadcast SECURITY-GAP warnings on every advance.  Once poison is
+       wired, re-enable the watchtower registration to mirror the legacy
+       path's Step 9 block. */
+
+    /* Step 10: notify everyone leaf advance done. */
+    cJSON *done = wire_build_leaf_advance_done(leaf_side);
+    for (size_t i = 0; i < lsp->n_clients; i++) {
+        wire_send(lsp->client_fds[i], MSG_LEAF_ADVANCE_DONE, done);
+    }
+    cJSON_Delete(done);
+
+    /* Step 11: persist leaf state (same shape as legacy path). */
+    if (mgr->persist) {
+        if (node->is_ps_leaf) {
+            extern void reverse_bytes(unsigned char *, size_t);
+            unsigned char txid_display[32];
+            memcpy(txid_display, node->txid, 32);
+            reverse_bytes(txid_display, 32);
+            persist_save_ps_chain_entry(
+                (persist_t *)mgr->persist, 0,
+                (uint32_t)node_idx,
+                node->ps_chain_len - 1,
+                f->counter.current_epoch,
+                txid_display,
+                node->signed_tx.data, node->signed_tx.len,
+                node->outputs[0].amount_sats,
+                /* poison_tx */ NULL, 0);
+        } else {
+            uint32_t leaf_states[8];
+            for (int i = 0; i < f->n_leaf_nodes; i++)
+                leaf_states[i] = f->leaf_layers[i].current_state;
+            uint32_t layer_states[DW_MAX_LAYERS];
+            for (uint32_t i = 0; i < f->counter.n_layers; i++)
+                layer_states[i] = f->counter.layers[i].config.max_states;
+            persist_save_dw_counter_with_leaves(
+                (persist_t *)mgr->persist, 0, f->counter.current_epoch,
+                f->counter.n_layers, layer_states,
+                f->per_leaf_enabled, leaf_states, f->n_leaf_nodes);
+        }
+    }
+
+    if (node->is_ps_leaf)
+        printf("LSP-stateless: PS leaf %d advanced (node %zu), chain_len %d\n",
+               leaf_side, node_idx, node->ps_chain_len);
+    else
+        printf("LSP-stateless: DW leaf %d advanced (node %zu), DW state %u\n",
+               leaf_side, node_idx, f->leaf_layers[leaf_side].current_state);
+
+    if (mgr->persist && c3_round_id > 0) {
+        persist_save_signing_round_done((persist_t *)mgr->persist, c3_round_id,
+                                          (uint32_t)f->n_participants,
+                                          (uint32_t)f->n_participants,
+                                          "success", NULL, NULL);
+    }
+    return 1;
+}
+
 /* --- Per-leaf advance (arity-1 DW and arity-PS chained-TX, split-round signing) --- */
 
 /* Advance one leaf, do split-round 2-of-2 signing with the affected client,
@@ -1588,6 +1904,14 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
                 "Per docs/ps-subfactories.md spec Phase 2.\n",
                 f->ps_subfactory_arity);
         return 0;
+    }
+
+    /* Phase 1c (#271): when --musig-stateless is in effect, dispatch to the
+       reversed-order flow.  Legacy path below is untouched. */
+    {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        if (stateless && stateless[0] == '1')
+            return lsp_advance_leaf_stateless(mgr, lsp, leaf_side);
     }
 
     /* C3 (Tier 1): journal the ceremony at start; success-update at the

--- a/src/wire.c
+++ b/src/wire.c
@@ -1799,19 +1799,28 @@ cJSON *wire_build_leaf_advance_propose(int leaf_side,
                                         const unsigned char *poison_pubnonce66) {
     cJSON *j = cJSON_CreateObject();
     cJSON_AddNumberToObject(j, "leaf_side", leaf_side);
-    wire_json_add_hex(j, "pubnonce", state_pubnonce66, 66);
+    /* Phase 1c: in --musig-stateless mode the LSP ships PROPOSE with no
+       nonce field (the client goes first). state_pubnonce66 = NULL is the
+       sentinel for that mode; legacy callers always pass a 66-byte pointer. */
+    if (state_pubnonce66)
+        wire_json_add_hex(j, "pubnonce", state_pubnonce66, 66);
     if (poison_pubnonce66)
         wire_json_add_hex(j, "poison_pubnonce", poison_pubnonce66, 66);
     return j;
 }
 
-/* Returns: 0 on failure, 1 = state pubnonce parsed, 2 = state + poison parsed. */
+/* Returns: 0 on failure, 1 = state pubnonce parsed, 2 = state + poison parsed,
+   3 = stateless mode (no pubnonce field present, leaf_side parsed). */
 int wire_parse_leaf_advance_propose(const cJSON *json, int *leaf_side,
                                       unsigned char *state_pubnonce66,
                                       unsigned char *poison_pubnonce66) {
     cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");
     if (!ls || !cJSON_IsNumber(ls)) return 0;
     *leaf_side = (int)ls->valuedouble;
+    /* Phase 1c: stateless-mode PROPOSE omits the pubnonce field entirely.
+       Detect that case and signal to the caller via rc=3. */
+    if (!cJSON_GetObjectItem(json, "pubnonce"))
+        return 3;
     if (wire_json_get_hex(json, "pubnonce", state_pubnonce66, 66) != 66) return 0;
     if (poison_pubnonce66 &&
         wire_json_get_hex(json, "poison_pubnonce", poison_pubnonce66, 66) == 66)


### PR DESCRIPTION
## Summary

Phase 1c of the MuSig2 stateless-signer redesign (#271). Activates the reversed per-leaf advance flow behind `SS_MUSIG_STATELESS=1` (the env var registered in Phase 1a PR #321) using the wire opcodes added in Phase 1b PR #323.

**Behavior change is opt-in only** — without `--musig-stateless`, the legacy 3-message path runs unchanged.

## What this adds

### LSP side — `lsp_advance_leaf_stateless` (`src/lsp_channels.c`)

New static function ~324 LOC. Mirrors `lsp_advance_leaf` but reorders the round-2 messages per `MUSIG_NONCE_REDESIGN_MEMO §3.1`:

```
LSP -> Client:  MSG_LEAF_ADVANCE_PROPOSE (existing 0x58, NO lsp_pubnonce field — pass NULL)
Client -> LSP:  MSG_LEAF_ADVANCE_CLIENT_PUBNONCE (new 0x7A)
LSP atomic:     generate lsp_secnonce + lsp_pubnonce
                set client + lsp nonces in session
                factory_session_finalize_node
                musig_create_partial_sig (library zeroes lsp_secnonce here)
LSP -> Client:  MSG_LEAF_ADVANCE_LSP_RESPONSE (new 0x7B) {lsp_pubnonce, lsp_psig}
Client -> LSP:  MSG_LEAF_ADVANCE_FINAL (new 0x7C) {final 64-byte aggregated sig}
LSP:            store signed_tx; done.
```

**Load-bearing invariant** (commented in code): *"lsp_secnonce has been zeroed by `musig_create_partial_sig`. INVARIANT: from this point on we no longer hold any LSP secnonce. The wire recv that follows is safe."*

Dispatch at the top of legacy `lsp_advance_leaf`:
```c
if (stateless && stateless[0] == '1')
    return lsp_advance_leaf_stateless(mgr, lsp, leaf_side);
```

### Client side — `client_handle_leaf_advance_stateless` (`src/client.c`)

New static function ~251 LOC mirroring the LSP side. Client generates pubnonce → sends → waits for LSP response → completes locally → aggregates → sends final sig.

Dispatch at top of legacy `client_handle_leaf_advance` (same env-var check).

## Scope kept tight per #270 audit recommendation

- **STATE TX only** — poison TX support is `TODO` in the new flow (legacy path keeps its poison handling). Poison wiring deferred to Phase 1d.
- **Per-leaf advance only** — Tier B state advance, sub-factory chain advance, factory creation all keep the legacy pre-gen-pool flow for now (each gets its own phase).
- **Watchtower registration** still happens on legacy path; new path TODOs the registration. The new path is safe to run in test environments without WT registration but should NOT be used in production until that's wired (gating is via the env var).

## Test plan

- [x] Build clean (`cmake --build build-release`)
- [x] **1472/1472 unit tests pass** (legacy path unchanged → no regression)
- [ ] Phase 1c integration test: spawn LSP + client with `SS_MUSIG_STATELESS=1`, run `--demo --test-leaf-advance`, verify the new flow completes end-to-end and signed_tx is valid (follow-up after merge)
- [ ] Audit: verify no `secp256k1_musig_secnonce` lifetime spans a `wire_recv` call in the new function (follow-up; the in-code comment asserts this)

## Phase 1 progress

| Phase | Status | What |
|---|---|---|
| 1a (#321) | ✅ merged | `MSG_CEREMONY_ABORT` opcode + `--musig-stateless` flag |
| 1b (#323) | ✅ merged | Wire opcodes for new flow |
| **1c (this PR)** | **opening** | **Reversed flow wired into per-leaf advance code paths** |
| 1d | future | Poison TX support in new flow |
| 1e | future | Same pattern for Tier B + sub-factory advance + factory creation |
| 1f | future | Phase 2: switch the default + signet validation |

Closes the Phase 1c portion of task #271 (master MuSig redesign #261).

## References

- `MUSIG_NONCE_REDESIGN_MEMO.md` §3.1 (happy-path flow)
- `docs/musig-stateless-audit.md` §3a (current per-leaf advance shape this PR reverses)
- PR #321 (Phase 1a — opcode + flag groundwork)
- PR #323 (Phase 1b — wire opcodes for new flow)
