### PR TITLE
feat(musig): stateless sub-factory poison ceremony + watchtower registration

### DIFF
--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -520,29 +520,43 @@ int    wire_parse_subfactory_propose_intent(const cJSON *json,
                                               uint64_t *out_delta_sats);
 
 cJSON *wire_build_subfactory_client_pubnonces(const unsigned char *pubnonces_per_input /* n_inputs * 66 */,
-                                                uint32_t n_inputs);
+                                                uint32_t n_inputs,
+                                                const unsigned char *poison_pubnonce /* 66 or NULL */);
+/* Returns 1 (no poison), 2 (poison_pubnonce present), 0 (parse error). */
 int    wire_parse_subfactory_client_pubnonces(const cJSON *json,
                                                 unsigned char *out_pubnonces_per_input /* n_inputs * 66 */,
-                                                uint32_t expected_n_inputs);
+                                                uint32_t expected_n_inputs,
+                                                unsigned char *out_poison_pubnonce /* 66 or NULL */);
 
 cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per_input /* n_inputs * 66 */,
                                             const unsigned char *lsp_psigs_per_input /* n_inputs * 32 */,
                                             uint32_t n_inputs,
                                             const unsigned char *all_signer_pubnonces_flat /* all_len bytes or NULL (single-input k>=2: n_signers*66) */,
-                                            uint32_t all_signer_pubnonces_len);
+                                            uint32_t all_signer_pubnonces_len,
+                                            const unsigned char *all_signer_poison_pubnonces_flat /* n_signers*66 or NULL */,
+                                            uint32_t all_signer_poison_pubnonces_len,
+                                            const unsigned char *lsp_poison_psig /* 32 or NULL */);
+/* Returns 1 (no poison), 2 (poison present), 0 (parse error). */
 int    wire_parse_subfactory_lsp_response(const cJSON *json,
                                             unsigned char *out_lsp_pubnonces_per_input,
                                             unsigned char *out_lsp_psigs_per_input,
                                             uint32_t expected_n_inputs,
                                             unsigned char *out_all_signer_pubnonces_flat /* max_all_len bytes or NULL */,
                                             uint32_t max_all_signer_pubnonces_len,
-                                            uint32_t *out_all_signer_pubnonces_len /* or NULL */);
+                                            uint32_t *out_all_signer_pubnonces_len /* or NULL */,
+                                            unsigned char *out_all_signer_poison_pubnonces_flat /* max_poison_len or NULL */,
+                                            uint32_t max_all_signer_poison_pubnonces_len,
+                                            uint32_t *out_all_signer_poison_pubnonces_len /* or NULL */,
+                                            unsigned char *out_lsp_poison_psig /* 32 or NULL */);
 
 cJSON *wire_build_subfactory_client_final_psigs(const unsigned char *psigs_per_input /* n_inputs * 32 */,
-                                                  uint32_t n_inputs);
+                                                  uint32_t n_inputs,
+                                                  const unsigned char *poison_psig /* 32 or NULL */);
+/* Returns 1 (no poison), 2 (poison_psig present), 0 (parse error). */
 int    wire_parse_subfactory_client_final_psigs(const cJSON *json,
                                                   unsigned char *out_psigs_per_input,
-                                                  uint32_t expected_n_inputs);
+                                                  uint32_t expected_n_inputs,
+                                                  unsigned char *out_poison_psig /* 32 or NULL */);
 
 /* Phase 1e.2.a Tier B state advance reversed flow wire codec.  Multi-leaf
    ceremony: per-leaf arrays of pubnonces + psigs.  n_affected_leaves is

--- a/src/client.c
+++ b/src/client.c
@@ -3122,21 +3122,46 @@ static int client_handle_subfactory_advance_stateless_multi(
         return 0;
     }
 
+    /* Poison prep (deterministic; single-input side-channel mirroring the LSP).
+       Snapshot the OLD chain[N-1] state BEFORE advance_unsigned mutates it. */
+    const uint64_t POISON_FEE_SATS = 1000;
+    int poison_prepared_c = 0;
+    {
+        size_t old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
+        uint64_t old_sstock = (sub->n_outputs > 0)
+            ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
+        if (old_sstock > POISON_FEE_SATS + (uint64_t)old_n_chans * 330u) {
+            unsigned char old_chain_txid[32];
+            memcpy(old_chain_txid, sub->txid, 32);
+            if (factory_session_prepare_poison_tx_subfactory(
+                    factory, sub_node_i, old_chain_txid, (uint32_t)old_n_chans,
+                    old_sstock, POISON_FEE_SATS))
+                poison_prepared_c = 1;
+        }
+    }
+
     /* Apply the advance locally so unsigned_tx matches the LSP deterministically. */
     if (!factory_subfactory_chain_advance_unsigned(factory, leaf_side, sub_idx,
                                                      channel_idx, delta_sats)) {
         fprintf(stderr, "Client-stateless MULTI %u: chain_advance_unsigned failed\n",
                 my_index);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
 
-    /* Init one state session per input (no poison in stateless MVP). */
+    /* Init one state session per input + (when prepared) poison session. */
     for (size_t i = 0; i < n_inputs; i++) {
         if (!factory_session_init_node_input(factory, sub_node_i, i)) {
             fprintf(stderr, "Client-stateless MULTI %u: init input %zu failed\n",
                     my_index, i);
+            factory_session_reset_poison(factory, sub_node_i);
             return 0;
         }
+    }
+    if (poison_prepared_c &&
+        !factory_session_init_node_poison(factory, sub_node_i)) {
+        factory_session_reset_poison(factory, sub_node_i);
+        poison_prepared_c = 0;
     }
 
     int my_slot = factory_find_signer_slot(factory, sub_node_i, my_index);
@@ -3181,18 +3206,40 @@ static int client_handle_subfactory_advance_stateless_multi(
                     my_index, i);
             memset(my_seckey, 0, 32);
             free(my_secnonces); free(my_pn_flat);
+            factory_session_reset_poison(factory, sub_node_i);
             return 0;
+        }
+    }
+
+    /* Poison (single-input side-channel): gen own poison secnonce + set own
+       poison nonce while my_seckey is still live. */
+    secp256k1_musig_secnonce my_poison_secnonce;
+    unsigned char my_poison_pn_ser[66] = {0};
+    if (poison_prepared_c) {
+        secp256k1_musig_pubnonce my_poison_pubnonce;
+        if (!musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                    my_seckey, &my_pubkey, &sub->keyagg.cache) ||
+            !factory_session_set_nonce_poison(factory, sub_node_i,
+                                                (size_t)my_slot, &my_poison_pubnonce)) {
+            memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+            factory_session_reset_poison(factory, sub_node_i);
+            poison_prepared_c = 0;
+        } else {
+            musig_pubnonce_serialize(ctx, my_poison_pn_ser, &my_poison_pubnonce);
         }
     }
     memset(my_seckey, 0, 32);
 
