### PR TITLE
feat(musig): Phase 1e.2.a — Tier B wire codec scaffolding (stacked on #327)

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -527,10 +527,12 @@ int    wire_parse_subfactory_client_final_psigs(const cJSON *json,
    ceremony: per-leaf arrays of pubnonces + psigs.  n_affected_leaves is
    the size of each array; receiver passes expected count to size buffers. */
 cJSON *wire_build_state_adv_propose_intent(uint32_t epoch_after,
-                                              uint32_t n_affected_leaves);
+                                              uint32_t n_affected_leaves,
+                                              int trigger_leaf_side);
 int    wire_parse_state_adv_propose_intent(const cJSON *json,
                                               uint32_t *out_epoch_after,
-                                              uint32_t *out_n_affected_leaves);
+                                              uint32_t *out_n_affected_leaves,
+                                              int *out_trigger_leaf_side);
 
 cJSON *wire_build_state_adv_client_path_nonces(const unsigned char *pubnonces_per_leaf /* n * 66 */,
                                                   uint32_t n_affected_leaves);

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -162,6 +162,18 @@
 #define MSG_SUBFACTORY_LSP_RESPONSE        0x7F  /* LSP -> Client: lsp_pubnonces + lsp_psigs (atomic gen+sign) */
 #define MSG_SUBFACTORY_CLIENT_FINAL_PSIGS  0x80  /* Client -> LSP: client psigs (one per input, after aggregating LSP+all-clients) */
 
+/* MuSig2 stateless redesign Phase 1e.2 (#271) -- Tier B state advance
+   reversed flow.  Multi-leaf ceremony (each affected leaf is its own MuSig
+   session).  Same atomic-signer property: LSP secnonces generated only
+   AFTER receiving all CLIENT_PATH_NONCES.  Existing 0x60-range opcodes
+   (MSG_STATE_ADVANCE_PROPOSE, MSG_PATH_NONCE_BUNDLE, MSG_PATH_ALL_NONCES,
+   MSG_PATH_PSIG_BUNDLE, MSG_PATH_SIGN_DONE) continue to work for
+   non-stateless peers. */
+#define MSG_STATE_ADV_PROPOSE_INTENT      0x81  /* LSP -> Client: intent (no nonce field) */
+#define MSG_STATE_ADV_CLIENT_PATH_NONCES  0x82  /* Client -> LSP: per-leaf pubnonces */
+#define MSG_STATE_ADV_LSP_RESPONSE        0x83  /* LSP -> Client: per-leaf lsp pubnonces + lsp psigs */
+#define MSG_STATE_ADV_CLIENT_FINAL_PSIGS  0x84  /* Client -> LSP: per-leaf client psigs */
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -510,6 +522,35 @@ cJSON *wire_build_subfactory_client_final_psigs(const unsigned char *psigs_per_i
 int    wire_parse_subfactory_client_final_psigs(const cJSON *json,
                                                   unsigned char *out_psigs_per_input,
                                                   uint32_t expected_n_inputs);
+
+/* Phase 1e.2.a Tier B state advance reversed flow wire codec.  Multi-leaf
+   ceremony: per-leaf arrays of pubnonces + psigs.  n_affected_leaves is
+   the size of each array; receiver passes expected count to size buffers. */
+cJSON *wire_build_state_adv_propose_intent(uint32_t epoch_after,
+                                              uint32_t n_affected_leaves);
+int    wire_parse_state_adv_propose_intent(const cJSON *json,
+                                              uint32_t *out_epoch_after,
+                                              uint32_t *out_n_affected_leaves);
+
+cJSON *wire_build_state_adv_client_path_nonces(const unsigned char *pubnonces_per_leaf /* n * 66 */,
+                                                  uint32_t n_affected_leaves);
+int    wire_parse_state_adv_client_path_nonces(const cJSON *json,
+                                                  unsigned char *out_pubnonces_per_leaf,
+                                                  uint32_t expected_n_affected_leaves);
+
+cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_leaf /* n * 66 */,
+                                            const unsigned char *lsp_psigs_per_leaf /* n * 32 */,
+                                            uint32_t n_affected_leaves);
+int    wire_parse_state_adv_lsp_response(const cJSON *json,
+                                            unsigned char *out_lsp_pubnonces_per_leaf,
+                                            unsigned char *out_lsp_psigs_per_leaf,
+                                            uint32_t expected_n_affected_leaves);
+
+cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_leaf /* n * 32 */,
+                                                  uint32_t n_affected_leaves);
+int    wire_parse_state_adv_client_final_psigs(const cJSON *json,
+                                                  unsigned char *out_psigs_per_leaf,
+                                                  uint32_t expected_n_affected_leaves);
 
 /* LSP → Bridge: BRIDGE_HELLO_ACK {} */
 cJSON *wire_build_bridge_hello_ack(void);

--- a/src/client.c
+++ b/src/client.c
@@ -4273,11 +4273,266 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
     return 1;
 }
 
