### PR TITLE
feat(musig): watchtower registration + poison-TX persist in stateless leaf advance

### DIFF
--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1954,11 +1954,61 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        LSP_RESPONSE, and FINAL.  lsp_poison_secnonce zeroed by
        musig_create_partial_sig before any wire recv. */
 
-    /* TODO(Phase 2): watchtower_watch_factory_node_with_channels.  Skipped
-       in MVP because the new flow has no poison TX yet -- degrading would
-       broadcast SECURITY-GAP warnings on every advance.  Once poison is
-       wired, re-enable the watchtower registration to mirror the legacy
-       path's Step 9 block. */
+    /* Phase 1d.3 (#271): register old leaf state + wire-ceremony poison TX
+       with the watchtower for breach detection, mirroring the legacy path's
+       Step 9 block.  The stateless ceremony is always multi-process, so the
+       poison TX is the wire-signed one (no single-process burn_tx fallback).
+       poison_snapshot survives factory_session_reset_poison for Step 11
+       persist (reset frees node->poison_signed_tx). */
+    unsigned char *poison_snapshot = NULL;
+    size_t poison_snapshot_len = 0;
+    if (had_old_signed && mgr->watchtower) {
+        int have_poison_wire = (leaf_poison_prepared &&
+                                node->poison_is_signed &&
+                                node->poison_signed_tx.len > 0);
+        const unsigned char *poison_data = NULL;
+        size_t poison_len = 0;
+        if (have_poison_wire) {
+            poison_data = node->poison_signed_tx.data;
+            poison_len  = node->poison_signed_tx.len;
+            printf("LSP-stateless: leaf %d wire-ceremony L-stock poison TX "
+                   "registered (%zu bytes, L-stock %llu sats -> %zu clients)\n",
+                   leaf_side, poison_len,
+                   (unsigned long long)old_l_amount,
+                   node->n_signers - 1);
+        } else if (old_n_outputs >= 2) {
+            fprintf(stderr,
+                    "LSP-stateless: registering watchtower without poison TX "
+                    "(poison_prepared=%d, poison_is_signed=%d) -- DEGRADED, "
+                    "breach cannot redistribute L-stock\n",
+                    leaf_poison_prepared, node->poison_is_signed);
+        }
+
+        /* Collect channel indices that live on this leaf node. */
+        uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+        size_t n_leaf_ch = 0;
+        for (size_t c = 0; c < mgr->n_channels; c++) {
+            size_t c_node; uint32_t c_vout;
+            client_to_leaf(c, f, &c_node, &c_vout);
+            if (c_node == node_idx)
+                leaf_ch_ids[n_leaf_ch++] = (uint32_t)c;
+        }
+        watchtower_watch_factory_node_with_channels(mgr->watchtower,
+            (uint32_t)node_idx, old_leaf_txid,
+            node->signed_tx.data, node->signed_tx.len,
+            poison_data, poison_len,
+            leaf_ch_ids, n_leaf_ch);
+
+        /* Snapshot poison bytes for Step 11 persist before reset frees them. */
+        if (poison_data && poison_len > 0) {
+            poison_snapshot = malloc(poison_len);
+            if (poison_snapshot) {
+                memcpy(poison_snapshot, poison_data, poison_len);
+                poison_snapshot_len = poison_len;
+            }
+        }
+        factory_session_reset_poison(f, node_idx);
+    }
 
     /* Step 10: notify everyone leaf advance done. */
     cJSON *done = wire_build_leaf_advance_done(leaf_side);
@@ -1982,7 +2032,7 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                 txid_display,
                 node->signed_tx.data, node->signed_tx.len,
                 node->outputs[0].amount_sats,
-                /* poison_tx */ NULL, 0);
+                /* poison_tx */ poison_snapshot, poison_snapshot_len);
         } else {
             uint32_t leaf_states[8];
             for (int i = 0; i < f->n_leaf_nodes; i++)
@@ -2010,6 +2060,7 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                           (uint32_t)f->n_participants,
                                           "success", NULL, NULL);
     }
+    free(poison_snapshot);
     return 1;
 }
 

