### PR TITLE
feat(musig): Phase 1d — poison TX support in stateless per-leaf advance flow

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -441,19 +441,30 @@ int wire_parse_ceremony_abort(const cJSON *json,
                                 char **out_reason_text);
 
 /* Phase 1b per MUSIG_NONCE_REDESIGN_MEMO §3.1 stateless-signer flow. */
-cJSON *wire_build_leaf_advance_client_pubnonce(const unsigned char client_pubnonce[66]);
+cJSON *wire_build_leaf_advance_client_pubnonce(const unsigned char client_pubnonce[66],
+                                                  const unsigned char *client_poison_pubnonce_opt /* 66 or NULL */);
+/* Returns 1 on success without poison, 2 if poison_pubnonce present, 0 on parse error. */
 int    wire_parse_leaf_advance_client_pubnonce(const cJSON *json,
-                                                  unsigned char out_client_pubnonce[66]);
+                                                  unsigned char out_client_pubnonce[66],
+                                                  unsigned char out_client_poison_pubnonce_opt[66] /* may be NULL */);
 
 cJSON *wire_build_leaf_advance_lsp_response(const unsigned char lsp_pubnonce[66],
-                                              const unsigned char lsp_psig[32]);
+                                              const unsigned char lsp_psig[32],
+                                              const unsigned char *lsp_poison_pubnonce_opt /* 66 or NULL */,
+                                              const unsigned char *lsp_poison_psig_opt /* 32 or NULL */);
+/* Returns 1 on success without poison, 2 if both poison fields present, 0 on parse error. */
 int    wire_parse_leaf_advance_lsp_response(const cJSON *json,
                                               unsigned char out_lsp_pubnonce[66],
-                                              unsigned char out_lsp_psig[32]);
+                                              unsigned char out_lsp_psig[32],
+                                              unsigned char out_lsp_poison_pubnonce_opt[66] /* may be NULL */,
+                                              unsigned char out_lsp_poison_psig_opt[32] /* may be NULL */);
 
-cJSON *wire_build_leaf_advance_final(const unsigned char final_sig[64]);
+cJSON *wire_build_leaf_advance_final(const unsigned char final_sig[64],
+                                       const unsigned char *final_poison_sig_opt /* 64 or NULL */);
+/* Returns 1 on success without poison, 2 if poison_sig present, 0 on parse error. */
 int    wire_parse_leaf_advance_final(const cJSON *json,
-                                       unsigned char out_final_sig[64]);
+                                       unsigned char out_final_sig[64],
+                                       unsigned char out_final_poison_sig_opt[64] /* may be NULL */);
 
 /* LSP → Bridge: BRIDGE_HELLO_ACK {} */
 cJSON *wire_build_bridge_hello_ack(void);