-    /* Send CLIENT_PUBNONCES with n_inputs own pubnonces. */
-    cJSON *cpn_json = wire_build_subfactory_client_pubnonces(my_pn_flat, (uint32_t)n_inputs);
+    /* Send CLIENT_PUBNONCES with n_inputs own pubnonces (+ poison nonce). */
+    cJSON *cpn_json = wire_build_subfactory_client_pubnonces(
+        my_pn_flat, (uint32_t)n_inputs, poison_prepared_c ? my_poison_pn_ser : NULL);
     free(my_pn_flat);
     if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_PUBNONCES, cpn_json)) {
         cJSON_Delete(cpn_json);
         fprintf(stderr, "Client-stateless MULTI %u: send CLIENT_PUBNONCES failed\n", my_index);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
         free(my_secnonces);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     cJSON_Delete(cpn_json);
@@ -3203,7 +3250,9 @@ static int client_handle_subfactory_advance_stateless_multi(
         fprintf(stderr, "Client-stateless MULTI %u: expected LSP_RESPONSE, got 0x%02x\n",
                 my_index, lr_msg.json ? lr_msg.msg_type : 0);
         if (lr_msg.json) cJSON_Delete(lr_msg.json);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
         free(my_secnonces);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     unsigned char *lsp_pn_flat = calloc(n_inputs, 66);
@@ -3217,19 +3266,37 @@ static int client_handle_subfactory_advance_stateless_multi(
         free(my_secnonces);
         return 0;
     }
-    uint32_t got_all_len = 0;
-    if (!wire_parse_subfactory_lsp_response(lr_msg.json, lsp_pn_flat, lsp_psig_flat,
+    unsigned char all_poison_pn_sub[FACTORY_MAX_SIGNERS][66];
+    unsigned char lsp_poison_psig_ser[32];
+    uint32_t got_all_len = 0, got_poison_len = 0;
+    memset(all_poison_pn_sub, 0, sizeof(all_poison_pn_sub));
+    int lr_rc = wire_parse_subfactory_lsp_response(lr_msg.json, lsp_pn_flat, lsp_psig_flat,
                                               (uint32_t)n_inputs,
                                               all_pn_per_input, (uint32_t)matrix_len,
-                                              &got_all_len)) {
+                                              &got_all_len,
+                                              poison_prepared_c ? (unsigned char *)all_poison_pn_sub : NULL,
+                                              poison_prepared_c ? (uint32_t)sizeof(all_poison_pn_sub) : 0,
+                                              poison_prepared_c ? &got_poison_len : NULL,
+                                              poison_prepared_c ? lsp_poison_psig_ser : NULL);
+    if (lr_rc == 0) {
         cJSON_Delete(lr_msg.json);
         free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
         free(my_secnonces);
+        factory_session_reset_poison(factory, sub_node_i);
         fprintf(stderr, "Client-stateless MULTI %u: parse LSP_RESPONSE failed\n", my_index);
         return 0;
     }
     cJSON_Delete(lr_msg.json);
     int have_matrix = (got_all_len == (uint32_t)matrix_len);
+    if (poison_prepared_c &&
+        (lr_rc < 2 || got_poison_len != (uint32_t)(sub->n_signers * 66))) {
+        fprintf(stderr, "Client-stateless MULTI %u: LSP omitted poison fields -- "
+                "degrading\n", my_index);
+        memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        factory_session_reset_poison(factory, sub_node_i);
+        poison_prepared_c = 0;
+    }
 
     /* Per input: set LSP nonce + every other co-signer's nonce (skip own and
        LSP slots, exactly like single-input), finalize, sign (zeros secnonce). */
@@ -3277,18 +3344,51 @@ static int client_handle_subfactory_advance_stateless_multi(
         /* my_secnonces[i] zeroed by musig_create_partial_sig. */
         musig_partial_sig_serialize(ctx, my_psig_flat + i * 32, &my_psig_i);
     }
+
+    /* Poison (single-input): set every signer's poison nonce from the forwarded
+       matrix (own already set), finalize, create own poison psig (zeros the
+       poison secnonce before the DONE recv). */
+    unsigned char my_poison_psig_ser[32] = {0};
+    if (poison_prepared_c) {
+        int pz_ok = 1;
+        for (size_t scs = 0; scs < sub->n_signers && pz_ok; scs++) {
+            if (scs == (size_t)my_slot) continue;  /* own already set */
+            secp256k1_musig_pubnonce ppn;
+            if (!musig_pubnonce_parse(ctx, &ppn, all_poison_pn_sub[scs]) ||
+                !factory_session_set_nonce_poison(factory, sub_node_i, scs, &ppn))
+                pz_ok = 0;
+        }
+        secp256k1_musig_partial_sig my_poison_psig;
+        pz_ok = pz_ok &&
+            factory_session_finalize_node_poison(factory, sub_node_i) &&
+            musig_create_partial_sig(ctx, &my_poison_psig, &my_poison_secnonce,
+                                       keypair, &sub->poison_signing_session);
+        memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        if (!pz_ok) {
+            fprintf(stderr, "Client-stateless MULTI %u: poison sign failed -- "
+                    "degrading\n", my_index);
+            factory_session_reset_poison(factory, sub_node_i);
+            poison_prepared_c = 0;
+        } else {
+            musig_partial_sig_serialize(ctx, my_poison_psig_ser, &my_poison_psig);
+        }
+    }
+
     free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
     free(my_secnonces);  /* all entries already zeroed by create_partial_sig */
 
-    /* Send CLIENT_FINAL_PSIGS with n_inputs psigs. */
-    cJSON *fp_json = wire_build_subfactory_client_final_psigs(my_psig_flat, (uint32_t)n_inputs);
+    /* Send CLIENT_FINAL_PSIGS with n_inputs psigs (+ poison psig). */
+    cJSON *fp_json = wire_build_subfactory_client_final_psigs(
+        my_psig_flat, (uint32_t)n_inputs, poison_prepared_c ? my_poison_psig_ser : NULL);
     free(my_psig_flat);
     if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_FINAL_PSIGS, fp_json)) {
         cJSON_Delete(fp_json);
         fprintf(stderr, "Client-stateless MULTI %u: send CLIENT_FINAL_PSIGS failed\n", my_index);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     cJSON_Delete(fp_json);
+    if (poison_prepared_c) factory_session_reset_poison(factory, sub_node_i);
 
     /* Wait for DONE. */
     wire_msg_t done_msg;
@@ -3307,6 +3407,8 @@ static int client_handle_subfactory_advance_stateless_multi(
 fail:
     free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
     free(my_secnonces); free(my_psig_flat);
+    if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+    factory_session_reset_poison(factory, sub_node_i);
     return 0;
 }
 
@@ -3351,6 +3453,29 @@ static int client_handle_subfactory_advance_stateless(int fd,
        complete, so no Gap B needed). Matching LSP-side refusal removed in
        d7bdfe4. */
 
+    /* Poison prep (deterministic; matches the LSP minus the watchtower gate,
+       which is LSP-only): snapshot the soon-to-be-stale chain[N-1] state
+       BEFORE advance_unsigned mutates sub->txid / sub->outputs[], then build
+       the same single-input L-stock poison TX so both sides reach a
+       byte-identical sighash.  poison_prepared_c is cleared if anything
+       degrades or the LSP fails to reciprocate poison fields. */
+    const uint64_t POISON_FEE_SATS = 1000;
+    int poison_prepared_c = 0;
+    {
+        size_t old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
+        uint64_t old_sstock = (sub->n_outputs > 0)
+            ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
+        if (old_sstock > POISON_FEE_SATS + (uint64_t)old_n_chans * 330u) {
+            unsigned char old_chain_txid[32];
+            memcpy(old_chain_txid, sub->txid, 32);
+            if (factory_session_prepare_poison_tx_subfactory(
+                    factory, sub_node_i, old_chain_txid, (uint32_t)old_n_chans,
+                    old_sstock, POISON_FEE_SATS)) {
+                poison_prepared_c = 1;  /* init_node_poison after state init */
+            }
+        }
+    }
+
     /* Phase 1e.1.b amendment: PROPOSE_INTENT now carries the advance params
        (leaf_side, sub_idx, channel_idx, delta_sats).  Apply the advance
        locally so unsigned_tx matches LSP's deterministically. */
@@ -3361,13 +3486,20 @@ static int client_handle_subfactory_advance_stateless(int fd,
             "(leaf=%d sub=%d ch=%d delta=%llu)\n",
             my_index, leaf_side, sub_idx, channel_idx,
             (unsigned long long)delta_sats);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
 
-        /* Init session (state only, no poison in MVP). */
+    /* Init state session + (when prepared) poison session. */
     if (!factory_session_init_node(factory, sub_node_i)) {
         fprintf(stderr, "Client-stateless subfactory %u: session_init failed\n", my_index);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
+    }
+    if (poison_prepared_c &&
+        !factory_session_init_node_poison(factory, sub_node_i)) {
+        factory_session_reset_poison(factory, sub_node_i);
+        poison_prepared_c = 0;
     }
 
     int my_slot = factory_find_signer_slot(factory, sub_node_i, my_index);
@@ -3387,29 +3519,50 @@ static int client_handle_subfactory_advance_stateless(int fd,
     }
     secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
 
-    secp256k1_musig_secnonce my_secnonce;
+    secp256k1_musig_secnonce my_secnonce, my_poison_secnonce;
     secp256k1_musig_pubnonce my_pubnonce;
     if (!musig_generate_nonce(ctx, &my_secnonce, &my_pubnonce,
                                 my_seckey, &my_pubkey,
                                 &sub->keyagg.cache)) {
         memset(my_seckey, 0, 32);
         fprintf(stderr, "Client-stateless subfactory %u: nonce gen failed\n", my_index);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
+    }
+    /* Poison: own nonce (my_seckey still live this scope). */
+    unsigned char my_poison_pn_ser[66] = {0};
+    if (poison_prepared_c) {
+        secp256k1_musig_pubnonce my_poison_pubnonce;
+        if (!musig_generate_nonce(ctx, &my_poison_secnonce, &my_poison_pubnonce,
+                                    my_seckey, &my_pubkey, &sub->keyagg.cache) ||
+            !factory_session_set_nonce_poison(factory, sub_node_i,
+                                                (size_t)my_slot, &my_poison_pubnonce)) {
+            memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+            factory_session_reset_poison(factory, sub_node_i);
+            poison_prepared_c = 0;
+        } else {
+            musig_pubnonce_serialize(ctx, my_poison_pn_ser, &my_poison_pubnonce);
+        }
     }
     memset(my_seckey, 0, 32);
     if (!factory_session_set_nonce(factory, sub_node_i, (size_t)my_slot, &my_pubnonce)) {
         fprintf(stderr, "Client-stateless subfactory %u: set own nonce failed\n", my_index);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
 
-    /* Send CLIENT_PUBNONCES with own pubnonce. */
+    /* Send CLIENT_PUBNONCES with own pubnonce (+ poison nonce when prepared). */
     unsigned char my_pubnonce_ser[66];
     musig_pubnonce_serialize(ctx, my_pubnonce_ser, &my_pubnonce);
-    cJSON *cpn_json = wire_build_subfactory_client_pubnonces(my_pubnonce_ser, 1);
+    cJSON *cpn_json = wire_build_subfactory_client_pubnonces(
+        my_pubnonce_ser, 1, poison_prepared_c ? my_poison_pn_ser : NULL);
     if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_PUBNONCES, cpn_json)) {
         cJSON_Delete(cpn_json);
         fprintf(stderr, "Client-stateless subfactory %u: send CLIENT_PUBNONCES failed\n",
                 my_index);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     cJSON_Delete(cpn_json);
@@ -3421,22 +3574,43 @@ static int client_handle_subfactory_advance_stateless(int fd,
             "Client-stateless subfactory %u: expected LSP_RESPONSE, got 0x%02x\n",
             my_index, lr_msg.json ? lr_msg.msg_type : 0);
         if (lr_msg.json) cJSON_Delete(lr_msg.json);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
     unsigned char all_pn_sub[FACTORY_MAX_SIGNERS][66];
-    uint32_t got_all_pn_len = 0;
-    if (!wire_parse_subfactory_lsp_response(lr_msg.json,
+    unsigned char all_poison_pn_sub[FACTORY_MAX_SIGNERS][66];
+    unsigned char lsp_poison_psig_ser[32];
+    uint32_t got_all_pn_len = 0, got_poison_len = 0;
+    memset(all_poison_pn_sub, 0, sizeof(all_poison_pn_sub));
+    int lr_rc = wire_parse_subfactory_lsp_response(lr_msg.json,
                                               lsp_pubnonce_ser, lsp_psig_ser, 1,
                                               (unsigned char *)all_pn_sub,
                                               (uint32_t)sizeof(all_pn_sub),
-                                              &got_all_pn_len)) {
+                                              &got_all_pn_len,
+                                              poison_prepared_c ? (unsigned char *)all_poison_pn_sub : NULL,
+                                              poison_prepared_c ? (uint32_t)sizeof(all_poison_pn_sub) : 0,
+                                              poison_prepared_c ? &got_poison_len : NULL,
+                                              poison_prepared_c ? lsp_poison_psig_ser : NULL);
+    if (lr_rc == 0) {
         cJSON_Delete(lr_msg.json);
         fprintf(stderr, "Client-stateless subfactory %u: parse LSP_RESPONSE failed\n",
                 my_index);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     cJSON_Delete(lr_msg.json);
+    /* LSP did not reciprocate poison (rc<2 or wrong matrix length) -> degrade. */
+    if (poison_prepared_c &&
+        (lr_rc < 2 || got_poison_len != (uint32_t)(sub->n_signers * 66))) {
+        fprintf(stderr, "Client-stateless subfactory %u: LSP omitted poison fields "
+                "-- degrading local poison\n", my_index);
+        memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        factory_session_reset_poison(factory, sub_node_i);
+        poison_prepared_c = 0;
+    }
 
     /* Set LSP nonce, then (k>=2) every OTHER signer's nonce from the forwarded
        matrix (own already set in Step 5, LSP set just below), then finalize. */
@@ -3461,7 +3635,39 @@ static int client_handle_subfactory_advance_stateless(int fd,
     }
     if (!factory_session_finalize_node(factory, sub_node_i)) {
         fprintf(stderr, "Client-stateless subfactory %u: finalize_node failed\n", my_index);
+        if (poison_prepared_c) memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
+    }
+
+    /* Poison: set every signer's poison nonce from the forwarded matrix (the
+       poison session is N-of-N like state), finalize.  Own poison nonce was set
+       in Step 5; set the rest here.  Degrade this leaf if any step fails. */
+    unsigned char my_poison_psig_ser[32] = {0};
+    if (poison_prepared_c) {
+        int pz_ok = 1;
+        for (size_t s = 0; s < sub->n_signers && pz_ok; s++) {
+            if (s == (size_t)my_slot) continue;  /* own already set */
+            secp256k1_musig_pubnonce ppn;
+            if (!musig_pubnonce_parse(ctx, &ppn, all_poison_pn_sub[s]) ||
+                !factory_session_set_nonce_poison(factory, sub_node_i, s, &ppn))
+                pz_ok = 0;
+        }
+        secp256k1_musig_partial_sig my_poison_psig;
+        pz_ok = pz_ok &&
+            factory_session_finalize_node_poison(factory, sub_node_i) &&
+            musig_create_partial_sig(ctx, &my_poison_psig, &my_poison_secnonce,
+                                       keypair, &sub->poison_signing_session);
+        /* Zero own poison secnonce on every path BEFORE the DONE recv. */
+        memset(&my_poison_secnonce, 0, sizeof(my_poison_secnonce));
+        if (!pz_ok) {
+            fprintf(stderr, "Client-stateless subfactory %u: poison sign failed "
+                    "-- degrading\n", my_index);
+            factory_session_reset_poison(factory, sub_node_i);
+            poison_prepared_c = 0;
+        } else {
+            musig_partial_sig_serialize(ctx, my_poison_psig_ser, &my_poison_psig);
+        }
     }
 
     /* Create own partial_sig (zeros own secnonce). */
@@ -3470,22 +3676,28 @@ static int client_handle_subfactory_advance_stateless(int fd,
                                     &sub->signing_session)) {
         fprintf(stderr, "Client-stateless subfactory %u: create_partial_sig failed\n",
                 my_index);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
-    /* my_secnonce zeroed by musig_create_partial_sig.
-       INVARIANT: we no longer hold any client secnonce for this signing session. */
+    /* my_secnonce + my_poison_secnonce zeroed by musig_create_partial_sig.
+       INVARIANT: we no longer hold any client secnonce (state or poison). */
 
-    /* Send CLIENT_FINAL_PSIGS with own psig.  LSP aggregates with its own psig. */
+    /* Send CLIENT_FINAL_PSIGS with own psig (+ poison psig).  LSP aggregates
+       and completes both the state and poison sessions. */
     unsigned char my_psig_ser[32];
     musig_partial_sig_serialize(ctx, my_psig_ser, &my_psig);
-    cJSON *fp_json = wire_build_subfactory_client_final_psigs(my_psig_ser, 1);
+    cJSON *fp_json = wire_build_subfactory_client_final_psigs(
+        my_psig_ser, 1, poison_prepared_c ? my_poison_psig_ser : NULL);
     if (!wire_send(fd, MSG_SUBFACTORY_CLIENT_FINAL_PSIGS, fp_json)) {
         cJSON_Delete(fp_json);
         fprintf(stderr, "Client-stateless subfactory %u: send CLIENT_FINAL_PSIGS failed\n",
                 my_index);
+        factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     cJSON_Delete(fp_json);
+    /* Local poison state handed off via the wire; free our copy. */
+    if (poison_prepared_c) factory_session_reset_poison(factory, sub_node_i);
 
     /* Wait for DONE. */
     wire_msg_t done_msg;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4716,21 +4716,58 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         return 0;
     }
 
+    /* Step 1.5 (poison prep): snapshot the soon-to-be-stale chain[N-1] state
+       BEFORE advance_unsigned mutates sub->txid / sub->outputs[], then build
+       the single-input L-stock poison TX (the poison side-channel is always
+       single-input even when the state advance is multi-input, mirroring the
+       legacy multi path).  Poison only when the watchtower is configured. */
+    const uint64_t POISON_FEE_SATS = 1000;
+    int poison_prepared = 0;
+    unsigned char wt_old_chain_txid[32];
+    memcpy(wt_old_chain_txid, sub->txid, 32);
+    size_t wt_old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
+    if (wt_old_n_chans > 16) wt_old_n_chans = 16;
+    uint64_t wt_old_chan_amounts[16] = {0};
+    for (size_t ci = 0; ci < wt_old_n_chans; ci++)
+        wt_old_chan_amounts[ci] = sub->outputs[ci].amount_sats;
+    uint64_t wt_old_sstock_amount = (sub->n_outputs > 0)
+        ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
+    if (mgr->watchtower &&
+        wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
+        if (factory_session_prepare_poison_tx_subfactory(
+                f, sub_node_i, wt_old_chain_txid, (uint32_t)wt_old_n_chans,
+                wt_old_sstock_amount, POISON_FEE_SATS)) {
+            poison_prepared = 1;
+        } else {
+            fprintf(stderr, "LSP-stateless subfactory MULTI: poison TX prep "
+                    "failed -- NULL poison_tx\n");
+        }
+    }
+
     /* Step 1: rebuild unsigned_tx (deterministic; clients do the same). */
     if (!factory_subfactory_chain_advance_unsigned(f, leaf_side,
                                                     sub_idx_in_leaf,
                                                     channel_idx_in_sub,
                                                     delta_sats)) {
         fprintf(stderr, "LSP-stateless subfactory MULTI: advance_unsigned failed\n");
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
 
-    /* Step 2: init one state session per input (no poison in stateless MVP). */
+    /* Step 2: init one state session per input + (when prepared) poison. */
     for (size_t i = 0; i < n_inputs; i++) {
         if (!factory_session_init_node_input(f, sub_node_i, i)) {
             fprintf(stderr, "LSP-stateless subfactory MULTI: init input %zu failed\n", i);
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
         }
+    }
+    if (poison_prepared &&
+        !factory_session_init_node_poison(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless subfactory MULTI: poison init failed -- "
+                "degrading\n");
+        factory_session_reset_poison(f, sub_node_i);
+        poison_prepared = 0;
     }
 
     int lsp_slot = factory_find_signer_slot(f, sub_node_i, 0);
@@ -4755,9 +4792,12 @@ static int lsp_subfactory_chain_advance_stateless_multi(
        layout as the legacy multi-input path so the matrix forwarded to
        clients in LSP_RESPONSE is indexed identically on both sides. */
     unsigned char *all_pn_per_input = calloc(sub->n_signers * n_inputs, 66);
-    if (!all_pn_per_input) return 0;
+    if (!all_pn_per_input) { factory_session_reset_poison(f, sub_node_i); return 0; }
+    /* Poison side-channel is single-input: one poison nonce per signer. */
+    unsigned char all_poison_pn[FACTORY_MAX_SIGNERS][66];
+    memset(all_poison_pn, 0, sizeof(all_poison_pn));
 
-    /* Step 4: collect each client's n_inputs pubnonces. */
+    /* Step 4: collect each client's n_inputs pubnonces (+ 1 poison nonce). */
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_msg_t nmsg;
@@ -4769,23 +4809,42 @@ static int lsp_subfactory_chain_advance_stateless_multi(
                     sub_clients[ci], nmsg.msg_type);
             if (nmsg.json) cJSON_Delete(nmsg.json);
             free(all_pn_per_input);
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
         }
         unsigned char *client_pn_buf = calloc(n_inputs, 66);
-        if (!client_pn_buf) { cJSON_Delete(nmsg.json); free(all_pn_per_input); return 0; }
-        if (!wire_parse_subfactory_client_pubnonces(nmsg.json, client_pn_buf,
-                                                     (uint32_t)n_inputs)) {
+        if (!client_pn_buf) {
+            cJSON_Delete(nmsg.json); free(all_pn_per_input);
+            factory_session_reset_poison(f, sub_node_i); return 0;
+        }
+        unsigned char client_poison_pn[66];
+        int parse_rc = wire_parse_subfactory_client_pubnonces(
+            nmsg.json, client_pn_buf, (uint32_t)n_inputs,
+            poison_prepared ? client_poison_pn : NULL);
+        if (parse_rc == 0) {
             cJSON_Delete(nmsg.json);
             free(client_pn_buf); free(all_pn_per_input);
+            factory_session_reset_poison(f, sub_node_i);
             fprintf(stderr, "LSP-stateless MULTI: parse CLIENT_PUBNONCES failed\n");
             return 0;
         }
         cJSON_Delete(nmsg.json);
+        if (poison_prepared && parse_rc < 2) {
+            fprintf(stderr, "LSP-stateless MULTI: client %u omitted poison nonce "
+                    "-- degrading\n", sub_clients[ci]);
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        }
         int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
-        if (client_slot < 0) { free(client_pn_buf); free(all_pn_per_input); return 0; }
+        if (client_slot < 0) {
+            free(client_pn_buf); free(all_pn_per_input);
+            factory_session_reset_poison(f, sub_node_i); return 0;
+        }
         for (size_t i = 0; i < n_inputs; i++)
             memcpy(all_pn_per_input + ((size_t)client_slot * n_inputs + i) * 66,
                    client_pn_buf + i * 66, 66);
+        if (poison_prepared)
+            memcpy(all_poison_pn[client_slot], client_poison_pn, 66);
         free(client_pn_buf);
     }
 
@@ -4805,15 +4864,17 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         memset(lsp_seckey, 0, 32);
         free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
         free(all_pn_per_input);
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
 
-    /* Build the LSP keypair once for the per-input psig calls. */
+    /* Build the LSP keypair once for the per-input + poison psig calls. */
     secp256k1_keypair lsp_kp;
     if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
         memset(lsp_seckey, 0, 32);
         free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
         free(all_pn_per_input);
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
 
@@ -4878,6 +4939,55 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         }
         musig_partial_sig_serialize(lsp->ctx, lsp_psig_ser[i], &lsp_psig_i);
     }
+
+    /* Poison (same atomic region, lsp_seckey still live, no wire_recv): gen the
+       LSP poison secnonce, set every signer's poison nonce, finalize, create
+       the LSP poison partial sig (which zeros lsp_poison_secnonce).  The poison
+       secnonce never survives to the Step-7 recv. */
+    unsigned char lsp_poison_pn_ser[66] = {0};
+    unsigned char lsp_poison_psig_ser[32] = {0};
+    if (poison_prepared) {
+        secp256k1_musig_secnonce lsp_poison_secnonce;
+        secp256k1_musig_pubnonce lsp_poison_pubnonce;
+        if (!musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce,
+                                   &lsp_poison_pubnonce, lsp_seckey,
+                                   &lsp->lsp_pubkey, &sub->keyagg.cache)) {
+            fprintf(stderr, "LSP-stateless MULTI: poison nonce gen failed -- "
+                    "degrading\n");
+            memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        } else {
+            musig_pubnonce_serialize(lsp->ctx, lsp_poison_pn_ser, &lsp_poison_pubnonce);
+            memcpy(all_poison_pn[lsp_slot], lsp_poison_pn_ser, 66);
+            int pz_ok = 1;
+            for (size_t s = 0; s < sub->n_signers && pz_ok; s++) {
+                secp256k1_musig_pubnonce ppn;
+                if (!musig_pubnonce_parse(lsp->ctx, &ppn, all_poison_pn[s]) ||
+                    !factory_session_set_nonce_poison(f, sub_node_i, s, &ppn))
+                    pz_ok = 0;
+            }
+            secp256k1_musig_partial_sig lsp_poison_psig;
+            pz_ok = pz_ok &&
+                factory_session_finalize_node_poison(f, sub_node_i) &&
+                musig_create_partial_sig(lsp->ctx, &lsp_poison_psig,
+                                           &lsp_poison_secnonce, &lsp_kp,
+                                           &sub->poison_signing_session) &&
+                factory_session_set_partial_sig_poison(f, sub_node_i,
+                                                         (size_t)lsp_slot, &lsp_poison_psig);
+            /* Zero the poison secnonce on every path before the recv that follows. */
+            memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
+            if (!pz_ok) {
+                fprintf(stderr, "LSP-stateless MULTI: LSP poison sign failed -- "
+                        "degrading\n");
+                factory_session_reset_poison(f, sub_node_i);
+                poison_prepared = 0;
+            } else {
+                musig_partial_sig_serialize(lsp->ctx, lsp_poison_psig_ser, &lsp_poison_psig);
+            }
+        }
+    }
+
     memset(lsp_seckey, 0, 32);
     free(lsp_secnonces);  /* all entries already zeroed by create_partial_sig */
 
@@ -4888,6 +4998,7 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         free(lsp_pn_flat); free(lsp_psig_flat);
         free(lsp_pn_ser); free(lsp_psig_ser);
         free(all_pn_per_input);
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
     for (size_t i = 0; i < n_inputs; i++) {
@@ -4898,11 +5009,15 @@ static int lsp_subfactory_chain_advance_stateless_multi(
 
     /* Step 6: LSP_RESPONSE -- per-input LSP nonces + psigs, plus the full
        signer x input matrix (all_pn_per_input) as the all-signer blob so each
-       client can set every co-signer's per-input nonce and finalize. */
+       client can set every co-signer's per-input nonce and finalize.  Carries
+       the single-input LSP poison nonce + psig when poison is still active. */
     cJSON *response = wire_build_subfactory_lsp_response(
         lsp_pn_flat, lsp_psig_flat, (uint32_t)n_inputs,
         all_pn_per_input,
-        (uint32_t)(sub->n_signers * n_inputs * 66));
+        (uint32_t)(sub->n_signers * n_inputs * 66),
+        poison_prepared ? (const unsigned char *)all_poison_pn : NULL,
+        poison_prepared ? (uint32_t)(sub->n_signers * 66) : 0,
+        poison_prepared ? lsp_poison_psig_ser : NULL);
     free(lsp_pn_flat); free(lsp_psig_flat);
     free(all_pn_per_input);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
@@ -4911,6 +5026,7 @@ static int lsp_subfactory_chain_advance_stateless_multi(
             cJSON_Delete(response);
             fprintf(stderr, "LSP-stateless MULTI: send LSP_RESPONSE failed for client %u\n",
                     sub_clients[ci]);
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
         }
     }
@@ -4930,17 +5046,33 @@ static int lsp_subfactory_chain_advance_stateless_multi(
             return 0;
         }
         unsigned char *client_psig_buf = calloc(n_inputs, 32);
-        if (!client_psig_buf) { cJSON_Delete(pmsg.json); return 0; }
-        if (!wire_parse_subfactory_client_final_psigs(pmsg.json, client_psig_buf,
-                                                       (uint32_t)n_inputs)) {
+        if (!client_psig_buf) {
+            cJSON_Delete(pmsg.json);
+            factory_session_reset_poison(f, sub_node_i); return 0;
+        }
+        unsigned char client_poison_psig_ser[32];
+        int parse_rc = wire_parse_subfactory_client_final_psigs(
+            pmsg.json, client_psig_buf, (uint32_t)n_inputs,
+            poison_prepared ? client_poison_psig_ser : NULL);
+        if (parse_rc == 0) {
             cJSON_Delete(pmsg.json);
             free(client_psig_buf);
+            factory_session_reset_poison(f, sub_node_i);
             fprintf(stderr, "LSP-stateless MULTI: parse CLIENT_FINAL_PSIGS failed\n");
             return 0;
         }
         cJSON_Delete(pmsg.json);
+        if (poison_prepared && parse_rc < 2) {
+            fprintf(stderr, "LSP-stateless MULTI: client %u omitted poison psig "
+                    "-- degrading\n", sub_clients[ci]);
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        }
         int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
-        if (client_slot < 0) { free(client_psig_buf); return 0; }
+        if (client_slot < 0) {
+            free(client_psig_buf);
+            factory_session_reset_poison(f, sub_node_i); return 0;
+        }
         for (size_t i = 0; i < n_inputs; i++) {
             secp256k1_musig_partial_sig client_psig_i;
             if (!musig_partial_sig_parse(lsp->ctx, &client_psig_i,
@@ -4951,16 +5083,35 @@ static int lsp_subfactory_chain_advance_stateless_multi(
                 fprintf(stderr, "LSP-stateless MULTI: set client psig (client %u input %zu) failed\n",
                         sub_clients[ci], i);
                 free(client_psig_buf);
+                factory_session_reset_poison(f, sub_node_i);
                 return 0;
             }
         }
         free(client_psig_buf);
+        if (poison_prepared) {
+            secp256k1_musig_partial_sig client_poison_psig;
+            if (!musig_partial_sig_parse(lsp->ctx, &client_poison_psig, client_poison_psig_ser) ||
+                !factory_session_set_partial_sig_poison(f, sub_node_i,
+                                                          (size_t)client_slot, &client_poison_psig)) {
+                fprintf(stderr, "LSP-stateless MULTI: set client poison psig "
+                        "(client %u) failed -- degrading\n", sub_clients[ci]);
+                factory_session_reset_poison(f, sub_node_i);
+                poison_prepared = 0;
+            }
+        }
     }
 
-    /* Step 8: aggregate + assemble the k+1-witness signed TX. */
+    /* Step 8: aggregate + assemble the k+1-witness signed TX + complete poison. */
     if (!factory_session_assemble_signed_tx_multi(f, sub_node_i)) {
         fprintf(stderr, "LSP-stateless MULTI: assemble_signed_tx_multi failed\n");
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
+    }
+    if (poison_prepared &&
+        !factory_session_complete_node_poison(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless MULTI: poison complete failed -- degrading\n");
+        factory_session_reset_poison(f, sub_node_i);
+        poison_prepared = 0;
     }
 
     /* Step 9: DONE to each client. */
@@ -4985,6 +5136,12 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         if (n_chans > 16) n_chans = 16;
         for (int ci = 0; ci < n_chans; ci++)
             chan_amounts[ci] = sub->outputs[ci].amount_sats;
+        const unsigned char *poison_bytes = NULL;
+        size_t poison_bytes_len = 0;
+        if (poison_prepared && sub->poison_is_signed && sub->poison_signed_tx.len > 0) {
+            poison_bytes     = sub->poison_signed_tx.data;
+            poison_bytes_len = sub->poison_signed_tx.len;
+        }
         persist_save_subfactory_chain_entry(
             (persist_t *)mgr->persist, /* factory_id = */ 0,
             (uint32_t)sub_node_i,
@@ -4994,7 +5151,31 @@ static int lsp_subfactory_chain_advance_stateless_multi(
             sub->signed_tx.data, sub->signed_tx.len,
             sub->outputs[sstock_vout].amount_sats,
             chan_amounts, n_chans,
-            NULL, 0);
+            poison_bytes, poison_bytes_len);
+    }
+
+    /* Step 10b (poison + WT registration): register the now-stale chain[N-1]
+       + wire-co-signed L-stock poison TX with the watchtower, as legacy does. */
+    if (mgr->watchtower && sub->ps_chain_len >= 1) {
+        int have_poison = (poison_prepared && sub->poison_is_signed &&
+                           sub->poison_signed_tx.len > 0);
+        if (have_poison)
+            printf("LSP-stateless: sub-factory MULTI %d.%d wire-ceremony poison TX "
+                   "signed (%zu bytes, sales-stock %llu sats -> %zu clients)\n",
+                   leaf_side, sub_idx_in_leaf, sub->poison_signed_tx.len,
+                   (unsigned long long)wt_old_sstock_amount, wt_old_n_chans);
+        else
+            fprintf(stderr, "LSP-stateless subfactory MULTI advance: registering "
+                    "watchtower without poison TX -- DEGRADED\n");
+        watchtower_watch_subfactory_node(mgr->watchtower,
+            (uint32_t)sub_node_i,
+            wt_old_chain_txid,
+            sub->signed_tx.data, sub->signed_tx.len,
+            have_poison ? sub->poison_signed_tx.data : NULL,
+            have_poison ? sub->poison_signed_tx.len  : 0,
+            wt_old_chan_amounts, wt_old_n_chans,
+            wt_old_sstock_amount);
+        factory_session_reset_poison(f, sub_node_i);
     }
 
     printf("LSP-stateless subfactory MULTI-INPUT advance (n_inputs=%zu) DONE\n", n_inputs);
@@ -5055,19 +5236,60 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
             leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);
     }
 
+    /* Step 1.5 (poison prep): snapshot the soon-to-be-stale chain[N-1] state
+       (txid + per-channel amounts + sales-stock) BEFORE advance_unsigned
+       mutates sub->txid / sub->outputs[], then build the unsigned L-stock
+       poison TX (mirror of legacy lsp_subfactory_chain_advance Step "poison
+       TX prep" + Tier B 1eda8aa).  Clients run the same prepare from their
+       own OLD snapshot so both sides reach a byte-identical sighash.  Poison
+       only when the watchtower is configured (LSP-only gate). */
+    const uint64_t POISON_FEE_SATS = 1000;
+    int poison_prepared = 0;
+    unsigned char wt_old_chain_txid[32];
+    memcpy(wt_old_chain_txid, sub->txid, 32);
+    size_t wt_old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
+    if (wt_old_n_chans > 16) wt_old_n_chans = 16;
+    uint64_t wt_old_chan_amounts[16] = {0};
+    for (size_t ci = 0; ci < wt_old_n_chans; ci++)
+        wt_old_chan_amounts[ci] = sub->outputs[ci].amount_sats;
+    uint64_t wt_old_sstock_amount = (sub->n_outputs > 0)
+        ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
+    if (mgr->watchtower &&
+        wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
+        if (factory_session_prepare_poison_tx_subfactory(
+                f, sub_node_i, wt_old_chain_txid, (uint32_t)wt_old_n_chans,
+                wt_old_sstock_amount, POISON_FEE_SATS)) {
+            poison_prepared = 1;  /* init_node_poison after state init */
+        } else {
+            fprintf(stderr,
+                    "LSP-stateless subfactory advance: poison TX prep failed "
+                    "(sstock=%llu sats, n_chans=%zu) -- NULL poison_tx\n",
+                    (unsigned long long)wt_old_sstock_amount, wt_old_n_chans);
+        }
+    }
+
     /* Step 1: factory_subfactory_chain_advance_unsigned — rebuild unsigned_tx. */
     if (!factory_subfactory_chain_advance_unsigned(f, leaf_side,
                                                     sub_idx_in_leaf,
                                                     channel_idx_in_sub,
                                                     delta_sats)) {
         fprintf(stderr, "LSP-stateless subfactory advance: advance_unsigned failed\n");
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
 
-    /* Step 2: init session (state only — no poison in MVP). */
+    /* Step 2: init state session + (when prepared) poison session. */
     if (!factory_session_init_node(f, sub_node_i)) {
         fprintf(stderr, "LSP-stateless subfactory advance: session init failed\n");
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
+    }
+    if (poison_prepared &&
+        !factory_session_init_node_poison(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless subfactory advance: poison session init "
+                "failed -- degrading\n");
+        factory_session_reset_poison(f, sub_node_i);
+        poison_prepared = 0;
     }
 
     /* Step 3: send PROPOSE_INTENT to each sub-client (NO LSP nonce). */
@@ -5083,8 +5305,10 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     }
     cJSON_Delete(propose);
 
-    /* Step 4: collect CLIENT_PUBNONCES from each client. */
+    /* Step 4: collect CLIENT_PUBNONCES from each client (state + poison). */
     unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
+    memset(all_poison_pubnonces, 0, sizeof(all_poison_pubnonces));
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_msg_t nmsg;
@@ -5095,18 +5319,31 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
                     "LSP-stateless: expected CLIENT_PUBNONCES from client %u, got 0x%02x\n",
                     sub_clients[ci], nmsg.msg_type);
             if (nmsg.json) cJSON_Delete(nmsg.json);
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
         }
