### PR TITLE
MuSig2 stateless-signer redesign (BIP-327): complete ceremony set + harness robustness

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -611,11 +611,16 @@ int    wire_parse_factory_client_pubnonces(const cJSON *json,
 
 cJSON *wire_build_factory_lsp_response(const unsigned char *lsp_pubnonces_per_node /* n * 66 */,
                                           const unsigned char *lsp_psigs_per_node /* n * 32 */,
-                                          uint32_t n_nodes);
+                                          uint32_t n_nodes,
+                                          const unsigned char *all_signer_pubnonces_flat /* all_len bytes or NULL */,
+                                          uint32_t all_signer_pubnonces_len);
 int    wire_parse_factory_lsp_response(const cJSON *json,
                                           unsigned char *out_lsp_pubnonces_per_node,
                                           unsigned char *out_lsp_psigs_per_node,
-                                          uint32_t expected_n_nodes);
+                                          uint32_t expected_n_nodes,
+                                          unsigned char *out_all_signer_pubnonces_flat /* max_all_len bytes or NULL */,
+                                          uint32_t max_all_signer_pubnonces_len,
+                                          uint32_t *out_all_signer_pubnonces_len /* or NULL */);
 
 cJSON *wire_build_factory_client_final_psigs(const unsigned char *psigs_per_node /* n * 32 */,
                                                 uint32_t n_nodes);

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -527,11 +527,16 @@ int    wire_parse_subfactory_client_pubnonces(const cJSON *json,
 
 cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per_input /* n_inputs * 66 */,
                                             const unsigned char *lsp_psigs_per_input /* n_inputs * 32 */,
-                                            uint32_t n_inputs);
+                                            uint32_t n_inputs,
+                                            const unsigned char *all_signer_pubnonces_flat /* all_len bytes or NULL (single-input k>=2: n_signers*66) */,
+                                            uint32_t all_signer_pubnonces_len);
 int    wire_parse_subfactory_lsp_response(const cJSON *json,
                                             unsigned char *out_lsp_pubnonces_per_input,
                                             unsigned char *out_lsp_psigs_per_input,
-                                            uint32_t expected_n_inputs);
+                                            uint32_t expected_n_inputs,
+                                            unsigned char *out_all_signer_pubnonces_flat /* max_all_len bytes or NULL */,
+                                            uint32_t max_all_signer_pubnonces_len,
+                                            uint32_t *out_all_signer_pubnonces_len /* or NULL */);
 
 cJSON *wire_build_subfactory_client_final_psigs(const unsigned char *psigs_per_input /* n_inputs * 32 */,
                                                   uint32_t n_inputs);

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -184,6 +184,12 @@
 #define MSG_FACTORY_LSP_RESPONSE        0x87  /* LSP -> Client: per-node lsp pubnonces + psigs */
 #define MSG_FACTORY_CLIENT_FINAL_PSIGS  0x88
 
+/* LSP -> Client: full per-node signer partial-sig matrix (Gap B), so each
+   client can locally complete multi-signer Tier B nodes (it only holds its own
+   + the LSP's psig).  Mirror of the 0x83 all-signer nonce matrix.  Flat layout:
+   affected nodes in order, each n_signers slots of 32 bytes. */
+#define MSG_STATE_ADV_ALL_PSIGS           0x89
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -557,14 +563,19 @@ cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_
                                             const unsigned char *lsp_psigs_per_leaf /* n * 32 */,
                                             uint32_t n_affected_leaves,
                                             const unsigned char *lsp_poison_pubnonces_per_leaf /* n * 66 or NULL */,
-                                            const unsigned char *lsp_poison_psigs_per_leaf /* n * 32 or NULL */);
+                                            const unsigned char *lsp_poison_psigs_per_leaf /* n * 32 or NULL */,
+                                            const unsigned char *all_signer_pubnonces_flat /* all_len bytes or NULL */,
+                                            uint32_t all_signer_pubnonces_len);
 /* Returns 1 (no poison), 2 (poison present), 0 (parse error). */
 int    wire_parse_state_adv_lsp_response(const cJSON *json,
                                             unsigned char *out_lsp_pubnonces_per_leaf,
                                             unsigned char *out_lsp_psigs_per_leaf,
                                             uint32_t expected_n_affected_leaves,
                                             unsigned char *out_lsp_poison_pubnonces_per_leaf /* n * 66 or NULL */,
-                                            unsigned char *out_lsp_poison_psigs_per_leaf /* n * 32 or NULL */);
+                                            unsigned char *out_lsp_poison_psigs_per_leaf /* n * 32 or NULL */,
+                                            unsigned char *out_all_signer_pubnonces_flat /* max_all_len bytes or NULL */,
+                                            uint32_t max_all_signer_pubnonces_len,
+                                            uint32_t *out_all_signer_pubnonces_len /* or NULL */);
 
 cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_leaf /* n * 32 */,
                                                   uint32_t n_affected_leaves,
@@ -574,6 +585,13 @@ int    wire_parse_state_adv_client_final_psigs(const cJSON *json,
                                                   unsigned char *out_psigs_per_leaf,
                                                   uint32_t expected_n_affected_leaves,
                                                   unsigned char *out_poison_psigs_per_leaf /* n * 32 or NULL */);
+
+cJSON *wire_build_state_adv_all_psigs(const unsigned char *all_signer_psigs_flat /* all_len bytes */,
+                                         uint32_t all_signer_psigs_len);
+int    wire_parse_state_adv_all_psigs(const cJSON *json,
+                                         unsigned char *out_all_signer_psigs_flat,
+                                         uint32_t max_all_signer_psigs_len,
+                                         uint32_t *out_all_signer_psigs_len);
 
 /* Phase 1e.3.a factory creation reversed flow wire codec.  Multi-node ceremony:
    per-node arrays of pubnonces + psigs. */

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -545,24 +545,35 @@ int    wire_parse_state_adv_propose_intent(const cJSON *json,
                                               int *out_trigger_leaf_side);
 
 cJSON *wire_build_state_adv_client_path_nonces(const unsigned char *pubnonces_per_leaf /* n * 66 */,
-                                                  uint32_t n_affected_leaves);
+                                                  uint32_t n_affected_leaves,
+                                                  const unsigned char *poison_pubnonces_per_leaf /* n * 66 or NULL */);
+/* Returns 1 (no poison), 2 (poison_pubnonces present), 0 (parse error). */
 int    wire_parse_state_adv_client_path_nonces(const cJSON *json,
                                                   unsigned char *out_pubnonces_per_leaf,
-                                                  uint32_t expected_n_affected_leaves);
+                                                  uint32_t expected_n_affected_leaves,
+                                                  unsigned char *out_poison_pubnonces_per_leaf /* n * 66 or NULL */);
 
 cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_leaf /* n * 66 */,
                                             const unsigned char *lsp_psigs_per_leaf /* n * 32 */,
-                                            uint32_t n_affected_leaves);
+                                            uint32_t n_affected_leaves,
+                                            const unsigned char *lsp_poison_pubnonces_per_leaf /* n * 66 or NULL */,
+                                            const unsigned char *lsp_poison_psigs_per_leaf /* n * 32 or NULL */);
+/* Returns 1 (no poison), 2 (poison present), 0 (parse error). */
 int    wire_parse_state_adv_lsp_response(const cJSON *json,
                                             unsigned char *out_lsp_pubnonces_per_leaf,
                                             unsigned char *out_lsp_psigs_per_leaf,
-                                            uint32_t expected_n_affected_leaves);
+                                            uint32_t expected_n_affected_leaves,
+                                            unsigned char *out_lsp_poison_pubnonces_per_leaf /* n * 66 or NULL */,
+                                            unsigned char *out_lsp_poison_psigs_per_leaf /* n * 32 or NULL */);
 
 cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_leaf /* n * 32 */,
-                                                  uint32_t n_affected_leaves);
+                                                  uint32_t n_affected_leaves,
+                                                  const unsigned char *poison_psigs_per_leaf /* n * 32 or NULL */);
+/* Returns 1 (no poison), 2 (poison_psigs present), 0 (parse error). */
 int    wire_parse_state_adv_client_final_psigs(const cJSON *json,
                                                   unsigned char *out_psigs_per_leaf,
-                                                  uint32_t expected_n_affected_leaves);
+                                                  uint32_t expected_n_affected_leaves,
+                                                  unsigned char *out_poison_psigs_per_leaf /* n * 32 or NULL */);
 
 /* Phase 1e.3.a factory creation reversed flow wire codec.  Multi-node ceremony:
    per-node arrays of pubnonces + psigs. */

--- a/src/client.c
+++ b/src/client.c
@@ -2901,18 +2901,12 @@ static int client_handle_subfactory_advance_stateless(int fd,
     size_t sub_node_i = (size_t)sub_node_id;
     factory_node_t *sub = &factory->nodes[sub_node_i];
 
-    /* MVP: refuse k>=2 (multi-client) -- matches LSP-side refusal. */
-    {
-        size_t check_n_clients = 0;
-        for (size_t s = 1; s < sub->n_signers; s++) check_n_clients++;
-        if (check_n_clients > 1) {
-            fprintf(stderr,
-                "Client-stateless subfactory %u: k>=2 (n_clients=%zu) not yet "
-                "supported -- LSP should fall back to legacy\n",
-                my_index, check_n_clients);
-            return 0;
-        }
-    }
+    /* k>=2 (multi-client sub-factory) is supported: the LSP forwards the full
+       all-signer pubnonce matrix in LSP_RESPONSE (Gap A), and the co-signer
+       nonce loop below sets every other signer's nonce before finalize. The
+       client sends its CLIENT_FINAL_PSIGS for the LSP to aggregate (no local
+       complete, so no Gap B needed). Matching LSP-side refusal removed in
+       d7bdfe4. */
 
     /* Phase 1e.1.b amendment: PROPOSE_INTENT now carries the advance params
        (leaf_side, sub_idx, channel_idx, delta_sats).  Apply the advance

--- a/src/client.c
+++ b/src/client.c
@@ -476,7 +476,8 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
                 continue;
             }
             if (msg.msg_type == MSG_LEAF_ADVANCE_PROPOSE ||
-                msg.msg_type == MSG_STATE_ADVANCE_PROPOSE) {
+                msg.msg_type == MSG_STATE_ADVANCE_PROPOSE ||
+                msg.msg_type == MSG_STATE_ADV_PROPOSE_INTENT) {
                 /* Participate in the (per-leaf or whole-tree state-advance)
                    ceremony inline.  Derive my_index from the factory's pubkey
                    list. */
@@ -647,7 +648,8 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
             continue;
         }
         if (all_nonces_msg.msg_type == MSG_LEAF_ADVANCE_PROPOSE ||
-            all_nonces_msg.msg_type == MSG_STATE_ADVANCE_PROPOSE) {
+            all_nonces_msg.msg_type == MSG_STATE_ADVANCE_PROPOSE ||
+            all_nonces_msg.msg_type == MSG_STATE_ADV_PROPOSE_INTENT) {
             uint32_t my_idx = UINT32_MAX;
             for (size_t p = 0; p < factory->n_participants; p++) {
                 unsigned char a[33], b[33]; size_t la = 33, lb = 33;

--- a/src/client.c
+++ b/src/client.c
@@ -4504,18 +4504,45 @@ static int client_handle_state_advance_stateless(int fd,
     unsigned char lsp_poison_psigs_per_node[FACTORY_MAX_NODES][32];
     memset(lsp_poison_pubnonces_per_node, 0, sizeof(lsp_poison_pubnonces_per_node));
     memset(lsp_poison_psigs_per_node, 0, sizeof(lsp_poison_psigs_per_node));
+    /* Gap A: per-node base offset + total slots for the forwarded all-signer
+       nonce matrix (must match the LSP's layout: nodes in affected[] order,
+       each occupying n_signers slots of 66 bytes). */
+    size_t node_nonce_base[FACTORY_MAX_NODES];
+    size_t total_nonce_slots = 0;
+    for (size_t k = 0; k < n_affected; k++) {
+        node_nonce_base[k] = total_nonce_slots;
+        total_nonce_slots += factory->nodes[affected[k]].n_signers;
+    }
+    unsigned char *all_pn_flat_c = calloc(total_nonce_slots ? total_nonce_slots : 1, 66);
+    if (!all_pn_flat_c) {
+        cJSON_Delete(lr.json);
+        fprintf(stderr, "Client-stateless Tier B %u: alloc all_pn_flat_c failed\n", my_index);
+        return 0;
+    }
+    uint32_t got_all_len = 0;
     if (!wire_parse_state_adv_lsp_response(lr.json,
                                              (unsigned char *)lsp_pubnonces_per_node,
                                              (unsigned char *)lsp_psigs_per_node,
                                              (uint32_t)n_affected,
                                              (unsigned char *)lsp_poison_pubnonces_per_node,
-                                             (unsigned char *)lsp_poison_psigs_per_node)) {
+                                             (unsigned char *)lsp_poison_psigs_per_node,
+                                             all_pn_flat_c,
+                                             (uint32_t)(total_nonce_slots * 66),
+                                             &got_all_len)) {
         cJSON_Delete(lr.json);
+        free(all_pn_flat_c);
         fprintf(stderr,
             "Client-stateless Tier B %u: parse LSP_RESPONSE failed\n", my_index);
         return 0;
     }
     cJSON_Delete(lr.json);
+    if (got_all_len != (uint32_t)(total_nonce_slots * 66)) {
+        free(all_pn_flat_c);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: all-signer nonce matrix len %u != expected %zu\n",
+            my_index, got_all_len, total_nonce_slots * 66);
+        return 0;
+    }
 
     /* Step 8: for each affected node, set LSP nonce + finalize + set LSP psig +
        create own partial_sig (zeros own secnonce) + set own psig + complete. */
@@ -4528,20 +4555,40 @@ static int client_handle_state_advance_stateless(int fd,
             fprintf(stderr,
                 "Client-stateless Tier B %u: LSP not signer on %zu (invariant violation)\n",
                 my_index, affected[k]);
+            free(all_pn_flat_c);
             return 0;
         }
-        secp256k1_musig_pubnonce lsp_pn;
-        if (!musig_pubnonce_parse(ctx, &lsp_pn, lsp_pubnonces_per_node[k]) ||
-            !factory_session_set_nonce(factory, affected[k], (size_t)lsp_slot, &lsp_pn)) {
-            fprintf(stderr,
-                "Client-stateless Tier B %u: set LSP nonce for %zu failed\n",
-                my_index, affected[k]);
-            return 0;
+        if (!my_signs_per_node[k]) continue;  /* only nodes this client signs (mirror legacy) */
+        /* Gap A: set EVERY signer's pubnonce (LSP slot 0 + all clients) from the
+           forwarded matrix so the aggnonce can be built for multi-signer nodes. */
+        {
+            factory_node_t *an_k = &factory->nodes[affected[k]];
+            int nonce_ok = 1;
+            for (size_t s = 0; s < an_k->n_signers; s++) {
+                /* Own slot was already set in Step 5 (when we generated the
+                   secnonce); the matrix echoes it back -- re-setting would
+                   double-count nonces_collected and fail finalize. */
+                if (s == (size_t)my_slot_per_node[k]) continue;
+                secp256k1_musig_pubnonce pn_s;
+                if (!musig_pubnonce_parse(ctx, &pn_s,
+                        all_pn_flat_c + (node_nonce_base[k] + s) * 66) ||
+                    !factory_session_set_nonce(factory, affected[k], s, &pn_s)) {
+                    nonce_ok = 0; break;
+                }
+            }
+            if (!nonce_ok) {
+                fprintf(stderr,
+                    "Client-stateless Tier B %u: set all-signer nonces for %zu failed\n",
+                    my_index, affected[k]);
+                free(all_pn_flat_c);
+                return 0;
+            }
         }
         if (!factory_session_finalize_node(factory, affected[k])) {
             fprintf(stderr,
                 "Client-stateless Tier B %u: finalize_node[%zu] failed\n",
                 my_index, affected[k]);
+            free(all_pn_flat_c);
             return 0;
         }
         /* Set LSP's psig into the session. */
@@ -4551,16 +4598,19 @@ static int client_handle_state_advance_stateless(int fd,
             fprintf(stderr,
                 "Client-stateless Tier B %u: set LSP psig for %zu failed\n",
                 my_index, affected[k]);
+            free(all_pn_flat_c);
             return 0;
         }
-        /* Create own partial_sig (zeros own secnonce). */
-        if (my_signs_per_node[k]) {
+        /* Create own partial_sig (zeros own secnonce).  Always runs: non-signed
+           nodes were skipped above via `continue`. */
+        {
             secp256k1_musig_partial_sig my_psig;
             if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonces[k], keypair,
                                             &factory->nodes[affected[k]].signing_session)) {
                 fprintf(stderr,
                     "Client-stateless Tier B %u: create_partial_sig[%zu] failed\n",
                     my_index, affected[k]);
+                free(all_pn_flat_c);
                 return 0;
             }
             musig_partial_sig_serialize(ctx, my_psigs_per_node[k], &my_psig);
@@ -4569,6 +4619,7 @@ static int client_handle_state_advance_stateless(int fd,
                 fprintf(stderr,
                     "Client-stateless Tier B %u: set own psig[%zu] failed\n",
                     my_index, affected[k]);
+                free(all_pn_flat_c);
                 return 0;
             }
         }
@@ -4602,6 +4653,7 @@ static int client_handle_state_advance_stateless(int fd,
         }
     }
     /* INVARIANT: own state + poison secnonces zeroed by musig_create_partial_sig. */