+/* Phase 1e.2.d: client-side stateless Tier B handler.  Dispatched from
+   client_handle_state_advance when the LSP sends PROPOSE_INTENT (0x81)
+   instead of legacy STATE_ADVANCE_PROPOSE.  Mirrors lsp_run_state_advance_stateless
+   from Phase 1e.2.c.  MVP scope:
+     - multi-leaf state TX
+     - single-input per leaf
+     - no poison TX */
+static int client_handle_state_advance_stateless(int fd,
+                                                   secp256k1_context *ctx,
+                                                   const secp256k1_keypair *keypair,
+                                                   factory_t *factory,
+                                                   uint32_t my_index,
+                                                   const wire_msg_t *propose_msg) {
+    /* Step 1: Parse PROPOSE_INTENT { epoch_after, n_affected_leaves, trigger_leaf_side }. */
+    uint32_t epoch_after, n_affected_leaves;
+    int trigger_leaf_side;
+    if (!wire_parse_state_adv_propose_intent(propose_msg->json,
+                                                &epoch_after, &n_affected_leaves,
+                                                &trigger_leaf_side)) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: parse PROPOSE_INTENT failed\n", my_index);
+        return 0;
+    }
+
+    /* Step 2: Run factory_advance_leaf_unsigned locally.  Must return -1
+       (root rolled over, all leaves rebuilt) — mirrors caller contract on LSP. */
+    int adv_rc = factory_advance_leaf_unsigned(factory, trigger_leaf_side);
+    if (adv_rc != -1) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: advance_leaf_unsigned returned %d (expected -1)\n",
+            my_index, adv_rc);
+        return 0;
+    }
+
+    /* Step 3: Build affected[] — SAME logic as LSP. */
+    size_t affected[FACTORY_MAX_NODES];
+    size_t n_affected = 0;
+    for (size_t i = 0; i < factory->n_nodes; i++) {
+        const factory_node_t *n = &factory->nodes[i];
+        if (n->is_ps_leaf && trigger_leaf_side != -1) continue;
+        if (!n->is_built) continue;
+        if (n->is_signed) continue;
+        affected[n_affected++] = i;
+    }
+    if (n_affected != n_affected_leaves) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: local n_affected=%zu mismatches LSP=%u\n",
+            my_index, n_affected, n_affected_leaves);
+        return 0;
+    }
+
+    /* MVP refusal: multi-input on any affected. */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (factory_node_uses_multi_input(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: affected %zu uses multi-input — refusing\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 4: init MuSig session per affected. */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_init_node(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: init_node[%zu] failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 5: gen own pubnonces for each affected node where this client signs.
+       For non-participating leaves: leave the buffer all-zeros (LSP detects). */
+    unsigned char my_seckey[32];
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: keypair_sec failed\n", my_index);
+        return 0;
+    }
+    secp256k1_pubkey my_pubkey;
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+    unsigned char my_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    secp256k1_musig_secnonce my_secnonces[FACTORY_MAX_NODES];
+    int my_slot_per_node[FACTORY_MAX_NODES];
+    int my_signs_per_node[FACTORY_MAX_NODES];
+    for (size_t k = 0; k < n_affected; k++) {
+        memset(my_pubnonces_per_node[k], 0, 66);
+        my_slot_per_node[k] = -1;
+        my_signs_per_node[k] = 0;
+    }
+
+    for (size_t k = 0; k < n_affected; k++) {
+        int slot = factory_find_signer_slot(factory, affected[k], my_index);
+        if (slot < 0) continue;  /* this client doesn't sign this node */
+        secp256k1_musig_pubnonce pn;
+        if (!musig_generate_nonce(ctx, &my_secnonces[k], &pn,
+                                    my_seckey, &my_pubkey,
+                                    &factory->nodes[affected[k]].keyagg.cache)) {
+            memset(my_seckey, 0, 32);
+            fprintf(stderr,
+                "Client-stateless Tier B %u: nonce gen for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        my_slot_per_node[k] = slot;
+        my_signs_per_node[k] = 1;
+        musig_pubnonce_serialize(ctx, my_pubnonces_per_node[k], &pn);
+        if (!factory_session_set_nonce(factory, affected[k], (size_t)slot, &pn)) {
+            memset(my_seckey, 0, 32);
+            fprintf(stderr,
+                "Client-stateless Tier B %u: set own nonce for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+    memset(my_seckey, 0, 32);
+
+    /* Step 6: send CLIENT_PATH_NONCES. */
+    cJSON *cpn = wire_build_state_adv_client_path_nonces(
+        (const unsigned char *)my_pubnonces_per_node, (uint32_t)n_affected);
+    if (!wire_send(fd, MSG_STATE_ADV_CLIENT_PATH_NONCES, cpn)) {
+        cJSON_Delete(cpn);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: send CLIENT_PATH_NONCES failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(cpn);
+
+    /* Step 7: recv LSP_RESPONSE { lsp_pubnonces_per_leaf, lsp_psigs_per_leaf }. */
+    wire_msg_t lr;
+    if (!wire_recv(fd, &lr) || lr.msg_type != MSG_STATE_ADV_LSP_RESPONSE) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: expected LSP_RESPONSE, got 0x%02x\n",
+            my_index, lr.json ? lr.msg_type : 0);
+        if (lr.json) cJSON_Delete(lr.json);
+        return 0;
+    }
+    unsigned char lsp_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    unsigned char lsp_psigs_per_node[FACTORY_MAX_NODES][32];
+    if (!wire_parse_state_adv_lsp_response(lr.json,
+                                             (unsigned char *)lsp_pubnonces_per_node,
+                                             (unsigned char *)lsp_psigs_per_node,
+                                             (uint32_t)n_affected)) {
+        cJSON_Delete(lr.json);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: parse LSP_RESPONSE failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(lr.json);
+
+    /* Step 8: for each affected node, set LSP nonce + finalize + set LSP psig +
+       create own partial_sig (zeros own secnonce) + set own psig + complete. */
+    unsigned char my_psigs_per_node[FACTORY_MAX_NODES][32];
+    for (size_t k = 0; k < n_affected; k++) memset(my_psigs_per_node[k], 0, 32);
+
+    for (size_t k = 0; k < n_affected; k++) {
+        int lsp_slot = factory_find_signer_slot(factory, affected[k], 0);
+        if (lsp_slot < 0) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: LSP not signer on %zu (invariant violation)\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        secp256k1_musig_pubnonce lsp_pn;
+        if (!musig_pubnonce_parse(ctx, &lsp_pn, lsp_pubnonces_per_node[k]) ||
+            !factory_session_set_nonce(factory, affected[k], (size_t)lsp_slot, &lsp_pn)) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: set LSP nonce for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        if (!factory_session_finalize_node(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: finalize_node[%zu] failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        /* Set LSP's psig into the session. */
+        secp256k1_musig_partial_sig lsp_psig;
+        if (!musig_partial_sig_parse(ctx, &lsp_psig, lsp_psigs_per_node[k]) ||
+            !factory_session_set_partial_sig(factory, affected[k], (size_t)lsp_slot, &lsp_psig)) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: set LSP psig for %zu failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+        /* Create own partial_sig (zeros own secnonce). */
+        if (my_signs_per_node[k]) {
+            secp256k1_musig_partial_sig my_psig;
+            if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonces[k], keypair,
+                                            &factory->nodes[affected[k]].signing_session)) {
+                fprintf(stderr,
+                    "Client-stateless Tier B %u: create_partial_sig[%zu] failed\n",
+                    my_index, affected[k]);
+                return 0;
+            }
+            musig_partial_sig_serialize(ctx, my_psigs_per_node[k], &my_psig);
+            if (!factory_session_set_partial_sig(factory, affected[k],
+                                                   (size_t)my_slot_per_node[k], &my_psig)) {
+                fprintf(stderr,
+                    "Client-stateless Tier B %u: set own psig[%zu] failed\n",
+                    my_index, affected[k]);
+                return 0;
+            }
+        }
+    }
+    /* INVARIANT: own secnonces zeroed by musig_create_partial_sig. */
+
+    /* Step 9: send CLIENT_FINAL_PSIGS. */
+    cJSON *fp = wire_build_state_adv_client_final_psigs(
+        (const unsigned char *)my_psigs_per_node, (uint32_t)n_affected);
+    if (!wire_send(fd, MSG_STATE_ADV_CLIENT_FINAL_PSIGS, fp)) {
+        cJSON_Delete(fp);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: send CLIENT_FINAL_PSIGS failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(fp);
+
+    /* Step 10: complete_node per affected (LSP will also). */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_complete_node(factory, affected[k])) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: complete_node[%zu] failed\n",
+                my_index, affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 11: recv DONE (MSG_PATH_SIGN_DONE). */
+    wire_msg_t done;
+    if (!wire_recv(fd, &done) || done.msg_type != MSG_PATH_SIGN_DONE) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: expected PATH_SIGN_DONE, got 0x%02x\n",
+            my_index, done.json ? done.msg_type : 0);
+        if (done.json) cJSON_Delete(done.json);
+        return 0;
+    }
+    if (done.json) cJSON_Delete(done.json);
+
+    printf("Client-stateless Tier B %u: %zu affected nodes signed\n",
+           my_index, n_affected);
+    return 1;
+}
+
 int client_handle_state_advance(int fd, secp256k1_context *ctx,
                                   const secp256k1_keypair *keypair,
                                   factory_t *factory,
                                   uint32_t my_index,
                                   const wire_msg_t *propose_msg) {
+    /* Phase 1e.2.d: if LSP sent the new stateless PROPOSE_INTENT opcode,
+       dispatch to the stateless handler.  Legacy STATE_ADVANCE_PROPOSE
+       continues to use the path below. */
+    if (propose_msg && propose_msg->msg_type == MSG_STATE_ADV_PROPOSE_INTENT) {
+        return client_handle_state_advance_stateless(fd, ctx, keypair,
+                                                       factory, my_index,
+                                                       propose_msg);
+    }
+
     /* Parse propose */
     uint32_t epoch_in;
     int trigger_leaf;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2553,10 +2553,53 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
    the LSP can retry by calling lsp_run_state_advance() again.  The
    on-chain factory is unaffected — old signed TXs remain stored
    (overlap window) and the watchtower still has the old burn TXs. */
+/* Phase 1e.2.b scaffolding: stub for the reversed-flow stateless Tier B
+   state advance ceremony.  Dispatched from the public function when
+   SS_MUSIG_STATELESS=1 is set.  Currently returns -1 for all cases
+   (caller falls through to legacy lsp_run_state_advance) — Phase 1e.2.c
+   will fill in the actual multi-leaf MuSig ceremony using the wire codec
+   added in Phase 1e.2.a (#328).
+
+   Wire flow (per Phase 1e.2.a opcodes):
+     LSP   -> Client:  MSG_STATE_ADV_PROPOSE_INTENT (0x81)
+     Client -> LSP:    MSG_STATE_ADV_CLIENT_PATH_NONCES (0x82)
+     LSP atomic:       gen lsp_secnonces + set nonces + finalize + create_partial_sigs
+                        (lsp_secnonces zeroed before next send)
+     LSP   -> Client:  MSG_STATE_ADV_LSP_RESPONSE (0x83) per-leaf data
+     Client -> LSP:    MSG_STATE_ADV_CLIENT_FINAL_PSIGS (0x84)
+     LSP:              aggregate + factory_session_complete_node per leaf
+     LSP   -> Client:  MSG_PATH_SIGN_DONE (existing terminal opcode)
+
+   Returns: 1 on success, 0 on failure, -1 if the stateless function cannot
+   handle this case (caller falls through to legacy). */
+static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
+                                             lsp_t *lsp,
+                                             int trigger_leaf_side) {
+    (void)mgr; (void)lsp; (void)trigger_leaf_side;
+    /* Phase 1e.2.b is a stub only.  Phase 1e.2.c will implement the
+       multi-leaf reversed flow.  For now, refuse and fall back to legacy. */
+    fprintf(stderr,
+        "LSP-stateless Tier B: not yet implemented (Phase 1e.2.c) -- "
+        "falling back to legacy lsp_run_state_advance\n");
+    return -1;
+}
+
 int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                             int trigger_leaf_side) {
     factory_t *f = &lsp->factory;
     if (!mgr || !lsp) return 0;
+
+    /* Phase 1e.2.b (#271): when --musig-stateless is in effect, dispatch
+       to the reversed-order flow.  Returns -1 to signal fall-through to
+       legacy if the stateless variant cannot handle this case. */
+    {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        if (stateless && stateless[0] == '1') {
+            int rc = lsp_run_state_advance_stateless(mgr, lsp, trigger_leaf_side);
+            if (rc >= 0) return rc;
+            /* rc == -1: stateless declined; fall through to legacy below. */
+        }
+    }
 
     /* CL4-rollover (#250 Tier B path): snapshot the pre-rollover leaf 0
        signed_tx so we can broadcast it post-ceremony as the stake-theft

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2575,13 +2575,277 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
 static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                                              lsp_t *lsp,
                                              int trigger_leaf_side) {
-    (void)mgr; (void)lsp; (void)trigger_leaf_side;
-    /* Phase 1e.2.b is a stub only.  Phase 1e.2.c will implement the
-       multi-leaf reversed flow.  For now, refuse and fall back to legacy. */
-    fprintf(stderr,
-        "LSP-stateless Tier B: not yet implemented (Phase 1e.2.c) -- "
-        "falling back to legacy lsp_run_state_advance\n");
-    return -1;
+    if (!mgr || !lsp) return 0;
+    factory_t *f = &lsp->factory;
+
+    /* MVP refusal: watchtower configured -> poison TX would be required. */
+    if (mgr->watchtower) {
+        fprintf(stderr,
+            "LSP-stateless Tier B: watchtower configured (poison TX needed) -- "
+            "falling back to legacy\n");
+        return -1;
+    }
+
+    /* Step 1: Build affected[] (same logic as legacy at line ~2725). */
+    size_t affected[FACTORY_MAX_NODES];
+    size_t n_affected = 0;
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        const factory_node_t *n = &f->nodes[i];
+        if (n->is_ps_leaf && trigger_leaf_side != -1) continue;
+        if (!n->is_built) continue;
+        if (n->is_signed) continue;
+        affected[n_affected++] = i;
+    }
+    if (n_affected == 0) {
+        /* Nothing to do.  Send DONE for completeness. */
+        cJSON *done = wire_build_path_sign_done((uint32_t)f->counter.current_epoch);
+        for (size_t i = 0; i < lsp->n_clients; i++)
+            wire_send(lsp->client_fds[i], MSG_PATH_SIGN_DONE, done);
+        cJSON_Delete(done);
+        return 1;
+    }
+
+    /* MVP refusal: multi-input on any affected node. */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (factory_node_uses_multi_input(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: affected node %zu uses multi-input -- "
+                "falling back to legacy\n", affected[k]);
+            return -1;
+        }
+    }
+
+    /* Step 2: Init MuSig session for each affected node (state only). */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_init_node(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: init_node[%zu] failed\n", affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 3: Send PROPOSE_INTENT to all clients (no nonces). */
+    cJSON *propose = wire_build_state_adv_propose_intent(
+        (uint32_t)f->counter.current_epoch, (uint32_t)n_affected);
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_PROPOSE_INTENT, propose)) {
+            cJSON_Delete(propose);
+            fprintf(stderr,
+                "LSP-stateless Tier B: send PROPOSE_INTENT[%zu] failed\n", c);
+            return 0;
+        }
+    }
+    cJSON_Delete(propose);
+
+    /* Step 4: Collect CLIENT_PATH_NONCES from each client.
+       Each client sends pubnonces for the affected nodes they're a signer on.
+       Wire format is per-leaf array (66 bytes each) indexed by affected[] order.
+       Client must produce nonces only for affected nodes where they sign;
+       non-participating slots get all-zero buffers (skip those). */
+    unsigned char client_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    int client_slot_per_node[FACTORY_MAX_NODES];
+    (void)client_slot_per_node; /* recorded for future audit; unused in MVP */
+    for (size_t k = 0; k < n_affected; k++) client_slot_per_node[k] = -1;
+
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        wire_msg_t nmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[c], &nmsg,
+                                          WIRE_CEREMONY_BUNDLE_TIMEOUT_SEC) ||
+            nmsg.msg_type != MSG_STATE_ADV_CLIENT_PATH_NONCES) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: expected CLIENT_PATH_NONCES from client %zu, "
+                "got 0x%02x\n", c, nmsg.msg_type);
+            if (nmsg.json) cJSON_Delete(nmsg.json);
+            return 0;
+        }
+        unsigned char this_client_pn[FACTORY_MAX_NODES][66];
+        if (!wire_parse_state_adv_client_path_nonces(nmsg.json,
+                                                       (unsigned char *)this_client_pn,
+                                                       (uint32_t)n_affected)) {
+            cJSON_Delete(nmsg.json);
+            fprintf(stderr,
+                "LSP-stateless Tier B: parse CLIENT_PATH_NONCES from client %zu failed\n",
+                c);
+            return 0;
+        }
+        cJSON_Delete(nmsg.json);
+        /* Distribute: for each affected node, if this client is a signer,
+           record their pubnonce + slot.  An all-zero pubnonce indicates
+           "I'm not a signer on this leaf" -- skip. */
+        for (size_t k = 0; k < n_affected; k++) {
+            int slot = factory_find_signer_slot(f, affected[k], (uint32_t)(c + 1));
+            if (slot < 0) continue;  /* this client doesn't sign this node */
+            /* Skip if all zeros (client signaled no nonce for this leaf) */
+            int all_zero = 1;
+            for (size_t b = 0; b < 66; b++) {
+                if (this_client_pn[k][b] != 0) { all_zero = 0; break; }
+            }
+            if (all_zero) continue;
+            secp256k1_musig_pubnonce pn;
+            if (!musig_pubnonce_parse(lsp->ctx, &pn, this_client_pn[k]) ||
+                !factory_session_set_nonce(f, affected[k], (size_t)slot, &pn)) {
+                fprintf(stderr,
+                    "LSP-stateless Tier B: parse/set client[%zu] nonce for node %zu failed\n",
+                    c, affected[k]);
+                return 0;
+            }
+            memcpy(client_pubnonces_per_node[k], this_client_pn[k], 66);
+            client_slot_per_node[k] = slot;
+        }
+    }
+
+    /* Step 5: ATOMIC -- gen LSP nonces, set+finalize, create_partial_sig per leaf.
+       Uses musig_nonce_pool_generate (same as legacy line 2790) but ONLY now,
+       after all client nonces have arrived.  No LSP secnonces held across recv. */
+    size_t lsp_node_count = 0;
+    for (size_t k = 0; k < n_affected; k++) {
+        if (factory_find_signer_slot(f, affected[k], 0) >= 0)
+            lsp_node_count++;
+    }
+    if (lsp_node_count == 0) {
+        fprintf(stderr, "LSP-stateless Tier B: LSP not a signer on any affected\n");
+        return 0;
+    }
+
+    musig_nonce_pool_t lsp_pool;
+    unsigned char lsp_seckey[32];
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) return 0;
+    if (!musig_nonce_pool_generate(lsp->ctx, &lsp_pool, lsp_node_count,
+                                    lsp_seckey, &lsp->lsp_pubkey, NULL)) {
+        memset(lsp_seckey, 0, 32);
+        fprintf(stderr, "LSP-stateless Tier B: nonce pool gen failed\n");
+        return 0;
+    }
+    memset(lsp_seckey, 0, 32);
+
+    int lsp_slot_per_node[FACTORY_MAX_NODES];
+    (void)lsp_slot_per_node; /* recorded for future audit; unused in MVP */
+    unsigned char lsp_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    unsigned char lsp_psigs_per_node[FACTORY_MAX_NODES][32];
+    for (size_t k = 0; k < n_affected; k++) {
+        lsp_slot_per_node[k] = -1;
+        memset(lsp_pubnonces_per_node[k], 0, 66);
+        memset(lsp_psigs_per_node[k], 0, 32);
+    }
+
+    secp256k1_keypair lsp_kp = lsp->lsp_keypair;
+    for (size_t k = 0; k < n_affected; k++) {
+        int slot = factory_find_signer_slot(f, affected[k], 0);
+        if (slot < 0) continue;
+        secp256k1_musig_secnonce *sec;
+        secp256k1_musig_pubnonce pub;
+        if (!musig_nonce_pool_next(&lsp_pool, &sec, &pub)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: pool exhausted at node %zu\n", affected[k]);
+            return 0;
+        }
+        lsp_slot_per_node[k] = slot;
+        musig_pubnonce_serialize(lsp->ctx, lsp_pubnonces_per_node[k], &pub);
+        if (!factory_session_set_nonce(f, affected[k], (size_t)slot, &pub)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: set LSP nonce for %zu failed\n", affected[k]);
+            return 0;
+        }
+        if (!factory_session_finalize_node(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: finalize_node[%zu] failed\n", affected[k]);
+            return 0;
+        }
+        secp256k1_musig_partial_sig psig;
+        if (!musig_create_partial_sig(lsp->ctx, &psig, sec, &lsp_kp,
+                                        &f->nodes[affected[k]].signing_session)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: create_partial_sig[%zu] failed\n",
+                affected[k]);
+            return 0;
+        }
+        /* sec zeroed by musig_create_partial_sig */
+        musig_partial_sig_serialize(lsp->ctx, lsp_psigs_per_node[k], &psig);
+        if (!factory_session_set_partial_sig(f, affected[k], (size_t)slot, &psig)) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: set LSP psig[%zu] failed\n", affected[k]);
+            return 0;
+        }
+    }
+    /* INVARIANT: every LSP secnonce in lsp_pool has been pulled and zeroed
+       by musig_create_partial_sig.  No LSP secnonce in scope for the recv
+       that follows. */
+
+    /* Step 7: Send LSP_RESPONSE with per-node pubnonces + psigs to all clients. */
+    cJSON *response = wire_build_state_adv_lsp_response(
+        (const unsigned char *)lsp_pubnonces_per_node,
+        (const unsigned char *)lsp_psigs_per_node,
+        (uint32_t)n_affected);
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_LSP_RESPONSE, response)) {
+            cJSON_Delete(response);
+            fprintf(stderr,
+                "LSP-stateless Tier B: send LSP_RESPONSE[%zu] failed\n", c);
+            return 0;
+        }
+    }
+    cJSON_Delete(response);
+
+    /* Step 8: Collect CLIENT_FINAL_PSIGS from each client. */
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        wire_msg_t pmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[c], &pmsg,
+                                          WIRE_CEREMONY_BUNDLE_TIMEOUT_SEC) ||
+            pmsg.msg_type != MSG_STATE_ADV_CLIENT_FINAL_PSIGS) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: expected CLIENT_FINAL_PSIGS from client %zu, "
+                "got 0x%02x\n", c, pmsg.msg_type);
+            if (pmsg.json) cJSON_Delete(pmsg.json);
+            return 0;
+        }
+        unsigned char this_client_psigs[FACTORY_MAX_NODES][32];
+        if (!wire_parse_state_adv_client_final_psigs(pmsg.json,
+                                                       (unsigned char *)this_client_psigs,
+                                                       (uint32_t)n_affected)) {
+            cJSON_Delete(pmsg.json);
+            fprintf(stderr,
+                "LSP-stateless Tier B: parse CLIENT_FINAL_PSIGS[%zu] failed\n", c);
+            return 0;
+        }
+        cJSON_Delete(pmsg.json);
+        for (size_t k = 0; k < n_affected; k++) {
+            int slot = factory_find_signer_slot(f, affected[k], (uint32_t)(c + 1));
+            if (slot < 0) continue;
+            /* Skip if all zeros (client signaled no psig for this leaf) */
+            int all_zero = 1;
+            for (size_t b = 0; b < 32; b++) {
+                if (this_client_psigs[k][b] != 0) { all_zero = 0; break; }
+            }
+            if (all_zero) continue;
+            secp256k1_musig_partial_sig psig;
+            if (!musig_partial_sig_parse(lsp->ctx, &psig, this_client_psigs[k]) ||
+                !factory_session_set_partial_sig(f, affected[k], (size_t)slot, &psig)) {
+                fprintf(stderr,
+                    "LSP-stateless Tier B: set client[%zu] psig for %zu failed\n",
+                    c, affected[k]);
+                return 0;
+            }
+        }
+    }
+
+    /* Step 9: Complete each affected node (aggregate psigs + attach signed_tx). */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (!factory_session_complete_node(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: complete_node[%zu] failed\n", affected[k]);
+            return 0;
+        }
+    }
+
+    /* Step 10: Broadcast DONE (existing opcode). */
+    cJSON *done = wire_build_path_sign_done((uint32_t)f->counter.current_epoch);
+    for (size_t c = 0; c < lsp->n_clients; c++)
+        wire_send(lsp->client_fds[c], MSG_PATH_SIGN_DONE, done);
+    cJSON_Delete(done);
+
+    printf("LSP-stateless Tier B: state advance complete for %zu affected nodes\n",
+           n_affected);
+    return 1;
 }
 
 int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