-        unsigned char client_pn_buf[66];
-        if (!wire_parse_subfactory_client_pubnonces(nmsg.json, client_pn_buf, 1)) {
+        unsigned char client_pn_buf[66], client_poison_pn[66];
+        int parse_rc = wire_parse_subfactory_client_pubnonces(
+            nmsg.json, client_pn_buf, 1,
+            poison_prepared ? client_poison_pn : NULL);
+        if (parse_rc == 0) {
             cJSON_Delete(nmsg.json);
             fprintf(stderr, "LSP-stateless: parse CLIENT_PUBNONCES failed\n");
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
         }
         cJSON_Delete(nmsg.json);
+        if (poison_prepared && parse_rc < 2) {
+            fprintf(stderr, "LSP-stateless: client %u omitted poison nonce -- "
+                    "degrading to NULL poison_tx\n", sub_clients[ci]);
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        }
         int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
-        if (client_slot < 0) return 0;
+        if (client_slot < 0) { factory_session_reset_poison(f, sub_node_i); return 0; }
         memcpy(all_pubnonces[client_slot], client_pn_buf, 66);
+        if (poison_prepared)
+            memcpy(all_poison_pubnonces[client_slot], client_poison_pn, 66);
     }
 
     /* Step 5 (THE CRITICAL ATOMIC BLOCK): gen LSP secnonce, set all nonces,
@@ -5131,26 +5368,74 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     musig_pubnonce_serialize(lsp->ctx, lsp_pubnonce_ser, &lsp_pubnonce);
     memcpy(all_pubnonces[lsp_slot], lsp_pubnonce_ser, 66);
 
-    /* Set every nonce on the session. */
+    /* Poison (same atomic block): generate the LSP poison secnonce HERE, after
+       the Step-4 recv, alongside the state secnonce.  It is a loop-local
+       zeroed by musig_create_partial_sig below before the Step-7 recv -- the
+       stateless invariant holds for the poison secnonce exactly as for state. */
+    secp256k1_musig_secnonce lsp_poison_secnonce;
+    secp256k1_musig_pubnonce lsp_poison_pubnonce;
+    unsigned char lsp_poison_pn_ser[66] = {0};
+    if (poison_prepared) {
+        if (!musig_generate_nonce(lsp->ctx, &lsp_poison_secnonce,
+                                   &lsp_poison_pubnonce, lsp_seckey,
+                                   &lsp->lsp_pubkey, &sub->keyagg.cache)) {
+            fprintf(stderr, "LSP-stateless subfactory: poison nonce gen failed "
+                    "-- degrading\n");
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        } else {
+            musig_pubnonce_serialize(lsp->ctx, lsp_poison_pn_ser, &lsp_poison_pubnonce);
+            memcpy(all_poison_pubnonces[lsp_slot], lsp_poison_pn_ser, 66);
+        }
+    }
+
+    /* Set every signer's nonce on the state session. */
     for (size_t s = 0; s < sub->n_signers; s++) {
         secp256k1_musig_pubnonce pn;
         if (!musig_pubnonce_parse(lsp->ctx, &pn, all_pubnonces[s]) ||
             !factory_session_set_nonce(f, sub_node_i, s, &pn)) {
             memset(lsp_seckey, 0, 32);
+            memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
             fprintf(stderr, "LSP-stateless subfactory: set_nonce[%zu] failed\n", s);
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
+        }
+    }
+    /* Set every signer's nonce on the poison session (degrade on failure). */
+    if (poison_prepared) {
+        for (size_t s = 0; s < sub->n_signers; s++) {
+            secp256k1_musig_pubnonce ppn;
+            if (!musig_pubnonce_parse(lsp->ctx, &ppn, all_poison_pubnonces[s]) ||
+                !factory_session_set_nonce_poison(f, sub_node_i, s, &ppn)) {
+                fprintf(stderr, "LSP-stateless subfactory: poison set_nonce[%zu] "
+                        "failed -- degrading\n", s);
+                factory_session_reset_poison(f, sub_node_i);
+                poison_prepared = 0;
+                break;
+            }
         }
     }
 
     if (!factory_session_finalize_node(f, sub_node_i)) {
         memset(lsp_seckey, 0, 32);
+        memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
         fprintf(stderr, "LSP-stateless subfactory: finalize_node failed\n");
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
+    }
+    if (poison_prepared &&
+        !factory_session_finalize_node_poison(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless subfactory: poison finalize failed -- "
+                "degrading\n");
+        factory_session_reset_poison(f, sub_node_i);
+        poison_prepared = 0;
     }
 
     secp256k1_keypair lsp_kp;
     if (!secp256k1_keypair_create(lsp->ctx, &lsp_kp, lsp_seckey)) {
         memset(lsp_seckey, 0, 32);
+        memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
     memset(lsp_seckey, 0, 32);
@@ -5158,37 +5443,73 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     secp256k1_musig_partial_sig lsp_psig;
     if (!musig_create_partial_sig(lsp->ctx, &lsp_psig, &lsp_secnonce, &lsp_kp,
                                     &sub->signing_session)) {
+        memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
         fprintf(stderr, "LSP-stateless subfactory: create_partial_sig failed\n");
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
     /* lsp_secnonce zeroed by musig_create_partial_sig.
-       INVARIANT: no LSP secnonce held across the wire recv that follows. */
+       INVARIANT: no LSP state secnonce held across the wire recv that follows. */
 
     unsigned char lsp_psig_ser[32];
     musig_partial_sig_serialize(lsp->ctx, lsp_psig_ser, &lsp_psig);
 
     if (!factory_session_set_partial_sig(f, sub_node_i, (size_t)lsp_slot, &lsp_psig)) {
+        memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
     }
 
+    /* Poison: create the LSP poison partial sig (zeros lsp_poison_secnonce) in
+       the SAME atomic block -- no wire_recv between gen and zero. */
+    unsigned char lsp_poison_psig_ser[32] = {0};
+    if (poison_prepared) {
+        secp256k1_musig_partial_sig lsp_poison_psig;
+        int pz_ok =
+            musig_create_partial_sig(lsp->ctx, &lsp_poison_psig,
+                                       &lsp_poison_secnonce, &lsp_kp,
+                                       &sub->poison_signing_session) &&
+            factory_session_set_partial_sig_poison(f, sub_node_i,
+                                                     (size_t)lsp_slot, &lsp_poison_psig);
+        /* Zero on every path: create_partial_sig zeroed it on success; on
+           failure clear the generated-but-unconsumed secnonce so none lingers
+           across the Step-7 recv. */
+        memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
+        if (!pz_ok) {
+            fprintf(stderr, "LSP-stateless subfactory: LSP poison psig failed -- "
+                    "degrading\n");
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        } else {
+            musig_partial_sig_serialize(lsp->ctx, lsp_poison_psig_ser, &lsp_poison_psig);
+        }
+    } else {
+        memset(&lsp_poison_secnonce, 0, sizeof(lsp_poison_secnonce));
+    }
+
     /* Step 6: send LSP_RESPONSE to each client (per-client copy so each can
-       individually finalize_node + sign).  Single-input -> 1 element each. */
+       individually finalize_node + sign).  Single-input -> 1 element each.
+       Carries the LSP poison pubnonce + psig when poison is still active. */
     cJSON *response = wire_build_subfactory_lsp_response(lsp_pubnonce_ser,
                                                           lsp_psig_ser, 1,
                                                           (const unsigned char *)all_pubnonces,
-                                                          (uint32_t)(sub->n_signers * 66));
+                                                          (uint32_t)(sub->n_signers * 66),
+                                                          poison_prepared ? (const unsigned char *)all_poison_pubnonces : NULL,
+                                                          poison_prepared ? (uint32_t)(sub->n_signers * 66) : 0,
+                                                          poison_prepared ? lsp_poison_psig_ser : NULL);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_LSP_RESPONSE, response)) {
             cJSON_Delete(response);
             fprintf(stderr, "LSP-stateless: send LSP_RESPONSE failed for client %u\n",
                     sub_clients[ci]);
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
         }
     }
     cJSON_Delete(response);
 
