### PR TITLE
feat(musig): Phase 1e.1 — stateless sub-factory chain advance (k=1 MVP)

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -151,6 +151,17 @@
 #define MSG_LEAF_ADVANCE_LSP_RESPONSE     0x7B  /* LSP -> Client: lsp_pubnonce + lsp_psig (atomic generate + sign on LSP) */
 #define MSG_LEAF_ADVANCE_FINAL            0x7C  /* Client -> LSP: final aggregated sig (optional confirmation for LSP records) */
 
+/* MuSig2 stateless redesign Phase 1e (#271) -- sub-factory chain advance
+   reversed flow.  Multi-client, multi-input ceremony.  Same atomic-signer
+   property as Phase 1c/1d: LSP secnonces generated only AFTER receiving all
+   client pubnonces, zeroed by musig_create_partial_sig before any subsequent
+   wire recv.  Existing 0x73-0x77 opcodes continue to work for non-stateless
+   peers. */
+#define MSG_SUBFACTORY_PROPOSE_INTENT      0x7D  /* LSP -> Client: intent (no nonce field) */
+#define MSG_SUBFACTORY_CLIENT_PUBNONCES    0x7E  /* Client -> LSP: this client's pubnonces (one per input) */
+#define MSG_SUBFACTORY_LSP_RESPONSE        0x7F  /* LSP -> Client: lsp_pubnonces + lsp_psigs (atomic gen+sign) */
+#define MSG_SUBFACTORY_CLIENT_FINAL_PSIGS  0x80  /* Client -> LSP: client psigs (one per input, after aggregating LSP+all-clients) */
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -465,6 +476,35 @@ cJSON *wire_build_leaf_advance_final(const unsigned char final_sig[64],
 int    wire_parse_leaf_advance_final(const cJSON *json,
                                        unsigned char out_final_sig[64],
                                        unsigned char out_final_poison_sig_opt[64] /* may be NULL */);
+
+/* Phase 1e sub-factory reversed flow scaffolding.  Wire builders/parsers
+   are minimal — the actual sub-factory advance ceremony (Phase 1e.1.b)
+   will define richer payloads (per-input arrays for multi-input).  For
+   now these are stubs to be filled in. */
+cJSON *wire_build_subfactory_propose_intent(uint32_t subfactory_id, uint32_t n_inputs);
+int    wire_parse_subfactory_propose_intent(const cJSON *json,
+                                              uint32_t *out_subfactory_id,
+                                              uint32_t *out_n_inputs);
+
+cJSON *wire_build_subfactory_client_pubnonces(const unsigned char *pubnonces_per_input /* n_inputs * 66 */,
+                                                uint32_t n_inputs);
+int    wire_parse_subfactory_client_pubnonces(const cJSON *json,
+                                                unsigned char *out_pubnonces_per_input /* n_inputs * 66 */,
+                                                uint32_t expected_n_inputs);
+
+cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per_input /* n_inputs * 66 */,
+                                            const unsigned char *lsp_psigs_per_input /* n_inputs * 32 */,
+                                            uint32_t n_inputs);
+int    wire_parse_subfactory_lsp_response(const cJSON *json,
+                                            unsigned char *out_lsp_pubnonces_per_input,
+                                            unsigned char *out_lsp_psigs_per_input,
+                                            uint32_t expected_n_inputs);
+
+cJSON *wire_build_subfactory_client_final_psigs(const unsigned char *psigs_per_input /* n_inputs * 32 */,
+                                                  uint32_t n_inputs);
+int    wire_parse_subfactory_client_final_psigs(const cJSON *json,
+                                                  unsigned char *out_psigs_per_input,
+                                                  uint32_t expected_n_inputs);
 
 /* LSP → Bridge: BRIDGE_HELLO_ACK {} */
 cJSON *wire_build_bridge_hello_ack(void);

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -162,6 +162,18 @@
 #define MSG_SUBFACTORY_LSP_RESPONSE        0x7F  /* LSP -> Client: lsp_pubnonces + lsp_psigs (atomic gen+sign) */
 #define MSG_SUBFACTORY_CLIENT_FINAL_PSIGS  0x80  /* Client -> LSP: client psigs (one per input, after aggregating LSP+all-clients) */
 
+/* MuSig2 stateless redesign Phase 1e.2 (#271) -- Tier B state advance
+   reversed flow.  Multi-leaf ceremony (each affected leaf is its own MuSig
+   session).  Same atomic-signer property: LSP secnonces generated only
+   AFTER receiving all CLIENT_PATH_NONCES.  Existing 0x60-range opcodes
+   (MSG_STATE_ADVANCE_PROPOSE, MSG_PATH_NONCE_BUNDLE, MSG_PATH_ALL_NONCES,
+   MSG_PATH_PSIG_BUNDLE, MSG_PATH_SIGN_DONE) continue to work for
+   non-stateless peers. */
+#define MSG_STATE_ADV_PROPOSE_INTENT      0x81  /* LSP -> Client: intent (no nonce field) */
+#define MSG_STATE_ADV_CLIENT_PATH_NONCES  0x82  /* Client -> LSP: per-leaf pubnonces */
+#define MSG_STATE_ADV_LSP_RESPONSE        0x83  /* LSP -> Client: per-leaf lsp pubnonces + lsp psigs */
+#define MSG_STATE_ADV_CLIENT_FINAL_PSIGS  0x84  /* Client -> LSP: per-leaf client psigs */
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -510,6 +522,37 @@ cJSON *wire_build_subfactory_client_final_psigs(const unsigned char *psigs_per_i
 int    wire_parse_subfactory_client_final_psigs(const cJSON *json,
                                                   unsigned char *out_psigs_per_input,
                                                   uint32_t expected_n_inputs);
+
+/* Phase 1e.2.a Tier B state advance reversed flow wire codec.  Multi-leaf
+   ceremony: per-leaf arrays of pubnonces + psigs.  n_affected_leaves is
+   the size of each array; receiver passes expected count to size buffers. */
+cJSON *wire_build_state_adv_propose_intent(uint32_t epoch_after,
+                                              uint32_t n_affected_leaves,
+                                              int trigger_leaf_side);
+int    wire_parse_state_adv_propose_intent(const cJSON *json,
+                                              uint32_t *out_epoch_after,
+                                              uint32_t *out_n_affected_leaves,
+                                              int *out_trigger_leaf_side);
+
+cJSON *wire_build_state_adv_client_path_nonces(const unsigned char *pubnonces_per_leaf /* n * 66 */,
+                                                  uint32_t n_affected_leaves);
+int    wire_parse_state_adv_client_path_nonces(const cJSON *json,
+                                                  unsigned char *out_pubnonces_per_leaf,
+                                                  uint32_t expected_n_affected_leaves);
+
+cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_leaf /* n * 66 */,
+                                            const unsigned char *lsp_psigs_per_leaf /* n * 32 */,
+                                            uint32_t n_affected_leaves);
+int    wire_parse_state_adv_lsp_response(const cJSON *json,
+                                            unsigned char *out_lsp_pubnonces_per_leaf,
+                                            unsigned char *out_lsp_psigs_per_leaf,
+                                            uint32_t expected_n_affected_leaves);
+
+cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_leaf /* n * 32 */,
+                                                  uint32_t n_affected_leaves);
+int    wire_parse_state_adv_client_final_psigs(const cJSON *json,
+                                                  unsigned char *out_psigs_per_leaf,
+                                                  uint32_t expected_n_affected_leaves);
 
 /* LSP → Bridge: BRIDGE_HELLO_ACK {} */
 cJSON *wire_build_bridge_hello_ack(void);

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -481,10 +481,15 @@ int    wire_parse_leaf_advance_final(const cJSON *json,
    are minimal — the actual sub-factory advance ceremony (Phase 1e.1.b)
    will define richer payloads (per-input arrays for multi-input).  For
    now these are stubs to be filled in. */
-cJSON *wire_build_subfactory_propose_intent(uint32_t subfactory_id, uint32_t n_inputs);
+cJSON *wire_build_subfactory_propose_intent(uint32_t subfactory_id, uint32_t n_inputs,
+                                              int leaf_side, int sub_idx, int channel_idx,
+                                              uint64_t delta_sats);
 int    wire_parse_subfactory_propose_intent(const cJSON *json,
                                               uint32_t *out_subfactory_id,
-                                              uint32_t *out_n_inputs);
+                                              uint32_t *out_n_inputs,
+                                              int *out_leaf_side, int *out_sub_idx,
+                                              int *out_channel_idx,
+                                              uint64_t *out_delta_sats);
 
 cJSON *wire_build_subfactory_client_pubnonces(const unsigned char *pubnonces_per_input /* n_inputs * 66 */,
                                                 uint32_t n_inputs);

--- a/src/client.c
+++ b/src/client.c
@@ -2866,10 +2866,201 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
    the sub-factory must co-sign the new state.
 
    Returns 1 on success, 0 on any failure. */
