### PR TITLE
test(musig): Phase 1c validation infra — --test-wire-leaf-advance flag + regtest

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -1332,6 +1332,7 @@ int main(int argc, char *argv[]) {
     const char *notify_webhook = NULL;  /* --notify-webhook URL */
     const char *notify_exec = NULL;     /* --notify-exec SCRIPT */
     int test_rebalance = 0;
+    int test_wire_leaf_advance = 0;  /* Phase 1c validation */
     int test_batch_rebalance = 0;
     int test_realloc = 0;
     int test_tier_b_rollover = 0;  /* Tier B (Gap B+F) — drive root rollover */
@@ -1558,6 +1559,8 @@ int main(int argc, char *argv[]) {
             breach_test = 2;  /* 2 = cheat-daemon mode (no LSP watchtower, sleep after breach) */
         else if (strcmp(argv[i], "--test-rebalance") == 0)
             test_rebalance = 1;
+        else if (strcmp(argv[i], "--test-wire-leaf-advance") == 0)
+            test_wire_leaf_advance = 1;  /* Phase 1c validation */
         else if (strcmp(argv[i], "--test-batch-rebalance") == 0)
             test_batch_rebalance = 1;
         else if (strcmp(argv[i], "--test-realloc") == 0)

--- a/tools/superscalar_lsp_post_daemon_tests.inc
+++ b/tools/superscalar_lsp_post_daemon_tests.inc
@@ -839,6 +839,27 @@
         return 0;
     }
 
+    /* === Phase 1c Validation: Post-Daemon Wire Leaf Advance ===
+       Existing leaf-advance tests run pre-daemon via single-process simulation
+       that bypasses lsp_advance_leaf entirely.  This test runs the REAL wire
+       ceremony against TCP-connected clients to validate both:
+         - Legacy path (default)
+         - Phase 1c new path (when SS_MUSIG_STATELESS=1) */
+    if (test_wire_leaf_advance && channels_active) {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        printf("\n=== POST-DAEMON WIRE LEAF ADVANCE TEST (stateless=%s) ===\n",
+               (stateless && stateless[0] == '1') ? "1" : "0");
+        fflush(stdout);
+        int adv_rc = lsp_channels_advance_ps_leaf(mgr, lsp_p, 0);
+        if (adv_rc == 1) {
+            printf("=== POST-DAEMON WIRE LEAF ADVANCE: PASS ===\n");
+        } else {
+            printf("=== POST-DAEMON WIRE LEAF ADVANCE: FAIL (rc=%d) ===\n", adv_rc);
+        }
+        fflush(stdout);
+        test_wire_leaf_advance = 0;  /* fire once */
+    }
+
     /* === Auto-Rebalance Test === */
     if (test_rebalance && channels_active) {
         printf("\n=== AUTO-REBALANCE TEST ===\n");

--- a/tools/test_regtest_wire_leaf_advance.sh
+++ b/tools/test_regtest_wire_leaf_advance.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Phase 1c validation regtest — drives lsp_advance_leaf via the POST-DAEMON
+# wire ceremony path (not the pre-daemon single-process simulation path that
+# every other existing leaf-advance test uses).
+#
+# Runs twice:
+#   1. Without SS_MUSIG_STATELESS — validates legacy wire ceremony works
+#   2. With SS_MUSIG_STATELESS=1   — validates Phase 1c new flow works
+#
+# PASS when both runs produce "POST-DAEMON WIRE LEAF ADVANCE: PASS" in the
+# LSP log.
+
+set -u
+BUILD_DIR="${SUPERSCALAR_BUILD_DIR:-/root/SuperScalar/build-release}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+N_CLIENTS=2
+FUNDING_SATS=100000
+LSP_PORT=29960  # distinct port
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+)
+RPCUSER="${RPCUSER:-rpcuser}"
+RPCPASSWORD="${RPCPASSWORD:-rpcpass}"
+
+PIDS=()
+cleanup() {
+    for pid in "${PIDS[@]}"; do
+        kill -9 "$pid" 2>/dev/null
+    done
+    wait 2>/dev/null
+}
+trap cleanup EXIT
+
+run_one() {
+    local label="$1"
+    local stateless="$2"
+
+    echo
+    echo "================================================================"
+    echo "= $label (SS_MUSIG_STATELESS=$stateless)"
+    echo "================================================================"
+
+    local TAG="wire_leaf_advance_${stateless}"
+    local LSP_LOG="/tmp/${TAG}_lsp.log"
+    local LSP_DB="/tmp/${TAG}.db"
+    rm -f "$LSP_DB" "$LSP_LOG" /tmp/${TAG}_client*.log
+
+    # Wallet must exist; reuse cheat_leaf miner pattern
+    bitcoin-cli -regtest -rpcuser="$RPCUSER" -rpcpassword="$RPCPASSWORD" \
+        createwallet ss_wire_leaf_advance_miner 2>/dev/null || true
+    bitcoin-cli -regtest -rpcuser="$RPCUSER" -rpcpassword="$RPCPASSWORD" \
+        -rpcwallet=ss_wire_leaf_advance_miner getnewaddress > /dev/null
+
+    # LSP
+    echo "--- LSP daemon (--demo --test-wire-leaf-advance) ---"
+    SS_MUSIG_STATELESS=$stateless \
+    ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+    "$LSP_BIN" \
+        --network regtest \
+        --port "$LSP_PORT" \
+        --clients "$N_CLIENTS" \
+        --arity 1 \
+        --amount "$FUNDING_SATS" \
+        --fee-rate 1000 \
+        --confirm-timeout 600 \
+        --active-blocks 6 \
+        --dying-blocks 4 \
+        --step-blocks 1 \
+        --states-per-layer 2 \
+        --seckey "$LSP_SECKEY" \
+        --rpcuser "$RPCUSER" \
+        --rpcpassword "$RPCPASSWORD" \
+        --wallet ss_wire_leaf_advance_miner \
+        --db "$LSP_DB" \
+        --demo --test-wire-leaf-advance \
+        --lsp-balance-pct 50 \
+        > "$LSP_LOG" 2>&1 &
+    LSP_PID=$!
+    PIDS+=($LSP_PID)
+
+    # Wait for LSP listening
+    for i in $(seq 1 60); do
+        sleep 1
+        if grep -q "LSP: listening" "$LSP_LOG" 2>/dev/null; then
+            break
+        fi
+    done
+    if ! grep -q "LSP: listening" "$LSP_LOG" 2>/dev/null; then
+        echo "  FAIL: LSP did not start listening (see $LSP_LOG)"
+        return 1
+    fi
+
+    # Spawn clients
+    for n in $(seq 0 $((N_CLIENTS - 1))); do
+        local CLIENT_LOG="/tmp/${TAG}_client${n}.log"
+        SS_MUSIG_STATELESS=$stateless \
+        ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+        "$CLIENT_BIN" \
+            --network regtest \
+            --host 127.0.0.1 --port "$LSP_PORT" \
+            --daemon \
+            --seckey "${CLIENT_SECKEYS[$n]}" \
+            --fee-rate 1000 \
+            --lsp-balance-pct 50 \
+            --participant-id "$n" \
+            --rpcuser "$RPCUSER" \
+            --rpcpassword "$RPCPASSWORD" \
+            --wallet ss_wire_leaf_advance_miner \
+            --db "/tmp/${TAG}_client${n}.db" \
+            > "$CLIENT_LOG" 2>&1 &
+        PIDS+=($!)
+    done
+
+    # Wait for LSP to print PASS or FAIL for our test
+    echo "--- waiting for POST-DAEMON WIRE LEAF ADVANCE result (max 180s) ---"
+    local seen_result=0
+    for i in $(seq 1 180); do
+        sleep 1
+        if grep -q "POST-DAEMON WIRE LEAF ADVANCE: PASS\|POST-DAEMON WIRE LEAF ADVANCE: FAIL" "$LSP_LOG" 2>/dev/null; then
+            seen_result=1
+            break
+        fi
+    done
+
+    if [ "$seen_result" -eq 0 ]; then
+        echo "  FAIL: never saw POST-DAEMON WIRE LEAF ADVANCE result in $LSP_LOG"
+        echo "  tail of log:"
+        tail -15 "$LSP_LOG" | sed 's/^/    /'
+        return 1
+    fi
+
+    # Kill LSP + clients
+    for pid in "${PIDS[@]}"; do kill -9 "$pid" 2>/dev/null; done
+    PIDS=()
+    sleep 2
+
+    if grep -q "POST-DAEMON WIRE LEAF ADVANCE: PASS" "$LSP_LOG"; then
+        echo "  RESULT: PASS"
+        # Sanity: confirm stateless path was used if requested
+        if [ "$stateless" = "1" ]; then
+            if grep -q "lsp_advance_leaf_stateless" "$LSP_LOG" 2>/dev/null; then
+                echo "  STATELESS PATH: confirmed (lsp_advance_leaf_stateless invoked)"
+            else
+                echo "  WARN: SS_MUSIG_STATELESS=1 set but no stateless markers in log"
+                echo "        (Phase 1c dispatch may not have fired — investigate)"
+            fi
+        fi
+        return 0
+    else
+        echo "  RESULT: FAIL"
+        return 1
+    fi
+}
+
+LEGACY_RC=0
+STATELESS_RC=0
+
+if ! run_one "RUN 1: LEGACY wire ceremony" "0"; then
+    LEGACY_RC=1
+fi
+echo
+if ! run_one "RUN 2: PHASE 1C stateless flow" "1"; then
+    STATELESS_RC=1
+fi
+
+echo
+echo "================================================================"
+echo "= Phase 1c validation regtest result"
+echo "================================================================"
+echo "  RUN 1 (legacy):    $([ $LEGACY_RC    -eq 0 ] && echo PASS || echo FAIL)"
+echo "  RUN 2 (stateless): $([ $STATELESS_RC -eq 0 ] && echo PASS || echo FAIL)"
+
+[ $LEGACY_RC -eq 0 ] && [ $STATELESS_RC -eq 0 ]


### PR DESCRIPTION
## Summary

Adds the infrastructure to validate Phase 1c (PR #324) at runtime, which was missing.

## Why this is needed

While preparing Phase 1d, I added a probe `fprintf` at the top of `lsp_advance_leaf` and ran every existing `--test-leaf-advance` regtest with `SS_MUSIG_STATELESS=1`. **The probe never fired.** All existing leaf-advance tests exercise the pre-daemon single-process simulation path that calls MuSig directly on the LSP — they bypass `lsp_advance_leaf` (the wire-ceremony function) entirely.

So Phase 1c's new code path had **zero runtime coverage** in CI. Unit tests pass because they only hit the legacy path. The new Phase 1c code could be silently broken and no existing test would catch it.

The post-daemon wire-ceremony path lives at `src/lsp_channels.c:5316` and `:5319`, triggered automatically after HTLC fulfillment. No existing regtest exercises that entry.

## What this PR adds

1. **`--test-wire-leaf-advance` LSP flag** (`tools/superscalar_lsp.c`). When set, runs `lsp_channels_advance_ps_leaf(0)` ONCE post-daemon (in the `channels_active` block of `post_daemon_tests.inc`) — invokes the REAL wire ceremony against TCP-connected clients.

2. **`tools/test_regtest_wire_leaf_advance.sh`** — runs the test twice:
   - **RUN 1** (`SS_MUSIG_STATELESS=0`): validates legacy wire ceremony works
   - **RUN 2** (`SS_MUSIG_STATELESS=1`): validates Phase 1c new flow works
   - Asserts `POST-DAEMON WIRE LEAF ADVANCE: PASS` in LSP log for both
   - RUN 2 additionally greps for `lsp_advance_leaf_stateless` markers to confirm the new code path actually ran (not just that the env var was set)

## Validation status

- [x] Build clean
- [x] 1472/1472 unit tests pass (no regression on legacy path)
- [ ] **End-to-end test run** — couldn't complete in this session (SSH connection instability during the long 600s timeout). The infrastructure is ready; one run command verifies both paths.

## How to validate after merge

```bash
SUPERSCALAR_BUILD_DIR=/path/to/build-release \
  bash tools/test_regtest_wire_leaf_advance.sh
```

Expected output:
```
RUN 1 (legacy):    PASS
RUN 2 (stateless): PASS
```

If RUN 2 FAILs, Phase 1c has a runtime bug. If RUN 1 FAILs, **the legacy wire ceremony has a long-standing bug** (which is also valuable to know — none of our existing tests would have caught it).

## Next phases

This unblocks safe progression:
- **Phase 1d** (poison TX in new flow) — now has a test to validate
- **Phase 1e** (Tier B / sub-factory / factory creation) — will use the same pattern
- **Phase 2** (flip default) — much safer with this test infrastructure

Closes the validation infrastructure gap from #324.

## References

- PR #321 (Phase 1a — opcode + flag)
- PR #323 (Phase 1b — wire opcodes)
- PR #324 (Phase 1c — flow wired)
- `MUSIG_NONCE_REDESIGN_MEMO.md` §3.1
