### PR TITLE
fix(static): resolve cppcheck nullPointerRedundantCheck in client.c stateless dispatch

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -3052,7 +3052,8 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
     /* Phase 1e.1.c (#271): if the LSP sent PROPOSE_INTENT (new opcode),
        it'''s the reversed stateless flow -- dispatch.  Legacy PROPOSE
        (0x73) keeps using the path below. */
-    if (propose_msg && propose_msg->msg_type == MSG_SUBFACTORY_PROPOSE_INTENT) {
+    if (!propose_msg) return 0;
+    if (propose_msg->msg_type == MSG_SUBFACTORY_PROPOSE_INTENT) {
         return client_handle_subfactory_advance_stateless(fd, ctx, keypair,
                                                             factory, my_index,
                                                             propose_msg);
@@ -4527,7 +4528,8 @@ int client_handle_state_advance(int fd, secp256k1_context *ctx,
     /* Phase 1e.2.d: if LSP sent the new stateless PROPOSE_INTENT opcode,
        dispatch to the stateless handler.  Legacy STATE_ADVANCE_PROPOSE
        continues to use the path below. */
-    if (propose_msg && propose_msg->msg_type == MSG_STATE_ADV_PROPOSE_INTENT) {
+    if (!propose_msg) return 0;
+    if (propose_msg->msg_type == MSG_STATE_ADV_PROPOSE_INTENT) {
         return client_handle_state_advance_stateless(fd, ctx, keypair,
                                                        factory, my_index,
                                                        propose_msg);


### PR DESCRIPTION
## Summary

Greens the **Static Analysis** CI job, which has been red since the 1e.1.c/1e.2.d stateless-dispatch work landed on `main`.

cppcheck flags `nullPointerRedundantCheck` at `client.c:3064` and `:4541`: the dispatch guards read `if (propose_msg && propose_msg->msg_type == ...)` (implying `propose_msg` may be NULL), but the legacy code immediately below dereferences `propose_msg->json` unconditionally.

Both call sites pass the address of a stack-local `wire_msg_t` (`&msg` / `&all_nonces_msg`), so `propose_msg` is never NULL and the `&&` was redundant. Replaced with an explicit early-return null guard so `propose_msg` is provably non-null for both the dispatch check and the later deref. A hypothetical NULL now returns 0 ("not handled") instead of dereferencing — strictly safer.

## Validation
- [x] `build-release` clean
- [x] **1472/1472 unit tests pass**
- [x] targeted cppcheck on `client.c` no longer reports the `propose_msg` findings

Tiny diff (2 lines → 4). Behavior-preserving for all real (non-null) inputs.