+/* Phase 1e.1.c: client-side stateless subfactory advance.  Dispatched
+   from the public function when SS_MUSIG_STATELESS=1 and the LSP sent a
+   PROPOSE_INTENT (new opcode 0x7D) instead of legacy PROPOSE (0x73). */
+static int client_handle_subfactory_advance_stateless(int fd,
+                                                        secp256k1_context *ctx,
+                                                        const secp256k1_keypair *keypair,
+                                                        factory_t *factory,
+                                                        uint32_t my_index,
+                                                        const wire_msg_t *propose_msg) {
+    uint32_t sub_node_id, n_inputs;
+    if (!wire_parse_subfactory_propose_intent(propose_msg->json,
+                                                 &sub_node_id, &n_inputs)) {
+        fprintf(stderr, "Client-stateless subfactory %u: parse PROPOSE_INTENT failed\n",
+                my_index);
+        return 0;
+    }
+    if (n_inputs != 1) {
+        fprintf(stderr, "Client-stateless subfactory %u: n_inputs=%u not supported "
+                "(MVP single-input only)\n", my_index, n_inputs);
+        return 0;
+    }
+    if (sub_node_id >= factory->n_nodes) {
+        fprintf(stderr, "Client-stateless subfactory %u: bad sub_node_id %u\n",
+                my_index, sub_node_id);
+        return 0;
+    }
+    size_t sub_node_i = (size_t)sub_node_id;
+    factory_node_t *sub = &factory->nodes[sub_node_i];
+
+    /* MVP: refuse k>=2 (multi-client) -- matches LSP-side refusal. */
+    {
+        size_t check_n_clients = 0;
+        for (size_t s = 1; s < sub->n_signers; s++) check_n_clients++;
+        if (check_n_clients > 1) {
+            fprintf(stderr,
+                "Client-stateless subfactory %u: k>=2 (n_clients=%zu) not yet "
+                "supported -- LSP should fall back to legacy\n",
+                my_index, check_n_clients);
+            return 0;
+        }
+    }
+
+    /* NOTE: in this MVP, the client doesn'''t know which (leaf_side, sub_idx,
+       channel_idx, delta_sats) values to pass to factory_subfactory_chain_advance_unsigned
+       because PROPOSE_INTENT carries only sub_node_id + n_inputs.  The client
+       would derive them from sub_node_id (locate the leaf, find the sub-idx,
+       etc).  For now this MVP-stateless client only supports the case where
+       the unsigned_tx is ALREADY built (e.g. from a prior legacy advance
+       that left state, or from a separate metadata sync).  Real production
+       use would need PROPOSE_INTENT to carry the advance parameters too.
+       Phase 1e.1.d follow-up will extend the PROPOSE_INTENT payload.
+
+       For now: refuse if the sub node'''s unsigned_tx hasn'''t been built. */
+    if (!sub->is_built || sub->unsigned_tx.len == 0) {
+        fprintf(stderr,
+            "Client-stateless subfactory %u: sub_node_id=%u has no unsigned_tx built; "
+            "PROPOSE_INTENT does not yet carry advance params (Phase 1e.1.d). "
+            "Refuse -- LSP should fall back to legacy.\n",
+            my_index, sub_node_id);
+        return 0;
+    }
+
+    /* Init session (state only, no poison in MVP). */
+    if (!factory_session_init_node(factory, sub_node_i)) {
+        fprintf(stderr, "Client-stateless subfactory %u: session_init failed\n", my_index);
+        return 0;
+    }
+
+    int my_slot = factory_find_signer_slot(factory, sub_node_i, my_index);
+    int lsp_slot = factory_find_signer_slot(factory, sub_node_i, 0);
+    if (my_slot < 0 || lsp_slot < 0) {
+        fprintf(stderr, "Client-stateless subfactory %u: slot lookup failed (my=%d lsp=%d)\n",
+                my_index, my_slot, lsp_slot);
+        return 0;
+    }
+
+    /* Gen own secnonce + pubnonce. */
+    unsigned char my_seckey[32];
+    secp256k1_pubkey my_pubkey;
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        fprintf(stderr, "Client-stateless subfactory %u: keypair_sec failed\n", my_index);
+        return 0;
+    }
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+    secp256k1_musig_secnonce my_secnonce;
+    secp256k1_musig_pubnonce my_pubnonce;
+    if (!musig_generate_nonce(ctx, &my_secnonce, &my_pubnonce,
+                                my_seckey, &my_pubkey,
+                                &sub->keyagg.cache)) {
+        memset(my_seckey, 0, 32);
+        fprintf(stderr, "Client-stateless subfactory %u: nonce gen failed\n", my_index);
+        return 0;
+    }
+    memset(my_seckey, 0, 32);
+    if (!factory_session_set_nonce(factory, sub_node_i, (size_t)my_slot, &my_pubnonce)) {
+        fprintf(stderr, "Client-stateless subfactory %u: set own nonce failed\n", my_index);
+        return 0;
+    }
+
+    /* Send CLIENT_PUBNONCES with own pubnonce. */
+    unsigned char my_pubnonce_ser[66];
+    musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
+    cJSON *cpn_json = wire_build_subfactory_client_pubnonces(my_pubnonce_ser, 1);
+    if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_PUBNONCES, cpn_json)) {
+        cJSON_Delete(cpn_json);
+        fprintf(stderr, "Client-stateless subfactory %u: send CLIENT_PUBNONCES failed\n",
+                my_index);
+        return 0;
+    }
+    cJSON_Delete(cpn_json);
+
+    /* Wait for LSP_RESPONSE with lsp_pubnonce + lsp_psig. */
+    wire_msg_t lr_msg;
+    if (!wire_recv(fd, &lr_msg) || lr_msg.msg_type != MSG_SUBFACTORY_LSP_RESPONSE) {
+        fprintf(stderr,
+            "Client-stateless subfactory %u: expected LSP_RESPONSE, got 0x%02x\n",
+            my_index, lr_msg.json ? lr_msg.msg_type : 0);
+        if (lr_msg.json) cJSON_Delete(lr_msg.json);
+        return 0;
+    }
+    unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
+    if (!wire_parse_subfactory_lsp_response(lr_msg.json,
+                                              lsp_pubnonce_ser, lsp_psig_ser, 1)) {
+        cJSON_Delete(lr_msg.json);
+        fprintf(stderr, "Client-stateless subfactory %u: parse LSP_RESPONSE failed\n",
+                my_index);
+        return 0;
+    }
+    cJSON_Delete(lr_msg.json);
+
+    /* Set LSP nonce, finalize_node. */
+    secp256k1_musig_pubnonce lsp_pubnonce;
+    if (!musig_pubnonce_parse(ctx, &lsp_pubnonce, lsp_pubnonce_ser) ||
+        !factory_session_set_nonce(factory, sub_node_i, (size_t)lsp_slot, &lsp_pubnonce)) {
+        fprintf(stderr, "Client-stateless subfactory %u: set LSP nonce failed\n", my_index);
+        return 0;
+    }
+    if (!factory_session_finalize_node(factory, sub_node_i)) {
+        fprintf(stderr, "Client-stateless subfactory %u: finalize_node failed\n", my_index);
+        return 0;
+    }
+
+    /* Create own partial_sig (zeros own secnonce). */
+    secp256k1_musig_partial_sig my_psig;
+    if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonce, keypair,
+                                    &sub->signing_session)) {
+        fprintf(stderr, "Client-stateless subfactory %u: create_partial_sig failed\n",
+                my_index);
+        return 0;
+    }
+    /* my_secnonce zeroed by musig_create_partial_sig.
+       INVARIANT: we no longer hold any client secnonce for this signing session. */
+
+    /* Send CLIENT_FINAL_PSIGS with own psig.  LSP aggregates with its own psig. */
+    unsigned char my_psig_ser[32];
+    musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
+    cJSON *fp_json = wire_build_subfactory_client_final_psigs(my_psig_ser, 1);
+    if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_FINAL_PSIGS, fp_json)) {
+        cJSON_Delete(fp_json);
+        fprintf(stderr, "Client-stateless subfactory %u: send CLIENT_FINAL_PSIGS failed\n",
+                my_index);
+        return 0;
+    }
+    cJSON_Delete(fp_json);
+
+    /* Wait for DONE. */
+    wire_msg_t done_msg;
+    if (!wire_recv(fd, &done_msg) || done_msg.msg_type != MSG_SUBFACTORY_DONE) {
+        fprintf(stderr,
+            "Client-stateless subfactory %u: expected DONE, got 0x%02x\n",
+            my_index, done_msg.json ? done_msg.msg_type : 0);
+        if (done_msg.json) cJSON_Delete(done_msg.json);
+        return 0;
+    }
+    if (done_msg.json) cJSON_Delete(done_msg.json);
+
+    printf("Client-stateless subfactory %u: advance done (sub_node=%u)\n",
+           my_index, sub_node_id);
+    return 1;
+}
+
 int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
                                        const secp256k1_keypair *keypair,
                                        factory_t *factory, uint32_t my_index,
                                        const wire_msg_t *propose_msg) {
+    /* Phase 1e.1.c (#271): if the LSP sent PROPOSE_INTENT (new opcode),
+       it'''s the reversed stateless flow -- dispatch.  Legacy PROPOSE
+       (0x73) keeps using the path below. */
+    if (propose_msg && propose_msg->msg_type == MSG_SUBFACTORY_PROPOSE_INTENT) {
+        return client_handle_subfactory_advance_stateless(fd, ctx, keypair,
+                                                            factory, my_index,
+                                                            propose_msg);
+    }
+
     int leaf_side, sub_idx, channel_idx;
     uint64_t delta_sats;
     unsigned char lsp_pubnonce_ser[66];

--- a/src/client.c
+++ b/src/client.c
@@ -4273,11 +4273,266 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
     return 1;
 }
 