+    free(all_pn_flat_c);  /* all-signer nonce matrix no longer needed */
 
     /* Step 9: send CLIENT_FINAL_PSIGS. */
     cJSON *fp = wire_build_state_adv_client_final_psigs(
@@ -4615,15 +4667,70 @@ static int client_handle_state_advance_stateless(int fd,
     }
     cJSON_Delete(fp);
 
-    /* Step 10: complete_node per affected (LSP will also). */
+    /* Step 9b (Gap B): receive the full per-node signer-PSIG matrix so we can
+       complete multi-signer nodes locally (we only hold our own + LSP psig).
+       Reuses node_nonce_base[] (slot offsets) -- psigs are 32 bytes/slot. */
+    wire_msg_t apm;
+    if (!wire_recv(fd, &apm) || apm.msg_type != MSG_STATE_ADV_ALL_PSIGS) {
+        fprintf(stderr,
+            "Client-stateless Tier B %u: expected ALL_PSIGS, got 0x%02x\n",
+            my_index, apm.json ? apm.msg_type : 0);
+        if (apm.json) cJSON_Delete(apm.json);
+        return 0;
+    }
+    unsigned char *all_psig_flat_c = calloc(total_nonce_slots ? total_nonce_slots : 1, 32);
+    if (!all_psig_flat_c) {
+        cJSON_Delete(apm.json);
+        fprintf(stderr, "Client-stateless Tier B %u: alloc all_psig_flat_c failed\n", my_index);
+        return 0;
+    }
+    uint32_t got_psig_len = 0;
+    if (!wire_parse_state_adv_all_psigs(apm.json, all_psig_flat_c,
+                                          (uint32_t)(total_nonce_slots * 32), &got_psig_len) ||
+        got_psig_len != (uint32_t)(total_nonce_slots * 32)) {
+        cJSON_Delete(apm.json);
+        free(all_psig_flat_c);
+        fprintf(stderr,
+            "Client-stateless Tier B %u: parse ALL_PSIGS failed (len %u != %zu)\n",
+            my_index, got_psig_len, total_nonce_slots * 32);
+        return 0;
+    }
+    cJSON_Delete(apm.json);
+
+    /* Step 10: for each node we sign, set the co-signer psigs (own + LSP were
+       already set in Step 8) then complete_node locally.  Skip nodes we don't
+       sign (mirror legacy). */
     for (size_t k = 0; k < n_affected; k++) {
+        if (!my_signs_per_node[k]) continue;
+        int lsp_slot10 = factory_find_signer_slot(factory, affected[k], 0);
+        factory_node_t *an_k = &factory->nodes[affected[k]];
+        int psig_ok = 1;
+        for (size_t s = 0; s < an_k->n_signers; s++) {
+            if (s == (size_t)my_slot_per_node[k] || (int)s == lsp_slot10)
+                continue;  /* own + LSP psig already set in Step 8 */
+            secp256k1_musig_partial_sig ps_s;
+            if (!musig_partial_sig_parse(ctx, &ps_s,
+                    all_psig_flat_c + (node_nonce_base[k] + s) * 32) ||
+                !factory_session_set_partial_sig(factory, affected[k], s, &ps_s)) {
+                psig_ok = 0; break;
+            }
+        }
+        if (!psig_ok) {
+            fprintf(stderr,
+                "Client-stateless Tier B %u: set co-signer psigs for %zu failed\n",
+                my_index, affected[k]);
+            free(all_psig_flat_c);
+            return 0;
+        }
         if (!factory_session_complete_node(factory, affected[k])) {
             fprintf(stderr,
                 "Client-stateless Tier B %u: complete_node[%zu] failed\n",
                 my_index, affected[k]);
+            free(all_psig_flat_c);
             return 0;
         }
     }
+    free(all_psig_flat_c);
 
     /* Step 11: recv DONE (MSG_PATH_SIGN_DONE). */
     wire_msg_t done;

--- a/src/client.c
+++ b/src/client.c
@@ -4300,14 +4300,47 @@ static int client_handle_state_advance_stateless(int fd,
         return 0;
     }
 
-    /* Step 2: Run factory_advance_leaf_unsigned locally.  Must return -1
-       (root rolled over, all leaves rebuilt) — mirrors caller contract on LSP. */
-    int adv_rc = factory_advance_leaf_unsigned(factory, trigger_leaf_side);
-    if (adv_rc != -1) {
-        fprintf(stderr,
-            "Client-stateless Tier B %u: advance_leaf_unsigned returned %d (expected -1)\n",
-            my_index, adv_rc);
-        return 0;
+    /* Step 2: Advance local state to mirror the LSP-side rollover, using the
+       same proven logic as the legacy client_handle_state_advance.  The client
+       may be N ticks behind the LSP (the LSP doesn't send a per-tick PROPOSE
+       before rollover), so loop until rc==-1 (rollover; trees rebuilt):
+         - root-driven  (trigger_leaf_side < 0): factory_tick_root — PS Tier B
+           block-height rollover; mirrors lsp_factory_tick_root.  Per-tick rc==0
+           means advanced within the epoch (keep ticking).
+         - leaf-driven  (>= 0): factory_advance_leaf_unsigned on the trigger
+           leaf — DW counter exhaustion.  Per-step rc==1 means advanced (keep
+           going). */
+    int adv_rc = 0;
+    {
+        int max_steps = (int)(factory->states_per_layer + 2);
+        if (max_steps < 4) max_steps = 4;
+        if (trigger_leaf_side < 0) {
+            for (int s = 0; s < max_steps; s++) {
+                adv_rc = factory_tick_root(factory);
+                if (adv_rc == -1) break;
+                if (adv_rc != 0) {
+                    fprintf(stderr, "Client-stateless Tier B %u: root tick step %d "
+                            "returned unexpected %d\n", my_index, s, adv_rc);
+                    return 0;
+                }
+            }
+        } else {
+            for (int s = 0; s < max_steps; s++) {
+                adv_rc = factory_advance_leaf_unsigned(factory, trigger_leaf_side);
+                if (adv_rc == -1) break;
+                if (adv_rc != 1) {
+                    fprintf(stderr, "Client-stateless Tier B %u: advance step %d "
+                            "returned %d\n", my_index, s, adv_rc);
+                    return 0;
+                }
+            }
+        }
+        if (adv_rc != -1) {
+            fprintf(stderr, "Client-stateless Tier B %u: rollover not reached "
+                    "within %d steps (trigger_leaf=%d)\n",
+                    my_index, max_steps, trigger_leaf_side);
+            return 0;
+        }
     }
 
     /* Step 3: Build affected[] — SAME logic as LSP. */

--- a/src/client.c
+++ b/src/client.c
@@ -2987,8 +2987,13 @@ static int client_handle_subfactory_advance_stateless(int fd,
         return 0;
     }
     unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
+    unsigned char all_pn_sub[FACTORY_MAX_SIGNERS][66];
+    uint32_t got_all_pn_len = 0;
     if (!wire_parse_subfactory_lsp_response(lr_msg.json,
-                                              lsp_pubnonce_ser, lsp_psig_ser, 1)) {
+                                              lsp_pubnonce_ser, lsp_psig_ser, 1,
+                                              (unsigned char *)all_pn_sub,
+                                              (uint32_t)sizeof(all_pn_sub),
+                                              &got_all_pn_len)) {
         cJSON_Delete(lr_msg.json);
         fprintf(stderr, "Client-stateless subfactory %u: parse LSP_RESPONSE failed\n",
                 my_index);
@@ -2996,12 +3001,26 @@ static int client_handle_subfactory_advance_stateless(int fd,
     }
     cJSON_Delete(lr_msg.json);
 
-    /* Set LSP nonce, finalize_node. */
+    /* Set LSP nonce, then (k>=2) every OTHER signer's nonce from the forwarded
+       matrix (own already set in Step 5, LSP set just below), then finalize. */
     secp256k1_musig_pubnonce lsp_pubnonce;
     if (!musig_pubnonce_parse(ctx, &lsp_pubnonce, lsp_pubnonce_ser) ||
         !factory_session_set_nonce(factory, sub_node_i, (size_t)lsp_slot, &lsp_pubnonce)) {
         fprintf(stderr, "Client-stateless subfactory %u: set LSP nonce failed\n", my_index);
         return 0;
+    }
+    if (got_all_pn_len == (uint32_t)(sub->n_signers * 66)) {
+        for (size_t s = 0; s < sub->n_signers; s++) {
+            if (s == (size_t)my_slot || s == (size_t)lsp_slot) continue;
+            secp256k1_musig_pubnonce pn_s;
+            if (!musig_pubnonce_parse(ctx, &pn_s, all_pn_sub[s]) ||
+                !factory_session_set_nonce(factory, sub_node_i, s, &pn_s)) {
+                fprintf(stderr,
+                    "Client-stateless subfactory %u: set co-signer nonce[%zu] failed\n",
+                    my_index, s);
+                return 0;
+            }
+        }
     }
     if (!factory_session_finalize_node(factory, sub_node_i)) {
         fprintf(stderr, "Client-stateless subfactory %u: finalize_node failed\n", my_index);

--- a/src/client.c
+++ b/src/client.c
@@ -4394,7 +4394,7 @@ static int client_handle_state_advance_stateless(int fd,
 
     /* Step 6: send CLIENT_PATH_NONCES. */
     cJSON *cpn = wire_build_state_adv_client_path_nonces(
-        (const unsigned char *)my_pubnonces_per_node, (uint32_t)n_affected);
+        (const unsigned char *)my_pubnonces_per_node, (uint32_t)n_affected, NULL);
     if (!wire_send(fd, MSG_STATE_ADV_CLIENT_PATH_NONCES, cpn)) {
         cJSON_Delete(cpn);
         fprintf(stderr,
@@ -4417,7 +4417,8 @@ static int client_handle_state_advance_stateless(int fd,
     if (!wire_parse_state_adv_lsp_response(lr.json,
                                              (unsigned char *)lsp_pubnonces_per_node,
                                              (unsigned char *)lsp_psigs_per_node,
-                                             (uint32_t)n_affected)) {
+                                             (uint32_t)n_affected,
+                                             NULL, NULL)) {
         cJSON_Delete(lr.json);
         fprintf(stderr,
             "Client-stateless Tier B %u: parse LSP_RESPONSE failed\n", my_index);
@@ -4485,7 +4486,7 @@ static int client_handle_state_advance_stateless(int fd,
 
     /* Step 9: send CLIENT_FINAL_PSIGS. */
     cJSON *fp = wire_build_state_adv_client_final_psigs(
-        (const unsigned char *)my_psigs_per_node, (uint32_t)n_affected);
+        (const unsigned char *)my_psigs_per_node, (uint32_t)n_affected, NULL);
     if (!wire_send(fd, MSG_STATE_ADV_CLIENT_FINAL_PSIGS, fp)) {
         cJSON_Delete(fp);
         fprintf(stderr,

--- a/src/client.c
+++ b/src/client.c
@@ -1341,6 +1341,221 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
 
 /* --- Main ceremony (factory creation + optional channels + close) --- */
 
+/* Phase 1e.3.c (#271): client-side stateless factory-creation signing.
+
+   Runs the reversed nonce/psig exchange for INITIAL factory creation, looped
+   per NODE.  Called from client_run_with_channels after the client has built
+   its factory from FACTORY_PROPOSE and run factory_sessions_init, when
+   SS_MUSIG_STATELESS=1 and the LSP sent PROPOSE_INTENT (0x85).  On return the
+   factory sessions are finalized + each node the client signs has its own
+   partial sig sent to the LSP; the caller proceeds to recv FACTORY_READY
+   exactly as the legacy path does.
+
+   Per-node client secnonce is generated in the pubnonce phase and
+   consumed/zeroed by musig_create_partial_sig before CLIENT_FINAL_PSIGS is
+   sent, mirroring the validated sub-factory / leaf / state-advance client
+   stateless paths.
+
+   Returns 1 on success, 0 on failure. */
+static int client_factory_creation_stateless_signing(
+        int fd, secp256k1_context *ctx, const secp256k1_keypair *keypair,
+        factory_t *factory, uint32_t my_index) {
+    secp256k1_pubkey my_pubkey;
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+    /* Recv PROPOSE_INTENT (0x85) -- begin reversed flow. */
+    wire_msg_t imsg;
+    if (!wire_recv_handle_ping(fd, &imsg, 0) || check_msg_error(&imsg) ||
+        imsg.msg_type != MSG_FACTORY_PROPOSE_INTENT) {
+        fprintf(stderr, "Client-stateless %u: expected PROPOSE_INTENT, got 0x%02x\n",
+                my_index, imsg.json ? imsg.msg_type : 0);
+        if (imsg.json) cJSON_Delete(imsg.json);
+        return 0;
+    }
+    uint32_t intent_n_nodes = 0;
+    if (!wire_parse_factory_propose_intent(imsg.json, &intent_n_nodes)) {
+        fprintf(stderr, "Client-stateless %u: parse PROPOSE_INTENT failed\n", my_index);
+        cJSON_Delete(imsg.json);
+        return 0;
+    }
+    cJSON_Delete(imsg.json);
+    if (intent_n_nodes != (uint32_t)factory->n_nodes) {
+        fprintf(stderr, "Client-stateless %u: n_nodes mismatch (intent=%u local=%zu)\n",
+                my_index, intent_n_nodes, factory->n_nodes);
+        return 0;
+    }
+
+    size_t nn = factory->n_nodes;
+
+    secp256k1_musig_secnonce *my_secnonces =
+        calloc(nn, sizeof(secp256k1_musig_secnonce));
+    int *my_slot = calloc(nn, sizeof(int));
+    unsigned char *my_pn_per_node = calloc(nn, 66);
+    if (!my_secnonces || !my_slot || !my_pn_per_node) {
+        free(my_secnonces); free(my_slot); free(my_pn_per_node);
+        return 0;
+    }
+    for (size_t i = 0; i < nn; i++) my_slot[i] = -1;
+
+    unsigned char my_seckey[32];
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        free(my_secnonces); free(my_slot); free(my_pn_per_node);
+        return 0;
+    }
+
+    /* Step B: gen own per-node pubnonce for each node this client signs. */
+    for (size_t nidx = 0; nidx < nn; nidx++) {
+        int slot = factory_find_signer_slot(factory, nidx, my_index);
+        if (slot < 0) continue;
+        my_slot[nidx] = slot;
+        secp256k1_musig_pubnonce my_pubnonce;
+        if (!musig_generate_nonce(ctx, &my_secnonces[nidx], &my_pubnonce,
+                                   my_seckey, &my_pubkey,
+                                   &factory->nodes[nidx].keyagg.cache)) {
+            fprintf(stderr, "Client-stateless %u: nonce gen node %zu failed\n", my_index, nidx);
+            memset(my_seckey, 0, 32);
+            free(my_secnonces); free(my_slot); free(my_pn_per_node);
+            return 0;
+        }
+        musig_pubnonce_serialize(ctx, my_pn_per_node + nidx * 66, &my_pubnonce);
+        if (!factory_session_set_nonce(factory, nidx, (size_t)slot, &my_pubnonce)) {
+            fprintf(stderr, "Client-stateless %u: set own nonce node %zu failed\n", my_index, nidx);
+            memset(my_seckey, 0, 32);
+            free(my_secnonces); free(my_slot); free(my_pn_per_node);
+            return 0;
+        }
+    }
+    memset(my_seckey, 0, 32);
+
+    /* Send CLIENT_PUBNONCES (per-node; unsigned nodes carry zero nonce). */
+    {
+        cJSON *cpn = wire_build_factory_client_pubnonces(my_pn_per_node, (uint32_t)nn);
+        free(my_pn_per_node);
+        if (!cpn || !wire_send(fd, MSG_FACTORY_CLIENT_PUBNONCES, cpn)) {
+            fprintf(stderr, "Client-stateless %u: send CLIENT_PUBNONCES failed\n", my_index);
+            if (cpn) cJSON_Delete(cpn);
+            free(my_secnonces); free(my_slot);
+            return 0;
+        }
+        cJSON_Delete(cpn);
+    }
+
+    /* Recv LSP_RESPONSE: per-node LSP nonces + psigs + full signer x node matrix. */
+    wire_msg_t lr;
+    if (!wire_recv(fd, &lr) || check_msg_error(&lr) ||
+        lr.msg_type != MSG_FACTORY_LSP_RESPONSE) {
+        fprintf(stderr, "Client-stateless %u: expected LSP_RESPONSE, got 0x%02x\n",
+                my_index, lr.json ? lr.msg_type : 0);
+        if (lr.json) cJSON_Delete(lr.json);
+        free(my_secnonces); free(my_slot);
+        return 0;
+    }
+    unsigned char *lsp_pn_per_node = calloc(nn, 66);
+    unsigned char *lsp_psig_per_node = calloc(nn, 32);
+    size_t mtx_stride = (size_t)FACTORY_MAX_SIGNERS * 66;
+    unsigned char *all_pn = calloc(nn, mtx_stride);
+    uint32_t got_matrix_len = 0;
+    if (!lsp_pn_per_node || !lsp_psig_per_node || !all_pn) {
+        cJSON_Delete(lr.json);
+        free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+        free(my_secnonces); free(my_slot);
+        return 0;
+    }
+    if (!wire_parse_factory_lsp_response(lr.json, lsp_pn_per_node,
+                                         lsp_psig_per_node, (uint32_t)nn,
+                                         all_pn, (uint32_t)(nn * mtx_stride),
+                                         &got_matrix_len)) {
+        fprintf(stderr, "Client-stateless %u: parse LSP_RESPONSE failed\n", my_index);
+        cJSON_Delete(lr.json);
+        free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+        free(my_secnonces); free(my_slot);
+        return 0;
+    }
+    cJSON_Delete(lr.json);
+    (void)lsp_psig_per_node;  /* LSP psigs are aggregated LSP-side, not by client. */
+
+    int have_matrix = (got_matrix_len == (uint32_t)(nn * mtx_stride));
+
+    /* For each node this client signs: set LSP nonce + every co-signer nonce
+       from the matrix (skip own + LSP slots), finalize, create own psig. */
+    for (size_t nidx = 0; nidx < nn; nidx++) {
+        if (my_slot[nidx] < 0) continue;
+        int lsp_slot = factory_find_signer_slot(factory, nidx, 0);
+        if (lsp_slot < 0) {
+            fprintf(stderr, "Client-stateless %u: no LSP slot node %zu\n", my_index, nidx);
+            free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+            free(my_secnonces); free(my_slot);
+            return 0;
+        }
+        secp256k1_musig_pubnonce lsp_pn;
+        if (!musig_pubnonce_parse(ctx, &lsp_pn, lsp_pn_per_node + nidx * 66) ||
+            !factory_session_set_nonce(factory, nidx, (size_t)lsp_slot, &lsp_pn)) {
+            fprintf(stderr, "Client-stateless %u: set LSP nonce node %zu failed\n", my_index, nidx);
+            free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+            free(my_secnonces); free(my_slot);
+            return 0;
+        }
+        if (have_matrix) {
+            size_t ns = factory->nodes[nidx].n_signers;
+            for (size_t snum = 0; snum < ns; snum++) {
+                if (snum == (size_t)my_slot[nidx] || snum == (size_t)lsp_slot) continue;
+                const unsigned char *pn_ser =
+                    all_pn + (nidx * (size_t)FACTORY_MAX_SIGNERS + snum) * 66;
+                secp256k1_musig_pubnonce pn_s;
+                if (!musig_pubnonce_parse(ctx, &pn_s, pn_ser) ||
+                    !factory_session_set_nonce(factory, nidx, snum, &pn_s)) {
+                    fprintf(stderr, "Client-stateless %u: set co-signer nonce node %zu slot %zu failed\n",
+                            my_index, nidx, snum);
+                    free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+                    free(my_secnonces); free(my_slot);
+                    return 0;
+                }
+            }
+        }
+        if (!factory_session_finalize_node(factory, nidx)) {
+            fprintf(stderr, "Client-stateless %u: finalize_node %zu failed\n", my_index, nidx);
+            free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+            free(my_secnonces); free(my_slot);
+            return 0;
+        }
+    }
+    free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+
+    /* Create own per-node psigs (zeroes each consumed secnonce). */
+    unsigned char *my_psig_per_node = calloc(nn, 32);
+    if (!my_psig_per_node) { free(my_secnonces); free(my_slot); return 0; }
+    for (size_t nidx = 0; nidx < nn; nidx++) {
+        if (my_slot[nidx] < 0) continue;
+        secp256k1_musig_partial_sig my_psig;
+        if (!musig_create_partial_sig(ctx, &my_psig, &my_secnonces[nidx],
+                                       keypair,
+                                       &factory->nodes[nidx].signing_session)) {
+            fprintf(stderr, "Client-stateless %u: create_partial_sig node %zu failed\n", my_index, nidx);
+            free(my_psig_per_node); free(my_secnonces); free(my_slot);
+            return 0;
+        }
+        /* my_secnonces[nidx] zeroed by musig_create_partial_sig. */
+        musig_partial_sig_serialize(ctx, my_psig_per_node + nidx * 32, &my_psig);
+    }
+    free(my_secnonces); free(my_slot);
+
+    /* Send CLIENT_FINAL_PSIGS (per-node; unsigned nodes carry zero psig). */
+    {
+        cJSON *fp = wire_build_factory_client_final_psigs(my_psig_per_node, (uint32_t)nn);
+        free(my_psig_per_node);
+        if (!fp || !wire_send(fd, MSG_FACTORY_CLIENT_FINAL_PSIGS, fp)) {
+            fprintf(stderr, "Client-stateless %u: send CLIENT_FINAL_PSIGS failed\n", my_index);
+            if (fp) cJSON_Delete(fp);
+            return 0;
+        }
+        cJSON_Delete(fp);
+    }
+
+    printf("Client-stateless %u: factory-creation signing done (%zu nodes)\n",
+           my_index, nn);
+    return 1;
+}
+
 int client_run_with_channels(secp256k1_context *ctx,
                               const secp256k1_keypair *keypair,
                               const char *host, int port,
@@ -1719,6 +1934,25 @@ int client_run_with_channels(secp256k1_context *ctx,
         return 0;
     }
 
+    /* Phase 1e.3.c (#271): stateless reversed-flow factory creation.  When
+       SS_MUSIG_STATELESS=1 the LSP sends PROPOSE_INTENT (0x85) after
+       FACTORY_PROPOSE; run the per-node reversed signing, then converge at the
+       FACTORY_READY recv (post-creation steps unchanged).  The legacy
+       round-1-first nonce/psig path is wrapped in the else branch so its
+       function-scope locals stay confined. */
+    int ss_stateless_creation = 0;
+    {
+        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        ss_stateless_creation = (stateless && stateless[0] == '1');
+    }
+    /* Hoisted to function scope so done:/fail: can free it on either path.
+       The stateless path leaves it NULL (free(NULL) is a no-op). */
+    wire_bundle_entry_t *nonce_entries = NULL;
+    if (ss_stateless_creation) {
+        if (!client_factory_creation_stateless_signing(fd, ctx, keypair,
+                                                        factory, my_index))
+            goto fail;
+    } else {
     /* Generate nonces via pool */
     unsigned char my_seckey[32];
     secp256k1_keypair_sec(ctx, my_seckey, keypair);
@@ -1740,7 +1974,7 @@ int client_run_with_channels(secp256k1_context *ctx,
     memset(my_seckey, 0, 32);
 
     secp256k1_musig_secnonce *my_secnonce_ptrs[FACTORY_MAX_NODES];
-    wire_bundle_entry_t *nonce_entries =
+    nonce_entries =
         (wire_bundle_entry_t *)calloc(my_node_count + 1, sizeof(wire_bundle_entry_t));
 
     if (my_node_count > 0 && !nonce_entries) {
@@ -1952,6 +2186,7 @@ int client_run_with_channels(secp256k1_context *ctx,
         cJSON_Delete(bundle);
         free(psig_entries);
     }
+    }  /* end else (legacy round-1-first nonce/psig path) */
 
     /* Receive FACTORY_READY */
     if (!wire_recv(fd, &msg) || check_msg_error(&msg) || msg.msg_type != MSG_FACTORY_READY) {

--- a/src/client.c
+++ b/src/client.c
@@ -4335,13 +4335,49 @@ static int client_handle_state_advance_stateless(int fd,
         }
     }
 
-    /* Step 4: init MuSig session per affected. */
+    /* Step 3.5 (Tier B poison): prepare the L-stock poison TX for each affected
+       DW leaf with an old signed state (deterministic; matches the LSP minus
+       the watchtower gate, which is LSP-only).  PS leaves carry no L-stock
+       poison.  poison_prepared[k] is cleared per-leaf if anything degrades or
+       if the LSP doesn't reciprocate poison fields. */
+    const uint64_t TIERB_POISON_FEE_SATS = 1000;
+    int poison_prepared_c[FACTORY_MAX_NODES];
+    secp256k1_musig_secnonce my_poison_secnonces[FACTORY_MAX_NODES];
+    unsigned char my_poison_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    unsigned char my_poison_psigs_per_node[FACTORY_MAX_NODES][32];
+    for (size_t k = 0; k < n_affected; k++) {
+        poison_prepared_c[k] = 0;
+        memset(my_poison_pubnonces_per_node[k], 0, 66);
+        memset(my_poison_psigs_per_node[k], 0, 32);
+        factory_node_t *an = &factory->nodes[affected[k]];
+        int had_old = (an->is_signed && an->signed_tx.len > 0);
+        int old_no = an->n_outputs;
+        uint64_t old_l = (old_no >= 2) ? an->outputs[old_no - 1].amount_sats : 0;
+        if (!an->is_ps_leaf && had_old && old_no >= 2 &&
+            old_l > TIERB_POISON_FEE_SATS +
+                (uint64_t)(an->n_signers - 1) * 330u) {
+            unsigned char old_txid[32];
+            memcpy(old_txid, an->txid, 32);
+            if (factory_session_prepare_poison_tx_leaf(
+                    factory, affected[k], old_txid, (uint32_t)(old_no - 1),
+                    old_l, TIERB_POISON_FEE_SATS)) {
+                poison_prepared_c[k] = 1;  /* init_node_poison after state init */
+            }
+        }
+    }
+
+    /* Step 4: init MuSig session per affected (state + poison). */
     for (size_t k = 0; k < n_affected; k++) {
         if (!factory_session_init_node(factory, affected[k])) {
             fprintf(stderr,
                 "Client-stateless Tier B %u: init_node[%zu] failed\n",
                 my_index, affected[k]);
             return 0;
+        }
+        if (poison_prepared_c[k] &&
+            !factory_session_init_node_poison(factory, affected[k])) {
+            factory_session_reset_poison(factory, affected[k]);
+            poison_prepared_c[k] = 0;
         }
     }
 
@@ -4389,12 +4425,27 @@ static int client_handle_state_advance_stateless(int fd,
                 my_index, affected[k]);
             return 0;
         }
+        /* Poison: own nonce for this leaf (my_seckey still live this loop). */
+        if (poison_prepared_c[k]) {
+            secp256k1_musig_pubnonce ppn;
+            if (!musig_generate_nonce(ctx, &my_poison_secnonces[k], &ppn,
+                                        my_seckey, &my_pubkey,
+                                        &factory->nodes[affected[k]].keyagg.cache) ||
+                !factory_session_set_nonce_poison(factory, affected[k],
+                                                    (size_t)slot, &ppn)) {
+                factory_session_reset_poison(factory, affected[k]);
+                poison_prepared_c[k] = 0;
+            } else {
+                musig_pubnonce_serialize(ctx, my_poison_pubnonces_per_node[k], &ppn);
+            }
+        }
     }
     memset(my_seckey, 0, 32);
 
     /* Step 6: send CLIENT_PATH_NONCES. */
     cJSON *cpn = wire_build_state_adv_client_path_nonces(
-        (const unsigned char *)my_pubnonces_per_node, (uint32_t)n_affected, NULL);
+        (const unsigned char *)my_pubnonces_per_node, (uint32_t)n_affected,
+        (const unsigned char *)my_poison_pubnonces_per_node);
     if (!wire_send(fd, MSG_STATE_ADV_CLIENT_PATH_NONCES, cpn)) {
         cJSON_Delete(cpn);
         fprintf(stderr,
@@ -4414,11 +4465,16 @@ static int client_handle_state_advance_stateless(int fd,
     }
     unsigned char lsp_pubnonces_per_node[FACTORY_MAX_NODES][66];
     unsigned char lsp_psigs_per_node[FACTORY_MAX_NODES][32];
+    unsigned char lsp_poison_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    unsigned char lsp_poison_psigs_per_node[FACTORY_MAX_NODES][32];
+    memset(lsp_poison_pubnonces_per_node, 0, sizeof(lsp_poison_pubnonces_per_node));
+    memset(lsp_poison_psigs_per_node, 0, sizeof(lsp_poison_psigs_per_node));
     if (!wire_parse_state_adv_lsp_response(lr.json,
                                              (unsigned char *)lsp_pubnonces_per_node,
                                              (unsigned char *)lsp_psigs_per_node,
                                              (uint32_t)n_affected,
-                                             NULL, NULL)) {
+                                             (unsigned char *)lsp_poison_pubnonces_per_node,
+                                             (unsigned char *)lsp_poison_psigs_per_node)) {
         cJSON_Delete(lr.json);
         fprintf(stderr,
             "Client-stateless Tier B %u: parse LSP_RESPONSE failed\n", my_index);
@@ -4481,12 +4537,41 @@ static int client_handle_state_advance_stateless(int fd,
                 return 0;
             }
         }
+
+        /* Poison (lockstep): set LSP poison nonce + finalize + set LSP poison
+           psig + create own poison psig + complete.  Degrade this leaf if the
+           LSP sent no poison (poison field all-zero) or any step fails. */
+        if (poison_prepared_c[k]) {
+            int lsp_pz_zero = 1;
+            for (size_t b = 0; b < 66; b++)
+                if (lsp_poison_pubnonces_per_node[k][b]) { lsp_pz_zero = 0; break; }
+            secp256k1_musig_pubnonce lsp_ppn;
+            secp256k1_musig_partial_sig lsp_ppsig, my_ppsig;
+            if (lsp_pz_zero ||
+                !musig_pubnonce_parse(ctx, &lsp_ppn, lsp_poison_pubnonces_per_node[k]) ||
+                !factory_session_set_nonce_poison(factory, affected[k], (size_t)lsp_slot, &lsp_ppn) ||
+                !factory_session_finalize_node_poison(factory, affected[k]) ||
+                !musig_partial_sig_parse(ctx, &lsp_ppsig, lsp_poison_psigs_per_node[k]) ||
+                !factory_session_set_partial_sig_poison(factory, affected[k], (size_t)lsp_slot, &lsp_ppsig) ||
+                !musig_create_partial_sig(ctx, &my_ppsig, &my_poison_secnonces[k], keypair,
+                                            &factory->nodes[affected[k]].poison_signing_session) ||
+                !factory_session_set_partial_sig_poison(factory, affected[k],
+                                                          (size_t)my_slot_per_node[k], &my_ppsig) ||
+                !factory_session_complete_node_poison(factory, affected[k])) {
+                factory_session_reset_poison(factory, affected[k]);
+                poison_prepared_c[k] = 0;
+            } else {
+                musig_partial_sig_serialize(ctx, my_poison_psigs_per_node[k], &my_ppsig);
+            }
+            memset(&my_poison_secnonces[k], 0, sizeof(my_poison_secnonces[k]));
+        }
     }
-    /* INVARIANT: own secnonces zeroed by musig_create_partial_sig. */
+    /* INVARIANT: own state + poison secnonces zeroed by musig_create_partial_sig. */
 
     /* Step 9: send CLIENT_FINAL_PSIGS. */
     cJSON *fp = wire_build_state_adv_client_final_psigs(
-        (const unsigned char *)my_psigs_per_node, (uint32_t)n_affected, NULL);
+        (const unsigned char *)my_psigs_per_node, (uint32_t)n_affected,
+        (const unsigned char *)my_poison_psigs_per_node);
     if (!wire_send(fd, MSG_STATE_ADV_CLIENT_FINAL_PSIGS, fp)) {
         cJSON_Delete(fp);
         fprintf(stderr,

--- a/src/client.c
+++ b/src/client.c
@@ -2871,6 +2871,210 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
 /* Phase 1e.1.c: client-side stateless subfactory advance.  Dispatched
    from the public function when SS_MUSIG_STATELESS=1 and the LSP sent a
    PROPOSE_INTENT (new opcode 0x7D) instead of legacy PROPOSE (0x73). */
+/* Phase 1e.1.e: MULTI-INPUT stateless sub-factory advance (client side).
+   Mirrors client_handle_subfactory_advance_stateless looped per input.
+   STATELESS INVARIANT: each per-input client secnonce is generated once and
+   consumed/zeroed by musig_create_partial_sig before the DONE recv. */
+static int client_handle_subfactory_advance_stateless_multi(
+        int fd, secp256k1_context *ctx, const secp256k1_keypair *keypair,
+        factory_t *factory, uint32_t my_index, size_t sub_node_i,
+        factory_node_t *sub, uint32_t n_inputs_u,
+        int leaf_side, int sub_idx, int channel_idx, uint64_t delta_sats) {
+    size_t n_inputs = (size_t)n_inputs_u;
+    if (n_inputs < 1) {
+        fprintf(stderr, "Client-stateless MULTI %u: n_inputs=%zu invalid\n",
+                my_index, n_inputs);
+        return 0;
+    }
+
+    /* Apply the advance locally so unsigned_tx matches the LSP deterministically. */
+    if (!factory_subfactory_chain_advance_unsigned(factory, leaf_side, sub_idx,
+                                                     channel_idx, delta_sats)) {
+        fprintf(stderr, "Client-stateless MULTI %u: chain_advance_unsigned failed\n",
+                my_index);
+        return 0;
+    }
+
+    /* Init one state session per input (no poison in stateless MVP). */
+    for (size_t i = 0; i < n_inputs; i++) {
+        if (!factory_session_init_node_input(factory, sub_node_i, i)) {
+            fprintf(stderr, "Client-stateless MULTI %u: init input %zu failed\n",
+                    my_index, i);
+            return 0;
+        }
+    }
+
+    int my_slot = factory_find_signer_slot(factory, sub_node_i, my_index);
+    int lsp_slot = factory_find_signer_slot(factory, sub_node_i, 0);
+    if (my_slot < 0 || lsp_slot < 0) {
+        fprintf(stderr, "Client-stateless MULTI %u: slot lookup failed (my=%d lsp=%d)\n",
+                my_index, my_slot, lsp_slot);
+        return 0;
+    }
+
+    /* Gen own per-input secnonces + pubnonces; set own nonce on each input. */
+    unsigned char my_seckey[32];
+    secp256k1_pubkey my_pubkey;
+    if (!secp256k1_keypair_sec(ctx, my_seckey, keypair)) {
+        fprintf(stderr, "Client-stateless MULTI %u: keypair_sec failed\n", my_index);
+        return 0;
+    }
+    secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
+
+    secp256k1_musig_secnonce *my_secnonces =
+        calloc(n_inputs, sizeof(secp256k1_musig_secnonce));
+    unsigned char *my_pn_flat = calloc(n_inputs, 66);
+    if (!my_secnonces || !my_pn_flat) {
+        memset(my_seckey, 0, 32);
+        free(my_secnonces); free(my_pn_flat);
+        return 0;
+    }
+    for (size_t i = 0; i < n_inputs; i++) {
+        secp256k1_musig_pubnonce my_pubnonce_i;
+        if (!musig_generate_nonce(ctx, &my_secnonces[i], &my_pubnonce_i,
+                                   my_seckey, &my_pubkey, &sub->keyagg.cache)) {
+            fprintf(stderr, "Client-stateless MULTI %u: nonce gen input %zu failed\n",
+                    my_index, i);
+            memset(my_seckey, 0, 32);
+            free(my_secnonces); free(my_pn_flat);
+            return 0;
+        }
+        musig_pubnonce_serialize(ctx, my_pn_flat + i * 66, &my_pubnonce_i);
+        if (!factory_session_set_nonce_input(factory, sub_node_i, i,
+                                             (size_t)my_slot, &my_pubnonce_i)) {
+            fprintf(stderr, "Client-stateless MULTI %u: set own nonce input %zu failed\n",
+                    my_index, i);
+            memset(my_seckey, 0, 32);
+            free(my_secnonces); free(my_pn_flat);
+            return 0;
+        }
+    }
+    memset(my_seckey, 0, 32);
+
+    /* Send CLIENT_PUBNONCES with n_inputs own pubnonces. */
+    cJSON *cpn_json = wire_build_subfactory_client_pubnonces(my_pn_flat, (uint32_t)n_inputs);
+    free(my_pn_flat);
+    if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_PUBNONCES, cpn_json)) {
+        cJSON_Delete(cpn_json);
+        fprintf(stderr, "Client-stateless MULTI %u: send CLIENT_PUBNONCES failed\n", my_index);
+        free(my_secnonces);
+        return 0;
+    }
+    cJSON_Delete(cpn_json);
+
+    /* Wait for LSP_RESPONSE (per-input LSP nonces + psigs + signer x input matrix). */
+    wire_msg_t lr_msg;
+    if (!wire_recv(fd, &lr_msg) || lr_msg.msg_type != MSG_SUBFACTORY_LSP_RESPONSE) {
+        fprintf(stderr, "Client-stateless MULTI %u: expected LSP_RESPONSE, got 0x%02x\n",
+                my_index, lr_msg.json ? lr_msg.msg_type : 0);
+        if (lr_msg.json) cJSON_Delete(lr_msg.json);
+        free(my_secnonces);
+        return 0;
+    }
+    unsigned char *lsp_pn_flat = calloc(n_inputs, 66);
+    unsigned char *lsp_psig_flat = calloc(n_inputs, 32);
+    /* all_pn_per_input: signer x input matrix, same layout as LSP. */
+    size_t matrix_len = sub->n_signers * n_inputs * 66;
+    unsigned char *all_pn_per_input = calloc(sub->n_signers * n_inputs, 66);
+    if (!lsp_pn_flat || !lsp_psig_flat || !all_pn_per_input) {
+        cJSON_Delete(lr_msg.json);
+        free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
+        free(my_secnonces);
+        return 0;
+    }
+    uint32_t got_all_len = 0;
+    if (!wire_parse_subfactory_lsp_response(lr_msg.json, lsp_pn_flat, lsp_psig_flat,
+                                              (uint32_t)n_inputs,
+                                              all_pn_per_input, (uint32_t)matrix_len,
+                                              &got_all_len)) {
+        cJSON_Delete(lr_msg.json);
+        free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
+        free(my_secnonces);
+        fprintf(stderr, "Client-stateless MULTI %u: parse LSP_RESPONSE failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(lr_msg.json);
+    int have_matrix = (got_all_len == (uint32_t)matrix_len);
+
+    /* Per input: set LSP nonce + every other co-signer's nonce (skip own and
+       LSP slots, exactly like single-input), finalize, sign (zeros secnonce). */
+    unsigned char *my_psig_flat = calloc(n_inputs, 32);
+    if (!my_psig_flat) {
+        free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
+        free(my_secnonces);
+        return 0;
+    }
+    for (size_t i = 0; i < n_inputs; i++) {
+        secp256k1_musig_pubnonce lsp_pubnonce_i;
+        if (!musig_pubnonce_parse(ctx, &lsp_pubnonce_i, lsp_pn_flat + i * 66) ||
+            !factory_session_set_nonce_input(factory, sub_node_i, i,
+                                             (size_t)lsp_slot, &lsp_pubnonce_i)) {
+            fprintf(stderr, "Client-stateless MULTI %u: set LSP nonce input %zu failed\n",
+                    my_index, i);
+            goto fail;
+        }
+        if (have_matrix) {
+            for (size_t scs = 0; scs < sub->n_signers; scs++) {
+                if (scs == (size_t)my_slot || scs == (size_t)lsp_slot) continue;
+                secp256k1_musig_pubnonce pn_s;
+                if (!musig_pubnonce_parse(ctx, &pn_s,
+                        all_pn_per_input + (scs * n_inputs + i) * 66) ||
+                    !factory_session_set_nonce_input(factory, sub_node_i, i, scs, &pn_s)) {
+                    fprintf(stderr,
+                            "Client-stateless MULTI %u: set co-signer nonce[%zu] input %zu failed\n",
+                            my_index, scs, i);
+                    goto fail;
+                }
+            }
+        }
+        if (!factory_session_finalize_node_input(factory, sub_node_i, i)) {
+            fprintf(stderr, "Client-stateless MULTI %u: finalize input %zu failed\n",
+                    my_index, i);
+            goto fail;
+        }
+        secp256k1_musig_partial_sig my_psig_i;
+        if (!musig_create_partial_sig(ctx, &my_psig_i, &my_secnonces[i], keypair,
+                                       &sub->input_signing_sessions[i])) {
+            fprintf(stderr, "Client-stateless MULTI %u: create_partial_sig input %zu failed\n",
+                    my_index, i);
+            goto fail;
+        }
+        /* my_secnonces[i] zeroed by musig_create_partial_sig. */
+        musig_partial_sig_serialize(ctx, my_psig_flat + i * 32, &my_psig_i);
+    }
+    free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
+    free(my_secnonces);  /* all entries already zeroed by create_partial_sig */
+
+    /* Send CLIENT_FINAL_PSIGS with n_inputs psigs. */
+    cJSON *fp_json = wire_build_subfactory_client_final_psigs(my_psig_flat, (uint32_t)n_inputs);
+    free(my_psig_flat);
+    if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_FINAL_PSIGS, fp_json)) {
+        cJSON_Delete(fp_json);
+        fprintf(stderr, "Client-stateless MULTI %u: send CLIENT_FINAL_PSIGS failed\n", my_index);
+        return 0;
+    }
+    cJSON_Delete(fp_json);
+
+    /* Wait for DONE. */
+    wire_msg_t done_msg;
+    if (!wire_recv(fd, &done_msg) || done_msg.msg_type != MSG_SUBFACTORY_DONE) {
+        fprintf(stderr, "Client-stateless MULTI %u: expected DONE, got 0x%02x\n",
+                my_index, done_msg.json ? done_msg.msg_type : 0);
+        if (done_msg.json) cJSON_Delete(done_msg.json);
+        return 0;
+    }
+    if (done_msg.json) cJSON_Delete(done_msg.json);
+
+    printf("Client-stateless subfactory MULTI-INPUT %u: advance done (sub_node=%zu, n_inputs=%zu)\n",
+           my_index, sub_node_i, n_inputs);
+    return 1;
+
+fail:
+    free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
+    free(my_secnonces); free(my_psig_flat);
+    return 0;
+}
+
 static int client_handle_subfactory_advance_stateless(int fd,
                                                         secp256k1_context *ctx,
                                                         const secp256k1_keypair *keypair,
@@ -2888,11 +3092,6 @@ static int client_handle_subfactory_advance_stateless(int fd,
                 my_index);
         return 0;
     }
-    if (n_inputs != 1) {
-        fprintf(stderr, "Client-stateless subfactory %u: n_inputs=%u not supported "
-                "(MVP single-input only)\n", my_index, n_inputs);
-        return 0;
-    }
     if (sub_node_id >= factory->n_nodes) {
         fprintf(stderr, "Client-stateless subfactory %u: bad sub_node_id %u\n",
                 my_index, sub_node_id);
@@ -2900,6 +3099,15 @@ static int client_handle_subfactory_advance_stateless(int fd,
     }
     size_t sub_node_i = (size_t)sub_node_id;
     factory_node_t *sub = &factory->nodes[sub_node_i];
+
+    /* Phase 1e.1.e: MULTI-INPUT now runs through the STATELESS path too.
+       Dispatch to the looped-per-input handler; single-input keeps the
+       existing flow below. */
+    if (n_inputs > 1) {
+        return client_handle_subfactory_advance_stateless_multi(
+            fd, ctx, keypair, factory, my_index, sub_node_i, sub,
+            n_inputs, leaf_side, sub_idx, channel_idx, delta_sats);
+    }
 
     /* k>=2 (multi-client sub-factory) is supported: the LSP forwards the full
        all-signer pubnonce matrix in LSP_RESPONSE (Gap A), and the co-signer

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -320,12 +320,352 @@ accept_fail:
 
    Returns 1 on success, 0 on failure, -1 if stateless can't handle (caller
    falls through to legacy). */
-int lsp_run_factory_creation_stateless(lsp_t *lsp) {
-    (void)lsp;
-    fprintf(stderr,
-        "LSP-stateless factory creation: not yet implemented (Phase 1e.3.c) -- "
-        "falling back to legacy lsp_run_factory_creation\n");
-    return -1;
+/* Phase 1e.3.c (#271): stateless reversed-flow factory creation ceremony.
+
+   Signs every node in f->nodes[0..n_nodes) (root N-of-N, intermediates,
+   2-of-2 / k+1 leaves), each with its own signer set + session.  The LSP
+   NEVER holds a secret nonce across a network wait: per node it generates
+   its secnonce ONLY after receiving every client's per-node pubnonce, and
+   musig_create_partial_sig zeroes that secnonce before the next wire_recv.
+
+   Setup (tree build / send FACTORY_PROPOSE / sessions_init) and completion
+   (sessions_complete / FACTORY_READY) mirror legacy lsp_run_factory_creation
+   so the post-signing behaviour is identical.  Only the middle nonce/psig
+   EXCHANGE is reversed.
+
+   Wire flow (opcodes 0x85-0x88):
+     LSP    -> Client:  MSG_FACTORY_PROPOSE        (tree shape; clients build)
+     LSP    -> Client:  MSG_FACTORY_PROPOSE_INTENT (n_nodes; begin reversed)
+     Client -> LSP:     MSG_FACTORY_CLIENT_PUBNONCES   (per-node pubnonces)
+     LSP atomic:        per node { gen lsp secnonce; set ALL signers' nonces;
+                          finalize_node; create lsp psig (zeroes secnonce);
+                          set lsp psig }
+     LSP    -> Client:  MSG_FACTORY_LSP_RESPONSE   (per-node lsp pn+psig +
+                          full signer x node nonce matrix)
+     Client -> LSP:     MSG_FACTORY_CLIENT_FINAL_PSIGS (per-node client psigs)
+     LSP:               complete every node + FACTORY_READY
+
+   Returns 1 on success, 0 on failure, -1 to decline (caller falls back to
+   legacy). */
+int lsp_run_factory_creation_stateless(lsp_t *lsp,
+        const unsigned char *funding_txid, uint32_t funding_vout,
+        uint64_t funding_amount,
+        const unsigned char *funding_spk, size_t funding_spk_len,
+        uint16_t step_blocks, uint32_t states_per_layer,
+        uint32_t cltv_timeout) {
+    if (!lsp) return -1;
+    factory_t *f = &lsp->factory;
+
+    /* ---- Setup: identical to legacy lsp_run_factory_creation ---- */
+    size_t n_total = 1 + lsp->n_clients;
+    secp256k1_pubkey all_pubkeys[FACTORY_MAX_SIGNERS];
+    all_pubkeys[0] = lsp->lsp_pubkey;
+    for (size_t i = 0; i < lsp->n_clients; i++)
+        all_pubkeys[i + 1] = lsp->client_pubkeys[i];
+
+    factory_arity_t saved_arity = f->leaf_arity;
+    size_t saved_n_level_arity = f->n_level_arity;
+    uint8_t saved_level_arity[FACTORY_MAX_LEVELS];
+    if (saved_n_level_arity > 0)
+        memcpy(saved_level_arity, f->level_arity,
+               saved_n_level_arity * sizeof(uint8_t));
+    uint32_t saved_static_threshold = f->static_threshold_depth;
+    uint32_t saved_ps_subfactory_arity = f->ps_subfactory_arity;
+    uint64_t saved_fee_per_tx = f->fee_per_tx;
+    placement_mode_t saved_placement = f->placement_mode;
+    economic_mode_t saved_econ = f->economic_mode;
+    participant_profile_t saved_profiles[FACTORY_MAX_SIGNERS];
+    memcpy(saved_profiles, f->profiles, sizeof(saved_profiles));
+    int saved_has_shachain = f->has_shachain;
+    int saved_use_flat = f->use_flat_secrets;
+    size_t saved_n_secrets = f->n_revocation_secrets;
+    unsigned char (*saved_secrets)[32] = (unsigned char (*)[32])calloc(FACTORY_MAX_EPOCHS, 32);
+    unsigned char saved_shachain_seed[32];
+    if (saved_use_flat && saved_secrets)
+        memcpy(saved_secrets, f->revocation_secrets, saved_n_secrets * 32);
+    else if (!saved_use_flat)
+        memcpy(saved_shachain_seed, f->shachain_seed, 32);
+    factory_init_from_pubkeys(f, lsp->ctx, all_pubkeys, n_total,
+                              step_blocks, states_per_layer);
+    if (saved_n_level_arity > 0) {
+        factory_set_level_arity(f, saved_level_arity, saved_n_level_arity);
+    } else if (saved_arity == FACTORY_ARITY_1) {
+        factory_set_arity(f, FACTORY_ARITY_1);
+    } else if (saved_arity == FACTORY_ARITY_PS) {
+        factory_set_arity(f, FACTORY_ARITY_PS);
+    }
+    if (saved_static_threshold > 0)
+        factory_set_static_near_root(f, saved_static_threshold);
+    if (saved_ps_subfactory_arity > 1)
+        factory_set_ps_subfactory_arity(f, saved_ps_subfactory_arity);
+    if (saved_fee_per_tx > 200)
+        f->fee_per_tx = saved_fee_per_tx;
+    f->cltv_timeout = cltv_timeout;
+    f->placement_mode = saved_placement;
+    f->economic_mode = saved_econ;
+    memcpy(f->profiles, saved_profiles, sizeof(saved_profiles));
+    if (saved_has_shachain) {
+        if (saved_use_flat && saved_secrets)
+            factory_set_flat_secrets(f, saved_secrets, saved_n_secrets);
+        else if (!saved_use_flat)
+            factory_set_shachain_seed(f, saved_shachain_seed);
+    }
+    free(saved_secrets);
+    factory_set_funding(f, funding_txid, funding_vout, funding_amount,
+                        funding_spk, funding_spk_len);
+
+    if (!factory_build_tree(f)) {
+        fprintf(stderr, "LSP-stateless factory creation: factory_build_tree failed\n");
+        return 0;
+    }
+
+    /* Send FACTORY_PROPOSE to all clients (tree shape) */
+    cJSON *propose = wire_build_factory_propose(f);
+    if (lsp->dist_client_amounts && lsp->dist_n_client_amounts > 0) {
+        cJSON *da = cJSON_CreateArray();
+        for (size_t i = 0; i < lsp->dist_n_client_amounts; i++)
+            cJSON_AddItemToArray(da, cJSON_CreateNumber((double)lsp->dist_client_amounts[i]));
+        cJSON_AddItemToObject(propose, "dist_amounts", da);
+    }
+    for (size_t i = 0; i < lsp->n_clients; i++) {
+        if (!wire_send(lsp->client_fds[i], MSG_FACTORY_PROPOSE, propose)) {
+            fprintf(stderr, "LSP-stateless: send FACTORY_PROPOSE to client %zu failed\n", i);
+            cJSON_Delete(propose);
+            return 0;
+        }
+    }
+    cJSON_Delete(propose);
+
+    if (!factory_sessions_init(f)) {
+        fprintf(stderr, "LSP-stateless: factory_sessions_init failed\n");
+        return 0;
+    }
+
+    /* Build unsigned distribution TX so the unsigned dist TX is attached to f
+       (legacy rotation re-signs it later).  Stateless MVP does NOT co-sign the
+       dist TX during creation -- matches the validated sub-factory / state-
+       advance stateless ceremonies which carry no dist TX.  FACTORY_READY
+       therefore omits distribution_tx_hex. */
+    {
+        tx_output_t dist_outputs[FACTORY_MAX_SIGNERS + 1];
+        size_t n_dist = factory_compute_distribution_outputs_balanced(f,
+            dist_outputs, FACTORY_MAX_SIGNERS + 1, 500,
+            lsp->dist_client_amounts, lsp->dist_n_client_amounts);
+        if (n_dist > 0 && f->cltv_timeout > 0)
+            (void)factory_build_distribution_tx_unsigned(
+                f, dist_outputs, n_dist, f->cltv_timeout);
+    }
+
+    /* ---- Reversed stateless signing exchange ---- */
+
+    /* Step A: PROPOSE_INTENT(n_nodes) to all clients (begin reversed flow). */
+    {
+        cJSON *intent = wire_build_factory_propose_intent((uint32_t)f->n_nodes);
+        for (size_t i = 0; i < lsp->n_clients; i++) {
+            if (!wire_send(lsp->client_fds[i], MSG_FACTORY_PROPOSE_INTENT, intent)) {
+                fprintf(stderr, "LSP-stateless: send PROPOSE_INTENT to client %zu failed\n", i);
+                cJSON_Delete(intent);
+                goto fail_pre;
+            }
+        }
+        cJSON_Delete(intent);
+    }
+
+    /* all_pn[(node_idx * FACTORY_MAX_SIGNERS + signer_slot) * 66] -- full
+       signer x node nonce matrix.  Filled from client pubnonces (Step B) and
+       LSP pubnonces (Step C), forwarded to clients in LSP_RESPONSE so each
+       client can set every co-signer's per-node nonce and finalize. */
+    size_t mtx_stride = (size_t)FACTORY_MAX_SIGNERS * 66;
+    unsigned char *all_pn = calloc(f->n_nodes, mtx_stride);
+    if (!all_pn) goto fail_pre;
+
+    /* Step B: collect each client's per-node pubnonces (only for nodes the
+       client signs; other node slots stay zero in that client's array). */
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        uint32_t my_part = (uint32_t)(c + 1);
+        wire_msg_t nmsg;
+        if (!wire_recv_skip_ping(lsp->client_fds[c], &nmsg) ||
+            nmsg.msg_type != MSG_FACTORY_CLIENT_PUBNONCES) {
+            if (nmsg.json && !check_client_error(&nmsg, c))
+                fprintf(stderr, "LSP-stateless: expected CLIENT_PUBNONCES from client %zu, got 0x%02x\n",
+                        c, nmsg.msg_type);
+            if (nmsg.json) cJSON_Delete(nmsg.json);
+            free(all_pn);
+            goto fail_pre;
+        }
+        unsigned char *client_pn = calloc(f->n_nodes, 66);
+        if (!client_pn) { cJSON_Delete(nmsg.json); free(all_pn); goto fail_pre; }
+        if (!wire_parse_factory_client_pubnonces(nmsg.json, client_pn,
+                                                  (uint32_t)f->n_nodes)) {
+            cJSON_Delete(nmsg.json);
+            free(client_pn); free(all_pn);
+            fprintf(stderr, "LSP-stateless: parse CLIENT_PUBNONCES (client %zu) failed\n", c);
+            goto fail_pre;
+        }
+        cJSON_Delete(nmsg.json);
+        for (size_t nidx = 0; nidx < f->n_nodes; nidx++) {
+            int slot = factory_find_signer_slot(f, nidx, my_part);
+            if (slot < 0) continue;  /* this client does not sign this node */
+            secp256k1_musig_pubnonce pn;
+            if (!musig_pubnonce_parse(lsp->ctx, &pn, client_pn + nidx * 66)) {
+                fprintf(stderr, "LSP-stateless: bad client pubnonce (client %zu node %zu)\n", c, nidx);
+                free(client_pn); free(all_pn);
+                goto fail_pre;
+            }
+            if (!factory_session_set_nonce(f, nidx, (size_t)slot, &pn)) {
+                fprintf(stderr, "LSP-stateless: set client nonce node %zu slot %d failed\n", nidx, slot);
+                free(client_pn); free(all_pn);
+                goto fail_pre;
+            }
+            memcpy(all_pn + (nidx * (size_t)FACTORY_MAX_SIGNERS + (size_t)slot) * 66,
+                   client_pn + nidx * 66, 66);
+        }
+        free(client_pn);
+    }
+
+    /* Step C (CRITICAL ATOMIC BLOCK -- no wire_recv inside): per node, gen the
+       LSP secnonce, set the LSP slot nonce (clients' already set in Step B),
+       finalize the node, create the LSP partial sig (which zeroes the
+       secnonce), set it.  STATELESS INVARIANT: every LSP secnonce is generated
+       only AFTER Step B's recv of all client pubnonces, and each is zeroed by
+       musig_create_partial_sig before Step E's recv. */
+    {
+        unsigned char lsp_seckey[32];
+        if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) { free(all_pn); goto fail_pre; }
+        unsigned char *lsp_pn_per_node = calloc(f->n_nodes, 66);
+        unsigned char *lsp_psig_per_node = calloc(f->n_nodes, 32);
+        if (!lsp_pn_per_node || !lsp_psig_per_node) {
+            memset(lsp_seckey, 0, 32);
+            free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+            goto fail_pre;
+        }
+        for (size_t nidx = 0; nidx < f->n_nodes; nidx++) {
+            int slot = factory_find_signer_slot(f, nidx, 0);
+            if (slot < 0) continue;  /* LSP signs every node, but guard. */
+            secp256k1_musig_secnonce lsp_secnonce;
+            secp256k1_musig_pubnonce lsp_pubnonce;
+            if (!musig_generate_nonce(lsp->ctx, &lsp_secnonce, &lsp_pubnonce,
+                                       lsp_seckey, &lsp->lsp_pubkey,
+                                       &f->nodes[nidx].keyagg.cache)) {
+                fprintf(stderr, "LSP-stateless: nonce gen node %zu failed\n", nidx);
+                memset(lsp_seckey, 0, 32);
+                free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+                goto fail_pre;
+            }
+            musig_pubnonce_serialize(lsp->ctx, lsp_pn_per_node + nidx * 66, &lsp_pubnonce);
+            memcpy(all_pn + (nidx * (size_t)FACTORY_MAX_SIGNERS + (size_t)slot) * 66,
+                   lsp_pn_per_node + nidx * 66, 66);
+            if (!factory_session_set_nonce(f, nidx, (size_t)slot, &lsp_pubnonce)) {
+                fprintf(stderr, "LSP-stateless: set LSP nonce node %zu failed\n", nidx);
+                memset(lsp_seckey, 0, 32);
+                free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+                goto fail_pre;
+            }
+            if (!factory_session_finalize_node(f, nidx)) {
+                fprintf(stderr, "LSP-stateless: finalize_node %zu failed\n", nidx);
+                memset(lsp_seckey, 0, 32);
+                free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+                goto fail_pre;
+            }
+            secp256k1_musig_partial_sig lsp_psig;
+            if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce,
+                                           &lsp->lsp_keypair,
+                                           &f->nodes[nidx].signing_session)) {
+                fprintf(stderr, "LSP-stateless: create_partial_sig node %zu failed\n", nidx);
+                memset(lsp_seckey, 0, 32);
+                free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+                goto fail_pre;
+            }
+            /* lsp_secnonce zeroed by musig_create_partial_sig. INVARIANT holds. */
+            if (!factory_session_set_partial_sig(f, nidx, (size_t)slot, &lsp_psig)) {
+                fprintf(stderr, "LSP-stateless: set LSP psig node %zu failed\n", nidx);
+                memset(lsp_seckey, 0, 32);
+                free(lsp_pn_per_node); free(lsp_psig_per_node); free(all_pn);
+                goto fail_pre;
+            }
+            musig_partial_sig_serialize(lsp->ctx, lsp_psig_per_node + nidx * 32, &lsp_psig);
+        }
+        memset(lsp_seckey, 0, 32);
+
+        /* Step D: LSP_RESPONSE -- per-node LSP nonces + psigs + full matrix. */
+        cJSON *response = wire_build_factory_lsp_response(
+            lsp_pn_per_node, lsp_psig_per_node, (uint32_t)f->n_nodes,
+            all_pn, (uint32_t)(f->n_nodes * mtx_stride));
+        free(lsp_pn_per_node); free(lsp_psig_per_node);
+        if (!response) { free(all_pn); goto fail_pre; }
+        for (size_t i = 0; i < lsp->n_clients; i++) {
+            if (!wire_send(lsp->client_fds[i], MSG_FACTORY_LSP_RESPONSE, response)) {
+                fprintf(stderr, "LSP-stateless: send LSP_RESPONSE to client %zu failed\n", i);
+                cJSON_Delete(response);
+                free(all_pn);
+                goto fail_pre;
+            }
+        }
+        cJSON_Delete(response);
+        free(all_pn);
+    }
+
+    /* Step E: collect each client's per-node final psigs. */
+    for (size_t c = 0; c < lsp->n_clients; c++) {
+        uint32_t my_part = (uint32_t)(c + 1);
+        wire_msg_t pmsg;
+        if (!wire_recv_skip_ping(lsp->client_fds[c], &pmsg) ||
+            pmsg.msg_type != MSG_FACTORY_CLIENT_FINAL_PSIGS) {
+            if (pmsg.json && !check_client_error(&pmsg, c))
+                fprintf(stderr, "LSP-stateless: expected CLIENT_FINAL_PSIGS from client %zu, got 0x%02x\n",
+                        c, pmsg.msg_type);
+            if (pmsg.json) cJSON_Delete(pmsg.json);
+            goto fail_pre;
+        }
+        unsigned char *client_psig = calloc(f->n_nodes, 32);
+        if (!client_psig) { cJSON_Delete(pmsg.json); goto fail_pre; }
+        if (!wire_parse_factory_client_final_psigs(pmsg.json, client_psig,
+                                                    (uint32_t)f->n_nodes)) {
+            cJSON_Delete(pmsg.json);
+            free(client_psig);
+            fprintf(stderr, "LSP-stateless: parse CLIENT_FINAL_PSIGS (client %zu) failed\n", c);
+            goto fail_pre;
+        }
+        cJSON_Delete(pmsg.json);
+        for (size_t nidx = 0; nidx < f->n_nodes; nidx++) {
+            int slot = factory_find_signer_slot(f, nidx, my_part);
+            if (slot < 0) continue;
+            secp256k1_musig_partial_sig psig;
+            if (!musig_partial_sig_parse(lsp->ctx, &psig, client_psig + nidx * 32) ||
+                !factory_session_set_partial_sig(f, nidx, (size_t)slot, &psig)) {
+                fprintf(stderr, "LSP-stateless: set client psig node %zu slot %d failed\n", nidx, slot);
+                free(client_psig);
+                goto fail_pre;
+            }
+        }
+        free(client_psig);
+    }
+
+    /* ---- Completion: identical to legacy lsp_run_factory_creation ---- */
+    if (!factory_sessions_complete(f)) {
+        fprintf(stderr, "LSP-stateless: factory_sessions_complete failed\n");
+        goto fail_pre;
+    }
+
+    {
+        cJSON *ready = wire_build_factory_ready(f);
+        for (size_t i = 0; i < lsp->n_clients; i++) {
+            if (!wire_send(lsp->client_fds[i], MSG_FACTORY_READY, ready)) {
+                fprintf(stderr, "LSP-stateless: send FACTORY_READY to client %zu failed\n", i);
+                cJSON_Delete(ready);
+                goto fail_pre;
+            }
+        }
+        cJSON_Delete(ready);
+    }
+
+    printf("LSP-stateless factory creation: %u nodes signed\n", (unsigned)f->n_nodes);
+    return 1;
+
+fail_pre:
+    lsp_abort_ceremony(lsp, "stateless factory creation failed");
+    factory_free(&lsp->factory);
+    return 0;
 }
 
 int lsp_run_factory_creation(lsp_t *lsp,
@@ -340,8 +680,13 @@ int lsp_run_factory_creation(lsp_t *lsp,
     {
         const char *stateless = getenv("SS_MUSIG_STATELESS");
         if (stateless && stateless[0] == '1') {
-            extern int lsp_run_factory_creation_stateless(lsp_t *);
-            int rc = lsp_run_factory_creation_stateless(lsp);
+            extern int lsp_run_factory_creation_stateless(lsp_t *,
+                const unsigned char *, uint32_t, uint64_t,
+                const unsigned char *, size_t, uint16_t, uint32_t, uint32_t);
+            int rc = lsp_run_factory_creation_stateless(
+                lsp, funding_txid, funding_vout, funding_amount,
+                funding_spk, funding_spk_len, step_blocks, states_per_layer,
+                cltv_timeout);
             if (rc >= 0) return rc;
             /* rc == -1: stateless declined; fall through to legacy. */
         }

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -176,38 +176,38 @@ int lsp_accept_clients(lsp_t *lsp) {
         else
             hs_ok = wire_noise_handshake_responder(fd, lsp->ctx);
         if (!hs_ok) {
-            fprintf(stderr, "LSP: noise handshake failed for client %zu\n", i);
+            fprintf(stderr, "LSP: noise handshake failed for client %zu -- dropping, retrying slot\n", i);
             rate_limiter_handshake_end(&lsp->rate_limiter);
             wire_close(fd);
-            goto accept_fail;
+            i--; continue;
         }
         rate_limiter_handshake_end(&lsp->rate_limiter);
 
         /* Receive HELLO */
         wire_msg_t msg;
         if (!wire_recv(fd, &msg) || msg.msg_type != MSG_HELLO) {
-            fprintf(stderr, "LSP: expected HELLO from client %zu\n", i);
+            fprintf(stderr, "LSP: expected HELLO from client %zu -- dropping, retrying slot\n", i);
             wire_close(fd);
             if (msg.json) cJSON_Delete(msg.json);
-            goto accept_fail;
+            i--; continue;
         }
 
         /* Parse client pubkey */
         cJSON *pk_item = cJSON_GetObjectItem(msg.json, "pubkey");
         if (!pk_item || !cJSON_IsString(pk_item)) {
-            fprintf(stderr, "LSP: bad pubkey in HELLO from client %zu\n", i);
+            fprintf(stderr, "LSP: bad pubkey in HELLO from client %zu -- dropping, retrying slot\n", i);
             cJSON_Delete(msg.json);
             wire_close(fd);
-            goto accept_fail;
+            i--; continue;
         }
 
         unsigned char pk_buf[33];
         if (hex_decode(pk_item->valuestring, pk_buf, 33) != 33 ||
             !secp256k1_ec_pubkey_parse(lsp->ctx, &lsp->client_pubkeys[i], pk_buf, 33)) {
-            fprintf(stderr, "LSP: invalid pubkey from client %zu\n", i);
+            fprintf(stderr, "LSP: invalid pubkey from client %zu -- dropping, retrying slot\n", i);
             cJSON_Delete(msg.json);
             wire_close(fd);
-            goto accept_fail;
+            i--; continue;
         }
 
         /* Optional slot_hint for deterministic keyagg ordering */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4683,6 +4683,317 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
    Dispatched from the public function when SS_MUSIG_STATELESS=1 AND the
    target node is single-input (factory_node_uses_multi_input returns 0).
    Multi-input + poison + WT registration deferred to Phase 1e.1.c. */
+/* Phase 1e.1.e: MULTI-INPUT stateless sub-factory chain advance.
+   Mirrors lsp_subfactory_chain_advance_stateless (single-input) but loops
+   per input.  Called from the single-input function once the unsigned tx,
+   session, sub_clients[] and slots have been resolved -- but we re-derive
+   everything needed here from (f, sub_node_i, sub) so this stays a clean
+   self-contained block.
+
+   STATELESS INVARIANT: LSP per-input secnonces are generated in Step 5 AFTER
+   the Step-4 recv of every client's pubnonces, and each lsp_secnonces[i] is
+   zeroed by musig_create_partial_sig (Step 5) before the Step-7 recv. */
+static int lsp_subfactory_chain_advance_stateless_multi(
+        lsp_channel_mgr_t *mgr, lsp_t *lsp, factory_t *f,
+        size_t sub_node_i, factory_node_t *sub,
+        const uint32_t *sub_clients, size_t n_clients_in_sub,
+        int leaf_side, int sub_idx_in_leaf, int channel_idx_in_sub,
+        uint64_t delta_sats) {
+    size_t n_inputs = sub->ps_n_prev_outputs;
+    if (n_inputs < 1) {
+        fprintf(stderr, "LSP-stateless subfactory MULTI: n_inputs=%zu invalid\n",
+                n_inputs);
+        return 0;
+    }
+
+    /* Step 1: rebuild unsigned_tx (deterministic; clients do the same). */
+    if (!factory_subfactory_chain_advance_unsigned(f, leaf_side,
+                                                    sub_idx_in_leaf,
+                                                    channel_idx_in_sub,
+                                                    delta_sats)) {
+        fprintf(stderr, "LSP-stateless subfactory MULTI: advance_unsigned failed\n");
+        return 0;
+    }
+
+    /* Step 2: init one state session per input (no poison in stateless MVP). */
+    for (size_t i = 0; i < n_inputs; i++) {
+        if (!factory_session_init_node_input(f, sub_node_i, i)) {
+            fprintf(stderr, "LSP-stateless subfactory MULTI: init input %zu failed\n", i);
+            return 0;
+        }
+    }
+
+    int lsp_slot = factory_find_signer_slot(f, sub_node_i, 0);
+    if (lsp_slot < 0) return 0;
+
+    /* Step 3: PROPOSE_INTENT (n_inputs, NO LSP nonce). */
+    cJSON *propose = wire_build_subfactory_propose_intent(
+        (uint32_t)sub_node_i, (uint32_t)n_inputs,
+        leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_PROPOSE_INTENT, propose)) {
+            cJSON_Delete(propose);
+            fprintf(stderr, "LSP-stateless MULTI: send PROPOSE_INTENT failed for client %u\n",
+                    sub_clients[ci]);
+            return 0;
+        }
+    }
+    cJSON_Delete(propose);
+
+    /* all_pn_per_input[(signer_slot * n_inputs + input_idx) * 66] -- same
+       layout as the legacy multi-input path so the matrix forwarded to
+       clients in LSP_RESPONSE is indexed identically on both sides. */
+    unsigned char *all_pn_per_input = calloc(sub->n_signers * n_inputs, 66);
+    if (!all_pn_per_input) return 0;
+
+    /* Step 4: collect each client's n_inputs pubnonces. */
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t nmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &nmsg, WIRE_CEREMONY_RECV_TIMEOUT_SEC) ||
+            nmsg.msg_type != MSG_SUBFACTORY_CLIENT_PUBNONCES) {
+            fprintf(stderr,
+                    "LSP-stateless MULTI: expected CLIENT_PUBNONCES from client %u, got 0x%02x\n",
+                    sub_clients[ci], nmsg.msg_type);
+            if (nmsg.json) cJSON_Delete(nmsg.json);
+            free(all_pn_per_input);
+            return 0;
+        }
+        unsigned char *client_pn_buf = calloc(n_inputs, 66);
+        if (!client_pn_buf) { cJSON_Delete(nmsg.json); free(all_pn_per_input); return 0; }
+        if (!wire_parse_subfactory_client_pubnonces(nmsg.json, client_pn_buf,
+                                                     (uint32_t)n_inputs)) {
+            cJSON_Delete(nmsg.json);
+            free(client_pn_buf); free(all_pn_per_input);
+            fprintf(stderr, "LSP-stateless MULTI: parse CLIENT_PUBNONCES failed\n");
+            return 0;
+        }
+        cJSON_Delete(nmsg.json);
+        int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
+        if (client_slot < 0) { free(client_pn_buf); free(all_pn_per_input); return 0; }
+        for (size_t i = 0; i < n_inputs; i++)
+            memcpy(all_pn_per_input + ((size_t)client_slot * n_inputs + i) * 66,
+                   client_pn_buf + i * 66, 66);
+        free(client_pn_buf);
+    }
+
+    /* Step 5 (THE CRITICAL ATOMIC BLOCK): per input -- gen LSP secnonce, set
+       all signers' input-i nonces, finalize input-i, create LSP psig (zeros
+       secnonce[i]), set LSP psig.  No wire_recv anywhere in this block. */
+    unsigned char lsp_seckey[32];
+    if (!secp256k1_keypair_sec(lsp->ctx, lsp_seckey, &lsp->lsp_keypair)) {
+        free(all_pn_per_input);
+        return 0;
+    }
+    secp256k1_musig_secnonce *lsp_secnonces =
+        calloc(n_inputs, sizeof(secp256k1_musig_secnonce));
+    unsigned char (*lsp_pn_ser)[66] = calloc(n_inputs, sizeof(unsigned char[66]));
+    unsigned char (*lsp_psig_ser)[32] = calloc(n_inputs, sizeof(unsigned char[32]));
+    if (!lsp_secnonces || !lsp_pn_ser || !lsp_psig_ser) {
+        memset(lsp_seckey, 0, 32);
+        free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+        free(all_pn_per_input);
+        return 0;
+    }
+
+    /* Build the LSP keypair once for the per-input psig calls. */
+    secp256k1_keypair lsp_kp;
+    if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
+        memset(lsp_seckey, 0, 32);
+        free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+        free(all_pn_per_input);
+        return 0;
+    }
+
+    for (size_t i = 0; i < n_inputs; i++) {
+        secp256k1_musig_pubnonce lsp_pubnonce_i;
+        if (!musig_generate_nonce(lsp->ctx, &lsp_secnonces[i], &lsp_pubnonce_i,
+                                   lsp_seckey, &lsp->lsp_pubkey,
+                                   &sub->keyagg.cache)) {
+            fprintf(stderr, "LSP-stateless MULTI: nonce gen input %zu failed\n", i);
+            memset(lsp_seckey, 0, 32);
+            free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+            free(all_pn_per_input);
+            return 0;
+        }
+        musig_pubnonce_serialize(lsp->ctx, lsp_pn_ser[i], &lsp_pubnonce_i);
+        memcpy(all_pn_per_input + ((size_t)lsp_slot * n_inputs + i) * 66,
+               lsp_pn_ser[i], 66);
+
+        /* Set every signer's nonce for THIS input. */
+        for (size_t s = 0; s < sub->n_signers; s++) {
+            secp256k1_musig_pubnonce pn;
+            if (!musig_pubnonce_parse(lsp->ctx, &pn,
+                    all_pn_per_input + (s * n_inputs + i) * 66) ||
+                !factory_session_set_nonce_input(f, sub_node_i, i, s, &pn)) {
+                fprintf(stderr,
+                        "LSP-stateless MULTI: set_nonce_input(signer=%zu input=%zu) failed\n",
+                        s, i);
+                memset(lsp_seckey, 0, 32);
+                free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+                free(all_pn_per_input);
+                return 0;
+            }
+        }
+
+        if (!factory_session_finalize_node_input(f, sub_node_i, i)) {
+            fprintf(stderr, "LSP-stateless MULTI: finalize input %zu failed\n", i);
+            memset(lsp_seckey, 0, 32);
+            free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+            free(all_pn_per_input);
+            return 0;
+        }
+
+        secp256k1_musig_partial_sig lsp_psig_i;
+        if (!musig_create_partial_sig(lsp->ctx, &lsp_psig_i,
+                &lsp_secnonces[i], &lsp_kp,
+                &sub->input_signing_sessions[i])) {
+            fprintf(stderr, "LSP-stateless MULTI: create_partial_sig input %zu failed\n", i);
+            memset(lsp_seckey, 0, 32);
+            free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+            free(all_pn_per_input);
+            return 0;
+        }
+        /* lsp_secnonces[i] zeroed by musig_create_partial_sig.  INVARIANT:
+           no LSP secnonce for input i is held across the recv that follows. */
+        if (!factory_session_set_partial_sig_input(f, sub_node_i, i,
+                                                    (size_t)lsp_slot, &lsp_psig_i)) {
+            fprintf(stderr, "LSP-stateless MULTI: set_partial_sig_input %zu failed\n", i);
+            memset(lsp_seckey, 0, 32);
+            free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+            free(all_pn_per_input);
+            return 0;
+        }
+        musig_partial_sig_serialize(lsp->ctx, lsp_psig_ser[i], &lsp_psig_i);
+    }
+    memset(lsp_seckey, 0, 32);
+    free(lsp_secnonces);  /* all entries already zeroed by create_partial_sig */
+
+    /* Build flat per-input LSP arrays for the wire response. */
+    unsigned char *lsp_pn_flat = calloc(n_inputs, 66);
+    unsigned char *lsp_psig_flat = calloc(n_inputs, 32);
+    if (!lsp_pn_flat || !lsp_psig_flat) {
+        free(lsp_pn_flat); free(lsp_psig_flat);
+        free(lsp_pn_ser); free(lsp_psig_ser);
+        free(all_pn_per_input);
+        return 0;
+    }
+    for (size_t i = 0; i < n_inputs; i++) {
+        memcpy(lsp_pn_flat + i * 66, lsp_pn_ser[i], 66);
+        memcpy(lsp_psig_flat + i * 32, lsp_psig_ser[i], 32);
+    }
+    free(lsp_pn_ser); free(lsp_psig_ser);
+
+    /* Step 6: LSP_RESPONSE -- per-input LSP nonces + psigs, plus the full
+       signer x input matrix (all_pn_per_input) as the all-signer blob so each
+       client can set every co-signer's per-input nonce and finalize. */
+    cJSON *response = wire_build_subfactory_lsp_response(
+        lsp_pn_flat, lsp_psig_flat, (uint32_t)n_inputs,
+        all_pn_per_input,
+        (uint32_t)(sub->n_signers * n_inputs * 66));
+    free(lsp_pn_flat); free(lsp_psig_flat);
+    free(all_pn_per_input);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_LSP_RESPONSE, response)) {
+            cJSON_Delete(response);
+            fprintf(stderr, "LSP-stateless MULTI: send LSP_RESPONSE failed for client %u\n",
+                    sub_clients[ci]);
+            return 0;
+        }
+    }
+    cJSON_Delete(response);
+
+    /* Step 7: collect each client's n_inputs final psigs. */
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_msg_t pmsg;
+        if (!recv_timeout_service_bridge(mgr, lsp, lsp->client_fds[fd_idx],
+                                            &pmsg, WIRE_CEREMONY_RECV_TIMEOUT_SEC) ||
+            pmsg.msg_type != MSG_SUBFACTORY_CLIENT_FINAL_PSIGS) {
+            fprintf(stderr,
+                    "LSP-stateless MULTI: expected CLIENT_FINAL_PSIGS from client %u, got 0x%02x\n",
+                    sub_clients[ci], pmsg.msg_type);
+            if (pmsg.json) cJSON_Delete(pmsg.json);
+            return 0;
+        }
+        unsigned char *client_psig_buf = calloc(n_inputs, 32);
+        if (!client_psig_buf) { cJSON_Delete(pmsg.json); return 0; }
+        if (!wire_parse_subfactory_client_final_psigs(pmsg.json, client_psig_buf,
+                                                       (uint32_t)n_inputs)) {
+            cJSON_Delete(pmsg.json);
+            free(client_psig_buf);
+            fprintf(stderr, "LSP-stateless MULTI: parse CLIENT_FINAL_PSIGS failed\n");
+            return 0;
+        }
+        cJSON_Delete(pmsg.json);
+        int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
+        if (client_slot < 0) { free(client_psig_buf); return 0; }
+        for (size_t i = 0; i < n_inputs; i++) {
+            secp256k1_musig_partial_sig client_psig_i;
+            if (!musig_partial_sig_parse(lsp->ctx, &client_psig_i,
+                                          client_psig_buf + i * 32) ||
+                !factory_session_set_partial_sig_input(f, sub_node_i, i,
+                                                        (size_t)client_slot,
+                                                        &client_psig_i)) {
+                fprintf(stderr, "LSP-stateless MULTI: set client psig (client %u input %zu) failed\n",
+                        sub_clients[ci], i);
+                free(client_psig_buf);
+                return 0;
+            }
+        }
+        free(client_psig_buf);
+    }
+
+    /* Step 8: aggregate + assemble the k+1-witness signed TX. */
+    if (!factory_session_assemble_signed_tx_multi(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless MULTI: assemble_signed_tx_multi failed\n");
+        return 0;
+    }
+
+    /* Step 9: DONE to each client. */
+    cJSON *done = wire_build_subfactory_done(leaf_side, sub_idx_in_leaf, sub->ps_chain_len);
+    for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+        size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+        wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_DONE, done);
+    }
+    cJSON_Delete(done);
+
+    /* Step 10 (persist): record the chain row, mirroring the single-input
+       path's Step 10.  Without this an LSP restart loses the multi-input
+       advance and the e2e row-count assertion fails. */
+    if (mgr->persist) {
+        extern void reverse_bytes(unsigned char *, size_t);
+        unsigned char txid_display[32];
+        memcpy(txid_display, sub->txid, 32);
+        reverse_bytes(txid_display, 32);
+        size_t sstock_vout = sub->n_outputs - 1;
+        uint64_t chan_amounts[16] = {0};
+        int n_chans = (int)sstock_vout;
+        if (n_chans > 16) n_chans = 16;
+        for (int ci = 0; ci < n_chans; ci++)
+            chan_amounts[ci] = sub->outputs[ci].amount_sats;
+        persist_save_subfactory_chain_entry(
+            (persist_t *)mgr->persist, /* factory_id = */ 0,
+            (uint32_t)sub_node_i,
+            sub->ps_chain_len - 1,
+            f->counter.current_epoch,
+            txid_display,
+            sub->signed_tx.data, sub->signed_tx.len,
+            sub->outputs[sstock_vout].amount_sats,
+            chan_amounts, n_chans,
+            NULL, 0);
+    }
+
+    printf("LSP-stateless subfactory MULTI-INPUT advance (n_inputs=%zu) DONE\n", n_inputs);
+    printf("LSP-stateless subfactory chain advance: leaf %d sub %d chan %d delta %llu sats DONE\n",
+           leaf_side, sub_idx_in_leaf, channel_idx_in_sub,
+           (unsigned long long)delta_sats);
+    return 1;
+}
+
 static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
                                                     lsp_t *lsp,
                                                     int leaf_side,
