### PR TITLE
feat(musig): Phase 1e.3.a/b — factory creation wire codec + stub (completes 4-ceremony scaffold)

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -174,6 +174,16 @@
 #define MSG_STATE_ADV_LSP_RESPONSE        0x83  /* LSP -> Client: per-leaf lsp pubnonces + lsp psigs */
 #define MSG_STATE_ADV_CLIENT_FINAL_PSIGS  0x84  /* Client -> LSP: per-leaf client psigs */
 
+/* MuSig2 stateless redesign Phase 1e.3 (#271) -- factory creation reversed flow.
+   Initial ceremony where every signer participates over the full TX tree.
+   Same atomic-signer property: LSP secnonces generated only AFTER
+   CLIENT_PUBNONCES received from every client.  Existing 0x10-0x14 opcodes
+   continue to work for non-stateless peers. */
+#define MSG_FACTORY_PROPOSE_INTENT      0x85  /* LSP -> Client: intent (no nonces) */
+#define MSG_FACTORY_CLIENT_PUBNONCES    0x86  /* Client -> LSP: per-node pubnonces */
+#define MSG_FACTORY_LSP_RESPONSE        0x87  /* LSP -> Client: per-node lsp pubnonces + psigs */
+#define MSG_FACTORY_CLIENT_FINAL_PSIGS  0x88
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -553,6 +563,31 @@ cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_le
 int    wire_parse_state_adv_client_final_psigs(const cJSON *json,
                                                   unsigned char *out_psigs_per_leaf,
                                                   uint32_t expected_n_affected_leaves);
+
+/* Phase 1e.3.a factory creation reversed flow wire codec.  Multi-node ceremony:
+   per-node arrays of pubnonces + psigs. */
+cJSON *wire_build_factory_propose_intent(uint32_t n_nodes);
+int    wire_parse_factory_propose_intent(const cJSON *json, uint32_t *out_n_nodes);
+
+cJSON *wire_build_factory_client_pubnonces(const unsigned char *pubnonces_per_node /* n * 66 */,
+                                              uint32_t n_nodes);
+int    wire_parse_factory_client_pubnonces(const cJSON *json,
+                                              unsigned char *out_pubnonces_per_node,
+                                              uint32_t expected_n_nodes);
+
+cJSON *wire_build_factory_lsp_response(const unsigned char *lsp_pubnonces_per_node /* n * 66 */,
+                                          const unsigned char *lsp_psigs_per_node /* n * 32 */,
+                                          uint32_t n_nodes);
+int    wire_parse_factory_lsp_response(const cJSON *json,
+                                          unsigned char *out_lsp_pubnonces_per_node,
+                                          unsigned char *out_lsp_psigs_per_node,
+                                          uint32_t expected_n_nodes);
+
+cJSON *wire_build_factory_client_final_psigs(const unsigned char *psigs_per_node /* n * 32 */,
+                                                uint32_t n_nodes);
+int    wire_parse_factory_client_final_psigs(const cJSON *json,
+                                                unsigned char *out_psigs_per_node,
+                                                uint32_t expected_n_nodes);
 
 /* LSP → Bridge: BRIDGE_HELLO_ACK {} */
 cJSON *wire_build_bridge_hello_ack(void);

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -303,12 +303,50 @@ accept_fail:
     return 0;
 }
 