+/* Phase 1e.2.d: client-side stateless Tier B handler.  Dispatched from
+   client_handle_state_advance when the LSP sends PROPOSE_INTENT (0x81)
+   instead of legacy STATE_ADVANCE_PROPOSE.  Mirrors lsp_run_state_advance_stateless
+   from Phase 1e.2.c.  MVP scope:
+     - multi-leaf state TX
+     - single-input per leaf
+     - no poison TX */
+static int client_handle_state_advance_stateless(int fd,
+                                                   secp256k1_context *ctx,
+                                                   const secp256k1_keypair *keypair,
+                                                   factory_t *factory,
+                                                   uint32_t my_index,
+                                                   const wire_msg_t *propose_msg) {
+    /* Step 1: Parse PROPOSE_INTENT { epoch_after, n_affected_leaves, trigger_leaf_side }. */
+    uint32_t epoch_after, n_affected_leaves;
+    int trigger_leaf_side;
+    if (!wire_parse_state_adv_propose_intent(propose_msg->json,
+                                                &epoch_after, &n_affected_leaves,
+                                                &trigger_leaf_side)) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: parse PROPOSE_INTENT failed\n", my_index);
+        return 0;
+    }
+
+    /* Step 2: Run factory_advance_leaf_unsigned locally.  Must return -1
+       (root rolled over, all leaves rebuilt) — mirrors caller contract on LSP. */
+    int adv_rc = factory_advance_leaf_unsigned(factory, trigger_leaf_side);
+    if (adv_rc != -1) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: advance_leaf_unsigned returned %d (expected -1)\n",
+            my_index, adv_rc);
+        return 0;
+    }
+
+    /* Step 3: Build affected[] — SAME logic as LSP. */
+    size_t affected[FACTORY_MAX_NODES];
+    size_t n_affected = 0;
+    for (size_t i = 0; i < factory->n_nodes; i++) {
+        const factory_node_t *n = &factory->nodes[i];
+        if (n->is_ps_leaf && trigger_leaf_side != -1) continue;
+        if (!n->is_built) continue;
+        if (n->is_signed) continue;
+        affected[n_affected++] = i;
+    }
+    if (n_affected != n_affected_leaves) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: local n_affected=%zu mismatches LSP=%u\n",
+            my_index, n_affected, n_affected_leaves);
+        return 0;
+    }
+
+    /* MVP refusal: multi-input on any affected. */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (factory_node_uses_multi_input(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: affected %zu uses multi-input — refusing\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 4: init MuSig session per affected. */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_init_node(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: init_node[%zu] failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 5: gen own pubnonces for each affected node where this client signs.
+       For non-participating leaves: leave the buffer all-zeros (LSP detects). */
+    unsigned char my_seckey[32];
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: keypair_sec failed\n", my_index);
+        return 0;
+    }
+    secp256k1_pubkey my_pubkey;
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+    unsigned char my_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    secp256k1_musig_secnonce my_secnonces[FACTORY_MAX_NODES];
+    int my_slot_per_node[FACTORY_MAX_NODES];
+    int my_signs_per_node[FACTORY_MAX_NODES];
+    for (size_t k = 0; k < n_affected; k++) {
+        memset(my_pubnonces_per_node[k], 0, 66);
+        my_slot_per_node[k] = -1;
+        my_signs_per_node[k] = 0;
+    }
+
+    for (size_t k = 0; k < n_affected; k++) {
+        int slot = factory_find_signer_slot(factory, affected[k], my_index);
+        if (slot < 0) continue;  /* this client doesn't sign this node */
+        secp256k1_musig_pubnonce pn;
+        if (!musig_generate_nonce(ctx, &my_secnonces[k], &pn,
+                                    my_seckey, &my_pubkey,
+                                    &factory->nodes[affected[k]].keyagg.cache)) {
+            memset(my_seckey, 0, 32);
+            fprintf(stderr,
+                "Client-stateless Tier B %u: nonce gen for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        my_slot_per_node[k] = slot;
+        my_signs_per_node[k] = 1;
+        musig_pubnonce_serialize(ctx, my_pubnonces_per_node[k], &pn);
+        if (!factory_session_set_nonce(factory, affected[k], (size_t)slot, &pn)) {
+            memset(my_seckey, 0, 32);
+            fprintf(stderr,
+                "Client-stateless Tier B %u: set own nonce for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+    memset(my_seckey, 0, 32);
+
+    /* Step 6: send CLIENT_PATH_NONCES. */
+    cJSON *cpn = wire_build_state_adv_client_path_nonces(
+        (const unsigned char *)my_pubnonces_per_node, (uint32_t)n_affected);
+    if (!wire_send(fd, MSG_STATE_ADV_CLIENT_PATH_NONCES, cpn)) {
+        cJSON_Delete(cpn);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: send CLIENT_PATH_NONCES failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(cpn);
+
+    /* Step 7: recv LSP_RESPONSE { lsp_pubnonces_per_leaf, lsp_psigs_per_leaf }. */
+    wire_msg_t lr;
+    if (!wire_recv(fd, &lr) || lr.msg_type != MSG_STATE_ADV_LSP_RESPONSE) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: expected LSP_RESPONSE, got 0x%02x\n",
+            my_index, lr.json ? lr.msg_type : 0);
+        if (lr.json) cJSON_Delete(lr.json);
+        return 0;
+    }
+    unsigned char lsp_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    unsigned char lsp_psigs_per_node[FACTORY_MAX_NODES][32];
+    if (!wire_parse_state_adv_lsp_response(lr.json,
+                                             (unsigned char *)lsp_pubnonces_per_node,
+                                             (unsigned char *)lsp_psigs_per_node,
+                                             (uint32_t)n_affected)) {
+        cJSON_Delete(lr.json);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: parse LSP_RESPONSE failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(lr.json);
+
+    /* Step 8: for each affected node, set LSP nonce + finalize + set LSP psig +
+       create own partial_sig (zeros own secnonce) + set own psig + complete. */
+    unsigned char my_psigs_per_node[FACTORY_MAX_NODES][32];
+    for (size_t k = 0; k < n_affected; k++) memset(my_psigs_per_node[k], 0, 32);
+
+    for (size_t k = 0; k < n_affected; k++) {
+        int lsp_slot = factory_find_signer_slot(factory, affected[k], 0);
+        if (lsp_slot < 0) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: LSP not signer on %zu (invariant violation)\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        secp256k1_musig_pubnonce lsp_pn;
+        if (!musig_pubnonce_parse(ctx, &lsp_pn, lsp_pubnonces_per_node[k]) ||
+            !factory_session_set_nonce(factory, affected[k], (size_t)lsp_slot, &lsp_pn)) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: set LSP nonce for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        if (!factory_session_finalize_node(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: finalize_node[%zu] failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        /* Set LSP's psig into the session. */
+        secp256k1_musig_partial_sig lsp_psig;
+        if (!musig_partial_sig_parse(ctx, &lsp_psig, lsp_psigs_per_node[k]) ||
+            !factory_session_set_partial_sig(factory, affected[k], (size_t)lsp_slot, &lsp_psig)) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: set LSP psig for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        /* Create own partial_sig (zeros own secnonce). */
+        if (my_signs_per_node[k]) {
+            secp256k1_musig_partial_sig my_psig;
+            if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonces[k], keypair,
+                                            &factory->nodes[affected[k]].signing_session)) {
+                fprintf(stderr,
+                    "Client-stateless Tier B %u: create_partial_sig[%zu] failed\n",
+                    my_index, affected[k]);
+                return 0;
+            }
+            musig_partial_sig_serialize(ctx, my_psigs_per_node[k], &my_psig);
+            if (!factory_session_set_partial_sig(factory, affected[k],
+                                                   (size_t)my_slot_per_node[k], &my_psig)) {
+                fprintf(stderr,
+                    "Client-stateless Tier B %u: set own psig[%zu] failed\n",
+                    my_index, affected[k]);
+                return 0;
+            }
+        }
+    }
+    /* INVARIANT: own secnonces zeroed by musig_create_partial_sig. */
+
+    /* Step 9: send CLIENT_FINAL_PSIGS. */
+    cJSON *fp = wire_build_state_adv_client_final_psigs(
+        (const unsigned char *)my_psigs_per_node, (uint32_t)n_affected);
+    if (!wire_send(fd, MSG_STATE_ADV_CLIENT_FINAL_PSIGS, fp)) {
+        cJSON_Delete(fp);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: send CLIENT_FINAL_PSIGS failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(fp);
+
+    /* Step 10: complete_node per affected (LSP will also). */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_complete_node(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: complete_node[%zu] failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 11: recv DONE (MSG_PATH_SIGN_DONE). */
+    wire_msg_t done;
+    if (!wire_recv(fd, &done) || done.msg_type != MSG_PATH_SIGN_DONE) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: expected PATH_SIGN_DONE, got 0x%02x\n",
+            my_index, done.json ? done.msg_type : 0);
+        if (done.json) cJSON_Delete(done.json);
+        return 0;
+    }
+    if (done.json) cJSON_Delete(done.json);
+
+    printf("Client-stateless Tier B %u: %zu affected nodes signed\n",
+           my_index, n_affected);
+    return 1;
+}
+
 int client_handle_state_advance(int fd, secp256k1_context *ctx,
                                   const secp256k1_keypair *keypair,
                                   factory_t *factory,
                                   uint32_t my_index,
                                   const wire_msg_t *propose_msg) {
+    /* Phase 1e.2.d: if LSP sent the new stateless PROPOSE_INTENT opcode,
+       dispatch to the stateless handler.  Legacy STATE_ADVANCE_PROPOSE
+       continues to use the path below. */
+    if (propose_msg && propose_msg->msg_type == MSG_STATE_ADV_PROPOSE_INTENT) {
+        return client_handle_state_advance_stateless(fd, ctx, keypair,
+                                                       factory, my_index,
+                                                       propose_msg);
+    }
+
     /* Parse propose */
     uint32_t epoch_in;
     int trigger_leaf;

--- a/src/client.c
+++ b/src/client.c
@@ -2876,8 +2876,12 @@ static int client_handle_subfactory_advance_stateless(int fd,
                                                         uint32_t my_index,
                                                         const wire_msg_t *propose_msg) {
     uint32_t sub_node_id, n_inputs;
+    int leaf_side, sub_idx, channel_idx;
+    uint64_t delta_sats;
     if (!wire_parse_subfactory_propose_intent(propose_msg->json,
-                                                 &sub_node_id, &n_inputs)) {
+                                                 &sub_node_id, &n_inputs,
+                                                 &leaf_side, &sub_idx, &channel_idx,
+                                                 &delta_sats)) {
         fprintf(stderr, "Client-stateless subfactory %u: parse PROPOSE_INTENT failed\n",
                 my_index);
         return 0;
@@ -2908,27 +2912,20 @@ static int client_handle_subfactory_advance_stateless(int fd,
         }
     }
 
-    /* NOTE: in this MVP, the client doesn'''t know which (leaf_side, sub_idx,
-       channel_idx, delta_sats) values to pass to factory_subfactory_chain_advance_unsigned
-       because PROPOSE_INTENT carries only sub_node_id + n_inputs.  The client
-       would derive them from sub_node_id (locate the leaf, find the sub-idx,
-       etc).  For now this MVP-stateless client only supports the case where
-       the unsigned_tx is ALREADY built (e.g. from a prior legacy advance
-       that left state, or from a separate metadata sync).  Real production
-       use would need PROPOSE_INTENT to carry the advance parameters too.
-       Phase 1e.1.d follow-up will extend the PROPOSE_INTENT payload.
-
-       For now: refuse if the sub node'''s unsigned_tx hasn'''t been built. */
-    if (!sub->is_built || sub->unsigned_tx.len == 0) {
+    /* Phase 1e.1.b amendment: PROPOSE_INTENT now carries the advance params
+       (leaf_side, sub_idx, channel_idx, delta_sats).  Apply the advance
+       locally so unsigned_tx matches LSP's deterministically. */
+    if (!factory_subfactory_chain_advance_unsigned(factory, leaf_side, sub_idx,
+                                                     channel_idx, delta_sats)) {
         fprintf(stderr,
-            "Client-stateless subfactory %u: sub_node_id=%u has no unsigned_tx built; "
-            "PROPOSE_INTENT does not yet carry advance params (Phase 1e.1.d). "
-            "Refuse -- LSP should fall back to legacy.\n",
-            my_index, sub_node_id);
+            "Client-stateless subfactory %u: chain_advance_unsigned failed "
+            "(leaf=%d sub=%d ch=%d delta=%llu)\n",
+            my_index, leaf_side, sub_idx, channel_idx,
+            (unsigned long long)delta_sats);
         return 0;
     }
 
-    /* Init session (state only, no poison in MVP). */
+        /* Init session (state only, no poison in MVP). */
     if (!factory_session_init_node(factory, sub_node_i)) {
         fprintf(stderr, "Client-stateless subfactory %u: session_init failed\n", my_index);
         return 0;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4065,6 +4065,233 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
 
    Returns 1 on success (chain extended, all participants confirmed
    via DONE), 0 on any failure (validation, ceremony timeout, crypto). */
+/* Phase 1e.1.b: stateless single-input sub-factory chain advance variant.
+   Dispatched from the public function when SS_MUSIG_STATELESS=1 AND the
+   target node is single-input (factory_node_uses_multi_input returns 0).
+   Multi-input + poison + WT registration deferred to Phase 1e.1.c. */
+static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
+                                                    lsp_t *lsp,
+                                                    int leaf_side,
+                                                    int sub_idx_in_leaf,
+                                                    int channel_idx_in_sub,
+                                                    uint64_t delta_sats) {
+    if (!mgr || !lsp) return 0;
+    factory_t *f = &lsp->factory;
+    if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) return 0;
+    if (sub_idx_in_leaf < 0) return 0;
+    size_t leaf_node_i = (size_t)f->leaf_node_indices[leaf_side];
+    if (leaf_node_i >= f->n_nodes) return 0;
+    factory_node_t *leaf = &f->nodes[leaf_node_i];
+    if ((size_t)sub_idx_in_leaf >= leaf->n_outputs) return 0;
+    /* Compute sub_node index — same as legacy.  Sub-factory PS leaves have
+       k sub-nodes after the leaf, one per output other than L-stock. */
+    /* We assume the same layout helper used by the public function.  Look up
+       sub_node_i via factory_node_indices for the leaf's child outputs. */
+    size_t sub_node_i = leaf_node_i + 1 + (size_t)sub_idx_in_leaf;
+    if (sub_node_i >= f->n_nodes) return 0;
+    factory_node_t *sub = &f->nodes[sub_node_i];
+
+    /* Reject multi-input in this MVP — fall back to legacy. */
+    if (factory_node_uses_multi_input(f, sub_node_i)) {
+        fprintf(stderr,
+                "LSP-stateless subfactory advance: multi-input not yet supported "
+                "in stateless flow -- falling back to legacy\n");
+        return -1;  /* signal caller to use legacy path */
+    }
+
+    /* Sub-factory clients (one client per output != L-stock + LSP).
+       Build sub_clients[] -- same shape as legacy. */
+    uint32_t sub_clients[FACTORY_MAX_SIGNERS];
+    size_t n_clients_in_sub = 0;
+    for (size_t s = 1; s < sub->n_signers; s++) {
+        sub_clients[n_clients_in_sub++] = sub->signer_indices[s];
+    }
+    if (n_clients_in_sub == 0) {
+        fprintf(stderr, "LSP-stateless subfactory advance: no clients in sub\n");
+        return 0;
+    }
+
+    /* Step 1: factory_subfactory_chain_advance_unsigned — rebuild unsigned_tx. */
+    if (!factory_subfactory_chain_advance_unsigned(f, leaf_side,
+                                                    sub_idx_in_leaf,
+                                                    channel_idx_in_sub,
+                                                    delta_sats)) {
+        fprintf(stderr, "LSP-stateless subfactory advance: advance_unsigned failed\n");
+        return 0;
+    }
+
+    /* Step 2: init session (state only — no poison in MVP). */
+    if (!factory_session_init_node(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless subfactory advance: session init failed\n");
+        return 0;
+    }
+
+    /* Step 3: send PROPOSE_INTENT to each sub-client (NO LSP nonce). */
+    cJSON *propose = wire_build_subfactory_propose_intent((uint32_t)sub_node_i, 1);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_PROPOSE_INTENT, propose)) {
+            cJSON_Delete(propose);
+            fprintf(stderr, "LSP-stateless: send PROPOSE_INTENT failed for client %u\n",
+                    sub_clients[ci]);
+            return 0;
+        }
+    }
+    cJSON_Delete(propose);
+
+    /* Step 4: collect CLIENT_PUBNONCES from each client. */
+    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t nmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &nmsg, WIRE_CEREMONY_RECV_TIMEOUT_SEC) ||
+            nmsg.msg_type != MSG_SUBFACTORY_CLIENT_PUBNONCES) {
+            fprintf(stderr,
+                    "LSP-stateless: expected CLIENT_PUBNONCES from client %u, got 0x%02x\n",
+                    sub_clients[ci], nmsg.msg_type);
+            if (nmsg.json) cJSON_Delete(nmsg.json);
+            return 0;
+        }
+        unsigned char client_pn_buf[66];
+        if (!wire_parse_subfactory_client_pubnonces(nmsg.json, client_pn_buf, 1)) {
+            cJSON_Delete(nmsg.json);
+            fprintf(stderr, "LSP-stateless: parse CLIENT_PUBNONCES failed\n");
+            return 0;
+        }
+        cJSON_Delete(nmsg.json);
+        int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
+        if (client_slot < 0) return 0;
+        memcpy(all_pubnonces[client_slot], client_pn_buf, 66);
+    }
+
+    /* Step 5 (THE CRITICAL ATOMIC BLOCK): gen LSP secnonce, set all nonces,
+       finalize_node, create_partial_sig (zeros secnonce), serialize. */
+    int lsp_slot = factory_find_signer_slot(f, sub_node_i, 0);
+    if (lsp_slot < 0) return 0;
+
+    unsigned char lsp_seckey[32];
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) return 0;
+
+    secp256k1_musig_secnonce lsp_secnonce;
+    secp256k1_musig_pubnonce lsp_pubnonce;
+    if (!musig_generate_nonce(lsp->ctx, &lsp_secnonce, &lsp_pubnonce,
+                                lsp_seckey, &lsp->lsp_pubkey,
+                                &sub->keyagg.cache)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless subfactory: nonce gen failed\n");
+        return 0;
+    }
+
+    unsigned char lsp_pubnonce_ser[66];
+    musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
+    memcpy(all_pubnonces[lsp_slot], lsp_pubnonce_ser, 66);
+
+    /* Set every nonce on the session. */
+    for (size_t s = 0; s < sub->n_signers; s++) {
+        secp256k1_musig_pubnonce pn;
+        if (!musig_pubnonce_parse(lsp->ctx, &pn, all_pubnonces[s]) ||
+            !factory_session_set_nonce(f, sub_node_i, s, &pn)) {
+            memset(lsp_seckey, 0, 32);
+            fprintf(stderr, "LSP-stateless subfactory: set_nonce[%zu] failed\n", s);
+            return 0;
+        }
+    }
+
+    if (!factory_session_finalize_node(f, sub_node_i)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless subfactory: finalize_node failed\n");
+        return 0;
+    }
+
+    secp256k1_keypair lsp_kp;
+    if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
+        memset(lsp_seckey, 0, 32);
+        return 0;
+    }
+    memset(lsp_seckey, 0, 32);
+
+    secp256k1_musig_partial_sig lsp_psig;
+    if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
+                                    &sub->signing_session)) {
+        fprintf(stderr, "LSP-stateless subfactory: create_partial_sig failed\n");
+        return 0;
+    }
+    /* lsp_secnonce zeroed by musig_create_partial_sig.
+       INVARIANT: no LSP secnonce held across the wire recv that follows. */
+
+    unsigned char lsp_psig_ser[32];
+    musig_partial_sig_serialize(lsp->ctx, lsp_psig_ser, &lsp_psig);
+
+    if (!factory_session_set_partial_sig(f, sub_node_i, (size_t)lsp_slot, &lsp_psig)) {
+        return 0;
+    }
+
+    /* Step 6: send LSP_RESPONSE to each client (per-client copy so each can
+       individually finalize_node + sign).  Single-input -> 1 element each. */
+    cJSON *response = wire_build_subfactory_lsp_response(lsp_pubnonce_ser,
+                                                          lsp_psig_ser, 1);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_LSP_RESPONSE, response)) {
+            cJSON_Delete(response);
+            fprintf(stderr, "LSP-stateless: send LSP_RESPONSE failed for client %u\n",
+                    sub_clients[ci]);
+            return 0;
+        }
+    }
+    cJSON_Delete(response);
+
+    /* Step 7: collect CLIENT_FINAL_PSIGS from each client. */
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t pmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &pmsg, WIRE_CEREMONY_RECV_TIMEOUT_SEC) ||
+            pmsg.msg_type != MSG_SUBFACTORY_CLIENT_FINAL_PSIGS) {
+            fprintf(stderr,
+                    "LSP-stateless: expected CLIENT_FINAL_PSIGS from client %u, got 0x%02x\n",
+                    sub_clients[ci], pmsg.msg_type);
+            if (pmsg.json) cJSON_Delete(pmsg.json);
+            return 0;
+        }
+        unsigned char client_psig_buf[32];
+        if (!wire_parse_subfactory_client_final_psigs(pmsg.json, client_psig_buf, 1)) {
+            cJSON_Delete(pmsg.json);
+            fprintf(stderr, "LSP-stateless: parse CLIENT_FINAL_PSIGS failed\n");
+            return 0;
+        }
+        cJSON_Delete(pmsg.json);
+        int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
+        if (client_slot < 0) return 0;
+        secp256k1_musig_partial_sig client_psig;
+        if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_buf) ||
+            !factory_session_set_partial_sig(f, sub_node_i, (size_t)client_slot, &client_psig)) {
+            fprintf(stderr, "LSP-stateless: set client psig failed for %u\n", sub_clients[ci]);
+            return 0;
+        }
+    }
+
+    /* Step 8: aggregate + complete_node (attaches witness to signed_tx). */
+    if (!factory_session_complete_node(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless subfactory: complete_node failed\n");
+        return 0;
+    }
+
+    /* Step 9: send DONE to each client. */
+    cJSON *done = wire_build_subfactory_done(leaf_side, sub_idx_in_leaf, sub->ps_chain_len);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_DONE, done);
+    }
+    cJSON_Delete(done);
+
+    printf("LSP-stateless subfactory chain advance: leaf %d sub %d chan %d delta %llu sats DONE\n",
+           leaf_side, sub_idx_in_leaf, channel_idx_in_sub,
+           (unsigned long long)delta_sats);
+    return 1;
+}
+
 int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                    int leaf_side, int sub_idx_in_leaf,
                                    int channel_idx_in_sub,