-    /* Step 7: collect CLIENT_FINAL_PSIGS from each client. */
+    /* Step 7: collect CLIENT_FINAL_PSIGS from each client (state + poison). */
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_msg_t pmsg;
@@ -5201,27 +5522,57 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
             if (pmsg.json) cJSON_Delete(pmsg.json);
             return 0;
         }
-        unsigned char client_psig_buf[32];
-        if (!wire_parse_subfactory_client_final_psigs(pmsg.json, client_psig_buf, 1)) {
+        unsigned char client_psig_buf[32], client_poison_psig_ser[32];
+        int parse_rc = wire_parse_subfactory_client_final_psigs(
+            pmsg.json, client_psig_buf, 1,
+            poison_prepared ? client_poison_psig_ser : NULL);
+        if (parse_rc == 0) {
             cJSON_Delete(pmsg.json);
             fprintf(stderr, "LSP-stateless: parse CLIENT_FINAL_PSIGS failed\n");
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
         }
         cJSON_Delete(pmsg.json);
+        if (poison_prepared && parse_rc < 2) {
+            fprintf(stderr, "LSP-stateless: client %u omitted poison psig -- "
+                    "degrading\n", sub_clients[ci]);
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        }
         int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
-        if (client_slot < 0) return 0;
+        if (client_slot < 0) { factory_session_reset_poison(f, sub_node_i); return 0; }
         secp256k1_musig_partial_sig client_psig;
         if (!musig_partial_sig_parse(lsp->ctx, &client_psig, client_psig_buf) ||
             !factory_session_set_partial_sig(f, sub_node_i, (size_t)client_slot, &client_psig)) {
             fprintf(stderr, "LSP-stateless: set client psig failed for %u\n", sub_clients[ci]);
+            factory_session_reset_poison(f, sub_node_i);
             return 0;
+        }
+        if (poison_prepared) {
+            secp256k1_musig_partial_sig client_poison_psig;
+            if (!musig_partial_sig_parse(lsp->ctx, &client_poison_psig, client_poison_psig_ser) ||
+                !factory_session_set_partial_sig_poison(f, sub_node_i,
+                                                          (size_t)client_slot, &client_poison_psig)) {
+                fprintf(stderr, "LSP-stateless: set client poison psig failed for %u "
+                        "-- degrading\n", sub_clients[ci]);
+                factory_session_reset_poison(f, sub_node_i);
+                poison_prepared = 0;
+            }
         }
     }
 