@@ -4709,14 +5020,6 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
        forwards the full per-signer nonce array (all_pubnonces) so each client
        can build the aggnonce and finalize.  Mirror of Tier B Gap A. */
 
-    /* Reject multi-input in this MVP -- fall back to legacy. */
-    if (factory_node_uses_multi_input(f, sub_node_i)) {
-        fprintf(stderr,
-                "LSP-stateless subfactory advance: multi-input not yet supported "
-                "in stateless flow -- falling back to legacy\n");
-        return -1;  /* signal caller to use legacy path */
-    }
-
     /* Sub-factory clients (one client per output != L-stock + LSP).
        Build sub_clients[] -- same shape as legacy. */
     uint32_t sub_clients[FACTORY_MAX_SIGNERS];
@@ -4727,6 +5030,19 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     if (n_clients_in_sub == 0) {
         fprintf(stderr, "LSP-stateless subfactory advance: no clients in sub\n");
         return 0;
+    }
+
+    /* Phase 1e.1.e: MULTI-INPUT now runs through the STATELESS path too.
+       The single-input flow below is unchanged; multi-input gets its own
+       fully-looped block that mirrors the validated single-input ordering
+       per input.  The whole point is the same BIP-327 invariant: the LSP
+       generates its per-input secnonces ONLY after collecting every client's
+       pubnonces, and each lsp_secnonces[i] is consumed/zeroed by
+       musig_create_partial_sig before the next wire_recv. */
+    if (factory_node_uses_multi_input(f, sub_node_i)) {
+        return lsp_subfactory_chain_advance_stateless_multi(
+            mgr, lsp, f, sub_node_i, sub, sub_clients, n_clients_in_sub,
+            leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);
     }
 
     /* Step 1: factory_subfactory_chain_advance_unsigned — rebuild unsigned_tx. */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2938,13 +2938,36 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
        by musig_create_partial_sig.  No LSP secnonce in scope for the recv
        that follows. */
 
