### PR TITLE
fix(persist): journal stateless factory creation in ceremonies + ceremony_participants

### DIFF
--- a/src/lsp.c
+++ b/src/lsp.c
@@ -356,6 +356,31 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     if (!lsp) return -1;
     factory_t *f = &lsp->factory;
 
+    /* SF-CEREMONY-HELPERS #199 / wallet-team v34 API: journal this
+       stateless factory creation in the ceremonies table.  Mirrors the
+       legacy lsp_run_factory_creation minimum (ceremony_id derivation
+       + persist_save_ceremony at entry; participant_phase(SIGNED) per
+       client + state transition to FINALIZED at the success return).
+       cer_persisted gate so failure-to-persist is non-fatal (continues
+       the ceremony, just no journal). */
+    unsigned char cer_id[8] = {0};
+    int cer_persisted = 0;
+    if (lsp->db) {
+        lsp_ceremony_derive_id(funding_txid,
+                                PERSIST_CEREMONY_TYPE_INITIAL,
+                                (uint64_t)lsp->factory.counter.current_epoch,
+                                cer_id);
+        if (!persist_save_ceremony(lsp->db, cer_id, funding_txid,
+                                    PERSIST_CEREMONY_TYPE_INITIAL,
+                                    /*parent_ceremony_id8_or_null*/ NULL,
+                                    /*started_at_block*/ 0,
+                                    /*deadline_block*/ cltv_timeout)) {
+            fprintf(stderr, "LSP-stateless: persist_save_ceremony failed (continuing)\n");
+        } else {
+            cer_persisted = 1;
+        }
+    }
+
     /* ---- Setup: identical to legacy lsp_run_factory_creation ---- */
     size_t n_total = 1 + lsp->n_clients;
     secp256k1_pubkey all_pubkeys[FACTORY_MAX_SIGNERS];
@@ -657,6 +682,32 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
             }
         }
         cJSON_Delete(ready);
+    }
+
+    /* SF-CEREMONY-HELPERS #199: complete the ceremony journal.  Per-
+       client participant rows at SIGNED phase, then state transition
+       to FINALIZED (the persist_update_ceremony_state hard guard
+       requires every participant row at SIGNED — see persist.c:6836). */
+    if (cer_persisted) {
+        for (size_t i = 0; i < lsp->n_clients; i++) {
+            unsigned char pk33[33];
+            size_t pk33_len = 33;
+            if (!secp256k1_ec_pubkey_serialize(lsp->ctx, pk33, &pk33_len,
+                                                 &lsp->client_pubkeys[i],
+                                                 SECP256K1_EC_COMPRESSED)) {
+                fprintf(stderr, "LSP-stateless: serialize client %zu pubkey failed (continuing)\n", i);
+                continue;
+            }
+            if (!persist_save_participant_phase(lsp->db, cer_id, pk33,
+                                                 PERSIST_CEREMONY_PHASE_SIGNED,
+                                                 NULL, NULL, 0, 0)) {
+                fprintf(stderr, "LSP-stateless: persist_save_participant_phase(SIGNED) client %zu failed (continuing)\n", i);
+            }
+        }
+        if (!persist_update_ceremony_state(lsp->db, cer_id,
+                                            PERSIST_CEREMONY_STATE_FINALIZED)) {
+            fprintf(stderr, "LSP-stateless: persist_update_ceremony_state(FINALIZED) failed (continuing)\n");
+        }
     }
 
     printf("LSP-stateless factory creation: %u nodes signed\n", (unsigned)f->n_nodes);


### PR DESCRIPTION
## Summary

Audit found that **`lsp_run_factory_creation_stateless` had ZERO** of the 14+ ceremony-table persist calls present in legacy `lsp_run_factory_creation` (SF-CEREMONY-HELPERS #199 / wallet-team v34 API). Every stateless factory creation silently bypassed the `ceremonies` + `ceremony_participants` tables — wallet-team API consumers see empty result sets for stateless factories.

## Confirmation

Across all stateless test DBs from today's runs (poison_restart, subfactory_breach_multi, phase5 testnet4): `ceremonies=0`, `ceremony_participants=0`. Legacy runs of the same tests populate both.

## Fix (minimum viable mirroring legacy)

**At function entry** (after the "Setup: identical to legacy" comment):
- `lsp_ceremony_derive_id(funding_txid, INITIAL, epoch, cer_id)`
- `persist_save_ceremony` with `PERSIST_CEREMONY_TYPE_INITIAL`, parent=NULL, started_at_block=0, deadline_block=cltv_timeout
- `cer_persisted` gate so a DB failure logs but does not abort the ceremony (mirrors legacy)

**At success exit** (before the trailing printf):
- Per-client: serialize the compressed pubkey, then `persist_save_participant_phase` with `PERSIST_CEREMONY_PHASE_SIGNED`
- `persist_update_ceremony_state` with `PERSIST_CEREMONY_STATE_FINALIZED`

The persist hard guard at `persist.c:6836` requires every participant row at SIGNED before allowing FINALIZED — that is why participant rows are recorded before the state transition.

## Validation (regtest, `SS_MUSIG_STATELESS=1`, `test_regtest_k2_subfactory_breach`)

| | pre-fix | post-fix |
|---|---|---|
| EXIT | 0 | **0** |
| `ceremonies` rows | 0 | **1** ✓ |
| `ceremony_participants` rows | 0 | **4** ✓ (4 clients × SIGNED) |

## Deferred follow-ups

- **Per-phase journaling** (SENT after MSG_FACTORY_PROPOSE recv, NONCED after nonces collected, etc.) — current patch records only the final SIGNED phase, which satisfies the FINALIZED guard. Per-phase breakdown adds debugging granularity, not functional safety.
- **`persist_update_ceremony_artifacts`** (funding TX hex + tree hexes) — legacy calls these too; can be added in the same fashion in a follow-up.

Neither blocks Phase 2 default-flip.