-    /* Step 8: aggregate + complete_node (attaches witness to signed_tx). */
+    /* Step 8: aggregate + complete_node (attaches witness to signed_tx) + poison. */
     if (!factory_session_complete_node(f, sub_node_i)) {
         fprintf(stderr, "LSP-stateless subfactory: complete_node failed\n");
+        factory_session_reset_poison(f, sub_node_i);
         return 0;
+    }
+    if (poison_prepared &&
+        !factory_session_complete_node_poison(f, sub_node_i)) {
+        fprintf(stderr, "LSP-stateless subfactory: poison complete failed -- "
+                "degrading\n");
+        factory_session_reset_poison(f, sub_node_i);
+        poison_prepared = 0;
     }
 
     /* Step 9: send DONE to each client. */
@@ -5248,6 +5599,12 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
         if (n_chans > 16) n_chans = 16;
         for (int ci = 0; ci < n_chans; ci++)
             chan_amounts[ci] = sub->outputs[ci].amount_sats;
+        const unsigned char *poison_bytes = NULL;
+        size_t poison_bytes_len = 0;
+        if (poison_prepared && sub->poison_is_signed && sub->poison_signed_tx.len > 0) {
+            poison_bytes     = sub->poison_signed_tx.data;
+            poison_bytes_len = sub->poison_signed_tx.len;
+        }
         persist_save_subfactory_chain_entry(
             (persist_t *)mgr->persist, /* factory_id = */ 0,
             (uint32_t)sub_node_i,
@@ -5257,7 +5614,40 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
             sub->signed_tx.data, sub->signed_tx.len,
             sub->outputs[sstock_vout].amount_sats,
             chan_amounts, n_chans,
-            NULL, 0);
+            poison_bytes, poison_bytes_len);
+    }
+
+    /* Step 10b (poison + WT registration): register the now-stale chain[N-1]
+       with the watchtower along with the wire-co-signed L-stock poison TX,
+       exactly as the legacy lsp_subfactory_chain_advance does.  poison_tx is
+       NULL when poison degraded -- response_tx broadcast still works, but the
+       breach cannot redistribute the sales-stock. */
+    if (mgr->watchtower && sub->ps_chain_len >= 1) {
+        int have_poison = (poison_prepared && sub->poison_is_signed &&
+                           sub->poison_signed_tx.len > 0);
+        if (have_poison)
+            printf("LSP-stateless: sub-factory %d.%d wire-ceremony poison TX signed "
+                   "(%zu bytes, sales-stock %llu sats -> %zu clients)\n",
+                   leaf_side, sub_idx_in_leaf, sub->poison_signed_tx.len,
+                   (unsigned long long)wt_old_sstock_amount, wt_old_n_chans);
+        else
+            fprintf(stderr,
+                    "LSP-stateless subfactory advance: registering watchtower "
+                    "without poison TX (poison_prepared=%d, poison_is_signed=%d) "
+                    "-- DEGRADED, breach cannot redistribute sales-stock\n",
+                    poison_prepared, sub->poison_is_signed);
+
+        watchtower_watch_subfactory_node(mgr->watchtower,
+            (uint32_t)sub_node_i,
+            wt_old_chain_txid,
+            sub->signed_tx.data, sub->signed_tx.len,
+            have_poison ? sub->poison_signed_tx.data : NULL,
+            have_poison ? sub->poison_signed_tx.len  : 0,
+            wt_old_chan_amounts, wt_old_n_chans,
+            wt_old_sstock_amount);
+
+        /* Watchtower copied the bytes; safe to free the poison-session state. */
+        factory_session_reset_poison(f, sub_node_i);
     }
 
     printf("LSP-stateless subfactory chain advance: leaf %d sub %d chan %d delta %llu sats DONE\n",

--- a/src/wire.c
+++ b/src/wire.c
@@ -1219,33 +1219,46 @@ int wire_parse_subfactory_propose_intent(const cJSON *json,
 }
 
 cJSON *wire_build_subfactory_client_pubnonces(const unsigned char *pubnonces_per_input,
-                                                uint32_t n_inputs) {
+                                                uint32_t n_inputs,
+                                                const unsigned char *poison_pubnonce) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !pubnonces_per_input) { if(j) cJSON_Delete(j); return NULL; }
     wire_json_add_hex(j, "pubnonces_per_input", pubnonces_per_input,
                       (size_t)n_inputs * 66);