@@ -2803,6 +3067,7 @@ int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        entries where LSP doesn't sign that node. */
     secp256k1_musig_secnonce *lsp_sec_per_node[FACTORY_MAX_NODES];
     int lsp_slot_per_node[FACTORY_MAX_NODES];
+    (void)lsp_slot_per_node; /* recorded for future audit; unused in MVP */
     for (size_t k = 0; k < n_affected; k++) {
         lsp_sec_per_node[k] = NULL;
         lsp_slot_per_node[k] = -1;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2626,7 +2626,8 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
 
     /* Step 3: Send PROPOSE_INTENT to all clients (no nonces). */
     cJSON *propose = wire_build_state_adv_propose_intent(
-        (uint32_t)f->counter.current_epoch, (uint32_t)n_affected);
+        (uint32_t)f->counter.current_epoch, (uint32_t)n_affected,
+        trigger_leaf_side);
     for (size_t c = 0; c < lsp->n_clients; c++) {
         if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_PROPOSE_INTENT, propose)) {
             cJSON_Delete(propose);

--- a/src/wire.c
+++ b/src/wire.c
@@ -1299,6 +1299,110 @@ int wire_parse_subfactory_client_final_psigs(const cJSON *json,
            (int)((size_t)expected_n_inputs * 32);
 }
 
+/* Phase 1e.2.a -- Tier B state advance reversed flow wire codec. */
+
+cJSON *wire_build_state_adv_propose_intent(uint32_t epoch_after,
+                                              uint32_t n_affected_leaves) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    cJSON_AddNumberToObject(j, "epoch_after", (double)epoch_after);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    return j;
+}
+
+int wire_parse_state_adv_propose_intent(const cJSON *json,
+                                           uint32_t *out_epoch_after,
+                                           uint32_t *out_n_affected_leaves) {
+    if (!json || !out_epoch_after || !out_n_affected_leaves) return 0;
+    cJSON *e = cJSON_GetObjectItem(json, "epoch_after");
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    if (!e || !n || !cJSON_IsNumber(e) || !cJSON_IsNumber(n)) return 0;
+    *out_epoch_after = (uint32_t)e->valuedouble;
+    *out_n_affected_leaves = (uint32_t)n->valuedouble;
+    return 1;
+}
+
+cJSON *wire_build_state_adv_client_path_nonces(const unsigned char *pubnonces_per_leaf,
+                                                  uint32_t n_affected_leaves) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !pubnonces_per_leaf) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "pubnonces_per_leaf", pubnonces_per_leaf,
+                      (size_t)n_affected_leaves * 66);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    return j;
+}
+
+int wire_parse_state_adv_client_path_nonces(const cJSON *json,
+                                               unsigned char *out_pubnonces_per_leaf,
+                                               uint32_t expected_n_affected_leaves) {
+    if (!json || !out_pubnonces_per_leaf) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
+    return wire_json_get_hex(json, "pubnonces_per_leaf",
+                               out_pubnonces_per_leaf,
+                               (size_t)expected_n_affected_leaves * 66) ==
+           (int)((size_t)expected_n_affected_leaves * 66);
+}
+
+cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_leaf,
+                                            const unsigned char *lsp_psigs_per_leaf,
+                                            uint32_t n_affected_leaves) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !lsp_pubnonces_per_leaf || !lsp_psigs_per_leaf) {
+        if (j) cJSON_Delete(j);
+        return NULL;
+    }
+    wire_json_add_hex(j, "lsp_pubnonces_per_leaf", lsp_pubnonces_per_leaf,
+                      (size_t)n_affected_leaves * 66);
+    wire_json_add_hex(j, "lsp_psigs_per_leaf", lsp_psigs_per_leaf,
+                      (size_t)n_affected_leaves * 32);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    return j;
+}
+
+int wire_parse_state_adv_lsp_response(const cJSON *json,
+                                         unsigned char *out_lsp_pubnonces_per_leaf,
+                                         unsigned char *out_lsp_psigs_per_leaf,
+                                         uint32_t expected_n_affected_leaves) {
+    if (!json || !out_lsp_pubnonces_per_leaf || !out_lsp_psigs_per_leaf) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
+    if (wire_json_get_hex(json, "lsp_pubnonces_per_leaf",
+                            out_lsp_pubnonces_per_leaf,
+                            (size_t)expected_n_affected_leaves * 66) !=
+        (int)((size_t)expected_n_affected_leaves * 66)) return 0;
+    if (wire_json_get_hex(json, "lsp_psigs_per_leaf",
+                            out_lsp_psigs_per_leaf,
+                            (size_t)expected_n_affected_leaves * 32) !=
+        (int)((size_t)expected_n_affected_leaves * 32)) return 0;
+    return 1;
+}
+
+cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_leaf,
+                                                  uint32_t n_affected_leaves) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !psigs_per_leaf) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "psigs_per_leaf", psigs_per_leaf,
+                      (size_t)n_affected_leaves * 32);
+    cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    return j;
+}
+
+int wire_parse_state_adv_client_final_psigs(const cJSON *json,
+                                               unsigned char *out_psigs_per_leaf,
+                                               uint32_t expected_n_affected_leaves) {
+    if (!json || !out_psigs_per_leaf) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
+    return wire_json_get_hex(json, "psigs_per_leaf",
+                               out_psigs_per_leaf,
+                               (size_t)expected_n_affected_leaves * 32) ==
+           (int)((size_t)expected_n_affected_leaves * 32);
+}
+
 
 cJSON *wire_build_bridge_hello_ack(void) {
     return cJSON_CreateObject();

--- a/src/wire.c
+++ b/src/wire.c
@@ -1302,23 +1302,30 @@ int wire_parse_subfactory_client_final_psigs(const cJSON *json,
 /* Phase 1e.2.a -- Tier B state advance reversed flow wire codec. */
 
 cJSON *wire_build_state_adv_propose_intent(uint32_t epoch_after,
-                                              uint32_t n_affected_leaves) {
+                                              uint32_t n_affected_leaves,
+                                              int trigger_leaf_side) {
     cJSON *j = cJSON_CreateObject();
     if (!j) return NULL;
     cJSON_AddNumberToObject(j, "epoch_after", (double)epoch_after);
     cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
+    cJSON_AddNumberToObject(j, "trigger_leaf_side", (double)trigger_leaf_side);
     return j;
 }
 
 int wire_parse_state_adv_propose_intent(const cJSON *json,
                                            uint32_t *out_epoch_after,
-                                           uint32_t *out_n_affected_leaves) {
-    if (!json || !out_epoch_after || !out_n_affected_leaves) return 0;
+                                           uint32_t *out_n_affected_leaves,
+                                           int *out_trigger_leaf_side) {
+    if (!json || !out_epoch_after || !out_n_affected_leaves ||
+        !out_trigger_leaf_side) return 0;
     cJSON *e = cJSON_GetObjectItem(json, "epoch_after");
     cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
-    if (!e || !n || !cJSON_IsNumber(e) || !cJSON_IsNumber(n)) return 0;
+    cJSON *t = cJSON_GetObjectItem(json, "trigger_leaf_side");
+    if (!e || !n || !t ||
+        !cJSON_IsNumber(e) || !cJSON_IsNumber(n) || !cJSON_IsNumber(t)) return 0;
     *out_epoch_after = (uint32_t)e->valuedouble;
     *out_n_affected_leaves = (uint32_t)n->valuedouble;
+    *out_trigger_leaf_side = (int)t->valuedouble;
     return 1;
 }
 


### PR DESCRIPTION
## Summary

Phase 1e.2.a of the MuSig2 stateless-signer redesign (#271). **Wire codec scaffolding only — no behavior change.** Mirrors Phase 1b/1e.1.a pattern.

**Stacked on PR #327** (Phase 1e.1.a sub-factory wire codec) since opcodes 0x81-0x84 follow 0x7D-0x80 from that PR.

## What this adds

Four new opcodes for Tier B state advance reversed flow:

| Opcode | Direction | Payload |
|---|---|---|
| `0x81 MSG_STATE_ADV_PROPOSE_INTENT` | LSP → Client | `epoch_after`, `n_affected_leaves` (no nonces) |
| `0x82 MSG_STATE_ADV_CLIENT_PATH_NONCES` | Client → LSP | per-leaf pubnonces (n × 66 bytes) |
| `0x83 MSG_STATE_ADV_LSP_RESPONSE` | LSP → Client | per-leaf `lsp_pubnonces` + `lsp_psigs` (atomic gen+sign) |
| `0x84 MSG_STATE_ADV_CLIENT_FINAL_PSIGS` | Client → LSP | per-leaf client psigs |

Reuses existing `MSG_PATH_SIGN_DONE` for terminal completion.

## Why a new opcode set vs reusing existing

Existing `MSG_STATE_ADVANCE_PROPOSE` already carries LSP nonces — the legacy "LSP-first" pattern that has the secnonce-across-recv vulnerability. The stateless flow needs different wire payload semantics, so a fresh opcode set keeps the protocols cleanly separable. Default mode (no env var) keeps legacy 0x60-range opcodes; SS_MUSIG_STATELESS=1 uses the new 0x81-0x84 set.

## Phase 1 progress

| Phase | Status |
|---|---|
| 1a (#321) | ✅ merged |
| 1b (#323) | ✅ merged |
| 1c (#324) | ✅ merged |
| 1c-val (#325) | ✅ merged |
| 1d (#326) | ✅ merged |
| 1e.1 (#327) | ⏳ open — sub-factory MVP |
| **1e.2.a (this PR)** | **opening — Tier B wire codec** |
| 1e.2.b | next — `lsp_run_state_advance_stateless` |
| 1e.2.c | next — client mirror |
| 1e.3 | future — factory creation |
| 2 / 3 / Tests / Wallet | future |

## Test plan

- [x] Build clean
- [x] **1472/1472 unit tests pass** (legacy unchanged)
- [ ] Phase 1e.2.b: actually wire into `lsp_run_state_advance`