-    /* Step 7: Send LSP_RESPONSE with per-node pubnonces + psigs to all clients. */
+    /* Step 7: Send LSP_RESPONSE with per-node pubnonces + psigs to all clients.
+       Gap A: also forward EVERY signer's pubnonce per node (from the session,
+       which holds all collected nonces) so each client can build the aggnonce
+       for multi-signer nodes (root/intermediates), not just 2-of-2 leaves. */
+    size_t total_nonce_slots = 0;
+    for (size_t k = 0; k < n_affected; k++)
+        total_nonce_slots += f->nodes[affected[k]].n_signers;
+    unsigned char *all_pn_flat = calloc(total_nonce_slots ? total_nonce_slots : 1, 66);
+    if (!all_pn_flat) {
+        fprintf(stderr, "LSP-stateless Tier B: alloc all_pn_flat failed\n");
+        return 0;
+    }
+    {
+        size_t base = 0;
+        for (size_t k = 0; k < n_affected; k++) {
+            factory_node_t *an = &f->nodes[affected[k]];
+            for (size_t s = 0; s < an->n_signers; s++)
+                musig_pubnonce_serialize(lsp->ctx, all_pn_flat + (base + s) * 66,
+                                         &an->signing_session.pubnonces[s]);
+            base += an->n_signers;
+        }
+    }
     cJSON *response = wire_build_state_adv_lsp_response(
         (const unsigned char *)lsp_pubnonces_per_node,
         (const unsigned char *)lsp_psigs_per_node,
         (uint32_t)n_affected,
         (const unsigned char *)lsp_poison_pubnonces_per_node,
-        (const unsigned char *)lsp_poison_psigs_per_node);
+        (const unsigned char *)lsp_poison_psigs_per_node,
+        all_pn_flat, (uint32_t)(total_nonce_slots * 66));
+    free(all_pn_flat); all_pn_flat = NULL;
     for (size_t c = 0; c < lsp->n_clients; c++) {
         if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_LSP_RESPONSE, response)) {
             cJSON_Delete(response);
@@ -3036,6 +3059,43 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         }
     }
 