+    if (poison_pubnonce)
+        wire_json_add_hex(j, "poison_pubnonce", poison_pubnonce, 66);
     cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
     return j;
 }
 
 int wire_parse_subfactory_client_pubnonces(const cJSON *json,
                                              unsigned char *out_pubnonces_per_input,
-                                             uint32_t expected_n_inputs) {
+                                             uint32_t expected_n_inputs,
+                                             unsigned char *out_poison_pubnonce) {
     if (!json || !out_pubnonces_per_input) return 0;
     cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
     if (!ni || !cJSON_IsNumber(ni)) return 0;
     if ((uint32_t)ni->valuedouble != expected_n_inputs) return 0;
-    return wire_json_get_hex(json, "pubnonces_per_input",
-                               out_pubnonces_per_input,
-                               (size_t)expected_n_inputs * 66) ==
-           (int)((size_t)expected_n_inputs * 66);
+    if (wire_json_get_hex(json, "pubnonces_per_input",
+                            out_pubnonces_per_input,
+                            (size_t)expected_n_inputs * 66) !=
+        (int)((size_t)expected_n_inputs * 66)) return 0;
+    if (out_poison_pubnonce && cJSON_GetObjectItem(json, "poison_pubnonce")) {
+        if (wire_json_get_hex(json, "poison_pubnonce", out_poison_pubnonce, 66) != 66)
+            return 0;
+        return 2;
+    }
+    return 1;
 }
 
 cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per_input,
                                             const unsigned char *lsp_psigs_per_input,
                                             uint32_t n_inputs,
                                             const unsigned char *all_signer_pubnonces_flat,