--- a/tools/test_regtest_wire_leaf_advance.sh
+++ b/tools/test_regtest_wire_leaf_advance.sh
@@ -94,6 +94,16 @@ run_one() {
         return 1
     fi
 
+    # LSP runs in NK mode (--seckey); clients must authenticate with its
+    # static pubkey or the Noise handshake mismatches (NN client vs NK LSP).
+    # Parse it from the LSP log, mirroring tools/multi_arity_scenario.py.
+    local LSP_PUBKEY
+    LSP_PUBKEY=$(grep -oP "NK static pubkey: \\K[0-9a-f]+" "$LSP_LOG" | head -1)
+    if [ -z "$LSP_PUBKEY" ]; then
+        echo "  FAIL: could not parse LSP NK static pubkey from $LSP_LOG"
+        return 1
+    fi
+
     # Spawn clients
     for n in $(seq 0 $((N_CLIENTS - 1))); do
         local CLIENT_LOG="/tmp/${TAG}_client${n}.log"
@@ -102,6 +112,7 @@ run_one() {
         "$CLIENT_BIN" \
             --network regtest \
             --host 127.0.0.1 --port "$LSP_PORT" \
+            --lsp-pubkey "$LSP_PUBKEY" \
             --daemon \
             --seckey "${CLIENT_SECKEYS[$n]}" \
             --fee-rate 1000 \
@@ -142,8 +153,8 @@ run_one() {
         echo "  RESULT: PASS"
         # Sanity: confirm stateless path was used if requested
         if [ "$stateless" = "1" ]; then
-            if grep -q "lsp_advance_leaf_stateless" "$LSP_LOG" 2>/dev/null; then
-                echo "  STATELESS PATH: confirmed (lsp_advance_leaf_stateless invoked)"
+            if grep -q "LSP-stateless" "$LSP_LOG" 2>/dev/null; then
+                echo "  STATELESS PATH: confirmed (LSP-stateless markers present)"
             else
                 echo "  WARN: SS_MUSIG_STATELESS=1 set but no stateless markers in log"
                 echo "        (Phase 1c dispatch may not have fired — investigate)"


### PR DESCRIPTION
## Summary

Completes the watchtower wire-up for the **stateless per-leaf advance** ceremony of the MuSig2 stateless-signer redesign. The Phase 1c/1d `lsp_advance_leaf_stateless` carried a TODO where the legacy path performs its Step 9 (watchtower registration) and Step 11 (poison-TX persist). This fills both, mirroring the legacy path exactly. **Feature-gated behind `SS_MUSIG_STATELESS` (default OFF) — no production behavior change.**

## What this wires

**Watchtower registration** (`watchtower_watch_factory_node_with_channels`):
- Registers the old leaf state + the wire-ceremony signed L-stock poison TX for breach detection.
- No single-process `burn_tx` fallback: the stateless ceremony is always multi-process, so the poison TX is the wire-signed one. If the ceremony degraded (no poison), it registers without poison and warns, same as legacy.

**Poison-TX persist**:
- The PS-chain persist previously passed `NULL, 0` for the poison TX. Now threads the signed poison bytes through so the watchtower can re-register on restart.
- `poison_snapshot` is taken **before** `factory_session_reset_poison` (which frees `node->poison_signed_tx`), matching the legacy PR-B snapshot-before-reset ordering, and freed before return.

## Test-harness repairs (same branch)

The `test_regtest_wire_leaf_advance.sh` validation harness (added alongside the Phase 1c work) could never complete the Noise handshake:
- **NK/NN mismatch**: the LSP runs in NK mode (`--seckey`) but clients were launched without `--lsp-pubkey` (NN mode) → handshake mismatch → LSP timed out on HELLO. Now parses the LSP's NK static pubkey from its log and passes it to each client, mirroring `tools/multi_arity_scenario.py`.
- **Stale self-check**: the stateless-path sanity check grepped for the function name `lsp_advance_leaf_stateless` (never printed) instead of the `LSP-stateless:` runtime marker the code emits — fixed.

## Validation

- [x] `build-release` clean
- [x] **1472/1472 unit tests pass** (legacy path unchanged)
- [x] `test_regtest_wire_leaf_advance.sh`: **RUN 1 (legacy) PASS + RUN 2 (stateless) PASS**
- [x] Stateless run log confirms the new code path executes with a **real signed poison TX**:
  ```
  LSP-stateless: poison TX signed (162 bytes, L-stock 24700 sats)
  LSP-stateless: leaf 0 wire-ceremony L-stock poison TX registered (162 bytes, L-stock 24700 sats -> 1 clients)
  LSP-stateless: DW leaf 0 advanced (node 3), DW state 1
  POST-DAEMON WIRE LEAF ADVANCE: PASS
  ```
  (legacy RUN 1 log has 0 `LSP-stateless` markers, confirming the gate routes correctly)

## Scope

Per-leaf advance is now the **fully wired** stateless ceremony (state TX + poison TX + watchtower + persist). The remaining stateless ceremonies (sub-factory k≥2, Tier B, factory creation) continue under their own follow-ups.
