### PR TITLE
fix(cheat-engine): wire CL7 cheat-client into stateless leaf advance

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -4304,6 +4304,24 @@ static int client_handle_leaf_advance_stateless(int fd,
                               ? ps_node->outputs[old_n_outputs_c - 1].amount_sats
                               : 0;
 
+    /* CL7: snapshot pre-advance leaf signed_tx for --cheat-client.
+       Mirrors the legacy path in client_handle_leaf_advance below; the
+       stateless dispatch in MuSig2 redesign #271/#330 bypassed the
+       legacy CL7 hook so test_regtest_cheat_client failed under
+       SS_MUSIG_STATELESS.  Broadcast lives after LEAF_ADVANCE_DONE. */
+    tx_buf_t cl7_cheat_tx;
+    tx_buf_init(&cl7_cheat_tx, 0);
+    {
+        const char *cheat_env = getenv("SS_CHEAT_CLIENT_SIDE");
+        if (cheat_env && atoi(cheat_env) == leaf_side &&
+            had_old_signed_c && ps_node->signed_tx.len > 0) {
+            tx_buf_init(&cl7_cheat_tx, (int)ps_node->signed_tx.len);
+            memcpy(cl7_cheat_tx.data, ps_node->signed_tx.data,
+                   ps_node->signed_tx.len);
+            cl7_cheat_tx.len = ps_node->signed_tx.len;
+        }
+    }
+
     /* Step 1: advance local state to mirror the LSP. */
     int rc = factory_advance_leaf_unsigned(factory, leaf_side);
     if (rc <= 0) {
@@ -4626,6 +4644,26 @@ static int client_handle_leaf_advance_stateless(int fd,
         return 0;
     }
     if (done_msg.json) cJSON_Delete(done_msg.json);
+
+    /* CL7: broadcast the snapshotted stale leaf state now that the
+       advance is recorded.  LSP/standalone WT must respond with
+       response_tx + L-stock poison TX.  Mirrors the legacy path. */
+    if (cl7_cheat_tx.len > 0 && g_client_chain_rt) {
+        char hex[CL7_TX_HEX_MAX];
+        char txid_str[65] = {0};
+        if (cl7_cheat_tx.len * 2 + 1 < CL7_TX_HEX_MAX) {
+            hex_encode(cl7_cheat_tx.data, cl7_cheat_tx.len, hex);
+            int sent = regtest_send_raw_tx(g_client_chain_rt, hex, txid_str);
+            fprintf(stderr, "CL7: client %u broadcast STALE leaf %d state: %s (sent=%d)\n",
+                    my_index, leaf_side, txid_str, sent);
+            if (persist && sent) {
+                persist_log_broadcast(persist, txid_str,
+                                       "cheat_client_stale", hex,
+                                       "ok");
+            }
+        }
+    }
+    tx_buf_free(&cl7_cheat_tx);
 
     printf("Client-stateless %u: leaf %d advance complete\n", my_index, leaf_side);
     return 1;

--- a/tools/test_regtest_cheat_client.sh
+++ b/tools/test_regtest_cheat_client.sh
@@ -172,7 +172,7 @@ fi
 echo
 echo "=== Final result ==="
 if grep -q "LEAF ADVANCE TEST PASSED" "$LSP_LOG" 2>/dev/null; then
-    CL7_FIRED=$(grep -cE "CL7: client.*broadcast STALE" "$TMPDIR/client_${CHEATING_CLIENT}.log" 2>/dev/null || echo 0)
+    CL7_FIRED=$(grep -cE "CL7: client.*broadcast STALE" "$TMPDIR/client_${CHEATING_CLIENT}.log" 2>/dev/null)
     if [ "${CL7_FIRED:-0}" -ge 1 ]; then
         echo "  PASS: adversarial client CL7 path fired ($CL7_FIRED stale broadcasts), WT defense fired"
         


### PR DESCRIPTION
## Summary

Fixes `test_regtest_cheat_client` FAIL under `SS_MUSIG_STATELESS=1`. The `--cheat-client` CL7 snapshot+broadcast hook lives only in the legacy `client_handle_leaf_advance`; the MuSig2 stateless redesign (#271 / #330) added a separate `client_handle_leaf_advance_stateless` path but did not mirror the hook, so the adversarial client never broadcast its stale leaf state under stateless. The watchtower defense itself was working correctly — the test scaffold just had no cheat to react to.

## Confirmation it's a scaffold-only gap

- Legacy run (`SS_MUSIG_STATELESS` unset) on current `main`: PASS, 1 CL7 stale broadcast, 1 penalty TX.
- Stateless run pre-fix: FAIL with `no CL7 markers in cheating client log`.
- Same regression on the actual stateless code path: **none**. The WT successfully detects+penalizes when given a cheat to react to (proven by `k2_subfactory_breach` PASSing under stateless).

## Changes

### `src/client.c` — mirror the legacy CL7 block into the stateless handler

Two surgical additions to `client_handle_leaf_advance_stateless`:

1. **Snapshot** `ps_node->signed_tx` into `cl7_cheat_tx` immediately before `factory_advance_leaf_unsigned`, gated on `getenv("SS_CHEAT_CLIENT_SIDE") == leaf_side` and `had_old_signed_c && ps_node->signed_tx.len > 0`. Identical guard structure to the legacy block.
2. **Broadcast** the snapshot via `regtest_send_raw_tx` and journal it via `persist_log_broadcast(..., "cheat_client_stale", ...)` after `MSG_LEAF_ADVANCE_DONE` is received from the LSP. Then `tx_buf_free(&cl7_cheat_tx)` at the success return.

Honest clients (no `--cheat-client` set) hit the `if (cheat_env && ...)` gate as false → the buffer stays at len=0 → broadcast is skipped → free is a no-op. Zero-cost on the normal path.

### `tools/test_regtest_cheat_client.sh` — drop a spurious `|| echo 0`

`CL7_FIRED=$(grep -cE "..." 2>/dev/null || echo 0)` was producing `"0\n0"` when no markers were found (grep -c exits 1 on no-match and the fallback adds a second `0`), which choked the next integer test with `[: 0\n0: integer expression expected` and masked the real FAIL message. Dropped the fallback — `grep -c` always prints a count anyway.

## Validation (regtest)

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Legacy (`SS_MUSIG_STATELESS` unset) | PASS | **PASS** (no regression) |
| Stateless (`SS_MUSIG_STATELESS=1`) | **FAIL** (no CL7 markers) | **PASS** (1 CL7 stale broadcast, 1 penalty TX, 4 stateless markers in LSP log) |

Builds clean (`cmake --build build --target superscalar superscalar_client_bin -j2`, all targets up-to-date). No library, wire, or LSP code paths touched.

## Why this matters

The cheat-engine campaign tests (#218 / #281) are the security regression suite for client-initiated breaches. Having one of them silently regress under stateless would obscure any future real-issue with the CL7 trustless guarantee on the merged code path. This restores parity between legacy and stateless for `test_regtest_cheat_client` and brings the sweep from 31/34 → 32/34 PASS (only `cheat_daemon_rollover` = pending driver #250 and `wire_leaf_advance` = pre-existing legacy bug remaining).