+    /* Step 9c (Gap B): broadcast the full per-node signer-PSIG matrix so each
+       client can locally complete multi-signer nodes (it only holds its own +
+       the LSP's psig).  node->partial_sigs[] holds every psig after Step 8. */
+    {
+        size_t total_psig_slots = 0;
+        for (size_t k = 0; k < n_affected; k++)
+            total_psig_slots += f->nodes[affected[k]].n_signers;
+        unsigned char *all_psig_flat = calloc(total_psig_slots ? total_psig_slots : 1, 32);
+        if (!all_psig_flat) {
+            fprintf(stderr, "LSP-stateless Tier B: alloc all_psig_flat failed\n");
+            return 0;
+        }
+        size_t base = 0;
+        for (size_t k = 0; k < n_affected; k++) {
+            factory_node_t *an = &f->nodes[affected[k]];
+            for (size_t s = 0; s < an->n_signers; s++)
+                musig_partial_sig_serialize(lsp->ctx, all_psig_flat + (base + s) * 32,
+                                            &an->partial_sigs[s]);
+            base += an->n_signers;
+        }
+        cJSON *apm = wire_build_state_adv_all_psigs(all_psig_flat,
+                                                    (uint32_t)(total_psig_slots * 32));
+        free(all_psig_flat);
+        if (!apm) {
+            fprintf(stderr, "LSP-stateless Tier B: build ALL_PSIGS failed\n");
+            return 0;
+        }
+        for (size_t c = 0; c < lsp->n_clients; c++) {
+            if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_ALL_PSIGS, apm)) {
+                cJSON_Delete(apm);
+                fprintf(stderr, "LSP-stateless Tier B: send ALL_PSIGS[%zu] failed\n", c);
+                return 0;
+            }
+        }
+        cJSON_Delete(apm);
+    }
+
     /* Step 10 (Tier B poison): register each affected leaf's new state +
        wire-signed L-stock poison TX with the watchtower (mirror of legacy
        Step 10 / leaf-advance #330).  poison_signed_tx is NULL for leaves that
@@ -3069,6 +3129,18 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             if (poison_prepared[k])
                 factory_session_reset_poison(f, affected[k]);
         }
+    }
+
+    /* Step 11.5 (F1): persist new-epoch chain[0] for every PS leaf + sub-factory
+       node, mirroring the legacy lsp_run_state_advance.  Only fires on
+       root-driven Tier B (the only path that re-signs PS leaves).  Without this
+       the DB keeps the OLD epoch chain[0] and force-close after rollover cannot
+       reconstruct the new signed state ("persisted bytes differ"). */
+    if (trigger_leaf_side == -1 && mgr->persist) {
+        int saved = lsp_persist_ps_chain0_all(mgr->persist, f);
+        if (saved > 0)
+            printf("LSP: Tier B F1: persisted new-epoch chain[0] for %d PS node(s)\n",
+                   saved);
     }
 
     /* Step 10: Broadcast DONE (existing opcode). */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2629,13 +2629,11 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
     if (!mgr || !lsp) return 0;
     factory_t *f = &lsp->factory;
 