+/* Phase 1e.3.b scaffolding: stub for the reversed-flow stateless factory
+   creation ceremony.  Currently returns -1 for all cases (caller falls
+   through to legacy lsp_run_factory_creation).  Phase 1e.3.c will fill in
+   the actual multi-node MuSig ceremony using the wire codec from Phase
+   1e.3.a.
+
+   Wire flow (per Phase 1e.3.a opcodes 0x85-0x88):
+     LSP   -> Client: MSG_FACTORY_PROPOSE_INTENT (no nonces)
+     Client -> LSP:   MSG_FACTORY_CLIENT_PUBNONCES (per-node pubnonces)
+     LSP atomic:      gen lsp_secnonces + set + finalize + create_partial_sigs
+                       (lsp_secnonces zeroed by musig_create_partial_sig)
+     LSP   -> Client: MSG_FACTORY_LSP_RESPONSE (per-node lsp pubnonces + psigs)
+     Client -> LSP:   MSG_FACTORY_CLIENT_FINAL_PSIGS (per-node client psigs)
+     LSP:             aggregate per node + send MSG_FACTORY_READY (existing terminal)
+
+   Returns 1 on success, 0 on failure, -1 if stateless can't handle (caller
+   falls through to legacy). */
+int lsp_run_factory_creation_stateless(lsp_t *lsp) {
+    (void)lsp;
+    fprintf(stderr,
+        "LSP-stateless factory creation: not yet implemented (Phase 1e.3.c) -- "
+        "falling back to legacy lsp_run_factory_creation\n");
+    return -1;
+}
+
 int lsp_run_factory_creation(lsp_t *lsp,
                               const unsigned char *funding_txid, uint32_t funding_vout,
                               uint64_t funding_amount,
                               const unsigned char *funding_spk, size_t funding_spk_len,
                               uint16_t step_blocks, uint32_t states_per_layer,
                               uint32_t cltv_timeout) {
+    /* Phase 1e.3.b (#271): when --musig-stateless is set, dispatch to the
+       reversed-flow stub.  Returns -1 to signal fall-through to legacy if
+       the stateless variant cannot handle this case. */
+    {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        if (stateless && stateless[0] == '1') {
+            extern int lsp_run_factory_creation_stateless(lsp_t *);
+            int rc = lsp_run_factory_creation_stateless(lsp);
+            if (rc >= 0) return rc;
+            /* rc == -1: stateless declined; fall through to legacy. */
+        }
+    }
+
     size_t n_total = 1 + lsp->n_clients;
 
     /* Build all_pubkeys: LSP=0, clients=1..N */

--- a/src/wire.c
+++ b/src/wire.c
@@ -1410,6 +1410,103 @@ int wire_parse_state_adv_client_final_psigs(const cJSON *json,
            (int)((size_t)expected_n_affected_leaves * 32);
 }
 
+/* Phase 1e.3.a -- factory creation reversed flow wire codec. */
+
+cJSON *wire_build_factory_propose_intent(uint32_t n_nodes) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    cJSON_AddNumberToObject(j, "n_nodes", (double)n_nodes);
+    return j;
+}
+
+int wire_parse_factory_propose_intent(const cJSON *json, uint32_t *out_n_nodes) {
+    if (!json || !out_n_nodes) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_nodes");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    *out_n_nodes = (uint32_t)n->valuedouble;
+    return 1;
+}
+
+cJSON *wire_build_factory_client_pubnonces(const unsigned char *pubnonces_per_node,
+                                              uint32_t n_nodes) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !pubnonces_per_node) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "pubnonces_per_node", pubnonces_per_node,
+                      (size_t)n_nodes * 66);
+    cJSON_AddNumberToObject(j, "n_nodes", (double)n_nodes);
+    return j;
+}
+
+int wire_parse_factory_client_pubnonces(const cJSON *json,
+                                           unsigned char *out_pubnonces_per_node,
+                                           uint32_t expected_n_nodes) {
+    if (!json || !out_pubnonces_per_node) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_nodes");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_nodes) return 0;
+    return wire_json_get_hex(json, "pubnonces_per_node",
+                               out_pubnonces_per_node,
+                               (size_t)expected_n_nodes * 66) ==
+           (int)((size_t)expected_n_nodes * 66);
+}
+
+cJSON *wire_build_factory_lsp_response(const unsigned char *lsp_pubnonces_per_node,
+                                          const unsigned char *lsp_psigs_per_node,
+                                          uint32_t n_nodes) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !lsp_pubnonces_per_node || !lsp_psigs_per_node) {
+        if (j) cJSON_Delete(j);
+        return NULL;
+    }
+    wire_json_add_hex(j, "lsp_pubnonces_per_node", lsp_pubnonces_per_node,
+                      (size_t)n_nodes * 66);
+    wire_json_add_hex(j, "lsp_psigs_per_node", lsp_psigs_per_node,
+                      (size_t)n_nodes * 32);
+    cJSON_AddNumberToObject(j, "n_nodes", (double)n_nodes);
+    return j;
+}
+
+int wire_parse_factory_lsp_response(const cJSON *json,
+                                       unsigned char *out_lsp_pubnonces_per_node,
+                                       unsigned char *out_lsp_psigs_per_node,
+                                       uint32_t expected_n_nodes) {
+    if (!json || !out_lsp_pubnonces_per_node || !out_lsp_psigs_per_node) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_nodes");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_nodes) return 0;
+    if (wire_json_get_hex(json, "lsp_pubnonces_per_node",
+                            out_lsp_pubnonces_per_node,
+                            (size_t)expected_n_nodes * 66) !=
+        (int)((size_t)expected_n_nodes * 66)) return 0;
+    if (wire_json_get_hex(json, "lsp_psigs_per_node",
+                            out_lsp_psigs_per_node,
+                            (size_t)expected_n_nodes * 32) !=
+        (int)((size_t)expected_n_nodes * 32)) return 0;
+    return 1;
+}
+
+cJSON *wire_build_factory_client_final_psigs(const unsigned char *psigs_per_node,
+                                                uint32_t n_nodes) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !psigs_per_node) { if(j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "psigs_per_node", psigs_per_node, (size_t)n_nodes * 32);
+    cJSON_AddNumberToObject(j, "n_nodes", (double)n_nodes);
+    return j;
+}
+
+int wire_parse_factory_client_final_psigs(const cJSON *json,
+                                             unsigned char *out_psigs_per_node,
+                                             uint32_t expected_n_nodes) {
+    if (!json || !out_psigs_per_node) return 0;
+    cJSON *n = cJSON_GetObjectItem(json, "n_nodes");
+    if (!n || !cJSON_IsNumber(n)) return 0;
+    if ((uint32_t)n->valuedouble != expected_n_nodes) return 0;
+    return wire_json_get_hex(json, "psigs_per_node",
+                               out_psigs_per_node,
+                               (size_t)expected_n_nodes * 32) ==
+           (int)((size_t)expected_n_nodes * 32);
+}
+
 
 cJSON *wire_build_bridge_hello_ack(void) {
     return cJSON_CreateObject();


### PR DESCRIPTION
## Summary

Phase 1e.3.a + 1e.3.b of the MuSig2 stateless-signer redesign (#271). **Wire codec scaffold + dispatch stub for the 4th and final ceremony: factory creation.** No behavior change — the stub returns -1 (defer to legacy) for all cases.

This **completes the wire-codec scaffolding for ALL 4 ceremonies**:

| Ceremony | Opcodes | Status |
|---|---|---|
| per-leaf advance | 0x7A-0x7C | ✅ merged (#323) + flow (#324/#326) |
| sub-factory chain advance | 0x7D-0x80 | ✅ merged (#327, k=1 MVP) |
| Tier B state advance | 0x81-0x84 | ✅ merged (#328) |
| **factory creation** | **0x85-0x88** | **this PR (scaffold + stub)** |

## What this adds

**1e.3.a — wire codec** (4 new opcodes):

| Opcode | Direction | Payload |
|---|---|---|
| `0x85 MSG_FACTORY_PROPOSE_INTENT` | LSP → Client | `n_nodes` (no nonces) |
| `0x86 MSG_FACTORY_CLIENT_PUBNONCES` | Client → LSP | per-node pubnonces (n × 66) |
| `0x87 MSG_FACTORY_LSP_RESPONSE` | LSP → Client | per-node `lsp_pubnonces` + `lsp_psigs` |
| `0x88 MSG_FACTORY_CLIENT_FINAL_PSIGS` | Client → LSP | per-node psigs |

Reuses existing `MSG_FACTORY_READY` (0x14) for terminal.

**1e.3.b — dispatch stub** in `lsp_run_factory_creation` (`src/lsp.c`): when `SS_MUSIG_STATELESS=1`, calls `lsp_run_factory_creation_stateless` which returns -1 → falls back to legacy. Phase 1e.3.c fills in the real multi-node ceremony.

## Test plan

- [x] Build clean
- [x] **1472/1472 unit tests pass** (legacy unchanged, no behavior change)
- [ ] Phase 1e.3.c: study `lsp_run_factory_creation` (~800 LOC) + write real impl
- [ ] Phase 1e.3.d: client mirror

## Why factory creation is last + hardest

It's the **initial ceremony** — builds the entire TX tree, every signer participates over every node, funding TX assembly. The legacy `lsp_run_factory_creation` is ~800 LOC. The reversed flow follows the same atomic-signer pattern proven in #324/#326/#327/#328, but over the full node set. 1e.3.c will get a design doc (like `.claude/PHASE_1E2C_DESIGN.md` did for Tier B) before implementation.

## References

- `MUSIG_NONCE_REDESIGN_MEMO.md`
- PRs #321/#323/#324/#325/#326/#327/#328