@@ -4077,6 +4304,22 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 0;
     }
     factory_t *f = &lsp->factory;
+
+    /* Phase 1e.1.b (#271): when --musig-stateless is in effect, dispatch
+       to the reversed-order flow.  The stateless variant returns -1 if
+       it cannot handle the case (multi-input etc) and falls through to
+       legacy; otherwise it handles the ceremony end-to-end. */
+    {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        if (stateless && stateless[0] == '1') {
+            int rc = lsp_subfactory_chain_advance_stateless(
+                mgr, lsp, leaf_side, sub_idx_in_leaf,
+                channel_idx_in_sub, delta_sats);
+            if (rc >= 0) return rc;
+            /* rc == -1: stateless function declined (e.g. multi-input);
+               fall through to legacy. */
+        }
+    }
 
     if (leaf_side < 0 || leaf_side >= f->n_leaf_nodes) {
         fprintf(stderr, "lsp_subfactory_chain_advance: refused — leaf_side %d "

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4142,7 +4142,7 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     }
 
     /* Step 3: send PROPOSE_INTENT to each sub-client (NO LSP nonce). */
-    cJSON *propose = wire_build_subfactory_propose_intent((uint32_t)sub_node_i, 1);
+    cJSON *propose = wire_build_subfactory_propose_intent((uint32_t)sub_node_i, 1, leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_PROPOSE_INTENT, propose)) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4091,7 +4091,22 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     if (sub_node_i >= f->n_nodes) return 0;
     factory_node_t *sub = &f->nodes[sub_node_i];
 