-    /* MVP refusal: watchtower configured -> poison TX would be required. */
-    if (mgr->watchtower) {
-        fprintf(stderr,
-            "LSP-stateless Tier B: watchtower configured (poison TX needed) -- "
-            "falling back to legacy\n");
-        return -1;
-    }
+    /* Phase 1e.2.e (Tier B poison wiring): the watchtower is configured in
+       production.  Instead of refusing, we run the per-DW-leaf L-stock poison
+       ceremony in lockstep with the state ceremony (mirror of leaf-advance
+       #330, applied per affected leaf).  Each poison step is gated on
+       poison_prepared[k]; a degraded leaf simply registers without poison. */
 
     /* Step 1: Build affected[] (same logic as legacy at line ~2725). */
     size_t affected[FACTORY_MAX_NODES];
@@ -2666,12 +2664,55 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         }
     }
 
-    /* Step 2: Init MuSig session for each affected node (state only). */
+    /* Step 1.5 (Tier B poison): capture each affected DW leaf's OLD signed
+       state + prepare its L-stock poison TX (mirror of leaf-advance #330).
+       PS leaves carry no L-stock poison (it lives in their sub-factory chain).
+       Per-affected-node arrays indexed by affected[] order (k). */
+    const uint64_t TIERB_POISON_FEE_SATS = 1000;
+    int poison_prepared[FACTORY_MAX_NODES];
+    unsigned char poison_old_txid[FACTORY_MAX_NODES][32];
+    uint64_t poison_old_l_amount[FACTORY_MAX_NODES];
+    int poison_client_slot[FACTORY_MAX_NODES];
+    unsigned char lsp_poison_pubnonces_per_node[FACTORY_MAX_NODES][66];
+    unsigned char lsp_poison_psigs_per_node[FACTORY_MAX_NODES][32];
+    for (size_t k = 0; k < n_affected; k++) {
+        poison_prepared[k] = 0;
+        poison_client_slot[k] = -1;
+        poison_old_l_amount[k] = 0;
+        memset(poison_old_txid[k], 0, 32);
+        memset(lsp_poison_pubnonces_per_node[k], 0, 66);
+        memset(lsp_poison_psigs_per_node[k], 0, 32);
+        factory_node_t *an = &f->nodes[affected[k]];
+        int had_old = (an->is_signed && an->signed_tx.len > 0);
+        int old_no = an->n_outputs;
+        if (had_old) memcpy(poison_old_txid[k], an->txid, 32);
+        poison_old_l_amount[k] = (old_no >= 2)
+            ? an->outputs[old_no - 1].amount_sats : 0;
+        if (mgr->watchtower && !an->is_ps_leaf && had_old && old_no >= 2 &&
+            poison_old_l_amount[k] > TIERB_POISON_FEE_SATS +
+                (uint64_t)(an->n_signers - 1) * 330u) {
+            if (factory_session_prepare_poison_tx_leaf(
+                    f, affected[k], poison_old_txid[k], (uint32_t)(old_no - 1),
+                    poison_old_l_amount[k], TIERB_POISON_FEE_SATS)) {
+                poison_prepared[k] = 1;  /* init_node_poison after state init */
+            }
+        }
+    }
+
+    /* Step 2: Init MuSig session for each affected node (state + poison). */
     for (size_t k = 0; k < n_affected; k++) {
         if (!factory_session_init_node(f, affected[k])) {
             fprintf(stderr,
                 "LSP-stateless Tier B: init_node[%zu] failed\n", affected[k]);
             return 0;
+        }
+        if (poison_prepared[k] &&
+            !factory_session_init_node_poison(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: init_node_poison[%zu] -- degrading leaf\n",
+                affected[k]);
+            factory_session_reset_poison(f, affected[k]);
+            poison_prepared[k] = 0;
         }
     }
 
@@ -2711,10 +2752,12 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             return 0;
         }
         unsigned char this_client_pn[FACTORY_MAX_NODES][66];
+        unsigned char this_client_poison_pn[FACTORY_MAX_NODES][66];
+        memset(this_client_poison_pn, 0, sizeof(this_client_poison_pn));
         if (!wire_parse_state_adv_client_path_nonces(nmsg.json,
                                                        (unsigned char *)this_client_pn,
                                                        (uint32_t)n_affected,
-                                                       NULL)) {
+                                                       (unsigned char *)this_client_poison_pn)) {
             cJSON_Delete(nmsg.json);
             fprintf(stderr,
                 "LSP-stateless Tier B: parse CLIENT_PATH_NONCES from client %zu failed\n",
@@ -2744,6 +2787,33 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             }
             memcpy(client_pubnonces_per_node[k], this_client_pn[k], 66);
             client_slot_per_node[k] = slot;
+
+            /* Poison: if this leaf has a prepared poison TX and the client
+               sent a (non-zero) poison nonce, set it on the poison session. */
+            if (poison_prepared[k]) {
+                int pz = 1;
+                for (size_t b = 0; b < 66; b++)
+                    if (this_client_poison_pn[k][b]) { pz = 0; break; }
+                if (pz) {
+                    fprintf(stderr,
+                        "LSP-stateless Tier B: client %zu sent no poison nonce "
+                        "for node %zu -- degrading leaf poison\n", c, affected[k]);
+                    factory_session_reset_poison(f, affected[k]);
+                    poison_prepared[k] = 0;
+                } else {
+                    secp256k1_musig_pubnonce ppn;
+                    if (!musig_pubnonce_parse(lsp->ctx, &ppn, this_client_poison_pn[k]) ||
+                        !factory_session_set_nonce_poison(f, affected[k], (size_t)slot, &ppn)) {
+                        fprintf(stderr,
+                            "LSP-stateless Tier B: set client poison nonce node %zu "
+                            "-- degrading\n", affected[k]);
+                        factory_session_reset_poison(f, affected[k]);
+                        poison_prepared[k] = 0;
+                    } else {
+                        poison_client_slot[k] = slot;
+                    }
+                }
+            }
         }
     }
 
@@ -2819,6 +2889,50 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                 "LSP-stateless Tier B: set LSP psig[%zu] failed\n", affected[k]);
             return 0;
         }
+
+        /* Poison (lockstep): LSP poison nonce -> set -> finalize -> partial sig.
+           lsp_poison_secnonce is a loop local, zeroed by create_partial_sig in
+           this same iteration -- no poison secnonce held across the wire recv
+           that follows (same stateless invariant as the state nonce). */
+        if (poison_prepared[k]) {
+            secp256k1_musig_secnonce lsp_poison_secnonce;
+            secp256k1_musig_pubnonce lsp_poison_pubnonce;
+            secp256k1_musig_partial_sig lsp_poison_psig;
+            unsigned char lsp_psk[32];
+            /* musig_generate_nonce takes (seckey32, pubkey, keyagg.cache); the
+               state lsp_seckey was already zeroed after the pool gen, so derive
+               a fresh local seckey and zero it right after. */
+            int pz_ok =
+                secp256k1_keypair_sec(lsp->ctx, lsp_psk, &lsp->lsp_keypair) &&
+                musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce, &lsp_poison_pubnonce,
+                                       lsp_psk, &lsp->lsp_pubkey,
+                                       &f->nodes[affected[k]].keyagg.cache) &&
+                factory_session_set_nonce_poison(f, affected[k], (size_t)slot,
+                                                   &lsp_poison_pubnonce) &&
+                factory_session_finalize_node_poison(f, affected[k]) &&
+                musig_create_partial_sig(lsp->ctx, &lsp_poison_psig,
+                                           &lsp_poison_secnonce, &lsp_kp,
+                                           &f->nodes[affected[k]].poison_signing_session) &&
+                factory_session_set_partial_sig_poison(f, affected[k], (size_t)slot,
+                                                         &lsp_poison_psig);
+            memset(lsp_psk, 0, 32);
+            /* Zero the poison secnonce on any path: create_partial_sig already
+               zeroed it on success; on early-chain failure this clears the
+               generated-but-unconsumed secnonce so none lingers across the recv. */
+            memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
+            if (!pz_ok) {
+                fprintf(stderr,
+                    "LSP-stateless Tier B: LSP poison sign[%zu] -- degrading leaf\n",
+                    affected[k]);
+                factory_session_reset_poison(f, affected[k]);
+                poison_prepared[k] = 0;
+            } else {
+                musig_pubnonce_serialize(lsp->ctx, lsp_poison_pubnonces_per_node[k],
+                                          &lsp_poison_pubnonce);
+                musig_partial_sig_serialize(lsp->ctx, lsp_poison_psigs_per_node[k],
+                                             &lsp_poison_psig);
+            }
+        }
     }
     /* INVARIANT: every LSP secnonce in lsp_pool has been pulled and zeroed
        by musig_create_partial_sig.  No LSP secnonce in scope for the recv
@@ -2829,7 +2943,8 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         (const unsigned char *)lsp_pubnonces_per_node,
         (const unsigned char *)lsp_psigs_per_node,
         (uint32_t)n_affected,
-        NULL, NULL);
+        (const unsigned char *)lsp_poison_pubnonces_per_node,
+        (const unsigned char *)lsp_poison_psigs_per_node);
     for (size_t c = 0; c < lsp->n_clients; c++) {
         if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_LSP_RESPONSE, response)) {
             cJSON_Delete(response);
@@ -2853,10 +2968,12 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             return 0;
         }
         unsigned char this_client_psigs[FACTORY_MAX_NODES][32];
+        unsigned char this_client_poison_psigs[FACTORY_MAX_NODES][32];
+        memset(this_client_poison_psigs, 0, sizeof(this_client_poison_psigs));
         if (!wire_parse_state_adv_client_final_psigs(pmsg.json,
                                                        (unsigned char *)this_client_psigs,
                                                        (uint32_t)n_affected,
-                                                       NULL)) {
+                                                       (unsigned char *)this_client_poison_psigs)) {
             cJSON_Delete(pmsg.json);
             fprintf(stderr,
                 "LSP-stateless Tier B: parse CLIENT_FINAL_PSIGS[%zu] failed\n", c);
@@ -2880,6 +2997,33 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                     c, affected[k]);
                 return 0;
             }
+            /* Poison: set this client's poison partial sig if this leaf still
+               has poison active and the client signed for it. */
+            if (poison_prepared[k] && (int)slot == poison_client_slot[k]) {
+                secp256k1_musig_partial_sig ppsig;
+                if (!musig_partial_sig_parse(lsp->ctx, &ppsig, this_client_poison_psigs[k]) ||
+                    !factory_session_set_partial_sig_poison(f, affected[k],
+                                                              (size_t)slot, &ppsig)) {
+                    fprintf(stderr,
+                        "LSP-stateless Tier B: set client poison psig node %zu "
+                        "-- degrading\n", affected[k]);
+                    factory_session_reset_poison(f, affected[k]);
+                    poison_prepared[k] = 0;
+                }
+            }
+        }
+    }
+
+    /* Step 9b (poison): complete the poison session for each leaf that still
+       has poison active -> attaches node->poison_signed_tx. */
+    for (size_t k = 0; k < n_affected; k++) {
+        if (poison_prepared[k] &&
+            !factory_session_complete_node_poison(f, affected[k])) {
+            fprintf(stderr,
+                "LSP-stateless Tier B: complete_node_poison[%zu] -- degrading\n",
+                affected[k]);
+            factory_session_reset_poison(f, affected[k]);
+            poison_prepared[k] = 0;
         }
     }
 