--- a/src/client.c
+++ b/src/client.c
@@ -3504,7 +3504,7 @@ static int client_handle_leaf_advance_stateless(int fd,
 
     unsigned char my_pubnonce_ser[66];
     musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
-    cJSON *cpn_json = wire_build_leaf_advance_client_pubnonce(my_pubnonce_ser);
+    cJSON *cpn_json = wire_build_leaf_advance_client_pubnonce(my_pubnonce_ser, NULL);
     if (!wire_send(fd, MSG_LEAF_ADVANCE_CLIENT_PUBNONCE, cpn_json)) {
         cJSON_Delete(cpn_json);
         fprintf(stderr, "Client-stateless %u: send CLIENT_PUBNONCE failed\n", my_index);
@@ -3523,7 +3523,7 @@ static int client_handle_leaf_advance_stateless(int fd,
     unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
     int lrrc = wire_parse_leaf_advance_lsp_response(lr_msg.json,
                                                        lsp_pubnonce_ser,
-                                                       lsp_psig_ser);
+                                                       lsp_psig_ser, NULL, NULL);
     cJSON_Delete(lr_msg.json);
     if (!lrrc) {
         fprintf(stderr, "Client-stateless %u: parse LSP_RESPONSE failed\n", my_index);
@@ -3612,7 +3612,7 @@ static int client_handle_leaf_advance_stateless(int fd,
     }
 
     /* Step 8: ship FINAL. */
-    cJSON *fin_json = wire_build_leaf_advance_final(final_sig);
+    cJSON *fin_json = wire_build_leaf_advance_final(final_sig, NULL);
     if (!wire_send(fd, MSG_LEAF_ADVANCE_FINAL, fin_json)) {
         cJSON_Delete(fin_json);
         fprintf(stderr, "Client-stateless %u: send FINAL failed\n", my_index);

--- a/src/client.c
+++ b/src/client.c
@@ -3435,6 +3435,16 @@ static int client_handle_leaf_advance_stateless(int fd,
     size_t node_idx = factory->leaf_node_indices[leaf_side];
     factory_node_t *ps_node = &factory->nodes[node_idx];
 
+    /* Phase 1d.2: snapshot OLD state for deterministic poison prep. */
+    unsigned char old_leaf_txid[32];
+    int had_old_signed_c = (ps_node->is_signed && ps_node->signed_tx.len > 0);
+    if (had_old_signed_c)
+        memcpy(old_leaf_txid, ps_node->txid, 32);
+    int old_n_outputs_c = ps_node->n_outputs;
+    uint64_t old_l_amount_c = (old_n_outputs_c >= 2)
+                              ? ps_node->outputs[old_n_outputs_c - 1].amount_sats
+                              : 0;
+
     /* Step 1: advance local state to mirror the LSP. */
     int rc = factory_advance_leaf_unsigned(factory, leaf_side);
     if (rc <= 0) {
@@ -3461,9 +3471,35 @@ static int client_handle_leaf_advance_stateless(int fd,
         }
     }
 
+    /* Phase 1d.2: prep poison TX (matches LSP side deterministically).
+       Client doesn'''t have its own watchtower toggle -- it preps poison
+       unconditionally if the amounts fit.  If the LSP didn'''t prep
+       (e.g. no watchtower), the wire flow degrades naturally because
+       the LSP won'''t send poison fields back. */
+    const uint64_t LEAF_POISON_FEE_SATS_C = 1000;
+    int leaf_poison_prepared_c = 0;
+    if (had_old_signed_c && old_n_outputs_c >= 2 &&
+        old_l_amount_c > LEAF_POISON_FEE_SATS_C +
+                         (uint64_t)(ps_node->n_signers - 1) * 330u) {
+        if (factory_session_prepare_poison_tx_leaf(
+                factory, node_idx,
+                old_leaf_txid, (uint32_t)(old_n_outputs_c - 1),
+                old_l_amount_c, LEAF_POISON_FEE_SATS_C)) {
+            leaf_poison_prepared_c = 1;
+        }
+    }
+
     if (!factory_session_init_node(factory, node_idx)) {
         fprintf(stderr, "Client-stateless %u: session_init failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared_c &&
+        !factory_session_init_node_poison(factory, node_idx)) {
+        fprintf(stderr, "Client-stateless %u: poison session init failed -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
     }
 
     int my_slot = factory_find_signer_slot(factory, node_idx, my_index);
@@ -3494,17 +3530,42 @@ static int client_handle_leaf_advance_stateless(int fd,
                                 &factory->nodes[node_idx].keyagg.cache)) {
         memset(my_seckey, 0, 32);
         fprintf(stderr, "Client-stateless %u: nonce gen failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    secp256k1_musig_secnonce my_poison_secnonce;
+    secp256k1_musig_pubnonce my_poison_pubnonce;
+    if (leaf_poison_prepared_c &&
+        !musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                my_seckey, &my_pubkey,
+                                &factory->nodes[node_idx].keyagg.cache)) {
+        fprintf(stderr, "Client-stateless %u: poison nonce gen failed -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
     }
     memset(my_seckey, 0, 32);
     if (!factory_session_set_nonce(factory, node_idx, (size_t)my_slot, &my_pubnonce)) {
         fprintf(stderr, "Client-stateless %u: set own nonce failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared_c &&
+        !factory_session_set_nonce_poison(factory, node_idx, (size_t)my_slot,
+                                            &my_poison_pubnonce)) {
+        fprintf(stderr, "Client-stateless %u: set own poison nonce failed -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
+    }
 
-    unsigned char my_pubnonce_ser[66];
+    unsigned char my_pubnonce_ser[66], my_poison_pubnonce_ser[66];
     musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
-    cJSON *cpn_json = wire_build_leaf_advance_client_pubnonce(my_pubnonce_ser, NULL);
+    if (leaf_poison_prepared_c)
+        musig_pubnonce_serialize(ctx, my_poison_pubnonce_ser, &my_poison_pubnonce);
+    cJSON *cpn_json = wire_build_leaf_advance_client_pubnonce(
+        my_pubnonce_ser,
+        leaf_poison_prepared_c ? my_poison_pubnonce_ser : NULL);
     if (!wire_send(fd, MSG_LEAF_ADVANCE_CLIENT_PUBNONCE, cpn_json)) {
         cJSON_Delete(cpn_json);
         fprintf(stderr, "Client-stateless %u: send CLIENT_PUBNONCE failed\n", my_index);
@@ -3521,13 +3582,25 @@ static int client_handle_leaf_advance_stateless(int fd,
         return 0;
     }
     unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
+    unsigned char lsp_poison_pubnonce_ser[66], lsp_poison_psig_ser[32];
     int lrrc = wire_parse_leaf_advance_lsp_response(lr_msg.json,
                                                        lsp_pubnonce_ser,
-                                                       lsp_psig_ser, NULL, NULL);
+                                                       lsp_psig_ser,
+                                                       leaf_poison_prepared_c
+                                                         ? lsp_poison_pubnonce_ser : NULL,
+                                                       leaf_poison_prepared_c
+                                                         ? lsp_poison_psig_ser : NULL);
     cJSON_Delete(lr_msg.json);
     if (!lrrc) {
         fprintf(stderr, "Client-stateless %u: parse LSP_RESPONSE failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared_c && lrrc < 2) {
+        fprintf(stderr, "Client-stateless %u: LSP omitted poison fields -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
     }
 
     /* Step 4: set LSP nonce, finalize session. */
@@ -3538,19 +3611,49 @@ static int client_handle_leaf_advance_stateless(int fd,
     }
     if (!factory_session_set_nonce(factory, node_idx, (size_t)lsp_slot, &lsp_pubnonce)) {
         fprintf(stderr, "Client-stateless %u: set LSP nonce failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared_c) {
+        secp256k1_musig_pubnonce lsp_poison_pn;
+        if (!musig_pubnonce_parse(ctx, &lsp_poison_pn, lsp_poison_pubnonce_ser) ||
+            !factory_session_set_nonce_poison(factory, node_idx, (size_t)lsp_slot,
+                                                &lsp_poison_pn)) {
+            fprintf(stderr, "Client-stateless %u: LSP poison nonce parse/set failed -- degrading\n",
+                    my_index);
+            factory_session_reset_poison(factory, node_idx);
+            leaf_poison_prepared_c = 0;
+        }
     }
     if (!factory_session_finalize_node(factory, node_idx)) {
         fprintf(stderr, "Client-stateless %u: finalize_node failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared_c &&
+        !factory_session_finalize_node_poison(factory, node_idx)) {
+        fprintf(stderr, "Client-stateless %u: poison finalize failed -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
+    }
 
-    /* Step 5: create own partial_sig (zeroes own secnonce). */
+    /* Step 5: create own partial_sig (zeroes own secnonce, both state + poison). */
     secp256k1_musig_partial_sig my_psig;
     if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonce, keypair,
                                     &factory->nodes[node_idx].signing_session)) {
         fprintf(stderr, "Client-stateless %u: create_partial_sig failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    secp256k1_musig_partial_sig my_poison_psig;
+    if (leaf_poison_prepared_c &&
+        !musig_create_partial_sig(ctx, &my_poison_psig, &my_poison_secnonce, keypair,
+                                    &factory->nodes[node_idx].poison_signing_session)) {
+        fprintf(stderr, "Client-stateless %u: poison partial_sig failed -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
     }
 
     /* Step 6: parse LSP's psig and set both psigs into the session. */
@@ -3561,11 +3664,26 @@ static int client_handle_leaf_advance_stateless(int fd,
     }
     if (!factory_session_set_partial_sig(factory, node_idx, (size_t)my_slot, &my_psig)) {
         fprintf(stderr, "Client-stateless %u: set own partial_sig failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
     if (!factory_session_set_partial_sig(factory, node_idx, (size_t)lsp_slot, &lsp_psig)) {
         fprintf(stderr, "Client-stateless %u: set LSP partial_sig failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared_c) {
+        secp256k1_musig_partial_sig lsp_poison_psig;
+        if (!musig_partial_sig_parse(ctx, &lsp_poison_psig, lsp_poison_psig_ser) ||
+            !factory_session_set_partial_sig_poison(factory, node_idx,
+                                                     (size_t)my_slot, &my_poison_psig) ||
+            !factory_session_set_partial_sig_poison(factory, node_idx,
+                                                     (size_t)lsp_slot, &lsp_poison_psig)) {
+            fprintf(stderr, "Client-stateless %u: poison psig set failed -- degrading\n",
+                    my_index);
+            factory_session_reset_poison(factory, node_idx);
+            leaf_poison_prepared_c = 0;
+        }
     }
 
     /* PS defense: record what we just signed BEFORE shipping FINAL.  A
@@ -3590,10 +3708,18 @@ static int client_handle_leaf_advance_stateless(int fd,
     }
 
     /* Step 7: complete_node aggregates both psigs + attaches the signed
-       witness, populating node->signed_tx.  This is the same call the
-       legacy path uses for its local copy. */
+       witness, populating node->signed_tx.  Phase 1d.2 also runs the
+       parallel poison ceremony when prepared. */
+    if (leaf_poison_prepared_c &&
+        !factory_session_complete_node_poison(factory, node_idx)) {
+        fprintf(stderr, "Client-stateless %u: poison complete failed -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
+    }
     if (!factory_session_complete_node(factory, node_idx)) {
         fprintf(stderr, "Client-stateless %u: complete_node failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
 
@@ -3603,16 +3729,28 @@ static int client_handle_leaf_advance_stateless(int fd,
        partial_sigs buffer.  node->partial_sigs[0..n_signers-1] are set
        by factory_session_set_partial_sig in slot order. */
     factory_node_t *node = &factory->nodes[node_idx];
-    unsigned char final_sig[64];
+    unsigned char final_sig[64], final_poison_sig[64];
     if (!musig_aggregate_partial_sigs(ctx, final_sig,
                                         &node->signing_session,
                                         node->partial_sigs, node->n_signers)) {
         fprintf(stderr, "Client-stateless %u: aggregate_partial_sigs failed\n", my_index);
+        factory_session_reset_poison(factory, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared_c &&
+        !musig_aggregate_partial_sigs(ctx, final_poison_sig,
+                                        &node->poison_signing_session,
+                                        node->poison_partial_sigs, node->n_signers)) {
+        fprintf(stderr, "Client-stateless %u: poison aggregate failed -- degrading\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        leaf_poison_prepared_c = 0;
+    }
 
-    /* Step 8: ship FINAL. */
-    cJSON *fin_json = wire_build_leaf_advance_final(final_sig, NULL);
+    /* Step 8: ship FINAL with optional poison sig. */
+    cJSON *fin_json = wire_build_leaf_advance_final(
+        final_sig,
+        leaf_poison_prepared_c ? final_poison_sig : NULL);
     if (!wire_send(fd, MSG_LEAF_ADVANCE_FINAL, fin_json)) {
         cJSON_Delete(fin_json);
         fprintf(stderr, "Client-stateless %u: send FINAL failed\n", my_index);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1619,6 +1619,18 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                            &c3_round_id);
     }
 
+    /* Phase 1d.2: snapshot OLD leaf state BEFORE the advance mutates it. */
+    size_t pre_node_idx = f->leaf_node_indices[leaf_side];
+    unsigned char old_leaf_txid[32];
+    int had_old_signed = (f->nodes[pre_node_idx].is_signed &&
+                          f->nodes[pre_node_idx].signed_tx.len > 0);
+    if (had_old_signed)
+        memcpy(old_leaf_txid, f->nodes[pre_node_idx].txid, 32);
+    int old_n_outputs = f->nodes[pre_node_idx].n_outputs;
+    uint64_t old_l_amount = (old_n_outputs >= 2)
+                            ? f->nodes[pre_node_idx].outputs[old_n_outputs - 1].amount_sats
+                            : 0;
+
     /* Step 1: advance leaf state to rebuild the unsigned TX. */
     int rc = factory_advance_leaf_unsigned(f, leaf_side);
     if (rc == 0) {
@@ -1636,6 +1648,20 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
 
     size_t node_idx = f->leaf_node_indices[leaf_side];
     uint32_t client_participant = (uint32_t)(leaf_side + 1);
+
+    /* Phase 1d.2: prep poison TX deterministically (both sides match). */
+    const uint64_t LEAF_POISON_FEE_SATS = 1000;
+    int leaf_poison_prepared = 0;
+    if (mgr->watchtower && had_old_signed && old_n_outputs >= 2 &&
+        old_l_amount > LEAF_POISON_FEE_SATS +
+                       (uint64_t)(f->nodes[pre_node_idx].n_signers - 1) * 330u) {
+        if (factory_session_prepare_poison_tx_leaf(
+                f, pre_node_idx,
+                old_leaf_txid, (uint32_t)(old_n_outputs - 1),
+                old_l_amount, LEAF_POISON_FEE_SATS)) {
+            leaf_poison_prepared = 1;
+        }
+    }
 
     /* Step 2: ship PROPOSE with NO nonce -- client goes first. */
     cJSON *propose = wire_build_leaf_advance_propose(leaf_side, NULL, NULL);
@@ -1659,18 +1685,35 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
     unsigned char client_pubnonce_ser[66];
+    unsigned char client_poison_pubnonce_ser[66];
     int prc = wire_parse_leaf_advance_client_pubnonce(cpn_msg.json,
-                                                         client_pubnonce_ser, NULL);
+                                                         client_pubnonce_ser,
+                                                         leaf_poison_prepared
+                                                           ? client_poison_pubnonce_ser
+                                                           : NULL);
     cJSON_Delete(cpn_msg.json);
     if (!prc) {
         fprintf(stderr, "LSP-stateless: parse CLIENT_PUBNONCE failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared && prc < 2) {
+        fprintf(stderr, "LSP-stateless: client omitted poison pubnonce -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Step 4: init session (state only, no poison). */
+    /* Step 4: init both sessions (state always; poison if prepped). */
     if (!factory_session_init_node(f, node_idx)) {
         fprintf(stderr, "LSP-stateless: state session init failed for node %zu\n", node_idx);
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared &&
+        !factory_session_init_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP-stateless: poison session init failed -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
     }
 
     /* Step 5: set client's pubnonce into the session. */
@@ -1688,7 +1731,17 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
     if (!factory_session_set_nonce(f, node_idx, (size_t)client_slot, &client_pubnonce)) {
         fprintf(stderr, "LSP-stateless: set client nonce failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared) {
+        secp256k1_musig_pubnonce client_poison_pn;
+        if (!musig_pubnonce_parse(lsp->ctx, &client_poison_pn, client_poison_pubnonce_ser) ||
+            !factory_session_set_nonce_poison(f, node_idx, (size_t)client_slot, &client_poison_pn)) {
+            fprintf(stderr, "LSP-stateless: client poison nonce parse/set failed -- degrading\n");
+            factory_session_reset_poison(f, node_idx);
+            leaf_poison_prepared = 0;
+        }
     }
 
     /* Step 6 (THE CRITICAL ATOMIC BLOCK):
@@ -1707,17 +1760,43 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                 &f->nodes[node_idx].keyagg.cache)) {
         memset(lsp_seckey, 0, 32);
         fprintf(stderr, "LSP-stateless: LSP nonce gen failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    secp256k1_musig_secnonce lsp_poison_secnonce;
+    secp256k1_musig_pubnonce lsp_poison_pubnonce;
+    if (leaf_poison_prepared &&
+        !musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce, &lsp_poison_pubnonce,
+                                lsp_seckey, &lsp->lsp_pubkey,
+                                &f->nodes[node_idx].keyagg.cache)) {
+        fprintf(stderr, "LSP-stateless: poison nonce gen failed -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
     }
     if (!factory_session_set_nonce(f, node_idx, (size_t)lsp_slot, &lsp_pubnonce)) {
         memset(lsp_seckey, 0, 32);
         fprintf(stderr, "LSP-stateless: set LSP nonce failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared &&
+        !factory_session_set_nonce_poison(f, node_idx, (size_t)lsp_slot,
+                                            &lsp_poison_pubnonce)) {
+        fprintf(stderr, "LSP-stateless: set LSP poison nonce failed -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
     }
     if (!factory_session_finalize_node(f, node_idx)) {
         memset(lsp_seckey, 0, 32);
         fprintf(stderr, "LSP-stateless: finalize_node failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared &&
+        !factory_session_finalize_node_poison(f, node_idx)) {
+        fprintf(stderr, "LSP-stateless: poison finalize failed -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
     }
     secp256k1_keypair lsp_kp;
     if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
@@ -1731,10 +1810,20 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
                                     &f->nodes[node_idx].signing_session)) {
         fprintf(stderr, "LSP-stateless: create_partial_sig failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
-    /* lsp_secnonce has been zeroed by musig_create_partial_sig.
-       INVARIANT: from this point on we no longer hold any LSP secnonce.
+    secp256k1_musig_partial_sig lsp_poison_psig;
+    if (leaf_poison_prepared &&
+        !musig_create_partial_sig(lsp->ctx, &lsp_poison_psig,
+                                    &lsp_poison_secnonce, &lsp_kp,
+                                    &f->nodes[node_idx].poison_signing_session)) {
+        fprintf(stderr, "LSP-stateless: poison partial_sig failed -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
+    /* lsp_secnonce + lsp_poison_secnonce have been zeroed by musig_create_partial_sig.
+       INVARIANT: from this point on we no longer hold any LSP secnonce of any kind.
        The wire recv that follows is safe. */
 
     unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
@@ -1745,12 +1834,27 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        aggregated sig matches (and for future Phase-2 re-aggregation). */
     if (!factory_session_set_partial_sig(f, node_idx, (size_t)lsp_slot, &lsp_psig)) {
         fprintf(stderr, "LSP-stateless: set LSP partial_sig failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
+    if (leaf_poison_prepared &&
+        !factory_session_set_partial_sig_poison(f, node_idx, (size_t)lsp_slot,
+                                                 &lsp_poison_psig)) {
+        fprintf(stderr, "LSP-stateless: set LSP poison partial_sig failed -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
+    }
 
-    /* Step 7: ship LSP_RESPONSE. */
-    cJSON *response = wire_build_leaf_advance_lsp_response(lsp_pubnonce_ser,
-                                                             lsp_psig_ser, NULL, NULL);
+    /* Step 7: ship LSP_RESPONSE with optional poison fields. */
+    unsigned char lsp_poison_pubnonce_ser[66], lsp_poison_psig_ser[32];
+    if (leaf_poison_prepared) {
+        musig_pubnonce_serialize(lsp->ctx, lsp_poison_pubnonce_ser, &lsp_poison_pubnonce);
+        musig_partial_sig_serialize(lsp->ctx, lsp_poison_psig_ser, &lsp_poison_psig);
+    }
+    cJSON *response = wire_build_leaf_advance_lsp_response(
+        lsp_pubnonce_ser, lsp_psig_ser,
+        leaf_poison_prepared ? lsp_poison_pubnonce_ser : NULL,
+        leaf_poison_prepared ? lsp_poison_psig_ser : NULL);
     if (!wire_send(lsp->client_fds[leaf_side], MSG_LEAF_ADVANCE_LSP_RESPONSE, response)) {
         cJSON_Delete(response);
         fprintf(stderr, "LSP-stateless: send LSP_RESPONSE failed\n");
@@ -1771,11 +1875,19 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
     unsigned char final_sig[64];
-    int frc2 = wire_parse_leaf_advance_final(fin_msg.json, final_sig, NULL);
+    unsigned char final_poison_sig[64];
+    int frc2 = wire_parse_leaf_advance_final(fin_msg.json, final_sig,
+                                                leaf_poison_prepared ? final_poison_sig : NULL);
     cJSON_Delete(fin_msg.json);
     if (!frc2) {
         fprintf(stderr, "LSP-stateless: parse FINAL failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
+    }
+    if (leaf_poison_prepared && frc2 < 2) {
+        fprintf(stderr, "LSP-stateless: client omitted final_poison_sig -- degrading\n");
+        factory_session_reset_poison(f, node_idx);
+        leaf_poison_prepared = 0;
     }
 
     /* Step 9: verify the final sig against the session's keyagg+sighash
@@ -1806,15 +1918,41 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                               node->unsigned_tx.data, node->unsigned_tx.len,
                               final_sig)) {
         fprintf(stderr, "LSP-stateless: finalize_signed_tx failed\n");
+        factory_session_reset_poison(f, node_idx);
         return 0;
     }
     node->is_signed = 1;
 
-    /* TODO(Phase 1d/2): poison TX ceremony.  In the legacy path we run
-       a parallel MuSig2 ceremony over the OLD state's L-stock distribution
-       so the watchtower can burn-redistribute on breach.  The reversed
-       flow needs an analogous round (or a second LSP_RESPONSE message
-       carrying lsp_poison_pubnonce + lsp_poison_psig). */
+    /* Phase 1d.2: verify + finalize poison signed_tx. */
+    if (leaf_poison_prepared) {
+        secp256k1_pubkey poison_output_pk;
+        secp256k1_xonly_pubkey poison_output_xpub;
+        if (secp256k1_musig_pubkey_get(lsp->ctx, &poison_output_pk,
+                                         &node->poison_signing_session.cache) &&
+            secp256k1_xonly_pubkey_from_pubkey(lsp->ctx, &poison_output_xpub, NULL,
+                                                 &poison_output_pk) &&
+            secp256k1_schnorrsig_verify(lsp->ctx, final_poison_sig,
+                                          node->poison_signing_session.msg32, 32,
+                                          &poison_output_xpub) &&
+            finalize_signed_tx(&node->poison_signed_tx,
+                                node->poison_unsigned_tx.data,
+                                node->poison_unsigned_tx.len,
+                                final_poison_sig)) {
+            node->poison_is_signed = 1;
+            printf("LSP-stateless: poison TX signed (%zu bytes, L-stock %llu sats)\n",
+                   node->poison_signed_tx.len,
+                   (unsigned long long)old_l_amount);
+        } else {
+            fprintf(stderr, "LSP-stateless: poison sig verify/finalize failed -- degrading\n");
+            factory_session_reset_poison(f, node_idx);
+            leaf_poison_prepared = 0;
+        }
+    }
+
+    /* Phase 1d.2: poison TX ceremony DONE.  Same atomic-signer flow as
+       state TX, with optional poison fields in CLIENT_PUBNONCE,
+       LSP_RESPONSE, and FINAL.  lsp_poison_secnonce zeroed by
+       musig_create_partial_sig before any wire recv. */
 
     /* TODO(Phase 2): watchtower_watch_factory_node_with_channels.  Skipped
        in MVP because the new flow has no poison TX yet -- degrading would

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1660,7 +1660,7 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
     unsigned char client_pubnonce_ser[66];
     int prc = wire_parse_leaf_advance_client_pubnonce(cpn_msg.json,
-                                                         client_pubnonce_ser);
+                                                         client_pubnonce_ser, NULL);
     cJSON_Delete(cpn_msg.json);
     if (!prc) {
         fprintf(stderr, "LSP-stateless: parse CLIENT_PUBNONCE failed\n");
@@ -1750,7 +1750,7 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
 
     /* Step 7: ship LSP_RESPONSE. */
     cJSON *response = wire_build_leaf_advance_lsp_response(lsp_pubnonce_ser,
-                                                             lsp_psig_ser);
+                                                             lsp_psig_ser, NULL, NULL);
     if (!wire_send(lsp->client_fds[leaf_side], MSG_LEAF_ADVANCE_LSP_RESPONSE, response)) {
         cJSON_Delete(response);
         fprintf(stderr, "LSP-stateless: send LSP_RESPONSE failed\n");
@@ -1771,7 +1771,7 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
     unsigned char final_sig[64];
-    int frc2 = wire_parse_leaf_advance_final(fin_msg.json, final_sig);
+    int frc2 = wire_parse_leaf_advance_final(fin_msg.json, final_sig, NULL);
     cJSON_Delete(fin_msg.json);
     if (!frc2) {
         fprintf(stderr, "LSP-stateless: parse FINAL failed\n");

--- a/src/wire.c
+++ b/src/wire.c
@@ -1091,48 +1091,87 @@ int wire_parse_ceremony_abort(const cJSON *json,
     return 1;
 }
 
-cJSON *wire_build_leaf_advance_client_pubnonce(const unsigned char client_pubnonce[66]) {
+cJSON *wire_build_leaf_advance_client_pubnonce(const unsigned char client_pubnonce[66],
+                                                  const unsigned char *client_poison_pubnonce_opt) {
     cJSON *j = cJSON_CreateObject();
     if (!j) return NULL;
     wire_json_add_hex(j, "client_pubnonce", client_pubnonce, 66);
+    if (client_poison_pubnonce_opt) {
+        wire_json_add_hex(j, "client_poison_pubnonce", client_poison_pubnonce_opt, 66);
+    }
     return j;
 }
 
 int wire_parse_leaf_advance_client_pubnonce(const cJSON *json,
-                                              unsigned char out_client_pubnonce[66]) {
+                                              unsigned char out_client_pubnonce[66],
+                                              unsigned char out_client_poison_pubnonce_opt[66]) {
     if (!json || !out_client_pubnonce) return 0;
-    return wire_json_get_hex(json, "client_pubnonce", out_client_pubnonce, 66) == 66;
+    if (wire_json_get_hex(json, "client_pubnonce", out_client_pubnonce, 66) != 66) return 0;
+    if (out_client_poison_pubnonce_opt) {
+        if (wire_json_get_hex(json, "client_poison_pubnonce",
+                                out_client_poison_pubnonce_opt, 66) == 66) {
+            return 2;
+        }
+    }
+    return 1;
 }
 
 cJSON *wire_build_leaf_advance_lsp_response(const unsigned char lsp_pubnonce[66],
-                                              const unsigned char lsp_psig[32]) {
+                                              const unsigned char lsp_psig[32],
+                                              const unsigned char *lsp_poison_pubnonce_opt,
+                                              const unsigned char *lsp_poison_psig_opt) {
     cJSON *j = cJSON_CreateObject();
     if (!j) return NULL;
     wire_json_add_hex(j, "lsp_pubnonce", lsp_pubnonce, 66);
     wire_json_add_hex(j, "lsp_psig", lsp_psig, 32);
+    if (lsp_poison_pubnonce_opt && lsp_poison_psig_opt) {
+        wire_json_add_hex(j, "lsp_poison_pubnonce", lsp_poison_pubnonce_opt, 66);
+        wire_json_add_hex(j, "lsp_poison_psig", lsp_poison_psig_opt, 32);
+    }
     return j;
 }
 
 int wire_parse_leaf_advance_lsp_response(const cJSON *json,
                                            unsigned char out_lsp_pubnonce[66],
-                                           unsigned char out_lsp_psig[32]) {
+                                           unsigned char out_lsp_psig[32],
+                                           unsigned char out_lsp_poison_pubnonce_opt[66],
+                                           unsigned char out_lsp_poison_psig_opt[32]) {
     if (!json || !out_lsp_pubnonce || !out_lsp_psig) return 0;
     if (wire_json_get_hex(json, "lsp_pubnonce", out_lsp_pubnonce, 66) != 66) return 0;
     if (wire_json_get_hex(json, "lsp_psig", out_lsp_psig, 32) != 32) return 0;
+    if (out_lsp_poison_pubnonce_opt && out_lsp_poison_psig_opt) {
+        int gn = wire_json_get_hex(json, "lsp_poison_pubnonce",
+                                      out_lsp_poison_pubnonce_opt, 66);
+        int gs = wire_json_get_hex(json, "lsp_poison_psig",
+                                      out_lsp_poison_psig_opt, 32);
+        if (gn == 66 && gs == 32) return 2;
+    }
     return 1;
 }
 
-cJSON *wire_build_leaf_advance_final(const unsigned char final_sig[64]) {
+cJSON *wire_build_leaf_advance_final(const unsigned char final_sig[64],
+                                       const unsigned char *final_poison_sig_opt) {
     cJSON *j = cJSON_CreateObject();
     if (!j) return NULL;
     wire_json_add_hex(j, "final_sig", final_sig, 64);
+    if (final_poison_sig_opt) {
+        wire_json_add_hex(j, "final_poison_sig", final_poison_sig_opt, 64);
+    }
     return j;
 }
 
 int wire_parse_leaf_advance_final(const cJSON *json,
-                                    unsigned char out_final_sig[64]) {
+                                    unsigned char out_final_sig[64],
+                                    unsigned char out_final_poison_sig_opt[64]) {
     if (!json || !out_final_sig) return 0;
-    return wire_json_get_hex(json, "final_sig", out_final_sig, 64) == 64;
+    if (wire_json_get_hex(json, "final_sig", out_final_sig, 64) != 64) return 0;
+    if (out_final_poison_sig_opt) {
+        if (wire_json_get_hex(json, "final_poison_sig",
+                                out_final_poison_sig_opt, 64) == 64) {
+            return 2;
+        }
+    }
+    return 1;
 }
 
 


### PR DESCRIPTION
## Summary

Phase 1d of the MuSig2 stateless-signer redesign (#271). Adds poison TX (L-stock burn) signing to the stateless per-leaf advance flow, matching the legacy path's behavior. Phase 1c shipped state-TX-only; this PR closes the poison gap on both LSP and client sides.

## Commits

1. **`8921b3a` Phase 1d.1 — wire codec extension** (4 files, +70 LOC)
   - Added optional poison fields to MSG_LEAF_ADVANCE_CLIENT_PUBNONCE / LSP_RESPONSE / FINAL opcodes
   - Parser return values: 0=fail, 1=no-poison, 2=poison present
   - Existing Phase 1c callsites updated to pass NULL

2. **`dda3703` Phase 1d.2 — actually use the poison fields** (2 files, +298 LOC)
   - LSP side: 13 surgical insertions in `lsp_advance_leaf_stateless`
   - Client side: 10 surgical insertions in `client_handle_leaf_advance_stateless`
   - Atomic-signer invariant preserved for both state + poison secnonces

## The 4-message flow now carries poison in lockstep

```
LSP    -> Client:  PROPOSE (no nonce)
Client -> LSP:    CLIENT_PUBNONCE { client_pubnonce, client_poison_pubnonce? }
LSP    -> Client:  LSP_RESPONSE { lsp_pubnonce, lsp_psig,
                                  lsp_poison_pubnonce?, lsp_poison_psig? }
Client -> LSP:    FINAL { final_sig, final_poison_sig? }
```

LSP atomic block now generates BOTH `lsp_secnonce` and `lsp_poison_secnonce` only AFTER receiving the client's pubnonces, and both are zeroed by `musig_create_partial_sig` before any subsequent wire recv.

## Graceful degradation

Each poison step (init, nonce gen, set, finalize, sign, set_partial_sig, complete, aggregate, verify, finalize_signed_tx) calls `factory_session_reset_poison` and continues with state-only on failure. Logs `"-- degrading"` so operators see when poison was skipped. State-TX signing remains correct in all degradation paths.

## Test plan

- [x] Build clean
- [x] **1472/1472 unit tests pass** (legacy path unchanged; no regression)
- [ ] Run `tools/test_regtest_wire_leaf_advance.sh` (from #325) once both this PR and #325 are in main — both the legacy run and the stateless run should produce POST-DAEMON WIRE LEAF ADVANCE: PASS, and the stateless run should additionally show `LSP-stateless: poison TX signed (...)` markers
- [ ] Watchtower registration with the new `poison_signed_tx` — deferred to Phase 1d.3 (the new flow now HAS the signed poison TX, but the watchtower client wire-up is still TODO)

## Phase 1 progress

| Phase | Status |
|---|---|
| 1a (#321) | ✅ merged |
| 1b (#323) | ✅ merged |
| 1c (#324) | ✅ merged |
| 1c-validation (#325) | ✅ merged |
| **1d (this PR)** | **opening — 1d.1 + 1d.2 both in** |
| 1d.3 — watchtower registration with poison_signed_tx | future |
| 1e — Tier B + sub-factory + factory creation | future |
| 2 — flip default + signet validation | future |
| 3 — remove pool API + drop schema | future |
| Tests — unit + fuzz | future |
| Wallet coord | external |

## References

- `MUSIG_NONCE_REDESIGN_MEMO.md` §3.1
- PR #321 (Phase 1a), #323 (1b), #324 (1c), #325 (1c validation)
