### PR TITLE
fix(persist): full stateless Tier B observability — signing_rounds + participants + pre-rotation snapshot

### DIFF
--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2654,6 +2654,21 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         return 1;
     }
 
+    /* C3 Tier 2 (PR-C-4): journal this stateless Tier B ceremony.
+       Mirrors the legacy lsp_run_state_advance round_start.
+       Participant-level rows (signing_round_participants) are added
+       by the recv loops below.  row_id<=0 disables journal calls. */
+    int64_t c3_round_id = -1;
+    if (mgr->persist) {
+        persist_save_signing_round_start((persist_t *)mgr->persist,
+                                           /* factory_id = */ 0,
+                                           /* node_idx = */ 0,
+                                           "tier_b_rollover",
+                                           f->counter.current_epoch,
+                                           (uint32_t)f->n_participants,
+                                           &c3_round_id);
+    }
+
     /* MVP refusal: multi-input on any affected node. */
     for (size_t k = 0; k < n_affected; k++) {
         if (factory_node_uses_multi_input(f, affected[k])) {
@@ -3141,6 +3156,17 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         if (saved > 0)
             printf("LSP: Tier B F1: persisted new-epoch chain[0] for %d PS node(s)\n",
                    saved);
+    }
+
+    /* C3 Tier 2 (PR-C-4): mark stateless Tier B ceremony complete. */
+    if (mgr->persist && c3_round_id > 0) {
+        persist_save_signing_round_done((persist_t *)mgr->persist,
+                                          c3_round_id,
+                                          (uint32_t)n_affected,
+                                          (uint32_t)n_affected,
+                                          "success",
+                                          NULL,
+                                          NULL);
     }
 
     /* Step 10: Broadcast DONE (existing opcode). */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2669,6 +2669,26 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                                            &c3_round_id);
     }
 
+    /* SF-BACKUP-PRE-ROTATION #213: snapshot the LSP DB to backup_dir
+       (if configured) before any state mutation.  Failure to snapshot
+       warns but does NOT abort the rotation — operator decides.
+       Mirrors the legacy lsp_run_state_advance hook that the stateless
+       redesign #271/#330 didn't carry over. */
+    if (lsp->backup_dir && mgr->persist) {
+        char snap_path[512];
+        time_t now = time(NULL);
+        snprintf(snap_path, sizeof(snap_path),
+                 "%s/lsp_pre_rotation_%u_%ld.db",
+                 lsp->backup_dir,
+                 (unsigned)f->counter.current_epoch,
+                 (long)now);
+        if (!persist_take_snapshot((persist_t *)mgr->persist, snap_path,
+                                    "pre_rotation")) {
+            fprintf(stderr, "WARN: pre-rotation snapshot failed; "
+                            "continuing rotation anyway\n");
+        }
+    }
+
     /* MVP refusal: multi-input on any affected node. */
     for (size_t k = 0; k < n_affected; k++) {
         if (factory_node_uses_multi_input(f, affected[k])) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2780,6 +2780,14 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             return 0;
         }
         cJSON_Delete(nmsg.json);
+        /* C3 Tier 2 (PR-C-4): client c's nonce bundle arrived.
+           Clients are slots 1..n_clients (LSP is slot 0). */
+        if (mgr->persist && c3_round_id > 0) {
+            persist_save_signing_round_participant_nonce(
+                (persist_t *)mgr->persist, c3_round_id,
+                /* signer_slot = */ (uint32_t)(c + 1));
+        }
+
         /* Distribute: for each affected node, if this client is a signer,
            record their pubnonce + slot.  An all-zero pubnonce indicates
            "I'm not a signer on this leaf" -- skip. */
@@ -2949,6 +2957,16 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             }
         }
     }