@@ -2889,6 +3033,41 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             fprintf(stderr,
                 "LSP-stateless Tier B: complete_node[%zu] failed\n", affected[k]);
             return 0;
+        }
+    }
+
+    /* Step 10 (Tier B poison): register each affected leaf's new state +
+       wire-signed L-stock poison TX with the watchtower (mirror of legacy
+       Step 10 / leaf-advance #330).  poison_signed_tx is NULL for leaves that
+       degraded or were never poison-eligible (PS leaves / no old L-stock). */
+    if (mgr->watchtower) {
+        for (size_t k = 0; k < n_affected; k++) {
+            factory_node_t *an = &f->nodes[affected[k]];
+            const unsigned char *poison_data = NULL;
+            size_t poison_len = 0;
+            if (poison_prepared[k] && an->poison_is_signed &&
+                an->poison_signed_tx.len > 0) {
+                poison_data = an->poison_signed_tx.data;
+                poison_len  = an->poison_signed_tx.len;
+                printf("LSP-stateless Tier B: node %zu poison TX signed "
+                       "(%zu bytes, L-stock %llu sats)\n", affected[k], poison_len,
+                       (unsigned long long)poison_old_l_amount[k]);
+            }
+            uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+            size_t n_leaf_ch = 0;
+            for (size_t cc = 0; cc < mgr->n_channels; cc++) {
+                size_t c_node; uint32_t c_vout;
+                client_to_leaf(cc, f, &c_node, &c_vout);
+                if (c_node == affected[k])
+                    leaf_ch_ids[n_leaf_ch++] = (uint32_t)cc;
+            }
+            watchtower_watch_factory_node_with_channels(mgr->watchtower,
+                (uint32_t)affected[k], poison_old_txid[k],
+                an->signed_tx.data, an->signed_tx.len,
+                poison_data, poison_len,
+                leaf_ch_ids, n_leaf_ch);
+            if (poison_prepared[k])
+                factory_session_reset_poison(f, affected[k]);
         }
     }
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2713,7 +2713,8 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         unsigned char this_client_pn[FACTORY_MAX_NODES][66];
         if (!wire_parse_state_adv_client_path_nonces(nmsg.json,
                                                        (unsigned char *)this_client_pn,
-                                                       (uint32_t)n_affected)) {
+                                                       (uint32_t)n_affected,
+                                                       NULL)) {
             cJSON_Delete(nmsg.json);
             fprintf(stderr,
                 "LSP-stateless Tier B: parse CLIENT_PATH_NONCES from client %zu failed\n",
@@ -2827,7 +2828,8 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
     cJSON *response = wire_build_state_adv_lsp_response(
         (const unsigned char *)lsp_pubnonces_per_node,
         (const unsigned char *)lsp_psigs_per_node,
-        (uint32_t)n_affected);
+        (uint32_t)n_affected,
+        NULL, NULL);
     for (size_t c = 0; c < lsp->n_clients; c++) {
         if (!wire_send(lsp->client_fds[c], MSG_STATE_ADV_LSP_RESPONSE, response)) {
             cJSON_Delete(response);
@@ -2853,7 +2855,8 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         unsigned char this_client_psigs[FACTORY_MAX_NODES][32];
         if (!wire_parse_state_adv_client_final_psigs(pmsg.json,
                                                        (unsigned char *)this_client_psigs,
-                                                       (uint32_t)n_affected)) {
+                                                       (uint32_t)n_affected,
+                                                       NULL)) {
             cJSON_Delete(pmsg.json);
             fprintf(stderr,
                 "LSP-stateless Tier B: parse CLIENT_FINAL_PSIGS[%zu] failed\n", c);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4705,20 +4705,9 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     if (sub_node_i >= f->n_nodes) return 0;
     factory_node_t *sub = &f->nodes[sub_node_i];
 
-    /* Phase 1e.1.b MVP scope: reject k>=2 multi-client.  Wire codec does
-       not yet relay other client pubnonces in LSP_RESPONSE.  Phase 1e.1.d
-       follow-up will extend the codec.  For now, fall back to legacy. */
-    {
-        size_t check_n_clients = 0;
-        for (size_t s = 1; s < sub->n_signers; s++) check_n_clients++;
-        if (check_n_clients > 1) {
-            fprintf(stderr,
-                "LSP-stateless subfactory: k>=2 (n_clients=%zu) not yet "
-                "supported in stateless flow -- falling back to legacy\n",
-                check_n_clients);
-            return -1;
-        }
-    }
+    /* Phase 1e.1.d: k>=2 multi-client now supported -- LSP_RESPONSE (0x7F)
+       forwards the full per-signer nonce array (all_pubnonces) so each client
+       can build the aggnonce and finalize.  Mirror of Tier B Gap A. */
 
     /* Reject multi-input in this MVP -- fall back to legacy. */
     if (factory_node_uses_multi_input(f, sub_node_i)) {
@@ -4859,7 +4848,9 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     /* Step 6: send LSP_RESPONSE to each client (per-client copy so each can
        individually finalize_node + sign).  Single-input -> 1 element each. */
     cJSON *response = wire_build_subfactory_lsp_response(lsp_pubnonce_ser,
-                                                          lsp_psig_ser, 1);
+                                                          lsp_psig_ser, 1,
+                                                          (const unsigned char *)all_pubnonces,
+                                                          (uint32_t)(sub->n_signers * 66));
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_LSP_RESPONSE, response)) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4906,6 +4906,34 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     }
     cJSON_Delete(done);
 
+    /* Step 10 (persist): save the sub-factory chain entry to ps_subfactory_chains,
+       mirroring the legacy path (Step 10 below).  Without this the stateless
+       advance signs chain[N] but never persists the row, so an LSP restart loses
+       it (and the e2e row-count assertion fails).  Stateless MVP runs no poison
+       ceremony, so pass NULL/0 for the poison TX bytes. */
+    if (mgr->persist) {
+        extern void reverse_bytes(unsigned char *, size_t);
+        unsigned char txid_display[32];
+        memcpy(txid_display, sub->txid, 32);
+        reverse_bytes(txid_display, 32);
+        size_t sstock_vout = sub->n_outputs - 1;
+        uint64_t chan_amounts[16] = {0};
+        int n_chans = (int)sstock_vout;
+        if (n_chans > 16) n_chans = 16;
+        for (int ci = 0; ci < n_chans; ci++)
+            chan_amounts[ci] = sub->outputs[ci].amount_sats;
+        persist_save_subfactory_chain_entry(
+            (persist_t *)mgr->persist, /* factory_id = */ 0,
+            (uint32_t)sub_node_i,
+            sub->ps_chain_len - 1,
+            f->counter.current_epoch,
+            txid_display,
+            sub->signed_tx.data, sub->signed_tx.len,
+            sub->outputs[sstock_vout].amount_sats,
+            chan_amounts, n_chans,
+            NULL, 0);
+    }
+
     printf("LSP-stateless subfactory chain advance: leaf %d sub %d chan %d delta %llu sats DONE\n",
            leaf_side, sub_idx_in_leaf, channel_idx_in_sub,
            (unsigned long long)delta_sats);

--- a/src/wire.c
+++ b/src/wire.c
@@ -1243,7 +1243,9 @@ int wire_parse_subfactory_client_pubnonces(const cJSON *json,
 
 cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per_input,
                                             const unsigned char *lsp_psigs_per_input,
-                                            uint32_t n_inputs) {
+                                            uint32_t n_inputs,
+                                            const unsigned char *all_signer_pubnonces_flat,
+                                            uint32_t all_signer_pubnonces_len) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !lsp_pubnonces_per_input || !lsp_psigs_per_input) {
         if (j) cJSON_Delete(j);
@@ -1253,6 +1255,12 @@ cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per
                       (size_t)n_inputs * 66);
     wire_json_add_hex(j, "lsp_psigs_per_input", lsp_psigs_per_input,
                       (size_t)n_inputs * 32);
+    if (all_signer_pubnonces_flat && all_signer_pubnonces_len > 0) {
+        wire_json_add_hex(j, "all_signer_pubnonces", all_signer_pubnonces_flat,
+                          (size_t)all_signer_pubnonces_len);
+        cJSON_AddNumberToObject(j, "all_signer_pubnonces_len",
+                                (double)all_signer_pubnonces_len);
+    }
     cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
     return j;
 }
@@ -1260,7 +1268,10 @@ cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per
 int wire_parse_subfactory_lsp_response(const cJSON *json,
                                          unsigned char *out_lsp_pubnonces_per_input,
                                          unsigned char *out_lsp_psigs_per_input,
-                                         uint32_t expected_n_inputs) {
+                                         uint32_t expected_n_inputs,
+                                         unsigned char *out_all_signer_pubnonces_flat,
+                                         uint32_t max_all_signer_pubnonces_len,
+                                         uint32_t *out_all_signer_pubnonces_len) {
     if (!json || !out_lsp_pubnonces_per_input || !out_lsp_psigs_per_input) return 0;
     cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
     if (!ni || !cJSON_IsNumber(ni)) return 0;
@@ -1273,6 +1284,18 @@ int wire_parse_subfactory_lsp_response(const cJSON *json,
                             out_lsp_psigs_per_input,
                             (size_t)expected_n_inputs * 32) !=
         (int)((size_t)expected_n_inputs * 32)) return 0;
+    if (out_all_signer_pubnonces_len) *out_all_signer_pubnonces_len = 0;
+    if (out_all_signer_pubnonces_flat && out_all_signer_pubnonces_len) {
+        cJSON *al = cJSON_GetObjectItem(json, "all_signer_pubnonces_len");
+        if (al && cJSON_IsNumber(al)) {
+            uint32_t alen = (uint32_t)al->valuedouble;
+            if (alen > max_all_signer_pubnonces_len) return 0;
+            if (wire_json_get_hex(json, "all_signer_pubnonces",
+                                    out_all_signer_pubnonces_flat, (size_t)alen) !=
+                (int)alen) return 0;
+            *out_all_signer_pubnonces_len = alen;
+        }
+    }
     return 1;
 }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -1574,7 +1574,9 @@ int wire_parse_factory_client_pubnonces(const cJSON *json,
 
 cJSON *wire_build_factory_lsp_response(const unsigned char *lsp_pubnonces_per_node,
                                           const unsigned char *lsp_psigs_per_node,
-                                          uint32_t n_nodes) {
+                                          uint32_t n_nodes,
+                                          const unsigned char *all_signer_pubnonces_flat,
+                                          uint32_t all_signer_pubnonces_len) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !lsp_pubnonces_per_node || !lsp_psigs_per_node) {
         if (j) cJSON_Delete(j);
@@ -1584,6 +1586,18 @@ cJSON *wire_build_factory_lsp_response(const unsigned char *lsp_pubnonces_per_no
                       (size_t)n_nodes * 66);
     wire_json_add_hex(j, "lsp_psigs_per_node", lsp_psigs_per_node,
                       (size_t)n_nodes * 32);
+    /* Optional all-signer per-node nonce matrix (sparse (node,slot,nonce)
+       bundle serialized as a flat hex blob).  Required for multi-client
+       nodes (root N-of-N, intermediates): each client needs every co-signer's
+       per-node nonce to finalize its own session and create its partial sig.
+       Mirrors wire_build_subfactory_lsp_response's all_signer_pubnonces field.
+       Backward-compatible: omitted entirely when NULL/zero-length. */
+    if (all_signer_pubnonces_flat && all_signer_pubnonces_len > 0) {
+        wire_json_add_hex(j, "all_signer_pubnonces", all_signer_pubnonces_flat,
+                          (size_t)all_signer_pubnonces_len);
+        cJSON_AddNumberToObject(j, "all_signer_pubnonces_len",
+                                (double)all_signer_pubnonces_len);
+    }
     cJSON_AddNumberToObject(j, "n_nodes", (double)n_nodes);
     return j;
 }
@@ -1591,7 +1605,10 @@ cJSON *wire_build_factory_lsp_response(const unsigned char *lsp_pubnonces_per_no
 int wire_parse_factory_lsp_response(const cJSON *json,
                                        unsigned char *out_lsp_pubnonces_per_node,
                                        unsigned char *out_lsp_psigs_per_node,
-                                       uint32_t expected_n_nodes) {
+                                       uint32_t expected_n_nodes,
+                                       unsigned char *out_all_signer_pubnonces_flat,
+                                       uint32_t max_all_signer_pubnonces_len,
+                                       uint32_t *out_all_signer_pubnonces_len) {
     if (!json || !out_lsp_pubnonces_per_node || !out_lsp_psigs_per_node) return 0;
     cJSON *n = cJSON_GetObjectItem(json, "n_nodes");
     if (!n || !cJSON_IsNumber(n)) return 0;
@@ -1604,6 +1621,18 @@ int wire_parse_factory_lsp_response(const cJSON *json,
                             out_lsp_psigs_per_node,
                             (size_t)expected_n_nodes * 32) !=
         (int)((size_t)expected_n_nodes * 32)) return 0;
+    if (out_all_signer_pubnonces_len) *out_all_signer_pubnonces_len = 0;
+    if (out_all_signer_pubnonces_flat && out_all_signer_pubnonces_len) {
+        cJSON *al = cJSON_GetObjectItem(json, "all_signer_pubnonces_len");
+        if (al && cJSON_IsNumber(al)) {
+            uint32_t alen = (uint32_t)al->valuedouble;
+            if (alen > max_all_signer_pubnonces_len) return 0;
+            if (wire_json_get_hex(json, "all_signer_pubnonces",
+                                    out_all_signer_pubnonces_flat, (size_t)alen) !=
+                (int)alen) return 0;
+            *out_all_signer_pubnonces_len = alen;
+        }
+    }
     return 1;
 }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -1370,7 +1370,9 @@ cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_
                                             const unsigned char *lsp_psigs_per_leaf,
                                             uint32_t n_affected_leaves,
                                             const unsigned char *lsp_poison_pubnonces_per_leaf,
-                                            const unsigned char *lsp_poison_psigs_per_leaf) {
+                                            const unsigned char *lsp_poison_psigs_per_leaf,
+                                            const unsigned char *all_signer_pubnonces_flat,
+                                            uint32_t all_signer_pubnonces_len) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !lsp_pubnonces_per_leaf || !lsp_psigs_per_leaf) {
         if (j) cJSON_Delete(j);
@@ -1386,6 +1388,12 @@ cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_
         wire_json_add_hex(j, "lsp_poison_psigs_per_leaf", lsp_poison_psigs_per_leaf,
                           (size_t)n_affected_leaves * 32);
     }
+    if (all_signer_pubnonces_flat && all_signer_pubnonces_len > 0) {
+        wire_json_add_hex(j, "all_signer_pubnonces", all_signer_pubnonces_flat,
+                          (size_t)all_signer_pubnonces_len);
+        cJSON_AddNumberToObject(j, "all_signer_pubnonces_len",
+                                (double)all_signer_pubnonces_len);
+    }
     cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
     return j;
 }
@@ -1395,7 +1403,10 @@ int wire_parse_state_adv_lsp_response(const cJSON *json,
                                          unsigned char *out_lsp_psigs_per_leaf,
                                          uint32_t expected_n_affected_leaves,
                                          unsigned char *out_lsp_poison_pubnonces_per_leaf,
-                                         unsigned char *out_lsp_poison_psigs_per_leaf) {
+                                         unsigned char *out_lsp_poison_psigs_per_leaf,
+                                         unsigned char *out_all_signer_pubnonces_flat,
+                                         uint32_t max_all_signer_pubnonces_len,
+                                         uint32_t *out_all_signer_pubnonces_len) {
     if (!json || !out_lsp_pubnonces_per_leaf || !out_lsp_psigs_per_leaf) return 0;
     cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
     if (!n || !cJSON_IsNumber(n)) return 0;
@@ -1408,6 +1419,19 @@ int wire_parse_state_adv_lsp_response(const cJSON *json,
                             out_lsp_psigs_per_leaf,
                             (size_t)expected_n_affected_leaves * 32) !=
         (int)((size_t)expected_n_affected_leaves * 32)) return 0;
+    /* Gap A: optional full per-node signer-nonce matrix (flat). */
+    if (out_all_signer_pubnonces_len) *out_all_signer_pubnonces_len = 0;
+    if (out_all_signer_pubnonces_flat && out_all_signer_pubnonces_len) {
+        cJSON *al = cJSON_GetObjectItem(json, "all_signer_pubnonces_len");
+        if (al && cJSON_IsNumber(al)) {
+            uint32_t alen = (uint32_t)al->valuedouble;
+            if (alen > max_all_signer_pubnonces_len) return 0;
+            if (wire_json_get_hex(json, "all_signer_pubnonces",
+                                    out_all_signer_pubnonces_flat, (size_t)alen) !=
+                (int)alen) return 0;
+            *out_all_signer_pubnonces_len = alen;
+        }
+    }
     if (out_lsp_poison_pubnonces_per_leaf && out_lsp_poison_psigs_per_leaf &&
         cJSON_GetObjectItem(json, "lsp_poison_pubnonces_per_leaf")) {
         if (wire_json_get_hex(json, "lsp_poison_pubnonces_per_leaf",
@@ -1457,6 +1481,31 @@ int wire_parse_state_adv_client_final_psigs(const cJSON *json,
             (int)((size_t)expected_n_affected_leaves * 32)) return 0;
         return 2;
     }
+    return 1;
+}
+
+cJSON *wire_build_state_adv_all_psigs(const unsigned char *all_signer_psigs_flat,
+                                         uint32_t all_signer_psigs_len) {
+    cJSON *j = cJSON_CreateObject();
+    if (!j || !all_signer_psigs_flat) { if (j) cJSON_Delete(j); return NULL; }
+    wire_json_add_hex(j, "all_signer_psigs", all_signer_psigs_flat,
+                      (size_t)all_signer_psigs_len);
+    cJSON_AddNumberToObject(j, "all_signer_psigs_len", (double)all_signer_psigs_len);
+    return j;
+}
+
+int wire_parse_state_adv_all_psigs(const cJSON *json,
+                                      unsigned char *out_all_signer_psigs_flat,
+                                      uint32_t max_all_signer_psigs_len,
+                                      uint32_t *out_all_signer_psigs_len) {
+    if (!json || !out_all_signer_psigs_flat || !out_all_signer_psigs_len) return 0;
+    cJSON *al = cJSON_GetObjectItem(json, "all_signer_psigs_len");
+    if (!al || !cJSON_IsNumber(al)) return 0;
+    uint32_t alen = (uint32_t)al->valuedouble;
+    if (alen > max_all_signer_psigs_len) return 0;
+    if (wire_json_get_hex(json, "all_signer_psigs", out_all_signer_psigs_flat,
+                            (size_t)alen) != (int)alen) return 0;
+    *out_all_signer_psigs_len = alen;
     return 1;
 }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -1330,31 +1330,47 @@ int wire_parse_state_adv_propose_intent(const cJSON *json,
 }
 
 cJSON *wire_build_state_adv_client_path_nonces(const unsigned char *pubnonces_per_leaf,
-                                                  uint32_t n_affected_leaves) {
+                                                  uint32_t n_affected_leaves,
+                                                  const unsigned char *poison_pubnonces_per_leaf) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !pubnonces_per_leaf) { if(j) cJSON_Delete(j); return NULL; }
     wire_json_add_hex(j, "pubnonces_per_leaf", pubnonces_per_leaf,
                       (size_t)n_affected_leaves * 66);