-                                            uint32_t all_signer_pubnonces_len) {
+                                            uint32_t all_signer_pubnonces_len,
+                                            const unsigned char *all_signer_poison_pubnonces_flat,
+                                            uint32_t all_signer_poison_pubnonces_len,
+                                            const unsigned char *lsp_poison_psig) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !lsp_pubnonces_per_input || !lsp_psigs_per_input) {
         if (j) cJSON_Delete(j);
@@ -1261,6 +1274,18 @@ cJSON *wire_build_subfactory_lsp_response(const unsigned char *lsp_pubnonces_per
         cJSON_AddNumberToObject(j, "all_signer_pubnonces_len",
                                 (double)all_signer_pubnonces_len);
     }
+    /* Poison: forward the full all-signer poison-nonce matrix (the poison
+       session is N-of-N like state, so each client needs every co-signer's
+       poison nonce to finalize) + the LSP poison partial sig. */
+    if (all_signer_poison_pubnonces_flat && all_signer_poison_pubnonces_len > 0 &&
+        lsp_poison_psig) {
+        wire_json_add_hex(j, "all_signer_poison_pubnonces",
+                          all_signer_poison_pubnonces_flat,
+                          (size_t)all_signer_poison_pubnonces_len);
+        cJSON_AddNumberToObject(j, "all_signer_poison_pubnonces_len",
+                                (double)all_signer_poison_pubnonces_len);
+        wire_json_add_hex(j, "lsp_poison_psig", lsp_poison_psig, 32);
+    }
     cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
     return j;
 }