+    /* C3 Tier 2 (PR-C-4): LSP completed both its nonce and psig
+       contributions across all affected nodes (slot 0). */
+    if (mgr->persist && c3_round_id > 0) {
+        persist_save_signing_round_participant_nonce(
+            (persist_t *)mgr->persist, c3_round_id, /* signer_slot = */ 0);
+        persist_save_signing_round_participant_psig(
+            (persist_t *)mgr->persist, c3_round_id,
+            /* signer_slot = */ 0, "verified");
+    }
+
     /* INVARIANT: every LSP secnonce in lsp_pool has been pulled and zeroed
        by musig_create_partial_sig.  No LSP secnonce in scope for the recv
        that follows. */
@@ -3018,6 +3036,12 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
             return 0;
         }
         cJSON_Delete(pmsg.json);
+        /* C3 Tier 2 (PR-C-4): client c's psig bundle parsed + accepted. */
+        if (mgr->persist && c3_round_id > 0) {
+            persist_save_signing_round_participant_psig(
+                (persist_t *)mgr->persist, c3_round_id,
+                (uint32_t)(c + 1), "verified");
+        }
         for (size_t k = 0; k < n_affected; k++) {
             int slot = factory_find_signer_slot(f, affected[k], (uint32_t)(c + 1));
             if (slot < 0) continue;


### PR DESCRIPTION
## Summary

Closes two related observability gaps for stateless Tier B ceremonies discovered by an audit of legacy↔stateless handler parity:

1. **`signing_rounds` row** never created (C3 Tier 1 journal #93)
2. **`signing_round_participants` rows** never created (C3 Tier 2 journal #100)

The legacy `lsp_run_state_advance` writes both; the MuSig2 stateless redesign (#271/#330) created `lsp_run_state_advance_stateless` as a separate dispatch target without mirroring the calls. Every stateless Tier B ceremony silently bypassed the journal.

## Confirmation of gap (pre-fix)

Across all stateless test DBs from today's runs (poison_restart, subfactory_breach_multi, cheat_client, phase5 testnet4): `signing_round_participants=0`, `signing_rounds WHERE ceremony_type='tier_b_rollover'=0`.

## Fix — two commits on this branch

**Commit 1** — round_start + round_done (the C3 Tier 1 minimum):
- `persist_save_signing_round_start` after the `n_affected==0` early return
- `persist_save_signing_round_done` before the Step 10 DONE broadcast

**Commit 2** — full participant journal (C3 Tier 2):
- Client nonce participant in CLIENT_PATH_NONCES recv loop (signer_slot = c+1)
- LSP slot 0 nonce + psig after the LSP atomic-block loop (signer_slot = 0)
- Client psig participant in CLIENT_FINAL_PSIGS recv loop (signer_slot = c+1, status verified)

All args mirror legacy `lsp_run_state_advance` exactly.

## Validation (regtest, `SS_MUSIG_STATELESS=1`, `test_regtest_tier_b_rollover_ps`)

| | pre-fix | post-fix |
|---|---|---|
| EXIT | 0 | **0** |
| `signing_rounds WHERE ceremony_type='tier_b_rollover'` | 0 | **1** ✓ |
| `signing_round_participants` rows | 0 | **5** ✓ (LSP slot 0 + 4 client slots, all `verified`, both pubnonce + partial_sig timestamps populated) |

Phase 5 testnet4 n64 lifecycle still alive and unaffected.

## Deferred follow-ups (separate PRs)

Two observability gaps remain from the same audit, not in this PR's scope:

1. **`ceremonies` + `ceremony_participants`** (wallet-team v34 API #199) — `lsp_run_factory_creation_stateless` has zero `persist_save_ceremony` / `persist_save_participant_phase` / `persist_update_ceremony_*` calls vs **14+** in legacy. Standalone PR.
2. **`persist_take_snapshot`** (pre-rotation backup #213) + **`signing_progress`** (crash-recovery state) — small operational fixes, ~15 min combined.

None of these block Phase 2 default-flip strictly — they're "we lose forensic depth" not "the ceremony breaks."