+    if (poison_pubnonces_per_leaf)
+        wire_json_add_hex(j, "poison_pubnonces_per_leaf", poison_pubnonces_per_leaf,
+                          (size_t)n_affected_leaves * 66);
     cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
     return j;
 }
 
 int wire_parse_state_adv_client_path_nonces(const cJSON *json,
                                                unsigned char *out_pubnonces_per_leaf,
-                                               uint32_t expected_n_affected_leaves) {
+                                               uint32_t expected_n_affected_leaves,
+                                               unsigned char *out_poison_pubnonces_per_leaf) {
     if (!json || !out_pubnonces_per_leaf) return 0;
     cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
     if (!n || !cJSON_IsNumber(n)) return 0;
     if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
-    return wire_json_get_hex(json, "pubnonces_per_leaf",
-                               out_pubnonces_per_leaf,
-                               (size_t)expected_n_affected_leaves * 66) ==
-           (int)((size_t)expected_n_affected_leaves * 66);
+    if (wire_json_get_hex(json, "pubnonces_per_leaf",
+                            out_pubnonces_per_leaf,
+                            (size_t)expected_n_affected_leaves * 66) !=
+        (int)((size_t)expected_n_affected_leaves * 66)) return 0;
+    if (out_poison_pubnonces_per_leaf &&
+        cJSON_GetObjectItem(json, "poison_pubnonces_per_leaf")) {
+        if (wire_json_get_hex(json, "poison_pubnonces_per_leaf",
+                                out_poison_pubnonces_per_leaf,
+                                (size_t)expected_n_affected_leaves * 66) !=
+            (int)((size_t)expected_n_affected_leaves * 66)) return 0;
+        return 2;
+    }
+    return 1;
 }
 
 cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_leaf,
                                             const unsigned char *lsp_psigs_per_leaf,
-                                            uint32_t n_affected_leaves) {
+                                            uint32_t n_affected_leaves,
+                                            const unsigned char *lsp_poison_pubnonces_per_leaf,
+                                            const unsigned char *lsp_poison_psigs_per_leaf) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !lsp_pubnonces_per_leaf || !lsp_psigs_per_leaf) {
         if (j) cJSON_Delete(j);
@@ -1364,6 +1380,12 @@ cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_
                       (size_t)n_affected_leaves * 66);
     wire_json_add_hex(j, "lsp_psigs_per_leaf", lsp_psigs_per_leaf,
                       (size_t)n_affected_leaves * 32);
+    if (lsp_poison_pubnonces_per_leaf && lsp_poison_psigs_per_leaf) {
+        wire_json_add_hex(j, "lsp_poison_pubnonces_per_leaf", lsp_poison_pubnonces_per_leaf,
+                          (size_t)n_affected_leaves * 66);
+        wire_json_add_hex(j, "lsp_poison_psigs_per_leaf", lsp_poison_psigs_per_leaf,
+                          (size_t)n_affected_leaves * 32);
+    }
     cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
     return j;
 }
@@ -1371,7 +1393,9 @@ cJSON *wire_build_state_adv_lsp_response(const unsigned char *lsp_pubnonces_per_
 int wire_parse_state_adv_lsp_response(const cJSON *json,
                                          unsigned char *out_lsp_pubnonces_per_leaf,
                                          unsigned char *out_lsp_psigs_per_leaf,
-                                         uint32_t expected_n_affected_leaves) {
+                                         uint32_t expected_n_affected_leaves,
+                                         unsigned char *out_lsp_poison_pubnonces_per_leaf,
+                                         unsigned char *out_lsp_poison_psigs_per_leaf) {
     if (!json || !out_lsp_pubnonces_per_leaf || !out_lsp_psigs_per_leaf) return 0;
     cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
     if (!n || !cJSON_IsNumber(n)) return 0;
@@ -1384,30 +1408,56 @@ int wire_parse_state_adv_lsp_response(const cJSON *json,
                             out_lsp_psigs_per_leaf,
                             (size_t)expected_n_affected_leaves * 32) !=
         (int)((size_t)expected_n_affected_leaves * 32)) return 0;
+    if (out_lsp_poison_pubnonces_per_leaf && out_lsp_poison_psigs_per_leaf &&
+        cJSON_GetObjectItem(json, "lsp_poison_pubnonces_per_leaf")) {
+        if (wire_json_get_hex(json, "lsp_poison_pubnonces_per_leaf",
+                                out_lsp_poison_pubnonces_per_leaf,
+                                (size_t)expected_n_affected_leaves * 66) !=
+            (int)((size_t)expected_n_affected_leaves * 66)) return 0;
+        if (wire_json_get_hex(json, "lsp_poison_psigs_per_leaf",
+                                out_lsp_poison_psigs_per_leaf,
+                                (size_t)expected_n_affected_leaves * 32) !=
+            (int)((size_t)expected_n_affected_leaves * 32)) return 0;
+        return 2;
+    }
     return 1;
 }
 
 cJSON *wire_build_state_adv_client_final_psigs(const unsigned char *psigs_per_leaf,
-                                                  uint32_t n_affected_leaves) {
+                                                  uint32_t n_affected_leaves,
+                                                  const unsigned char *poison_psigs_per_leaf) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !psigs_per_leaf) { if(j) cJSON_Delete(j); return NULL; }
     wire_json_add_hex(j, "psigs_per_leaf", psigs_per_leaf,
                       (size_t)n_affected_leaves * 32);
+    if (poison_psigs_per_leaf)
+        wire_json_add_hex(j, "poison_psigs_per_leaf", poison_psigs_per_leaf,
+                          (size_t)n_affected_leaves * 32);
     cJSON_AddNumberToObject(j, "n_affected_leaves", (double)n_affected_leaves);
     return j;
 }
 
 int wire_parse_state_adv_client_final_psigs(const cJSON *json,
                                                unsigned char *out_psigs_per_leaf,
-                                               uint32_t expected_n_affected_leaves) {
+                                               uint32_t expected_n_affected_leaves,
+                                               unsigned char *out_poison_psigs_per_leaf) {
     if (!json || !out_psigs_per_leaf) return 0;
     cJSON *n = cJSON_GetObjectItem(json, "n_affected_leaves");
     if (!n || !cJSON_IsNumber(n)) return 0;
     if ((uint32_t)n->valuedouble != expected_n_affected_leaves) return 0;
-    return wire_json_get_hex(json, "psigs_per_leaf",
-                               out_psigs_per_leaf,
-                               (size_t)expected_n_affected_leaves * 32) ==
-           (int)((size_t)expected_n_affected_leaves * 32);
+    if (wire_json_get_hex(json, "psigs_per_leaf",
+                            out_psigs_per_leaf,
+                            (size_t)expected_n_affected_leaves * 32) !=
+        (int)((size_t)expected_n_affected_leaves * 32)) return 0;
+    if (out_poison_psigs_per_leaf &&
+        cJSON_GetObjectItem(json, "poison_psigs_per_leaf")) {
+        if (wire_json_get_hex(json, "poison_psigs_per_leaf",
+                                out_poison_psigs_per_leaf,
+                                (size_t)expected_n_affected_leaves * 32) !=
+            (int)((size_t)expected_n_affected_leaves * 32)) return 0;
+        return 2;
+    }
+    return 1;
 }
 
 /* Phase 1e.3.a -- factory creation reversed flow wire codec. */

--- a/tools/recover_stranded_coop_output.c
+++ b/tools/recover_stranded_coop_output.c
@@ -83,17 +83,17 @@ int main(int argc, char **argv) {
         SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
     /* Parse seckeys. Party 0 = LSP, 1..n = clients. */
-    unsigned char seckeys[16][32];
+    unsigned char seckeys[128][32];
     size_t n_signers = 1;
     if (!parse_hex32(lsp_sk_hex, seckeys[0])) {
         fprintf(stderr, "bad lsp-seckey hex\n"); return 1;
     }
     /* split client_sks_csv on ',' */
     {
-        char buf[1024]; strncpy(buf, client_sks_csv, sizeof(buf) - 1); buf[sizeof(buf)-1] = '\0';
+        char buf[9000]; strncpy(buf, client_sks_csv, sizeof(buf) - 1); buf[sizeof(buf)-1] = '\0';
         char *save = NULL;
         for (char *tok = strtok_r(buf, ",", &save); tok; tok = strtok_r(NULL, ",", &save)) {
-            if (n_signers >= 16) { fprintf(stderr, "too many signers\n"); return 1; }
+            if (n_signers >= 128) { fprintf(stderr, "too many signers\n"); return 1; }
             if (!parse_hex32(tok, seckeys[n_signers])) {
                 fprintf(stderr, "bad client seckey hex: %s\n", tok); return 1;
             }
@@ -103,8 +103,8 @@ int main(int argc, char **argv) {
     printf("Signers: %zu (1 LSP + %zu clients)\n", n_signers, n_signers - 1);
 
     /* Derive keypairs + pubkeys. */
-    secp256k1_keypair kps[16];
-    secp256k1_pubkey  pks[16];
+    secp256k1_keypair kps[128];
+    secp256k1_pubkey  pks[128];
     for (size_t i = 0; i < n_signers; i++) {
         if (!secp256k1_keypair_create(ctx, &kps[i], seckeys[i])) {
             fprintf(stderr, "keypair_create failed (signer %zu)\n", i); return 1;

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1874,6 +1874,7 @@ handle_message:
             break;
         }
 
+        case MSG_STATE_ADV_PROPOSE_INTENT:  /* stateless Tier B (#333): client_handle_state_advance dispatches by opcode */
         case MSG_STATE_ADVANCE_PROPOSE: {
             /* Tier B (Gap B + F): LSP detected per-leaf DW counter rollover
                and is driving the whole-tree re-sign ceremony.  Delegate to

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1889,6 +1889,7 @@ handle_message:
             break;
         }
 
+        case MSG_SUBFACTORY_PROPOSE_INTENT:  /* stateless sub-factory (#271/#142): client_handle_subfactory_advance dispatches by opcode */
         case MSG_SUBFACTORY_PROPOSE: {
             /* Phase 2c (Gap E followup): LSP "selling sales-stock" to a
                client.  Delegate to client_handle_subfactory_advance;
@@ -3305,12 +3306,12 @@ int main(int argc, char *argv[]) {
             }
             if (g_shutdown) break;
             if (!ok) {
-                fprintf(stderr, "Client: disconnected, retrying in 5s...\n");
+                fprintf(stderr, "Client: disconnected, retrying in 1s...\n");
                 /* Run watchtower check between reconnect attempts so we can
                    detect on-chain breaches even when the LSP is unreachable. */
                 if (cbd.wt)
                     watchtower_check(cbd.wt);
-                sleep(5);
+                sleep(1);
             } else {
                 break;  /* clean exit */
             }

--- a/tools/test_regtest_subfactory_chain_advance_multi.sh
+++ b/tools/test_regtest_subfactory_chain_advance_multi.sh
@@ -273,12 +273,22 @@ grep -E "chain_len=[0-9].*signed=1" "$LSP_LOG" | sed 's/^/    /'
 # --- Verify MULTI-INPUT ceremony marker (LSP side) ---
 echo ""
 echo "=== Verifying MULTI-INPUT ceremony fired ==="
-if ! grep -q "chain advance is MULTI-INPUT" "$LSP_LOG"; then
+# Accept EITHER the legacy multi-input marker ("chain advance is MULTI-INPUT")
+# OR the stateless multi-input marker ("MULTI-INPUT advance (n_inputs=...)").
+# Under SS_MUSIG_STATELESS=1 the stateless path runs and the legacy line is
+# (correctly) absent.  Also assert the stateless flow did NOT fall back to
+# legacy when stateless was requested.
+if grep -q "multi-input not yet supported in stateless flow" "$LSP_LOG"; then
+    echo "FAIL: stateless multi-input fell back to legacy (invariant violated)"
+    grep -E "multi-input not yet supported|MULTI-INPUT" "$LSP_LOG" | head -10
+    exit 1
+fi
+if ! grep -qE "chain advance is MULTI-INPUT|MULTI-INPUT advance \(n_inputs=" "$LSP_LOG"; then
     echo "FAIL: MULTI-INPUT ceremony marker missing from LSP log"
     grep -E "MULTI|SF-A|sub-factory" "$LSP_LOG" | head -20
     exit 1
 fi
-MULTI_LINE=$(grep "chain advance is MULTI-INPUT" "$LSP_LOG" | head -1)
+MULTI_LINE=$(grep -E "chain advance is MULTI-INPUT|MULTI-INPUT advance \(n_inputs=" "$LSP_LOG" | head -1)
 echo "  $MULTI_LINE"
 
 # --- Verify client mirror MULTI-INPUT marker ---
@@ -286,9 +296,9 @@ echo ""
 echo "=== Verifying clients ran the MULTI-INPUT mirror ==="
 N_MULTI_CLIENTS=0
 for i in $(seq 0 $((N_CLIENTS - 1))); do
-    if grep -q "advance is MULTI-INPUT\|advanced (MULTI)" "$TMPDIR/client_${i}.log" 2>/dev/null; then
+    if grep -qE "advance is MULTI-INPUT|advanced \(MULTI\)|subfactory MULTI-INPUT [0-9]+: advance done" "$TMPDIR/client_${i}.log" 2>/dev/null; then
         N_MULTI_CLIENTS=$((N_MULTI_CLIENTS + 1))
-        MARK=$(grep -E "advance is MULTI-INPUT|advanced \(MULTI\)" "$TMPDIR/client_${i}.log" | head -1)
+        MARK=$(grep -E "advance is MULTI-INPUT|advanced \(MULTI\)|subfactory MULTI-INPUT [0-9]+: advance done" "$TMPDIR/client_${i}.log" | head -1)
         echo "    client[$i]: $MARK"
     fi
 done

--- a/tools/test_regtest_subfactory_chain_advance_multi.sh
+++ b/tools/test_regtest_subfactory_chain_advance_multi.sh
@@ -68,6 +68,13 @@ cleanup() {
     for pid in "${PIDS[@]:-}"; do
         kill -9 "$pid" 2>/dev/null || true
     done
+    # Reap detached --daemon clients: they fork away from $PIDS so the PID-kill
+    # above misses them, and they leak onto the fixed port and pollute the next
+    # run. Match by the unique per-run tmpdir marker (no self-match: this shell
+    # cmdline does not contain $TMPDIR; pkill excludes its own pid).
+    pkill -f "$TMPDIR" 2>/dev/null || true
+    sleep 1
+    pkill -9 -f "$TMPDIR" 2>/dev/null || true
     cp "$LSP_LOG" /tmp/subfactory_multi_last_lsp.log 2>/dev/null || true
     cp "$LSP_DB"  /tmp/subfactory_multi_last_lsp.db  2>/dev/null || true
     for i in $(seq 0 $((N_CLIENTS - 1))); do
@@ -254,14 +261,14 @@ fi
 # --- Verify both advances fired ---
 echo ""
 echo "=== Verifying TWO sub-factory advances fired ==="
-ADV_LINES=$(grep -cE "sub-factory.*chain extended" "$LSP_LOG" 2>/dev/null || echo 0)
+ADV_LINES=$(grep -E "chain_len=[0-9].*signed=1" "$LSP_LOG" 2>/dev/null | wc -l)
 if [ "$ADV_LINES" -lt 2 ]; then
-    echo "FAIL: expected >= 2 advance lines, got $ADV_LINES"
-    grep -E "sub-factory|FAIL|chain extended" "$LSP_LOG" | head -30
+    echo "FAIL: expected >= 2 signed advances (chain_len progression), got $ADV_LINES"
+    grep -E "chain_len=|subfactory chain advance|MULTI-INPUT|FAIL|DONE" "$LSP_LOG" | head -30
     exit 1
 fi
-echo "  $ADV_LINES advance lines:"
-grep "sub-factory.*chain extended" "$LSP_LOG" | sed 's/^/    /'
+echo "  $ADV_LINES signed advances (chain_len progression):"
+grep -E "chain_len=[0-9].*signed=1" "$LSP_LOG" | sed 's/^/    /'
 
 # --- Verify MULTI-INPUT ceremony marker (LSP side) ---
 echo ""


### PR DESCRIPTION
## Summary

Implements the BIP-327 **stateless MuSig2 signer** flow across all SuperScalar ceremonies. The LSP never holds a secret nonce across a network wait: it generates its secnonce(s) only AFTER receiving all client pubnonces (inside an atomic block with no `wire_recv`), and zeroes them in `musig_create_partial_sig` before the next `recv`. Gated by `SS_MUSIG_STATELESS` / `--musig-stateless`; the legacy pool-based flow remains the default.

## Ceremonies (all reversed to the stateless flow)
- **Tier B state-advance** (multi-signer, with poison): `bb761e4`, `1eda8aa`, `3cc9e9e`, `37df0c6`, `bef2447`, `a8519a0` — removes the `if (mgr->watchtower) return -1` refusal that made the stateless root ceremony always fall back to legacy; wires the per-DW-leaf L-stock poison in the same atomic loop as the state sig; all-signer nonce + psig matrices so the N-of-N root / intermediate nodes finalize correctly.
- **Sub-factory chain advance**: single-input (`d7bdfe4`, `093889e`) and multi-input per-input loop (`6318255`).
- **Factory creation** (per-node, whole tree): `e7e739e` — extends the factory `LSP_RESPONSE` codec (0x87) with the all-signer per-node nonce matrix, required for the N-of-N root + multi-signer intermediates; backward-compatible (field omitted when absent).

## Harness robustness (`093889e`)
- `lsp_accept_clients`: a single bad/stale/racing connection (failed noise handshake / missing HELLO / bad pubkey) now drops that fd and retries the slot instead of aborting the whole accept ("LSP: failed to accept clients"). The rate-limiter still bounds abuse — strictly better for production DoS resistance, and it fixes the recurring regtest connect-flake.
- The sub-factory runner's `cleanup()` reaps detached `--daemon` clients (they fork away from `$PIDS`, so PID-kill missed them and they leaked onto the fixed port, polluting the next run).
- Client initial-connect / reconnect retry 5s -> 1s.

## Tooling (`6fe027b`)
- `recover_stranded_coop_output` handles >16 signers / >7 client keys.

## Stateless invariant
Verified per ceremony by code review: every LSP secnonce is generated strictly after the `recv` of all client pubnonces, inside an atomic block with no `wire_recv`, and consumed/zeroed by `musig_create_partial_sig` before the next `recv`. The client mirrors this (own secnonces zeroed before the DONE/READY recv). Heap arrays freed on all error paths.

## Validation (regtest, ASan build, `SS_MUSIG_STATELESS=1`)
- `test_regtest_subfactory_chain_advance_multi.sh`: **PASS** — advance 1 single-input stateless, advance 2 multi-input stateless (`n_inputs=3`), the factory itself created via the stateless ceremony ("4 nodes signed", no legacy fallback), 2 persisted `ps_subfactory_chains` rows.
- `test_regtest_tier_b_rollover_ps.sh`: **PASS** stateless AND legacy.
- Unit suite `test_superscalar`: **1472/1472**.

## Follow-ups (not in this PR)
- Wire `--musig-stateless` into the testnet4 phase5 runner + a testnet4 stateless long-run (deferred — VPS was under load).
- Phase 2 (flip default to stateless), Phase 3 (drop the nonce-pool API + `nonce_pools` schema), nonce-safety unit/fuzz tests, wallet-team coordination.

Internal: tasks #271 / #261.