@@ -1271,7 +1296,11 @@ int wire_parse_subfactory_lsp_response(const cJSON *json,
                                          uint32_t expected_n_inputs,
                                          unsigned char *out_all_signer_pubnonces_flat,
                                          uint32_t max_all_signer_pubnonces_len,
-                                         uint32_t *out_all_signer_pubnonces_len) {
+                                         uint32_t *out_all_signer_pubnonces_len,
+                                         unsigned char *out_all_signer_poison_pubnonces_flat,
+                                         uint32_t max_all_signer_poison_pubnonces_len,
+                                         uint32_t *out_all_signer_poison_pubnonces_len,
+                                         unsigned char *out_lsp_poison_psig) {
     if (!json || !out_lsp_pubnonces_per_input || !out_lsp_psigs_per_input) return 0;
     cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
     if (!ni || !cJSON_IsNumber(ni)) return 0;
@@ -1296,30 +1325,56 @@ int wire_parse_subfactory_lsp_response(const cJSON *json,
             *out_all_signer_pubnonces_len = alen;
         }
     }
+    if (out_all_signer_poison_pubnonces_len) *out_all_signer_poison_pubnonces_len = 0;
+    if (out_all_signer_poison_pubnonces_flat && out_all_signer_poison_pubnonces_len &&
+        out_lsp_poison_psig &&
+        cJSON_GetObjectItem(json, "all_signer_poison_pubnonces")) {
+        cJSON *pl = cJSON_GetObjectItem(json, "all_signer_poison_pubnonces_len");
+        if (!pl || !cJSON_IsNumber(pl)) return 0;
+        uint32_t plen = (uint32_t)pl->valuedouble;
+        if (plen > max_all_signer_poison_pubnonces_len) return 0;
+        if (wire_json_get_hex(json, "all_signer_poison_pubnonces",
+                                out_all_signer_poison_pubnonces_flat, (size_t)plen) !=
+            (int)plen) return 0;
+        if (wire_json_get_hex(json, "lsp_poison_psig", out_lsp_poison_psig, 32) != 32)
+            return 0;
+        *out_all_signer_poison_pubnonces_len = plen;
+        return 2;
+    }
     return 1;
 }
 
 cJSON *wire_build_subfactory_client_final_psigs(const unsigned char *psigs_per_input,
-                                                  uint32_t n_inputs) {
+                                                  uint32_t n_inputs,
+                                                  const unsigned char *poison_psig) {
     cJSON *j = cJSON_CreateObject();
     if (!j || !psigs_per_input) { if(j) cJSON_Delete(j); return NULL; }
     wire_json_add_hex(j, "psigs_per_input", psigs_per_input,
                       (size_t)n_inputs * 32);
+    if (poison_psig)
+        wire_json_add_hex(j, "poison_psig", poison_psig, 32);
     cJSON_AddNumberToObject(j, "n_inputs", (double)n_inputs);
     return j;
 }
 
 int wire_parse_subfactory_client_final_psigs(const cJSON *json,
                                                unsigned char *out_psigs_per_input,
-                                               uint32_t expected_n_inputs) {
+                                               uint32_t expected_n_inputs,
+                                               unsigned char *out_poison_psig) {
     if (!json || !out_psigs_per_input) return 0;
     cJSON *ni = cJSON_GetObjectItem(json, "n_inputs");
     if (!ni || !cJSON_IsNumber(ni)) return 0;
     if ((uint32_t)ni->valuedouble != expected_n_inputs) return 0;
-    return wire_json_get_hex(json, "psigs_per_input",
-                               out_psigs_per_input,
-                               (size_t)expected_n_inputs * 32) ==
-           (int)((size_t)expected_n_inputs * 32);
+    if (wire_json_get_hex(json, "psigs_per_input",
+                            out_psigs_per_input,
+                            (size_t)expected_n_inputs * 32) !=
+        (int)((size_t)expected_n_inputs * 32)) return 0;
+    if (out_poison_psig && cJSON_GetObjectItem(json, "poison_psig")) {
+        if (wire_json_get_hex(json, "poison_psig", out_poison_psig, 32) != 32)
+            return 0;
+        return 2;
+    }
+    return 1;
 }
 
 /* Phase 1e.2.a -- Tier B state advance reversed flow wire codec. */


### PR DESCRIPTION
## Summary

Closes a **stateless security gap** caught by the regtest breach matrix: the BIP-327 stateless sub-factory chain-advance signed the new state TX but **never prepared/signed the L-stock poison TX nor registered it with the watchtower** (it was marked "poison + WT registration deferred to Phase 1e.1.c / no poison in stateless MVP"). Result: a revoked **stateless** sub-factory broadcast went **unpenalized** — `test_regtest_k2_subfactory_breach` passes on legacy but failed on stateless (`watchtower did not detect sub-factory breach`).

This wires the full poison ceremony into the stateless sub-factory advance (single- and multi-input), mirroring the legacy sub-factory poison path and the Tier B stateless poison wiring.

## Changes
- **Wire codec** (`wire.h`, `wire.c`): optional poison fields on `MSG_SUBFACTORY_CLIENT_PUBNONCES` (0x7E), `MSG_SUBFACTORY_LSP_RESPONSE` (0x7F — carries the **full all-signer poison-nonce matrix**, since the sub-factory poison session is N-of-N, not 2-of-2), and `MSG_SUBFACTORY_CLIENT_FINAL_PSIGS` (0x80). Backward-compatible (omitted when no poison).
- **LSP** (`lsp_subfactory_chain_advance_stateless` + `_multi`): snapshot old chain[N-1], `prepare_poison_tx_subfactory` + `init_node_poison` when a watchtower is configured; generate the LSP poison secnonce in the **same atomic block** as the state secnonce (after the client-pubnonce recv), sign (zeroing the secnonce before any further recv), `complete_node_poison`, then `watchtower_watch_subfactory_node` with the signed poison TX + persist. Graceful state-only degrade if poison prep fails (mirrors legacy).
- **Client** (`client_handle_subfactory_advance_stateless` + `_multi`): deterministically prepares the same poison TX, contributes poison nonce + psig, own secnonce zeroed before DONE.

## Stateless invariant
Every LSP secnonce (state **and** poison) is generated only after the client-pubnonce recv, inside an atomic block with no `wire_recv`, and zeroed by `musig_create_partial_sig` before the next recv. Verified by code review.

## Validation (regtest, `SS_MUSIG_STATELESS=1`)
- **`test_regtest_k2_subfactory_breach`: PASS** — `sub-factory ... wire-ceremony poison TX signed`, `SUB-FACTORY BREACH DETECTED — 1 penalty tx broadcast`, poison TX confirmed with 2 per-client P2TR outputs (ran the stateless path; legacy poison-sign count = 0).
- Regressions green: `test_regtest_subfactory_chain_advance_multi` PASS, `test_regtest_tier_b_rollover_ps` PASS.
- Unit suite **1472/1472**; ASan + build-release clean.

Stacked on #334 (stateless-aware harness). Completes the stateless ceremony set; with this merged, stateless sub-factory advances are at parity with legacy on breach detection — a prerequisite for flipping the default (Phase 2).