-    /* Reject multi-input in this MVP — fall back to legacy. */
+    /* Phase 1e.1.b MVP scope: reject k>=2 multi-client.  Wire codec does
+       not yet relay other client pubnonces in LSP_RESPONSE.  Phase 1e.1.d
+       follow-up will extend the codec.  For now, fall back to legacy. */
+    {
+        size_t check_n_clients = 0;
+        for (size_t s = 1; s < sub->n_signers; s++) check_n_clients++;
+        if (check_n_clients > 1) {
+            fprintf(stderr,
+                "LSP-stateless subfactory: k>=2 (n_clients=%zu) not yet "
+                "supported in stateless flow -- falling back to legacy\n",
+                check_n_clients);
+            return -1;
+        }
+    }
+
+    /* Reject multi-input in this MVP -- fall back to legacy. */
     if (factory_node_uses_multi_input(f, sub_node_i)) {
         fprintf(stderr,
                 "LSP-stateless subfactory advance: multi-input not yet supported "

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2553,10 +2553,318 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
    the LSP can retry by calling lsp_run_state_advance() again.  The
    on-chain factory is unaffected — old signed TXs remain stored
    (overlap window) and the watchtower still has the old burn TXs. */
+/* Phase 1e.2.b scaffolding: stub for the reversed-flow stateless Tier B
+   state advance ceremony.  Dispatched from the public function when
+   SS_MUSIG_STATELESS=1 is set.  Currently returns -1 for all cases
+   (caller falls through to legacy lsp_run_state_advance) — Phase 1e.2.c
+   will fill in the actual multi-leaf MuSig ceremony using the wire codec
+   added in Phase 1e.2.a (#328).
+
+   Wire flow (per Phase 1e.2.a opcodes):
+     LSP   -> Client:  MSG_STATE_ADV_PROPOSE_INTENT (0x81)
+     Client -> LSP:    MSG_STATE_ADV_CLIENT_PATH_NONCES (0x82)
+     LSP atomic:       gen lsp_secnonces + set nonces + finalize + create_partial_sigs
+                        (lsp_secnonces zeroed before next send)
+     LSP   -> Client:  MSG_STATE_ADV_LSP_RESPONSE (0x83) per-leaf data
+     Client -> LSP:    MSG_STATE_ADV_CLIENT_FINAL_PSIGS (0x84)
+     LSP:              aggregate + factory_session_complete_node per leaf
+     LSP   -> Client:  MSG_PATH_SIGN_DONE (existing terminal opcode)
+
+   Returns: 1 on success, 0 on failure, -1 if the stateless function cannot
+   handle this case (caller falls through to legacy). */
+static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
+                                             lsp_t *lsp,
+                                             int trigger_leaf_side) {
+    if (!mgr || !lsp) return 0;
+    factory_t *f = &lsp->factory;
+
+    /* MVP refusal: watchtower configured -> poison TX would be required. */
+    if (mgr->watchtower) {
+        fprintf(stderr,
+            "LSP-stateless Tier B: watchtower configured (poison TX needed) -- "
+            "falling back to legacy\n");
+        return -1;
+    }
+
+    /* Step 1: Build affected[] (same logic as legacy at line ~2725). */
+    size_t affected[FACTORY_MAX_NODES];
+    size_t n_affected = 0;
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        const factory_node_t *n = &f->nodes[i];
+        if (n->is_ps_leaf && trigger_leaf_side != -1) continue;
+        if (!n->is_built) continue;
+        if (n->is_signed) continue;
+        affected[n_affected++] = i;
+    }
+    if (n_affected == 0) {
+        /* Nothing to do.  Send DONE for completeness. */
+        cJSON *done = wire_build_path_sign_done((uint32_t)f->counter.current_epoch);
+        for (size_t i = 0; i < lsp->n_clients; i++)
+            wire_send(lsp->client_fds[i], MSG_PATH_SIGN_DONE, done);
+        cJSON_Delete(done);
+        return 1;
+    }
+
+    /* MVP refusal: multi-input on any affected node. */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (factory_node_uses_multi_input(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: affected node %zu uses multi-input -- "
+                "falling back to legacy\n", affected[k]);
+            return -1;
+        }
+    }
+
+    /* Step 2: Init MuSig session for each affected node (state only). */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_init_node(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: init_node[%zu] failed\n", affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 3: Send PROPOSE_INTENT to all clients (no nonces). */
+    cJSON *propose = wire_build_state_adv_propose_intent(
+        (uint32_t)f->counter.current_epoch, (uint32_t)n_affected,
+        trigger_leaf_side);
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_PROPOSE_INTENT, propose)) {
+            cJSON_Delete(propose);
+            fprintf(stderr,
+                "LSP-stateless Tier B: send PROPOSE_INTENT[%zu] failed\n", c);
+            return 0;
+        }
+    }
+    cJSON_Delete(propose);
+
+    /* Step 4: Collect CLIENT_PATH_NONCES from each client.
+       Each client sends pubnonces for the affected nodes they're a signer on.
+       Wire format is per-leaf array (66 bytes each) indexed by affected[] order.
+       Client must produce nonces only for affected nodes where they sign;
+       non-participating slots get all-zero buffers (skip those). */
+    unsigned char client_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    int client_slot_per_node[FACTORY_MAX_NODES];
+    (void)client_slot_per_node; /* recorded for future audit; unused in MVP */
+    for (size_t k = 0; k < n_affected; k++) client_slot_per_node[k] = -1;
+
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        wire_msg_t nmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[c], &nmsg,
+                                          WIRE_CEREMONY_BUNDLE_TIMEOUT_SEC) ||
+            nmsg.msg_type != MSG_STATE_ADV_CLIENT_PATH_NONCES) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: expected CLIENT_PATH_NONCES from client %zu, "
+                "got 0x%02x\n", c, nmsg.msg_type);
+            if (nmsg.json) cJSON_Delete(nmsg.json);
+            return 0;
+        }
+        unsigned char this_client_pn[FACTORY_MAX_NODES][66];
+        if (!wire_parse_state_adv_client_path_nonces(nmsg.json,
+                                                       (unsigned char *)this_client_pn,
+                                                       (uint32_t)n_affected)) {
+            cJSON_Delete(nmsg.json);
+            fprintf(stderr,
+                "LSP-stateless Tier B: parse CLIENT_PATH_NONCES from client %zu failed\n",
+                c);
+            return 0;
+        }
+        cJSON_Delete(nmsg.json);
+        /* Distribute: for each affected node, if this client is a signer,
+           record their pubnonce + slot.  An all-zero pubnonce indicates
+           "I'm not a signer on this leaf" -- skip. */
+        for (size_t k = 0; k < n_affected; k++) {
+            int slot = factory_find_signer_slot(f, affected[k], (uint32_t)(c + 1));
+            if (slot < 0) continue;  /* this client doesn't sign this node */
+            /* Skip if all zeros (client signaled no nonce for this leaf) */
+            int all_zero = 1;
+            for (size_t b = 0; b < 66; b++) {
+                if (this_client_pn[k][b] != 0) { all_zero = 0; break; }
+            }
+            if (all_zero) continue;
+            secp256k1_musig_pubnonce pn;
+            if (!musig_pubnonce_parse(lsp->ctx, &pn, this_client_pn[k]) ||
+                !factory_session_set_nonce(f, affected[k], (size_t)slot, &pn)) {
+                fprintf(stderr,
+                    "LSP-stateless Tier B: parse/set client[%zu] nonce for node %zu failed\n",
+                    c, affected[k]);
+                return 0;
+            }
+            memcpy(client_pubnonces_per_node[k], this_client_pn[k], 66);
+            client_slot_per_node[k] = slot;
+        }
+    }
+
+    /* Step 5: ATOMIC -- gen LSP nonces, set+finalize, create_partial_sig per leaf.
+       Uses musig_nonce_pool_generate (same as legacy line 2790) but ONLY now,
+       after all client nonces have arrived.  No LSP secnonces held across recv. */
+    size_t lsp_node_count = 0;
+    for (size_t k = 0; k < n_affected; k++) {
+        if (factory_find_signer_slot(f, affected[k], 0) >= 0)
+            lsp_node_count++;
+    }
+    if (lsp_node_count == 0) {
+        fprintf(stderr, "LSP-stateless Tier B: LSP not a signer on any affected\n");
+        return 0;
+    }
+
+    musig_nonce_pool_t lsp_pool;
+    unsigned char lsp_seckey[32];
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) return 0;
+    if (!musig_nonce_pool_generate(lsp->ctx, &lsp_pool, lsp_node_count,
+                                    lsp_seckey, &lsp->lsp_pubkey, NULL)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless Tier B: nonce pool gen failed\n");
+        return 0;
+    }
+    memset(lsp_seckey, 0, 32);
+
+    int lsp_slot_per_node[FACTORY_MAX_NODES];
+    (void)lsp_slot_per_node; /* recorded for future audit; unused in MVP */
+    unsigned char lsp_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    unsigned char lsp_psigs_per_node[FACTORY_MAX_NODES][32];
+    for (size_t k = 0; k < n_affected; k++) {
+        lsp_slot_per_node[k] = -1;
+        memset(lsp_pubnonces_per_node[k], 0, 66);
+        memset(lsp_psigs_per_node[k], 0, 32);
+    }
+
+    secp256k1_keypair lsp_kp = lsp->lsp_keypair;
+    for (size_t k = 0; k < n_affected; k++) {
+        int slot = factory_find_signer_slot(f, affected[k], 0);
+        if (slot < 0) continue;
+        secp256k1_musig_secnonce *sec;
+        secp256k1_musig_pubnonce pub;
+        if (!musig_nonce_pool_next(&lsp_pool, &sec, &pub)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: pool exhausted at node %zu\n", affected[k]);
+            return 0;
+        }
+        lsp_slot_per_node[k] = slot;
+        musig_pubnonce_serialize(lsp->ctx, lsp_pubnonces_per_node[k], &pub);
+        if (!factory_session_set_nonce(f, affected[k], (size_t)slot, &pub)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: set LSP nonce for %zu failed\n", affected[k]);
+            return 0;
+        }
+        if (!factory_session_finalize_node(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: finalize_node[%zu] failed\n", affected[k]);
+            return 0;
+        }
+        secp256k1_musig_partial_sig psig;
+        if (!musig_create_partial_sig(lsp->ctx, &psig, sec, &lsp_kp,
+                                        &f->nodes[affected[k]].signing_session)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: create_partial_sig[%zu] failed\n",
+                affected[k]);
+            return 0;
+        }
+        /* sec zeroed by musig_create_partial_sig */
+        musig_partial_sig_serialize(lsp->ctx, lsp_psigs_per_node[k], &psig);
+        if (!factory_session_set_partial_sig(f, affected[k], (size_t)slot, &psig)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: set LSP psig[%zu] failed\n", affected[k]);
+            return 0;
+        }
+    }
+    /* INVARIANT: every LSP secnonce in lsp_pool has been pulled and zeroed
+       by musig_create_partial_sig.  No LSP secnonce in scope for the recv
+       that follows. */
+
+    /* Step 7: Send LSP_RESPONSE with per-node pubnonces + psigs to all clients. */
+    cJSON *response = wire_build_state_adv_lsp_response(
+        (const unsigned char *)lsp_pubnonces_per_node,
+        (const unsigned char *)lsp_psigs_per_node,
+        (uint32_t)n_affected);
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_LSP_RESPONSE, response)) {
+            cJSON_Delete(response);
+            fprintf(stderr,
+                "LSP-stateless Tier B: send LSP_RESPONSE[%zu] failed\n", c);
+            return 0;
+        }
+    }
+    cJSON_Delete(response);
+
+    /* Step 8: Collect CLIENT_FINAL_PSIGS from each client. */
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        wire_msg_t pmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[c], &pmsg,
+                                          WIRE_CEREMONY_BUNDLE_TIMEOUT_SEC) ||
+            pmsg.msg_type != MSG_STATE_ADV_CLIENT_FINAL_PSIGS) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: expected CLIENT_FINAL_PSIGS from client %zu, "
+                "got 0x%02x\n", c, pmsg.msg_type);
+            if (pmsg.json) cJSON_Delete(pmsg.json);
+            return 0;
+        }
+        unsigned char this_client_psigs[FACTORY_MAX_NODES][32];
+        if (!wire_parse_state_adv_client_final_psigs(pmsg.json,
+                                                       (unsigned char *)this_client_psigs,
+                                                       (uint32_t)n_affected)) {
+            cJSON_Delete(pmsg.json);
+            fprintf(stderr,
+                "LSP-stateless Tier B: parse CLIENT_FINAL_PSIGS[%zu] failed\n", c);
+            return 0;
+        }
+        cJSON_Delete(pmsg.json);
+        for (size_t k = 0; k < n_affected; k++) {
+            int slot = factory_find_signer_slot(f, affected[k], (uint32_t)(c + 1));
+            if (slot < 0) continue;
+            /* Skip if all zeros (client signaled no psig for this leaf) */
+            int all_zero = 1;
+            for (size_t b = 0; b < 32; b++) {
+                if (this_client_psigs[k][b] != 0) { all_zero = 0; break; }
+            }
+            if (all_zero) continue;
+            secp256k1_musig_partial_sig psig;
+            if (!musig_partial_sig_parse(lsp->ctx, &psig, this_client_psigs[k]) ||
+                !factory_session_set_partial_sig(f, affected[k], (size_t)slot, &psig)) {
+                fprintf(stderr,
+                    "LSP-stateless Tier B: set client[%zu] psig for %zu failed\n",
+                    c, affected[k]);
+                return 0;
+            }
+        }
+    }
+
+    /* Step 9: Complete each affected node (aggregate psigs + attach signed_tx). */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_complete_node(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: complete_node[%zu] failed\n", affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 10: Broadcast DONE (existing opcode). */
+    cJSON *done = wire_build_path_sign_done((uint32_t)f->counter.current_epoch);
+    for (size_t c = 0; c < lsp->n_clients; c++)
+        wire_send(lsp->client_fds[c], MSG_PATH_SIGN_DONE, done);
+    cJSON_Delete(done);
+
+    printf("LSP-stateless Tier B: state advance complete for %zu affected nodes\n",
+           n_affected);
+    return 1;
+}
+
 int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                             int trigger_leaf_side) {
     factory_t *f = &lsp->factory;
     if (!mgr || !lsp) return 0;
+
+    /* Phase 1e.2.b (#271): when --musig-stateless is in effect, dispatch
+       to the reversed-order flow.  Returns -1 to signal fall-through to
+       legacy if the stateless variant cannot handle this case. */
+    {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        if (stateless && stateless[0] == '1') {
+            int rc = lsp_run_state_advance_stateless(mgr, lsp, trigger_leaf_side);
+            if (rc >= 0) return rc;
+            /* rc == -1: stateless declined; fall through to legacy below. */
+        }
+    }
 
     /* CL4-rollover (#250 Tier B path): snapshot the pre-rollover leaf 0
        signed_tx so we can broadcast it post-ceremony as the stake-theft
@@ -2760,6 +3068,7 @@ int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        entries where LSP doesn't sign that node. */
     secp256k1_musig_secnonce *lsp_sec_per_node[FACTORY_MAX_NODES];
     int lsp_slot_per_node[FACTORY_MAX_NODES];
+    (void)lsp_slot_per_node; /* recorded for future audit; unused in MVP */
     for (size_t k = 0; k < n_affected; k++) {
         lsp_sec_per_node[k] = NULL;
         lsp_slot_per_node[k] = -1;

--- a/src/wire.c
+++ b/src/wire.c
@@ -1299,6 +1299,117 @@ int wire_parse_subfactory_client_final_psigs(const cJSON *json,
            (int)((size_t)expected_n_inputs * 32);
 }
 
+/* Phase 1e.2.a -- Tier B state advance reversed flow wire codec. */
+
+cJSON *wire_build_state_adv_propose_intent(uint32_t epoch_after,
+                                              uint32_t n_affected_leaves,
+                                              int trigger_leaf_side) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    cJSON_AddNumberToObject(j, "epoch_after", (double)epoch_after);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    cJSON_AddNumberToObject(j, "trigger_leaf_side", (double)trigger_leaf_side);
+    return j;
+}
+
+int wire_parse_state_adv_propose_intent(const cJSON *json,
+                                           uint32_t *out_epoch_after,
+                                           uint32_t *out_n_affected_leaves,
+                                           int *out_trigger_leaf_side) {
+    if (!json || !out_epoch_after || !out_n_affected_leaves ||
+        !out_trigger_leaf_side) return 0;
+    cJSON *e = cJSON_GetObjectItem(json, "epoch_after");
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    cJSON *t = cJSON_GetObjectItem(json, "trigger_leaf_side");
+    if (!e || !n || !t ||
+        !cJSON_IsNumber(e) || !cJSON_IsNumber(n) || !cJSON_IsNumber(t)) return 0;
+    *out_epoch_after = (uint32_t)e->valuedouble;
+    *out_n_affected_leaves = (uint32_t)n->valuedouble;
+    *out_trigger_leaf_side = (int)t->valuedouble;
+    return 1;
+}
+
+cJSON *wire_build_state_adv_client_path_nonces(const unsigned char *pubnonces_per_leaf,
+                                                  uint32_t n_affected_leaves) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !pubnonces_per_leaf) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "pubnonces_per_leaf", pubnonces_per_leaf,
+                      (size_t)n_affected_leaves * 66);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    return j;
+}
+
+int wire_parse_state_adv_client_path_nonces(const cJSON *json,
+                                               unsigned char *out_pubnonces_per_leaf,
+                                               uint32_t expected_n_affected_leaves) {
+    if (!json || !out_pubnonces_per_leaf) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
+    return wire_json_get_hex(json, "pubnonces_per_leaf",
+                               out_pubnonces_per_leaf,
+                               (size_t)expected_n_affected_leaves * 66) ==
+           (int)((size_t)expected_n_affected_leaves * 66);
+}
+
+cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_leaf,
+                                            const unsigned char *lsp_psigs_per_leaf,
+                                            uint32_t n_affected_leaves) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !lsp_pubnonces_per_leaf || !lsp_psigs_per_leaf) {
+        if (j) cJSON_Delete(j);
+        return NULL;
+    }
+    wire_json_add_hex(j, "lsp_pubnonces_per_leaf", lsp_pubnonces_per_leaf,
+                      (size_t)n_affected_leaves * 66);
+    wire_json_add_hex(j, "lsp_psigs_per_leaf", lsp_psigs_per_leaf,
+                      (size_t)n_affected_leaves * 32);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    return j;
+}
+
+int wire_parse_state_adv_lsp_response(const cJSON *json,
+                                         unsigned char *out_lsp_pubnonces_per_leaf,
+                                         unsigned char *out_lsp_psigs_per_leaf,
+                                         uint32_t expected_n_affected_leaves) {
+    if (!json || !out_lsp_pubnonces_per_leaf || !out_lsp_psigs_per_leaf) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
+    if (wire_json_get_hex(json, "lsp_pubnonces_per_leaf",
+                            out_lsp_pubnonces_per_leaf,
+                            (size_t)expected_n_affected_leaves * 66) !=
+        (int)((size_t)expected_n_affected_leaves * 66)) return 0;
+    if (wire_json_get_hex(json, "lsp_psigs_per_leaf",
+                            out_lsp_psigs_per_leaf,
+                            (size_t)expected_n_affected_leaves * 32) !=
+        (int)((size_t)expected_n_affected_leaves * 32)) return 0;
+    return 1;
+}
+
+cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_leaf,
+                                                  uint32_t n_affected_leaves) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !psigs_per_leaf) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "psigs_per_leaf", psigs_per_leaf,
+                      (size_t)n_affected_leaves * 32);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    return j;
+}
+
+int wire_parse_state_adv_client_final_psigs(const cJSON *json,
+                                               unsigned char *out_psigs_per_leaf,
+                                               uint32_t expected_n_affected_leaves) {
+    if (!json || !out_psigs_per_leaf) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
+    return wire_json_get_hex(json, "psigs_per_leaf",
+                               out_psigs_per_leaf,
+                               (size_t)expected_n_affected_leaves * 32) ==
+           (int)((size_t)expected_n_affected_leaves * 32);
+}
+
 
 cJSON *wire_build_bridge_hello_ack(void) {
     return cJSON_CreateObject();

--- a/src/wire.c
+++ b/src/wire.c
@@ -1178,23 +1178,43 @@ int wire_parse_leaf_advance_final(const cJSON *json,
    per-input arrays serialized as concatenated hex strings (n_inputs * size).
    The receiver passes expected_n_inputs to know how to split. */
 
-cJSON *wire_build_subfactory_propose_intent(uint32_t subfactory_id, uint32_t n_inputs) {
+cJSON *wire_build_subfactory_propose_intent(uint32_t subfactory_id, uint32_t n_inputs,
+                                              int leaf_side, int sub_idx, int channel_idx,
+                                              uint64_t delta_sats) {
     cJSON *j = cJSON_CreateObject();
     if (!j) return NULL;
     cJSON_AddNumberToObject(j, "subfactory_id", (double)subfactory_id);
     cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
+    cJSON_AddNumberToObject(j, "leaf_side", (double)leaf_side);
+    cJSON_AddNumberToObject(j, "sub_idx", (double)sub_idx);
+    cJSON_AddNumberToObject(j, "channel_idx", (double)channel_idx);
+    cJSON_AddNumberToObject(j, "delta_sats", (double)delta_sats);
     return j;
 }
 
 int wire_parse_subfactory_propose_intent(const cJSON *json,
                                            uint32_t *out_subfactory_id,
-                                           uint32_t *out_n_inputs) {
-    if (!json || !out_subfactory_id || !out_n_inputs) return 0;
+                                           uint32_t *out_n_inputs,
+                                           int *out_leaf_side, int *out_sub_idx,
+                                           int *out_channel_idx,
+                                           uint64_t *out_delta_sats) {
+    if (!json || !out_subfactory_id || !out_n_inputs ||
+        !out_leaf_side || !out_sub_idx || !out_channel_idx || !out_delta_sats) return 0;
     cJSON *sf = cJSON_GetObjectItem(json, "subfactory_id");
     cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
-    if (!sf || !ni || !cJSON_IsNumber(sf) || !cJSON_IsNumber(ni)) return 0;
+    cJSON *ls = cJSON_GetObjectItem(json, "leaf_side");
+    cJSON *si = cJSON_GetObjectItem(json, "sub_idx");
+    cJSON *ci = cJSON_GetObjectItem(json, "channel_idx");
+    cJSON *ds = cJSON_GetObjectItem(json, "delta_sats");
+    if (!sf || !ni || !ls || !si || !ci || !ds) return 0;
+    if (!cJSON_IsNumber(sf) || !cJSON_IsNumber(ni) || !cJSON_IsNumber(ls) ||
+        !cJSON_IsNumber(si) || !cJSON_IsNumber(ci) || !cJSON_IsNumber(ds)) return 0;
     *out_subfactory_id = (uint32_t)sf->valuedouble;
     *out_n_inputs = (uint32_t)ni->valuedouble;
+    *out_leaf_side = (int)ls->valuedouble;
+    *out_sub_idx = (int)si->valuedouble;
+    *out_channel_idx = (int)ci->valuedouble;
+    *out_delta_sats = (uint64_t)ds->valuedouble;
     return 1;
 }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -1174,6 +1174,111 @@ int wire_parse_leaf_advance_final(const cJSON *json,
     return 1;
 }
 
+/* Phase 1e.1.a -- sub-factory reversed flow wire codec.  Minimal payloads:
+   per-input arrays serialized as concatenated hex strings (n_inputs * size).
+   The receiver passes expected_n_inputs to know how to split. */
+
+cJSON *wire_build_subfactory_propose_intent(uint32_t subfactory_id, uint32_t n_inputs) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    cJSON_AddNumberToObject(j, "subfactory_id", (double)subfactory_id);
+    cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
+    return j;
+}
+
+int wire_parse_subfactory_propose_intent(const cJSON *json,
+                                           uint32_t *out_subfactory_id,
+                                           uint32_t *out_n_inputs) {
+    if (!json || !out_subfactory_id || !out_n_inputs) return 0;
+    cJSON *sf = cJSON_GetObjectItem(json, "subfactory_id");
+    cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
+    if (!sf || !ni || !cJSON_IsNumber(sf) || !cJSON_IsNumber(ni)) return 0;
+    *out_subfactory_id = (uint32_t)sf->valuedouble;
+    *out_n_inputs = (uint32_t)ni->valuedouble;
+    return 1;
+}
+
+cJSON *wire_build_subfactory_client_pubnonces(const unsigned char *pubnonces_per_input,
+                                                uint32_t n_inputs) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !pubnonces_per_input) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "pubnonces_per_input", pubnonces_per_input,
+                      (size_t)n_inputs * 66);
+    cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
+    return j;
+}
+
+int wire_parse_subfactory_client_pubnonces(const cJSON *json,
+                                             unsigned char *out_pubnonces_per_input,
+                                             uint32_t expected_n_inputs) {
+    if (!json || !out_pubnonces_per_input) return 0;
+    cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
+    if (!ni || !cJSON_IsNumber(ni)) return 0;
+    if ((uint32_t)ni->valuedouble != expected_n_inputs) return 0;
+    return wire_json_get_hex(json, "pubnonces_per_input",
+                               out_pubnonces_per_input,
+                               (size_t)expected_n_inputs * 66) ==
+           (int)((size_t)expected_n_inputs * 66);
+}
+
+cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per_input,
+                                            const unsigned char *lsp_psigs_per_input,
+                                            uint32_t n_inputs) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !lsp_pubnonces_per_input || !lsp_psigs_per_input) {
+        if (j) cJSON_Delete(j);
+        return NULL;
+    }
+    wire_json_add_hex(j, "lsp_pubnonces_per_input", lsp_pubnonces_per_input,
+                      (size_t)n_inputs * 66);
+    wire_json_add_hex(j, "lsp_psigs_per_input", lsp_psigs_per_input,
+                      (size_t)n_inputs * 32);
+    cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
+    return j;
+}
+
+int wire_parse_subfactory_lsp_response(const cJSON *json,
+                                         unsigned char *out_lsp_pubnonces_per_input,
+                                         unsigned char *out_lsp_psigs_per_input,
+                                         uint32_t expected_n_inputs) {
+    if (!json || !out_lsp_pubnonces_per_input || !out_lsp_psigs_per_input) return 0;
+    cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
+    if (!ni || !cJSON_IsNumber(ni)) return 0;
+    if ((uint32_t)ni->valuedouble != expected_n_inputs) return 0;
+    if (wire_json_get_hex(json, "lsp_pubnonces_per_input",
+                            out_lsp_pubnonces_per_input,
+                            (size_t)expected_n_inputs * 66) !=
+        (int)((size_t)expected_n_inputs * 66)) return 0;
+    if (wire_json_get_hex(json, "lsp_psigs_per_input",
+                            out_lsp_psigs_per_input,
+                            (size_t)expected_n_inputs * 32) !=
+        (int)((size_t)expected_n_inputs * 32)) return 0;
+    return 1;
+}
+
+cJSON *wire_build_subfactory_client_final_psigs(const unsigned char *psigs_per_input,
+                                                  uint32_t n_inputs) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !psigs_per_input) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "psigs_per_input", psigs_per_input,
+                      (size_t)n_inputs * 32);
+    cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
+    return j;
+}
+
+int wire_parse_subfactory_client_final_psigs(const cJSON *json,
+                                               unsigned char *out_psigs_per_input,
+                                               uint32_t expected_n_inputs) {
+    if (!json || !out_psigs_per_input) return 0;
+    cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
+    if (!ni || !cJSON_IsNumber(ni)) return 0;
+    if ((uint32_t)ni->valuedouble != expected_n_inputs) return 0;
+    return wire_json_get_hex(json, "psigs_per_input",
+                               out_psigs_per_input,
+                               (size_t)expected_n_inputs * 32) ==
+           (int)((size_t)expected_n_inputs * 32);
+}
+
 
 cJSON *wire_build_bridge_hello_ack(void) {
     return cJSON_CreateObject();


### PR DESCRIPTION
## Summary

Phase 1e.1 of the MuSig2 stateless-signer redesign (#271). Reverses the per-subfactory chain-advance ceremony for the simplest case (k=1 single-client + single-input, state TX only). This PR consolidates four commits:

| Commit | What | LOC |
|---|---|---|
| `8a1877b` 1e.1.a | Wire codec scaffolding — 4 new opcodes (`MSG_SUBFACTORY_PROPOSE_INTENT/CLIENT_PUBNONCES/LSP_RESPONSE/CLIENT_FINAL_PSIGS`) | +145 |
| `161963f` 1e.1.b | LSP-side stateless variant `lsp_subfactory_chain_advance_stateless` | +243 |
| `45aed88` 1e.1.b | MVP scope guard: refuse k≥2 multi-client (LSP_RESPONSE doesn't relay other clients' pubnonces yet) | +17 |
| `612d574` 1e.1.c | Client-side mirror `client_handle_subfactory_advance_stateless` | +191 |

**Total: +596 LOC across wire codec + LSP + client.**

## The 4-message reversed flow

```
LSP    -> Client: MSG_SUBFACTORY_PROPOSE_INTENT (0x7D) — no nonce field
Client -> LSP:    MSG_SUBFACTORY_CLIENT_PUBNONCES (0x7E) — own pubnonce
LSP atomic:       gen lsp_secnonce + set nonces + finalize_node + create_partial_sig
                   (lsp_secnonce zeroed before sending response)
LSP    -> Client: MSG_SUBFACTORY_LSP_RESPONSE (0x7F) { lsp_pubnonce, lsp_psig }
Client:           set lsp_nonce + finalize_node + create_partial_sig (zeros own secnonce)
Client -> LSP:    MSG_SUBFACTORY_CLIENT_FINAL_PSIGS (0x80) { own psig }
LSP:              aggregate + send DONE (existing 0x77)
```

## Atomic-signer invariant

Both LSP-side and client-side: secnonce is generated only after receiving the peer's pubnonce, and zeroed by `musig_create_partial_sig` before the next wire send. Mirrors Phase 1c/1d for per-leaf advance.

## MVP scope (intentional limits)

- ✅ k=1 single-client sub-factory
- ✅ Single-input
- ✅ State TX only
- ❌ k≥2 (refuses with `return -1` from LSP-side, falls back to legacy) — needs Phase 1e.1.d
- ❌ Multi-input (refuses, falls back) — needs Phase 1e.1.d
- ❌ Poison TX — needs Phase 1e.1.d
- ❌ Watchtower registration — needs Phase 1e.1.d
- ❌ Persist / C3 journal — needs Phase 1e.1.d

Each "❌" returns gracefully (legacy path runs) so this PR doesn't break any production traffic. Default is OFF (`SS_MUSIG_STATELESS` unset).

## Test plan

- [x] Build clean
- [x] **1472/1472 unit tests pass** (legacy unchanged → no regression)
- [ ] End-to-end regtest with SS_MUSIG_STATELESS=1 + k=1 sub-factory + single-input — needs new regtest script (Phase 1e.1.e validation infra)

## Phase 1 progress

| Phase | Status |
|---|---|
| 1a (#321) | ✅ merged |
| 1b (#323) | ✅ merged |
| 1c (#324) | ✅ merged |
| 1c-val (#325) | ✅ merged |
| 1d (#326) | ✅ merged |
| **1e.1.a/b/c (this PR)** | **opening — sub-factory MVP** |
| 1e.1.d | follow-up — k≥2, multi-input, poison, WT, persist |
| 1e.2 | future — Tier B state advance |
| 1e.3 | future — factory creation |
| 2 | future — flip default + signet validation |
| 3 | future — remove pool API + drop schema |
| Tests | future |
| Wallet coord | external |

## Why so much code for a "design done" feature?

The MuSig2 crypto itself is unchanged — same libsecp256k1 BIP-327 calls. What's being rewritten is the **lifetime of the LSP secret nonce**. The legacy flow holds it across `wire_recv()` calls (vulnerable to crash-recovery key extraction per Bitcoin Core PR #29675). The new flow generates it AFTER receiving client pubnonces and zeroes it atomically. This requires reordering the wire messages → new opcodes → both LSP and client sides updated → all four ceremonies need the same treatment.

References:
- `MUSIG_NONCE_REDESIGN_MEMO.md` §3.x
- PR #321/#323/#324/#325/#326
- Bitcoin Core PR #29675 (BIP-327 secnonce hygiene)
