### PR TITLE
feat(musig): MUSIG-PHASE-2 — flip stateless to default-on (SS_MUSIG_LEGACY=1 opt-out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to SuperScalar are documented here.
 
 ## Unreleased
 
+### MuSig2 Phase 2: stateless is now the default (#272)
+
+The BIP-327 stateless MuSig2 signer (introduced in #271 / #330 / #333 / #334 / #336 and validated through the full ceremony + breach + observability stack in #337-#341) is now the **default behavior**. The legacy nonce-pool path is opt-in via `SS_MUSIG_LEGACY=1`. The opt-in `SS_MUSIG_STATELESS=1` env var is now a no-op (the legacy path no longer reads it; test scripts that still set it continue to work but the variable has no effect).
+
+Migration:
+- **No action needed** if you want the new stateless behavior — it is the default.
+- If you need the legacy nonce-pool path for any reason (e.g. operational rollback), set `SS_MUSIG_LEGACY=1` in the LSP environment. This option will be removed in Phase 3.
+
 Major work merged since v0.1.13.  Roughly 220+ PRs (#88–#309).  Covers: PS k² sub-factories, full canonical mixed-arity + static-near-root, scale to N=128, all-four-paths wire-ceremony poison TX, Tier B multi-leaf state-advance ceremony, reorg correctness audit (R1–R6 mainnet pre-flight), schema migrations v22→v36, PTLC infrastructure (turnover ceremony journal, watchtower feed, security gating, production threading), cheat-engine campaign (CL1–CL7), ceremony crash-injection (API helpers + finalization guard + crash-checkpoints), dashboard buildout (12 tabs incl. Live Monitor, Defense Status, Payments, Ceremonies, TX Inventory, Outcomes, per-POV scoping), trustless watchtower schema design + Phase 1a, native Prometheus exporter, mainnet operator runbook, CLN bridge bLIP-56 skeleton (then split to external `superscalar-cln` repo), BIP-158 light-client end-to-end, splice wire-codec marked stub, and ~70 bug fixes.
 
 ### v0.1.14 audit phase 2 + 3 tests (PRs #88–#101)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ add_executable(test_superscalar
     tests/test_p2p.c
     tests/test_regtest.c
     tests/test_factory.c
+    tests/test_factory_multi_input_keyagg.c
     tests/test_tapscript.c
     tests/test_shachain.c
     tests/test_channel.c

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -206,6 +206,18 @@ typedef struct {
     int input_partial_sigs_received[FACTORY_MAX_OUTPUTS];   /* per-input count */
     size_t n_input_sessions;
 
+    /* SF-MULTI-KEYAGG (#283): per-input keyagg metadata.  Each input of a
+       multi-input chain advance spends a different prev-output: channel
+       outputs (2-of-2 {client_i, LSP} + factory_cltv merkle) for inputs
+       0..k-1, and the sub-factory sales-stock output (N-of-N, no merkle)
+       for input k.  These arrays are allocated by ensure_input_sessions_alloc
+       alongside input_signing_sessions and parallel-indexed by input_idx. */
+    musig_keyagg_t   *input_keyaggs;          /* length n_input_sessions */
+    uint32_t          input_signer_indices[FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS];
+    size_t            input_n_signers[FACTORY_MAX_OUTPUTS];
+    unsigned char     input_merkle_root[FACTORY_MAX_OUTPUTS][32];
+    int               input_has_merkle_root[FACTORY_MAX_OUTPUTS];
+
     /* PS sub-factory wiring (only used when ps_subfactory_arity > 1, the
        canonical k² shape from t/1242).
 
@@ -791,6 +803,21 @@ int factory_build_cooperative_close_unsigned(
 /* Find signer_slot for participant_idx in a node. Returns slot index or -1. */
 int factory_find_signer_slot(const factory_t *f, size_t node_idx,
                               uint32_t participant_idx);
+
+/* SF-MULTI-KEYAGG (#283): per-input signer-slot helpers.  Multi-input
+   sub-factory chain advance nodes use a per-input keyagg whose signer set
+   differs from the node-level signer set (channel inputs sign 2-of-2;
+   sales-stock input signs N-of-N).  These helpers expose the
+   participant->slot mapping so the wire layer can dispatch correctly. */
+int factory_session_get_input_signer_slot(const factory_t *f,
+                                            size_t node_idx,
+                                            size_t input_idx,
+                                            uint32_t participant_idx);
+int factory_session_input_signs(const factory_t *f,
+                                  size_t node_idx,
+                                  size_t input_idx,
+                                  uint32_t participant_idx);
+
 
 /* Initialize signing sessions for all nodes. Resets partial_sigs_received. */
 int factory_sessions_init(factory_t *f);

--- a/src/client.c
+++ b/src/client.c
@@ -1942,8 +1942,9 @@ int client_run_with_channels(secp256k1_context *ctx,
        function-scope locals stay confined. */
     int ss_stateless_creation = 0;
     {
-        const char *stateless = getenv("SS_MUSIG_STATELESS");
-        ss_stateless_creation = (stateless && stateless[0] == '1');
+        /* Phase 2 (#272): stateless is default-on; SS_MUSIG_LEGACY=1 opts out. */
+        const char *legacy = getenv("SS_MUSIG_LEGACY");
+        ss_stateless_creation = !(legacy && legacy[0] == '1');
     }
     /* Hoisted to function scope so done:/fail: can free it on either path.
        The stateless path leaves it NULL (free(NULL) is a no-op). */
@@ -4673,11 +4674,11 @@ int client_handle_leaf_advance(int fd, secp256k1_context *ctx,
                                  const secp256k1_keypair *keypair,
                                  factory_t *factory, uint32_t my_index,
                                  const wire_msg_t *propose_msg) {
-    /* Phase 1c (#271): when --musig-stateless is in effect, dispatch to the
-       reversed-order flow.  Legacy path below is untouched. */
+    /* Phase 2 (#272): stateless is default-on; SS_MUSIG_LEGACY=1 falls back
+       to the legacy nonce-pool path below.  Legacy path is deleted in Phase 3. */
     {
-        const char *stateless = getenv("SS_MUSIG_STATELESS");
-        if (stateless && stateless[0] == '1')
+        const char *legacy = getenv("SS_MUSIG_LEGACY");
+        if (!legacy || legacy[0] != '1')
             return client_handle_leaf_advance_stateless(fd, ctx, keypair,
                                                           factory, my_index,
                                                           propose_msg);

--- a/src/client.c
+++ b/src/client.c
@@ -3190,10 +3190,23 @@ static int client_handle_subfactory_advance_stateless_multi(
         free(my_secnonces); free(my_pn_flat);
         return 0;
     }
+    /* SF-MULTI-KEYAGG (#283): gen nonce against per-input keyagg cache, but
+       only for inputs this client signs.  Channel input j (0..k-1) is signed
+       only by LSP + client at sub->signer_indices[j+1]; sales-stock (input k)
+       is N-of-N.  For inputs we do NOT sign, write a 66-byte zero pubnonce as
+       a skipped-input wire marker and leave my_secnonces[i] zero so the later
+       per-input loop also skips us. */
     for (size_t i = 0; i < n_inputs; i++) {
+        if (!factory_session_input_signs(factory, sub_node_i, i, my_index)) {
+            /* Skipped input: 66 zero bytes on wire, no musig nonce gen, no
+               secnonce held to consume.  my_pn_flat slot already zero from
+               calloc; my_secnonces[i] already zero. */
+            continue;
+        }
         secp256k1_musig_pubnonce my_pubnonce_i;
         if (!musig_generate_nonce(ctx, &my_secnonces[i], &my_pubnonce_i,
-                                   my_seckey, &my_pubkey, &sub->keyagg.cache)) {
+                                   my_seckey, &my_pubkey,
+                                   &sub->input_keyaggs[i].cache)) {
             fprintf(stderr, "Client-stateless MULTI %u: nonce gen input %zu failed\n",
                     my_index, i);
             memset(my_seckey, 0, 32);
@@ -3201,10 +3214,13 @@ static int client_handle_subfactory_advance_stateless_multi(
             return 0;
         }
         musig_pubnonce_serialize(ctx, my_pn_flat + i * 66, &my_pubnonce_i);
-        if (!factory_session_set_nonce_input(factory, sub_node_i, i,
-                                             (size_t)my_slot, &my_pubnonce_i)) {
-            fprintf(stderr, "Client-stateless MULTI %u: set own nonce input %zu failed\n",
-                    my_index, i);
+        int my_slot_i = factory_session_get_input_signer_slot(
+            factory, sub_node_i, i, my_index);
+        if (my_slot_i < 0 ||
+            !factory_session_set_nonce_input(factory, sub_node_i, i,
+                                             (size_t)my_slot_i, &my_pubnonce_i)) {
+            fprintf(stderr, "Client-stateless MULTI %u: set own nonce input %zu (slot=%d) failed\n",
+                    my_index, i, my_slot_i);
             memset(my_seckey, 0, 32);
             free(my_secnonces); free(my_pn_flat);
             factory_session_reset_poison(factory, sub_node_i);
@@ -3299,8 +3315,19 @@ static int client_handle_subfactory_advance_stateless_multi(
         poison_prepared_c = 0;
     }
 
-    /* Per input: set LSP nonce + every other co-signer's nonce (skip own and
-       LSP slots, exactly like single-input), finalize, sign (zeros secnonce). */
+    /* SF-MULTI-KEYAGG (#283): per-input finalize+psig with per-input signer
+       slot remapping.  For each input i:
+         - If this client doesn't sign input i: skip the entire input (psig
+           slot stays zero, no secnonce to consume).
+         - Else: resolve own + LSP per-input slots, install LSP's nonce,
+           install every other co-signer's nonce (resolve participant via
+           node-level matrix row -> per-input slot; skip rows whose
+           participant isn't in this input's signer set), finalize, create
+           psig (zeros secnonce).
+       The matrix is indexed [node-level slot s][input i] (unchanged wire
+       layout); we translate each row's participant index through
+       factory_session_get_input_signer_slot.  Rows for participants outside
+       the per-input signer set carry zero placeholders and MUST be skipped. */
     unsigned char *my_psig_flat = calloc(n_inputs, 32);
     if (!my_psig_flat) {
         free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
@@ -3308,24 +3335,48 @@ static int client_handle_subfactory_advance_stateless_multi(
         return 0;
     }
     for (size_t i = 0; i < n_inputs; i++) {
+        if (!factory_session_input_signs(factory, sub_node_i, i, my_index)) {
+            /* Skipped input: nothing to sign, my_psig_flat slot stays zero. */
+            continue;
+        }
+        int my_slot_i = factory_session_get_input_signer_slot(
+            factory, sub_node_i, i, my_index);
+        int lsp_slot_i = factory_session_get_input_signer_slot(
+            factory, sub_node_i, i, 0);
+        if (my_slot_i < 0 || lsp_slot_i < 0) {
+            fprintf(stderr, "Client-stateless MULTI %u: per-input slot lookup "
+                    "failed input %zu (my=%d lsp=%d)\n",
+                    my_index, i, my_slot_i, lsp_slot_i);
+            goto fail;
+        }
         secp256k1_musig_pubnonce lsp_pubnonce_i;
         if (!musig_pubnonce_parse(ctx, &lsp_pubnonce_i, lsp_pn_flat + i * 66) ||
             !factory_session_set_nonce_input(factory, sub_node_i, i,
-                                             (size_t)lsp_slot, &lsp_pubnonce_i)) {
-            fprintf(stderr, "Client-stateless MULTI %u: set LSP nonce input %zu failed\n",
-                    my_index, i);
+                                             (size_t)lsp_slot_i, &lsp_pubnonce_i)) {
+            fprintf(stderr, "Client-stateless MULTI %u: set LSP nonce input %zu "
+                    "(per_input_slot=%d) failed\n", my_index, i, lsp_slot_i);
             goto fail;
         }
         if (have_matrix) {
             for (size_t scs = 0; scs < sub->n_signers; scs++) {
-                if (scs == (size_t)my_slot || scs == (size_t)lsp_slot) continue;
+                uint32_t participant = sub->signer_indices[scs];
+                /* Skip own + LSP (already set). */
+                if (participant == my_index || participant == 0) continue;
+                /* Skip co-signers who don't sign this input — their matrix
+                   row carries a 66-byte zero placeholder. */
+                int peer_slot_i = factory_session_get_input_signer_slot(
+                    factory, sub_node_i, i, participant);
+                if (peer_slot_i < 0) continue;
                 secp256k1_musig_pubnonce pn_s;
                 if (!musig_pubnonce_parse(ctx, &pn_s,
                         all_pn_per_input + (scs * n_inputs + i) * 66) ||
-                    !factory_session_set_nonce_input(factory, sub_node_i, i, scs, &pn_s)) {
+                    !factory_session_set_nonce_input(factory, sub_node_i, i,
+                                                     (size_t)peer_slot_i, &pn_s)) {
                     fprintf(stderr,
-                            "Client-stateless MULTI %u: set co-signer nonce[%zu] input %zu failed\n",
-                            my_index, scs, i);
+                            "Client-stateless MULTI %u: set co-signer nonce "
+                            "(participant=%u node_slot=%zu per_input_slot=%d) "
+                            "input %zu failed\n",
+                            my_index, participant, scs, peer_slot_i, i);
                     goto fail;
                 }
             }
@@ -3343,6 +3394,12 @@ static int client_handle_subfactory_advance_stateless_multi(
             goto fail;
         }
         /* my_secnonces[i] zeroed by musig_create_partial_sig. */
+        if (!factory_session_set_partial_sig_input(factory, sub_node_i, i,
+                                                    (size_t)my_slot_i, &my_psig_i)) {
+            fprintf(stderr, "Client-stateless MULTI %u: set own psig input %zu "
+                    "(per_input_slot=%d) failed\n", my_index, i, my_slot_i);
+            goto fail;
+        }
         musig_partial_sig_serialize(ctx, my_psig_flat + i * 32, &my_psig_i);
     }
 
@@ -3859,10 +3916,16 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
             factory_session_reset_poison(factory, (size_t)sub_node_i);
             return 0;
         }
+        /* SF-MULTI-KEYAGG (#283): gen against per-input keyagg, skip inputs we
+           don't sign (write 66-byte zero marker, leave secnonce zero). */
         for (size_t i = 0; i < n_inputs; i++) {
+            if (!factory_session_input_signs(factory, (size_t)sub_node_i, i, my_index)) {
+                /* my_pn_ser[i] already zero from calloc. */
+                continue;
+            }
             if (!musig_generate_nonce(ctx, &my_secnonces[i], &my_pubnonces[i],
                                        my_seckey, &my_pubkey,
-                                       &sub->keyagg.cache)) {
+                                       &sub->input_keyaggs[i].cache)) {
                 free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
                 memset(my_seckey, 0, 32);
                 factory_session_reset_poison(factory, (size_t)sub_node_i);
@@ -3951,16 +4014,28 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
             poison_prepared = 0;
         }
 
-        /* Set every nonce on every input session. */
+        /* SF-MULTI-KEYAGG (#283): set nonces per-input with slot remapping.
+           Matrix row s is the node-level signer slot.  For each (s, i):
+             - participant = sub->signer_indices[s]
+             - per_input_slot = factory_session_get_input_signer_slot(... participant)
+             - skip if per_input_slot < 0 (participant doesn't sign this input,
+               matrix cell holds a 66-byte zero placeholder).
+           Poison side-channel is still N-of-N, so poison nonces use the
+           node-level slot s directly. */
         for (size_t s = 0; s < sub->n_signers; s++) {
+            uint32_t participant = sub->signer_indices[s];
             for (size_t i = 0; i < n_inputs; i++) {
+                int per_input_slot = factory_session_get_input_signer_slot(
+                    factory, (size_t)sub_node_i, i, participant);
+                if (per_input_slot < 0) continue;  /* skipped — zero placeholder. */
                 secp256k1_musig_pubnonce pn;
                 if (!musig_pubnonce_parse(ctx, &pn,
                         all_pn_per_input + (s * n_inputs + i) * 66) ||
                     !factory_session_set_nonce_input(factory, (size_t)sub_node_i,
-                                                     i, s, &pn)) {
-                    fprintf(stderr, "Client %u: set_nonce_input(s=%zu, i=%zu) failed\n",
-                            my_index, s, i);
+                                                     i, (size_t)per_input_slot, &pn)) {
+                    fprintf(stderr, "Client %u: set_nonce_input(participant=%u "
+                            "node_slot=%zu per_input_slot=%d input=%zu) failed\n",
+                            my_index, participant, s, per_input_slot, i);
                     free(all_pn_per_input);
                     free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
                     memset(my_seckey, 0, 32);
@@ -3980,8 +4055,13 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
         }
         free(all_pn_per_input);
 
-        /* Finalize every input session + poison. */
+        /* SF-MULTI-KEYAGG (#283): finalize only the inputs we sign.  Inputs we
+           don't sign have only LSP's nonce installed (per-input slot 1 of a
+           2-of-2 keyagg) and missing nonce in the client slot -- finalize
+           would fail and we don't need the finalized session anyway. */
         for (size_t i = 0; i < n_inputs; i++) {
+            if (!factory_session_input_signs(factory, (size_t)sub_node_i, i, my_index))
+                continue;
             if (!factory_session_finalize_node_input(factory, (size_t)sub_node_i, i)) {
                 fprintf(stderr, "Client %u: finalize_input %zu failed\n",
                         my_index, i);
@@ -4005,7 +4085,23 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
             factory_session_reset_poison(factory, (size_t)sub_node_i);
             return 0;
         }
+        /* SF-MULTI-KEYAGG (#283): create + set partial sigs only for inputs we
+           sign.  Inputs we don't sign get a 32-byte zero psig marker on the
+           wire (my_psig_ser is zero-initialized from calloc). */
         for (size_t i = 0; i < n_inputs; i++) {
+            if (!factory_session_input_signs(factory, (size_t)sub_node_i, i, my_index))
+                continue;
+            int my_slot_i = factory_session_get_input_signer_slot(
+                factory, (size_t)sub_node_i, i, my_index);
+            if (my_slot_i < 0) {
+                fprintf(stderr, "Client %u: per-input slot lookup failed input %zu\n",
+                        my_index, i);
+                free(my_psig_ser);
+                free(my_secnonces); free(my_pubnonces); free(my_pn_ser);
+                memset(my_seckey, 0, 32);
+                factory_session_reset_poison(factory, (size_t)sub_node_i);
+                return 0;
+            }
             secp256k1_musig_partial_sig my_psig_i;
             if (!musig_create_partial_sig(ctx, &my_psig_i, &my_secnonces[i],
                                             keypair,
@@ -4018,6 +4114,8 @@ int client_handle_subfactory_advance(int fd, secp256k1_context *ctx,
                 factory_session_reset_poison(factory, (size_t)sub_node_i);
                 return 0;
             }
+            (void)factory_session_set_partial_sig_input(factory, (size_t)sub_node_i,
+                                                         i, (size_t)my_slot_i, &my_psig_i);
             musig_partial_sig_serialize(ctx, my_psig_ser[i], &my_psig_i);
         }
         free(my_secnonces); free(my_pubnonces); free(my_pn_ser);

--- a/src/factory.c
+++ b/src/factory.c
@@ -1649,6 +1649,37 @@ int factory_find_signer_slot(const factory_t *f, size_t node_idx,
     return -1;
 }
 
+/* SF-MULTI-KEYAGG (#283): return participant_idx's slot in the per-input
+   signer set for input_idx, or -1 if participant_idx does not sign this
+   input.  Requires that factory_session_init_node_input has already been
+   called for (node_idx, input_idx) so the per-input signer indices are
+   populated. */
+int factory_session_get_input_signer_slot(const factory_t *f,
+                                            size_t node_idx,
+                                            size_t input_idx,
+                                            uint32_t participant_idx) {
+    if (!f || node_idx >= f->n_nodes) return -1;
+    const factory_node_t *node = &f->nodes[node_idx];
+    if (!node->input_signing_sessions) return -1;
+    if (input_idx >= node->n_input_sessions) return -1;
+    size_t n = node->input_n_signers[input_idx];
+    if (n == 0 || n > (size_t)FACTORY_MAX_SIGNERS) return -1;
+    for (size_t i = 0; i < n; i++) {
+        if (node->input_signer_indices[input_idx][i] == participant_idx)
+            return (int)i;
+    }
+    return -1;
+}
+
+/* SF-MULTI-KEYAGG (#283): boolean wrapper. */
+int factory_session_input_signs(const factory_t *f,
+                                  size_t node_idx,
+                                  size_t input_idx,
+                                  uint32_t participant_idx) {
+    return factory_session_get_input_signer_slot(f, node_idx, input_idx,
+                                                   participant_idx) >= 0;
+}
+
 int factory_sessions_init(factory_t *f) {
     for (size_t i = 0; i < f->n_nodes; i++) {
         factory_node_t *node = &f->nodes[i];
@@ -2638,8 +2669,10 @@ static int ensure_input_sessions_alloc(factory_node_t *node) {
 
     free(node->input_signing_sessions);
     free(node->input_partial_sigs);
+    free(node->input_keyaggs);
     node->input_signing_sessions = NULL;
     node->input_partial_sigs = NULL;
+    node->input_keyaggs = NULL;
     node->n_input_sessions = 0;
 
     node->input_signing_sessions =
@@ -2656,9 +2689,143 @@ static int ensure_input_sessions_alloc(factory_node_t *node) {
         node->input_signing_sessions = NULL;
         return 0;
     }
+    /* SF-MULTI-KEYAGG (#283): per-input keyagg cache. */
+    node->input_keyaggs =
+        (musig_keyagg_t *)calloc(node->ps_n_prev_outputs,
+                                   sizeof(musig_keyagg_t));
+    if (!node->input_keyaggs) {
+        free(node->input_signing_sessions);
+        free(node->input_partial_sigs);
+        node->input_signing_sessions = NULL;
+        node->input_partial_sigs = NULL;
+        return 0;
+    }
     memset(node->input_partial_sigs_received, 0,
            sizeof(node->input_partial_sigs_received));
+    memset(node->input_n_signers, 0, sizeof(node->input_n_signers));
+    memset(node->input_signer_indices, 0, sizeof(node->input_signer_indices));
+    memset(node->input_merkle_root, 0, sizeof(node->input_merkle_root));
+    memset(node->input_has_merkle_root, 0, sizeof(node->input_has_merkle_root));
     node->n_input_sessions = node->ps_n_prev_outputs;
+    return 1;
+}
+
+/* SF-MULTI-KEYAGG (#283): recompute the per-channel CLTV taproot merkle
+   root used by sub-factory channel outputs.  Mirrors the chan_merkle_root
+   computation in setup_nway_leaf_outputs (~line 1240).  Returns 1 with
+   has_merkle = 1 + merkle_root32 populated when f->cltv_timeout > 0;
+   returns 1 with has_merkle = 0 (key-path only) otherwise.  Returns 0 on
+   secp256k1/tapscript failure. */
+static int compute_factory_chan_cltv_merkle(const factory_t *f,
+                                              unsigned char *merkle_root32,
+                                              int *has_merkle_out) {
+    if (!f || !merkle_root32 || !has_merkle_out) return 0;
+    *has_merkle_out = 0;
+    if (f->cltv_timeout == 0) return 1;
+    secp256k1_xonly_pubkey lsp_xonly;
+    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL,
+                                              &f->pubkeys[0]))
+        return 0;
+    tapscript_leaf_t chan_cltv_leaf;
+    if (!tapscript_build_cltv_timeout(&chan_cltv_leaf, f->cltv_timeout,
+                                        &lsp_xonly, f->ctx))
+        return 0;
+    if (!tapscript_merkle_root(merkle_root32, &chan_cltv_leaf, 1))
+        return 0;
+    *has_merkle_out = 1;
+    return 1;
+}
+
+/* SF-MULTI-KEYAGG (#283): recompute the L-stock CSV taproot merkle root
+   used by sub-factory sales-stock outputs (and leaf-level L-stock outputs).
+   Mirrors build_l_stock_spk's CSV merkle construction.  Returns 1 with
+   merkle populated on success. */
+static int compute_factory_lstock_merkle(const factory_t *f,
+                                          unsigned char *merkle_root32) {
+    if (!f || !merkle_root32) return 0;
+    secp256k1_xonly_pubkey lsp_xonly;
+    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL,
+                                              &f->pubkeys[0]))
+        return 0;
+    uint32_t csv = f->l_stock_csv_blocks > 0
+                   ? f->l_stock_csv_blocks
+                   : L_STOCK_CSV_DEFAULT_BLOCKS;
+    tapscript_leaf_t csv_leaf;
+    if (!tapscript_build_csv_delay(&csv_leaf, csv, &lsp_xonly, f->ctx))
+        return 0;
+    if (!tapscript_merkle_root(merkle_root32, &csv_leaf, 1))
+        return 0;
+    return 1;
+}
+
+/* SF-MULTI-KEYAGG (#283): compute the per-input keyagg + signer set +
+ * taproot merkle root for input `input_idx` of a multi-input sub-factory
+ * chain advance.
+ *
+ * Inputs 0..ps_n_prev_outputs-2 (channel inputs):
+ *   keyagg = MuSig({f->pubkeys[node->signer_indices[i+1]], f->pubkeys[0]})
+ *   signer order = {client, LSP}  (matches setup_nway_leaf_outputs)
+ *   merkle_root = factory channel-CLTV merkle (when cltv_timeout > 0).
+ *   n_signers = 2.
+ *
+ * Input ps_n_prev_outputs-1 (sales-stock input):
+ *   keyagg = node->keyagg  (sub-factory N-of-N).
+ *   signer order = node->signer_indices[]  (LSP at slot 0, clients 1..k).
+ *   merkle_root = node->has_taptree ? node->merkle_root : NULL.
+ *   n_signers = node->n_signers.
+ *
+ * Stores results into node->input_keyaggs[input_idx],
+ * node->input_signer_indices[input_idx][], node->input_n_signers[input_idx],
+ * node->input_merkle_root[input_idx][], node->input_has_merkle_root[input_idx].
+ *
+ * Returns 1 on success, 0 on failure. */
+static int derive_input_keyagg(const factory_t *f,
+                                factory_node_t *node,
+                                size_t input_idx) {
+    if (!f || !node) return 0;
+    if (input_idx >= node->ps_n_prev_outputs) return 0;
+    size_t k_plus_1 = node->ps_n_prev_outputs;
+    size_t sstock_idx = k_plus_1 - 1;
+
+    if (input_idx == sstock_idx) {
+        /* Sales-stock input: spends the prior chain's sales-stock output,
+           which build_l_stock_spk locks with `taproot_tweak(N-of-N agg,
+           L-stock CSV merkle)`.  The keyagg is therefore the sub-factory
+           N-of-N (node->keyagg), and the merkle root is the L-stock CSV
+           merkle (CSV delay + LSP CHECKSIG) -- NOT node->merkle_root,
+           which for PS sub-factory nodes is unused (has_taptree=0). */
+        node->input_keyaggs[input_idx] = node->keyagg;
+        node->input_n_signers[input_idx] = node->n_signers;
+        for (size_t i = 0; i < node->n_signers; i++)
+            node->input_signer_indices[input_idx][i] = node->signer_indices[i];
+        if (!compute_factory_lstock_merkle(f,
+                                            node->input_merkle_root[input_idx]))
+            return 0;
+        node->input_has_merkle_root[input_idx] = 1;
+        return 1;
+    }
+
+    /* Channel input i: per-channel keyagg {client_i, LSP} + factory chan
+       CLTV merkle (when cltv_timeout > 0).  setup_nway_leaf_outputs builds
+       channel SPKs as MuSig({client, LSP}) — signer order MUST match. */
+    if (input_idx + 1 >= node->n_signers) return 0;  /* signer_indices[i+1] must exist */
+    uint32_t client_participant = node->signer_indices[input_idx + 1];
+    secp256k1_pubkey pks[2];
+    pks[0] = f->pubkeys[client_participant];
+    pks[1] = f->pubkeys[0];
+    if (!musig_aggregate_keys(f->ctx, &node->input_keyaggs[input_idx], pks, 2))
+        return 0;
+    node->input_n_signers[input_idx] = 2;
+    node->input_signer_indices[input_idx][0] = client_participant;
+    node->input_signer_indices[input_idx][1] = 0;
+
+    int has_merkle = 0;
+    if (!compute_factory_chan_cltv_merkle(f,
+                                            node->input_merkle_root[input_idx],
+                                            &has_merkle))
+        return 0;
+    node->input_has_merkle_root[input_idx] = has_merkle;
+    if (!has_merkle) memset(node->input_merkle_root[input_idx], 0, 32);
     return 1;
 }
 
@@ -2670,12 +2837,27 @@ int factory_session_init_node_input(factory_t *f, size_t node_idx, size_t input_
     if (input_idx >= node->ps_n_prev_outputs) return 0;
     if (!ensure_input_sessions_alloc(node)) return 0;
 
+    /* SF-MULTI-KEYAGG (#283): derive the per-input keyagg before init.
+       Channel inputs use 2-of-2 {client_i, LSP}; sales-stock uses N-of-N. */
+    if (!derive_input_keyagg(f, node, input_idx)) {
+        fprintf(stderr,
+                "factory_session_init_node_input %zu/%zu: derive_input_keyagg failed\n",
+                node_idx, input_idx);
+        return 0;
+    }
     musig_session_init(&node->input_signing_sessions[input_idx],
-                        &node->keyagg, node->n_signers);
+                        &node->input_keyaggs[input_idx],
+                        node->input_n_signers[input_idx]);
     node->input_partial_sigs_received[input_idx] = 0;
     return 1;
 }
 
+/* SF-MULTI-KEYAGG (#283): `signer_slot` is the slot into the PER-INPUT
+   signer set (input_signer_indices[input_idx][]), NOT the node-level signer
+   set.  For channel inputs the per-input set has 2 entries ({client, LSP});
+   for the sales-stock input it matches node->signer_indices[].  Callers
+   should resolve participant_idx -> slot via factory_session_get_input_signer_slot
+   before calling this function. */
 int factory_session_set_nonce_input(factory_t *f, size_t node_idx, size_t input_idx,
                                       size_t signer_slot,
                                       const secp256k1_musig_pubnonce *pubnonce) {
@@ -2683,7 +2865,7 @@ int factory_session_set_nonce_input(factory_t *f, size_t node_idx, size_t input_
     factory_node_t *node = &f->nodes[node_idx];
     if (!node->input_signing_sessions) return 0;
     if (input_idx >= node->n_input_sessions) return 0;
-    if (signer_slot >= node->n_signers) return 0;
+    if (signer_slot >= node->input_n_signers[input_idx]) return 0;
     return musig_session_set_pubnonce(&node->input_signing_sessions[input_idx],
                                         signer_slot, pubnonce);
 }
@@ -2700,7 +2882,12 @@ int factory_session_finalize_node_input(factory_t *f, size_t node_idx, size_t in
                 node_idx, input_idx);
         return 0;
     }
-    const unsigned char *mr = node->has_taptree ? node->merkle_root : NULL;
+    /* SF-MULTI-KEYAGG (#283): per-input merkle root.  Channel inputs use the
+       factory channel-CLTV merkle (or NULL when cltv_timeout=0); sales-stock
+       input uses the sub-factory's own merkle (or NULL when no taptree). */
+    const unsigned char *mr = node->input_has_merkle_root[input_idx]
+                              ? node->input_merkle_root[input_idx]
+                              : NULL;
     int ok = musig_session_finalize_nonces(f->ctx,
                                             &node->input_signing_sessions[input_idx],
                                             sighash, mr, NULL);
@@ -2710,6 +2897,9 @@ int factory_session_finalize_node_input(factory_t *f, size_t node_idx, size_t in
     return ok;
 }
 
+/* SF-MULTI-KEYAGG (#283): `signer_slot` is into the PER-INPUT signer set
+   (input_signer_indices[input_idx][]).  Bounds check against
+   input_n_signers[input_idx], not node->n_signers. */
 int factory_session_set_partial_sig_input(factory_t *f, size_t node_idx, size_t input_idx,
                                             size_t signer_slot,
                                             const secp256k1_musig_partial_sig *psig) {
@@ -2718,7 +2908,7 @@ int factory_session_set_partial_sig_input(factory_t *f, size_t node_idx, size_t 
     if (!node->input_signing_sessions) return 0;
     if (input_idx >= node->n_input_sessions) return 0;
     if (signer_slot >= (size_t)FACTORY_MAX_SIGNERS) return 0;
-    if (signer_slot >= node->n_signers) return 0;
+    if (signer_slot >= node->input_n_signers[input_idx]) return 0;
     secp256k1_musig_partial_sig *slot =
         &node->input_partial_sigs[input_idx * (size_t)FACTORY_MAX_SIGNERS + signer_slot];
     *slot = *psig;
@@ -2735,7 +2925,9 @@ int factory_session_complete_node_input(factory_t *f, size_t node_idx, size_t in
     factory_node_t *node = &f->nodes[node_idx];
     if (!node->input_signing_sessions) return 0;
     if (input_idx >= node->n_input_sessions) return 0;
-    if (node->input_partial_sigs_received[input_idx] != (int)node->n_signers) return 0;
+    /* SF-MULTI-KEYAGG (#283): each input may have a different signer count. */
+    if (node->input_partial_sigs_received[input_idx] !=
+        (int)node->input_n_signers[input_idx]) return 0;
     return 1;
 }
 
@@ -2744,11 +2936,14 @@ int factory_session_assemble_signed_tx_multi(factory_t *f, size_t node_idx) {
     factory_node_t *node = &f->nodes[node_idx];
     if (!node->input_signing_sessions) return 0;
     if (node->n_input_sessions == 0) return 0;
-    /* All inputs must have full partial sigs collected. */
+    /* All inputs must have full partial sigs collected.  SF-MULTI-KEYAGG
+       (#283): the required count is per-input. */
     for (size_t i = 0; i < node->n_input_sessions; i++) {
-        if (node->input_partial_sigs_received[i] != (int)node->n_signers) {
+        if (node->input_partial_sigs_received[i] !=
+            (int)node->input_n_signers[i]) {
             fprintf(stderr, "assemble_signed_tx_multi node=%zu input=%zu has %d/%zu sigs\n",
-                    node_idx, i, node->input_partial_sigs_received[i], node->n_signers);
+                    node_idx, i, node->input_partial_sigs_received[i],
+                    node->input_n_signers[i]);
             return 0;
         }
     }
@@ -2758,9 +2953,11 @@ int factory_session_assemble_signed_tx_multi(factory_t *f, size_t node_idx) {
     for (size_t i = 0; i < node->n_input_sessions; i++) {
         secp256k1_musig_partial_sig *psigs =
             &node->input_partial_sigs[i * (size_t)FACTORY_MAX_SIGNERS];
+        /* SF-MULTI-KEYAGG (#283): aggregate with the per-input signer count
+           (not the node-level n_signers). */
         if (!musig_aggregate_partial_sigs(f->ctx, sigs64 + 64 * i,
                                             &node->input_signing_sessions[i],
-                                            psigs, node->n_signers)) {
+                                            psigs, node->input_n_signers[i])) {
             free(sigs64);
             return 0;
         }
@@ -4000,6 +4197,9 @@ void factory_free(factory_t *f) {
         f->nodes[i].input_signing_sessions = NULL;
         free(f->nodes[i].input_partial_sigs);
         f->nodes[i].input_partial_sigs = NULL;
+        /* SF-MULTI-KEYAGG (#283): free per-input keyagg cache. */
+        free(f->nodes[i].input_keyaggs);
+        f->nodes[i].input_keyaggs = NULL;
         f->nodes[i].n_input_sessions = 0;
     }
     /* F4: factory-level distribution TX buffer (populated by

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -725,12 +725,12 @@ int lsp_run_factory_creation(lsp_t *lsp,
                               const unsigned char *funding_spk, size_t funding_spk_len,
                               uint16_t step_blocks, uint32_t states_per_layer,
                               uint32_t cltv_timeout) {
-    /* Phase 1e.3.b (#271): when --musig-stateless is set, dispatch to the
-       reversed-flow stub.  Returns -1 to signal fall-through to legacy if
-       the stateless variant cannot handle this case. */
+    /* Phase 2 (#272): stateless is default-on; SS_MUSIG_LEGACY=1 falls back.
+       Stateless variant returns -1 to signal cases it cannot handle.
+       Phase 3 deletes the legacy fall-through. */
     {
-        const char *stateless = getenv("SS_MUSIG_STATELESS");
-        if (stateless && stateless[0] == '1') {
+        const char *legacy = getenv("SS_MUSIG_LEGACY");
+        if (!legacy || legacy[0] != '1') {
             extern int lsp_run_factory_creation_stateless(lsp_t *,
                 const unsigned char *, uint32_t, uint64_t,
                 const unsigned char *, size_t, uint16_t, uint32_t, uint32_t);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4954,10 +4954,12 @@ static int lsp_subfactory_chain_advance_stateless_multi(
     }
 
     for (size_t i = 0; i < n_inputs; i++) {
+        /* SF-MULTI-KEYAGG (#283): nonce against per-input keyagg cache
+           (channel inputs: 2-of-2; sales-stock: N-of-N). */
         secp256k1_musig_pubnonce lsp_pubnonce_i;
         if (!musig_generate_nonce(lsp->ctx, &lsp_secnonces[i], &lsp_pubnonce_i,
                                    lsp_seckey, &lsp->lsp_pubkey,
-                                   &sub->keyagg.cache)) {
+                                   &sub->input_keyaggs[i].cache)) {
             fprintf(stderr, "LSP-stateless MULTI: nonce gen input %zu failed\n", i);
             memset(lsp_seckey, 0, 32);
             free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
@@ -4968,15 +4970,24 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         memcpy(all_pn_per_input + ((size_t)lsp_slot * n_inputs + i) * 66,
                lsp_pn_ser[i], 66);
 
-        /* Set every signer's nonce for THIS input. */
+        /* SF-MULTI-KEYAGG (#283): set nonce for every signer that ACTUALLY
+           signs input i, mapping node-level slot s -> participant ->
+           per-input slot.  Skip slots where the participant doesn't sign
+           this input — wire matrix carries zero placeholders there. */
         for (size_t s = 0; s < sub->n_signers; s++) {
+            uint32_t participant = sub->signer_indices[s];
+            int per_input_slot = factory_session_get_input_signer_slot(
+                f, sub_node_i, i, participant);
+            if (per_input_slot < 0) continue;
             secp256k1_musig_pubnonce pn;
             if (!musig_pubnonce_parse(lsp->ctx, &pn,
                     all_pn_per_input + (s * n_inputs + i) * 66) ||
-                !factory_session_set_nonce_input(f, sub_node_i, i, s, &pn)) {
+                !factory_session_set_nonce_input(f, sub_node_i, i,
+                                                  (size_t)per_input_slot, &pn)) {
                 fprintf(stderr,
-                        "LSP-stateless MULTI: set_nonce_input(signer=%zu input=%zu) failed\n",
-                        s, i);
+                        "LSP-stateless MULTI: set_nonce_input(participant=%u "
+                        "input=%zu per_input_slot=%d) failed\n",
+                        participant, i, per_input_slot);
                 memset(lsp_seckey, 0, 32);
                 free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
                 free(all_pn_per_input);
@@ -4992,6 +5003,18 @@ static int lsp_subfactory_chain_advance_stateless_multi(
             return 0;
         }
 
+        /* SF-MULTI-KEYAGG (#283): LSP's per-input slot for this input. */
+        int lsp_slot_i = factory_session_get_input_signer_slot(
+            f, sub_node_i, i, 0);
+        if (lsp_slot_i < 0) {
+            fprintf(stderr,
+                    "LSP-stateless MULTI: LSP not in signer set of input %zu "
+                    "(impossible)\n", i);
+            memset(lsp_seckey, 0, 32);
+            free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
+            free(all_pn_per_input);
+            return 0;
+        }
         secp256k1_musig_partial_sig lsp_psig_i;
         if (!musig_create_partial_sig(lsp->ctx, &lsp_psig_i,
                 &lsp_secnonces[i], &lsp_kp,
@@ -5005,8 +5028,9 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         /* lsp_secnonces[i] zeroed by musig_create_partial_sig.  INVARIANT:
            no LSP secnonce for input i is held across the recv that follows. */
         if (!factory_session_set_partial_sig_input(f, sub_node_i, i,
-                                                    (size_t)lsp_slot, &lsp_psig_i)) {
-            fprintf(stderr, "LSP-stateless MULTI: set_partial_sig_input %zu failed\n", i);
+                                                    (size_t)lsp_slot_i, &lsp_psig_i)) {
+            fprintf(stderr, "LSP-stateless MULTI: set_partial_sig_input %zu "
+                    "(lsp_slot=%d) failed\n", i, lsp_slot_i);
             memset(lsp_seckey, 0, 32);
             free(lsp_secnonces); free(lsp_pn_ser); free(lsp_psig_ser);
             free(all_pn_per_input);
@@ -5143,20 +5167,32 @@ static int lsp_subfactory_chain_advance_stateless_multi(
             factory_session_reset_poison(f, sub_node_i);
             poison_prepared = 0;
         }
+        /* SF-MULTI-KEYAGG (#283): client_slot is the NODE-level slot used only
+           for the poison side-channel (N-of-N).  Per-input psig assignment
+           remaps via factory_session_get_input_signer_slot and skips inputs
+           the client does not sign. */
         int client_slot = factory_find_signer_slot(f, sub_node_i, sub_clients[ci]);
         if (client_slot < 0) {
             free(client_psig_buf);
             factory_session_reset_poison(f, sub_node_i); return 0;
         }
         for (size_t i = 0; i < n_inputs; i++) {
+            int per_input_slot = factory_session_get_input_signer_slot(
+                f, sub_node_i, i, sub_clients[ci]);
+            if (per_input_slot < 0) {
+                /* Client does not sign this input — wire carries a 32-byte
+                   zero psig placeholder (or, pre-Phase-3, garbage). */
+                continue;
+            }
             secp256k1_musig_partial_sig client_psig_i;
             if (!musig_partial_sig_parse(lsp->ctx, &client_psig_i,
                                           client_psig_buf + i * 32) ||
                 !factory_session_set_partial_sig_input(f, sub_node_i, i,
-                                                        (size_t)client_slot,
+                                                        (size_t)per_input_slot,
                                                         &client_psig_i)) {
-                fprintf(stderr, "LSP-stateless MULTI: set client psig (client %u input %zu) failed\n",
-                        sub_clients[ci], i);
+                fprintf(stderr, "LSP-stateless MULTI: set client psig "
+                        "(client %u input %zu per_input_slot=%d) failed\n",
+                        sub_clients[ci], i, per_input_slot);
                 free(client_psig_buf);
                 factory_session_reset_poison(f, sub_node_i);
                 return 0;
@@ -5963,9 +5999,13 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             return 0;
         }
         for (size_t i = 0; i < n_inputs; i++) {
+            /* SF-MULTI-KEYAGG (#283): generate LSP nonce against the per-input
+               keyagg cache.  Channel inputs are 2-of-2 {client_i, LSP};
+               sales-stock input is N-of-N — both keyagg caches differ from
+               sub->keyagg (the node-level N-of-N).  LSP signs every input. */
             if (!musig_generate_nonce(lsp->ctx, &lsp_secnonces[i], &lsp_pubnonces[i],
                                        lsp_seckey, &lsp->lsp_pubkey,
-                                       &sub->keyagg.cache)) {
+                                       &sub->input_keyaggs[i].cache)) {
                 fprintf(stderr, "LSP subfactory advance (multi): "
                         "nonce gen input %zu failed\n", i);
                 free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
@@ -6102,17 +6142,36 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                 memcpy(all_poison_pn[client_slot], client_poison_pn, 66);
         }
 
-        /* --- Multi-input Step 6: Set nonces on every input session, broadcast ALL_NONCES. --- */
+        /* --- Multi-input Step 6: Set nonces on every input session, broadcast ALL_NONCES. ---
+           SF-MULTI-KEYAGG (#283): set_nonce_input's signer_slot is now an index
+           into the PER-INPUT signer set (input_signer_indices[input_idx][]),
+           not the node-level set.  Channel inputs are 2-of-2 {client_i, LSP};
+           sales-stock input is N-of-N.  For each (node-level slot s, input i):
+             - map s -> participant_idx = sub->signer_indices[s]
+             - look up per-input slot via factory_session_get_input_signer_slot
+             - if participant doesn't sign this input (slot < 0), skip — the
+               wire matrix carries a zero placeholder we must NOT install.
+           The wire ALL_NONCES matrix still carries [node-level s][input i] so
+           clients can index it identically (no wire change). */
         for (size_t s = 0; s < sub->n_signers; s++) {
+            uint32_t participant = sub->signer_indices[s];
             for (size_t i = 0; i < n_inputs; i++) {
+                int per_input_slot = factory_session_get_input_signer_slot(
+                    f, (size_t)sub_node_i, i, participant);
+                if (per_input_slot < 0) {
+                    /* Signer at node-level slot s does NOT sign input i.
+                       Skip — matrix slot holds a zero pubnonce placeholder. */
+                    continue;
+                }
                 secp256k1_musig_pubnonce pn;
                 if (!musig_pubnonce_parse(lsp->ctx, &pn,
                         all_pn_per_input + (s * n_inputs + i) * 66) ||
                     !factory_session_set_nonce_input(f, (size_t)sub_node_i,
-                                                     i, s, &pn)) {
+                                                     i, (size_t)per_input_slot, &pn)) {
                     fprintf(stderr, "LSP subfactory advance (multi): "
-                            "set_nonce_input(signer=%zu, input=%zu) failed\n",
-                            s, i);
+                            "set_nonce_input(participant=%u, input=%zu, "
+                            "per_input_slot=%d) failed\n",
+                            participant, i, per_input_slot);
                     free(all_pn_per_input);
                     free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
                     memset(lsp_seckey, 0, 32);
@@ -6187,6 +6246,20 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             return 0;
         }
         for (size_t i = 0; i < n_inputs; i++) {
+            /* SF-MULTI-KEYAGG (#283): resolve LSP's slot within input i's signer
+               set.  LSP (participant 0) signs every input — channel inputs are
+               {client, LSP=slot1}; sales-stock is N-of-N where LSP is whichever
+               slot signer_indices[] places participant 0 in. */
+            int lsp_slot_i = factory_session_get_input_signer_slot(
+                f, (size_t)sub_node_i, i, 0);
+            if (lsp_slot_i < 0) {
+                fprintf(stderr, "LSP subfactory advance (multi): "
+                        "LSP not in signer set of input %zu (impossible)\n", i);
+                free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
+                free(lsp_psig_ser);
+                factory_session_reset_poison(f, (size_t)sub_node_i);
+                return 0;
+            }
             secp256k1_musig_partial_sig lsp_psig_i;
             if (!musig_create_partial_sig(lsp->ctx, &lsp_psig_i,
                     &lsp_secnonces[i], &lsp_kp,
@@ -6199,10 +6272,11 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                 return 0;
             }
             if (!factory_session_set_partial_sig_input(f, (size_t)sub_node_i,
-                                                        i, (size_t)lsp_slot,
+                                                        i, (size_t)lsp_slot_i,
                                                         &lsp_psig_i)) {
                 fprintf(stderr, "LSP subfactory advance (multi): "
-                        "set_partial_sig_input(input=%zu) failed\n", i);
+                        "set_partial_sig_input(input=%zu, lsp_slot=%d) failed\n",
+                        i, lsp_slot_i);
                 free(lsp_secnonces); free(lsp_pubnonces); free(lsp_pn_ser);
                 free(lsp_psig_ser);
                 factory_session_reset_poison(f, (size_t)sub_node_i);
@@ -6272,6 +6346,12 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                 factory_session_reset_poison(f, (size_t)sub_node_i);
                 return 0;
             }
+            /* SF-MULTI-KEYAGG (#283): client_slot is the NODE-level slot used
+               for poison only (poison is single-input N-of-N).  Per-input psig
+               assignment goes through factory_session_get_input_signer_slot so
+               we skip inputs the client does not sign (channel inputs are
+               2-of-2 LSP+client_j; client_i only signs its own channel + sales
+               stock). */
             int client_slot = factory_find_signer_slot(f, (size_t)sub_node_i,
                                                        sub_clients[ci]);
             if (client_slot < 0) {
@@ -6280,15 +6360,23 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                 return 0;
             }
             for (size_t i = 0; i < n_inputs; i++) {
+                int per_input_slot = factory_session_get_input_signer_slot(
+                    f, (size_t)sub_node_i, i, sub_clients[ci]);
+                if (per_input_slot < 0) {
+                    /* Client does not sign this input.  Wire carries a 32-byte
+                       zero psig placeholder (or, pre-Phase-3, garbage) — skip
+                       silently. */
+                    continue;
+                }
                 secp256k1_musig_partial_sig client_psig_i;
                 if (!musig_partial_sig_parse(lsp->ctx, &client_psig_i,
                                               client_psigs[i]) ||
                     !factory_session_set_partial_sig_input(f, (size_t)sub_node_i,
-                                                            i, (size_t)client_slot,
+                                                            i, (size_t)per_input_slot,
                                                             &client_psig_i)) {
                     fprintf(stderr, "LSP subfactory advance (multi): client %u "
-                            "psig parse/set input=%zu failed\n",
-                            sub_clients[ci], i);
+                            "psig parse/set input=%zu (per_input_slot=%d) failed\n",
+                            sub_clients[ci], i, per_input_slot);
                     free(lsp_psig_ser);
                     factory_session_reset_poison(f, (size_t)sub_node_i);
                     return 0;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4778,7 +4778,13 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         const uint32_t *sub_clients, size_t n_clients_in_sub,
         int leaf_side, int sub_idx_in_leaf, int channel_idx_in_sub,
         uint64_t delta_sats) {
-    size_t n_inputs = sub->ps_n_prev_outputs;
+    /* SF-MULTI-DISPATCH: n_inputs is the number of outputs on chain[N] that
+       chain[N+1] will spend.  Use sub->n_outputs (the PRE-advance count of
+       outputs on the current chain head) -- this is what advance_unsigned
+       will assign to sub->ps_n_prev_outputs.  Reading sub->ps_n_prev_outputs
+       here would be stale on the first advance (it's only populated by a
+       prior advance_unsigned call, of which there has been none). */
+    size_t n_inputs = sub->n_outputs;
     if (n_inputs < 1) {
         fprintf(stderr, "LSP-stateless subfactory MULTI: n_inputs=%zu invalid\n",
                 n_inputs);
@@ -5298,8 +5304,20 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
        per input.  The whole point is the same BIP-327 invariant: the LSP
        generates its per-input secnonces ONLY after collecting every client's
        pubnonces, and each lsp_secnonces[i] is consumed/zeroed by
-       musig_create_partial_sig before the next wire_recv. */
-    if (factory_node_uses_multi_input(f, sub_node_i)) {
+       musig_create_partial_sig before the next wire_recv.
+
+       SF-MULTI-DISPATCH: predict whether the chain[N+1] state we're about
+       to build is multi-input.  factory_node_uses_multi_input checks
+       ps_n_prev_outputs > 1, but that field is populated INSIDE
+       factory_subfactory_chain_advance_unsigned (called below), so at this
+       point it's still 0 for the first advance.  Predicate equivalent at
+       this point: PS sub-factory with k>=2 (n_outputs > 1) ALWAYS produces
+       a multi-input chain[N+1] -- rebuild_node_tx spends all n_outputs of
+       chain[N] as inputs.  The legacy path dispatches AFTER advance_unsigned
+       so it uses the post-state predicate; we must dispatch BEFORE because
+       _stateless_multi calls advance_unsigned itself. */
+    if (sub->is_ps_leaf && sub->type == NODE_PS_SUBFACTORY &&
+        sub->n_outputs > 1) {
         return lsp_subfactory_chain_advance_stateless_multi(
             mgr, lsp, f, sub_node_i, sub, sub_clients, n_clients_in_sub,
             leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2095,11 +2095,10 @@ static int lsp_advance_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp, int leaf_side) {
         return 0;
     }
 
-    /* Phase 1c (#271): when --musig-stateless is in effect, dispatch to the
-       reversed-order flow.  Legacy path below is untouched. */
+    /* Phase 2 (#272): stateless is default-on; SS_MUSIG_LEGACY=1 falls back. */
     {
-        const char *stateless = getenv("SS_MUSIG_STATELESS");
-        if (stateless && stateless[0] == '1')
+        const char *legacy = getenv("SS_MUSIG_LEGACY");
+        if (!legacy || legacy[0] != '1')
             return lsp_advance_leaf_stateless(mgr, lsp, leaf_side);
     }
 
@@ -3239,12 +3238,12 @@ int lsp_run_state_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     factory_t *f = &lsp->factory;
     if (!mgr || !lsp) return 0;
 
-    /* Phase 1e.2.b (#271): when --musig-stateless is in effect, dispatch
-       to the reversed-order flow.  Returns -1 to signal fall-through to
-       legacy if the stateless variant cannot handle this case. */
+    /* Phase 2 (#272): stateless is default-on; SS_MUSIG_LEGACY=1 falls back.
+       Stateless variant returns -1 to signal cases it cannot handle (legacy
+       then runs).  Phase 3 deletes the legacy fall-through. */
     {
-        const char *stateless = getenv("SS_MUSIG_STATELESS");
-        if (stateless && stateless[0] == '1') {
+        const char *legacy = getenv("SS_MUSIG_LEGACY");
+        if (!legacy || legacy[0] != '1') {
             int rc = lsp_run_state_advance_stateless(mgr, lsp, trigger_leaf_side);
             if (rc >= 0) return rc;
             /* rc == -1: stateless declined; fall through to legacy below. */
@@ -5739,13 +5738,12 @@ int lsp_subfactory_chain_advance(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
     factory_t *f = &lsp->factory;
 
-    /* Phase 1e.1.b (#271): when --musig-stateless is in effect, dispatch
-       to the reversed-order flow.  The stateless variant returns -1 if
-       it cannot handle the case (multi-input etc) and falls through to
-       legacy; otherwise it handles the ceremony end-to-end. */
+    /* Phase 2 (#272): stateless is default-on; SS_MUSIG_LEGACY=1 falls back.
+       Stateless variant returns -1 when it cannot handle a case (e.g.
+       multi-input edge cases); legacy then runs.  Phase 3 deletes legacy. */
     {
-        const char *stateless = getenv("SS_MUSIG_STATELESS");
-        if (stateless && stateless[0] == '1') {
+        const char *legacy = getenv("SS_MUSIG_LEGACY");
+        if (!legacy || legacy[0] != '1') {
             int rc = lsp_subfactory_chain_advance_stateless(
                 mgr, lsp, leaf_side, sub_idx_in_leaf,
                 channel_idx_in_sub, delta_sats);

--- a/test/sanitizer_suppressions/lsan.supp
+++ b/test/sanitizer_suppressions/lsan.supp
@@ -7,5 +7,17 @@
 # Add an entry only if the leak is provably in third-party code that we
 # cannot fix and cannot reasonably work around. Every entry should have a
 # comment explaining what it suppresses and why we accept it.
-#
-# (none yet)
+
+# sqlite3 library internals.  When a process exits without calling
+# sqlite3_close (e.g. the LSP is SIGTERM'd by a test harness before its
+# main loop sees g_shutdown), sqlite intentionally retains:
+#   - the FTS3 module init globals (allocated once at module load,
+#     never freed by design — see sqlite3Fts3Init)
+#   - per-connection builtin-function tables (also one-shot init)
+#   - some parser scratch space attached to in-flight prepare_v2 frames
+# None of these are SuperScalar code paths; they are 100% inside the
+# system libsqlite3.so.  Confirmed unfixable upstream — see the sqlite
+# source under ext/fts3 + src/func.c.
+leak:sqlite3Fts3Init
+leak:sqlite3RegisterPerConnectionBuiltinFunctions
+leak:sqlite3RunParser

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5500,12 +5500,17 @@ int test_factory_ps_subfactory_chain_extension(void) {
     {
         size_t n_inp = sub->ps_n_prev_outputs;
         TEST_ASSERT_EQ((long)n_inp, 3, "chain[1] n_inputs = k+1 = 3");
-        secp256k1_musig_secnonce secnonces[3][3];
+        /* SF-MULTI-KEYAGG (#283): channel inputs sign 2-of-2; sales-stock
+           input signs N-of-N.  Drive each input against its own signer set
+           (input_signer_indices[i][s], length input_n_signers[i]). */
+        secp256k1_musig_secnonce secnonces[3][FACTORY_MAX_SIGNERS];
+        memset(secnonces, 0, sizeof(secnonces));
         for (size_t i = 0; i < n_inp; i++) {
             TEST_ASSERT(factory_session_init_node_input(f, (size_t)sub0_node_idx, i),
                         "init per-input session");
-            for (size_t j = 0; j < sub->n_signers; j++) {
-                uint32_t participant = sub->signer_indices[j];
+            size_t this_n = sub->input_n_signers[i];
+            for (size_t s = 0; s < this_n; s++) {
+                uint32_t participant = sub->input_signer_indices[i][s];
                 unsigned char seckey[32];
                 secp256k1_pubkey pk;
                 TEST_ASSERT(secp256k1_keypair_sec(ctx, seckey, &kps[participant]),
@@ -5513,11 +5518,12 @@ int test_factory_ps_subfactory_chain_extension(void) {
                 TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[participant]),
                             "get pubkey");
                 secp256k1_musig_pubnonce pubnonce;
-                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i][j], &pubnonce,
-                                                   seckey, &pk, &sub->keyagg.cache),
+                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i][s], &pubnonce,
+                                                   seckey, &pk,
+                                                   &sub->input_keyaggs[i].cache),
                             "gen nonce");
                 TEST_ASSERT(factory_session_set_nonce_input(f, (size_t)sub0_node_idx,
-                                                              i, j, &pubnonce),
+                                                              i, s, &pubnonce),
                             "set nonce per-input");
                 memset(seckey, 0, 32);
             }
@@ -5525,15 +5531,16 @@ int test_factory_ps_subfactory_chain_extension(void) {
                         "finalize per-input");
         }
         for (size_t i = 0; i < n_inp; i++) {
-            for (size_t j = 0; j < sub->n_signers; j++) {
-                uint32_t participant = sub->signer_indices[j];
+            size_t this_n = sub->input_n_signers[i];
+            for (size_t s = 0; s < this_n; s++) {
+                uint32_t participant = sub->input_signer_indices[i][s];
                 secp256k1_musig_partial_sig psig;
                 TEST_ASSERT(musig_create_partial_sig(
-                                ctx, &psig, &secnonces[i][j], &kps[participant],
+                                ctx, &psig, &secnonces[i][s], &kps[participant],
                                 &sub->input_signing_sessions[i]),
                             "create per-input psig");
                 TEST_ASSERT(factory_session_set_partial_sig_input(
-                                f, (size_t)sub0_node_idx, i, j, &psig),
+                                f, (size_t)sub0_node_idx, i, s, &psig),
                             "set per-input psig");
             }
             TEST_ASSERT(factory_session_complete_node_input(
@@ -5566,26 +5573,30 @@ int test_factory_ps_subfactory_chain_extension(void) {
                     (long)(sstock_chain1 - delta2 - f->fee_per_tx),
                     "sales-stock = chain[1] - delta2 - fee");
 
-    /* Sign chain[2] via the per-input flow */
+    /* Sign chain[2] via the per-input flow.  SF-MULTI-KEYAGG (#283):
+       channel inputs sign 2-of-2; sales-stock signs N-of-N. */
     {
         size_t n_inp2 = sub->ps_n_prev_outputs;
         TEST_ASSERT_EQ((long)n_inp2, 3, "chain[2] n_inputs = 3");
-        secp256k1_musig_secnonce secnonces2[3][3];
+        secp256k1_musig_secnonce secnonces2[3][FACTORY_MAX_SIGNERS];
+        memset(secnonces2, 0, sizeof(secnonces2));
         for (size_t i = 0; i < n_inp2; i++) {
             TEST_ASSERT(factory_session_init_node_input(f, (size_t)sub0_node_idx, i),
                         "chain[2] init per-input");
-            for (size_t j = 0; j < sub->n_signers; j++) {
-                uint32_t participant = sub->signer_indices[j];
+            size_t this_n = sub->input_n_signers[i];
+            for (size_t s = 0; s < this_n; s++) {
+                uint32_t participant = sub->input_signer_indices[i][s];
                 unsigned char seckey[32];
                 secp256k1_pubkey pk;
                 secp256k1_keypair_sec(ctx, seckey, &kps[participant]);
                 secp256k1_keypair_pub(ctx, &pk, &kps[participant]);
                 secp256k1_musig_pubnonce pubnonce;
-                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces2[i][j], &pubnonce,
-                                                   seckey, &pk, &sub->keyagg.cache),
+                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces2[i][s], &pubnonce,
+                                                   seckey, &pk,
+                                                   &sub->input_keyaggs[i].cache),
                             "chain[2] gen nonce");
                 TEST_ASSERT(factory_session_set_nonce_input(f, (size_t)sub0_node_idx,
-                                                              i, j, &pubnonce),
+                                                              i, s, &pubnonce),
                             "chain[2] set per-input nonce");
                 memset(seckey, 0, 32);
             }
@@ -5593,15 +5604,16 @@ int test_factory_ps_subfactory_chain_extension(void) {
                         "chain[2] finalize per-input");
         }
         for (size_t i = 0; i < n_inp2; i++) {
-            for (size_t j = 0; j < sub->n_signers; j++) {
-                uint32_t participant = sub->signer_indices[j];
+            size_t this_n = sub->input_n_signers[i];
+            for (size_t s = 0; s < this_n; s++) {
+                uint32_t participant = sub->input_signer_indices[i][s];
                 secp256k1_musig_partial_sig psig;
                 TEST_ASSERT(musig_create_partial_sig(
-                                ctx, &psig, &secnonces2[i][j], &kps[participant],
+                                ctx, &psig, &secnonces2[i][s], &kps[participant],
                                 &sub->input_signing_sessions[i]),
                             "chain[2] create psig");
                 TEST_ASSERT(factory_session_set_partial_sig_input(
-                                f, (size_t)sub0_node_idx, i, j, &psig),
+                                f, (size_t)sub0_node_idx, i, s, &psig),
                             "chain[2] set per-input psig");
             }
             TEST_ASSERT(factory_session_complete_node_input(
@@ -5702,25 +5714,29 @@ int test_factory_ps_subfactory_chain_tx_validity(void) {
     TEST_ASSERT_EQ(factory_subfactory_chain_advance_unsigned(f, 0, 0, 0, delta), 1,
                     "advance ok");
 
-    /* Sign chain[1] via per-input flow. */
+    /* Sign chain[1] via per-input flow. SF-MULTI-KEYAGG (#283): channel
+       inputs sign 2-of-2; sales-stock signs N-of-N. */
     {
         size_t n_inp = sub->ps_n_prev_outputs;
-        secp256k1_musig_secnonce secnonces[3][3];
+        secp256k1_musig_secnonce secnonces[3][FACTORY_MAX_SIGNERS];
+        memset(secnonces, 0, sizeof(secnonces));
         for (size_t i = 0; i < n_inp; i++) {
             TEST_ASSERT(factory_session_init_node_input(f, (size_t)sub0_node_idx, i),
                         "init input");
-            for (size_t j = 0; j < sub->n_signers; j++) {
-                uint32_t participant = sub->signer_indices[j];
+            size_t this_n = sub->input_n_signers[i];
+            for (size_t s = 0; s < this_n; s++) {
+                uint32_t participant = sub->input_signer_indices[i][s];
                 unsigned char seckey[32];
                 secp256k1_pubkey pk;
                 secp256k1_keypair_sec(ctx, seckey, &kps[participant]);
                 secp256k1_keypair_pub(ctx, &pk, &kps[participant]);
                 secp256k1_musig_pubnonce pubnonce;
-                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i][j], &pubnonce,
-                                                   seckey, &pk, &sub->keyagg.cache),
+                TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i][s], &pubnonce,
+                                                   seckey, &pk,
+                                                   &sub->input_keyaggs[i].cache),
                             "gen nonce");
                 TEST_ASSERT(factory_session_set_nonce_input(f, (size_t)sub0_node_idx,
-                                                              i, j, &pubnonce),
+                                                              i, s, &pubnonce),
                             "set nonce");
                 memset(seckey, 0, 32);
             }
@@ -5728,15 +5744,16 @@ int test_factory_ps_subfactory_chain_tx_validity(void) {
                         "finalize input");
         }
         for (size_t i = 0; i < n_inp; i++) {
-            for (size_t j = 0; j < sub->n_signers; j++) {
-                uint32_t participant = sub->signer_indices[j];
+            size_t this_n = sub->input_n_signers[i];
+            for (size_t s = 0; s < this_n; s++) {
+                uint32_t participant = sub->input_signer_indices[i][s];
                 secp256k1_musig_partial_sig psig;
                 TEST_ASSERT(musig_create_partial_sig(
-                                ctx, &psig, &secnonces[i][j], &kps[participant],
+                                ctx, &psig, &secnonces[i][s], &kps[participant],
                                 &sub->input_signing_sessions[i]),
                             "create psig");
                 TEST_ASSERT(factory_session_set_partial_sig_input(
-                                f, (size_t)sub0_node_idx, i, j, &psig),
+                                f, (size_t)sub0_node_idx, i, s, &psig),
                             "set psig");
             }
         }

--- a/tests/test_factory_multi_input_keyagg.c
+++ b/tests/test_factory_multi_input_keyagg.c
@@ -1,0 +1,289 @@
+/* SF-MULTI-KEYAGG (#283) — per-input keyagg threading for sub-factory
+   multi-input ceremony.  Verifies:
+     1. After factory_session_init_node_input runs, the per-input metadata
+        is populated:
+          - input_n_signers[i] = 2 for channel inputs (0..k-1)
+          - input_n_signers[k] = node->n_signers for sales-stock input
+          - input_signer_indices[i][0..1] = {client_i, LSP} for channel inputs
+          - input_signer_indices[k][..] = node->signer_indices[..] for sales-stock
+     2. Driving the per-input ceremony to completion produces a signed TX
+        whose Schnorr signatures pass secp256k1_schnorrsig_verify against
+        the recorded prev-output SPKs (ps_prev_spks[]) for ALL k+1 inputs.
+     3. factory_session_get_input_signer_slot / factory_session_input_signs
+        report the expected per-input slot mappings.
+
+   Scope: pure libsuperscalar exercise; does not touch the wire layer. */
+
+#include "superscalar/factory.h"
+#include "superscalar/musig.h"
+#include "superscalar/sha256.h"
+#include "superscalar/tx_builder.h"
+#include <secp256k1.h>
+#include <secp256k1_musig.h>
+#include <secp256k1_schnorrsig.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TEST_ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d): %s\n", __func__, __LINE__, msg); \
+        return 0; \
+    } \
+} while(0)
+
+#define TEST_ASSERT_EQ(a, b, msg) do { \
+    if ((a) != (b)) { \
+        printf("  FAIL: %s (line %d): %s (got %ld, expected %ld)\n", \
+               __func__, __LINE__, msg, (long)(a), (long)(b)); \
+        return 0; \
+    } \
+} while(0)
+
+static secp256k1_context *mk_test_ctx(void) {
+    return secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+}
+
+/* Extract the 64-byte Schnorr sig from witness slot `input_idx` of a
+   signed multi-input TX whose layout matches finalize_signed_tx_multi:
+     nVersion(4) + marker(0x00) + flag(0x01)
+     vin_count varint
+     for each input: 32 (txid) + 4 (vout) + 1 (scriptSig=0) + 4 (nSeq) = 41
+     vout_count varint
+     for each output: 8 (amount) + 1 (spk_len varint) + spk_len
+     for each input: witness stack (1 byte count, sig_len byte, 64-byte sig). */
+static int extract_input_sig(const unsigned char *tx, size_t tx_len,
+                              size_t n_inputs, size_t n_outputs,
+                              size_t input_idx,
+                              unsigned char sig_out[64])
+{
+    if (tx_len < 10) return 0;
+    size_t pos = 6;                                 /* version(4)+marker(1)+flag(1) */
+    if ((size_t)tx[pos] != n_inputs) return 0;
+    pos += 1 + 41 * n_inputs;
+    if ((size_t)tx[pos] != n_outputs) return 0;
+    pos += 1;
+    for (size_t i = 0; i < n_outputs; i++) {
+        pos += 8;
+        size_t spk_len = (size_t)tx[pos];
+        pos += 1 + spk_len;
+    }
+    for (size_t i = 0; i < n_inputs; i++) {
+        if (tx[pos] != 0x01) return 0;
+        if (tx[pos + 1] != 0x40) return 0;
+        if (i == input_idx) {
+            memcpy(sig_out, tx + pos + 2, 64);
+            return 1;
+        }
+        pos += 66;
+    }
+    return 0;
+}
+
+int test_factory_multi_input_keyagg(void)
+{
+    secp256k1_context *ctx = mk_test_ctx();
+    /* N = 5 participants: LSP at slot 0 + 4 clients.  k = 2 sub-factory
+       means each leaf has k=2 sub-factories, and each sub-factory has
+       k=2 clients + sales-stock => 3 outputs.  A chain advance of one
+       sub-factory therefore spends 3 inputs from chain[0]. */
+    secp256k1_keypair kps[5];
+    for (int i = 0; i < 5; i++) {
+        unsigned char sk[32] = {0};
+        sk[31] = (unsigned char)(i + 1);
+        sk[0]  = 0xCD;
+        TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], sk), "keypair");
+    }
+
+    /* Build the funding SPK = P2TR(taproot_tweak(N-of-N agg key)). */
+    unsigned char fund_spk[34];
+    {
+        secp256k1_pubkey pks[5];
+        for (int i = 0; i < 5; i++)
+            TEST_ASSERT(secp256k1_keypair_pub(ctx, &pks[i], &kps[i]),
+                        "kp pub");
+        musig_keyagg_t ka;
+        TEST_ASSERT(musig_aggregate_keys(ctx, &ka, pks, 5), "agg keys");
+        unsigned char ser[32];
+        TEST_ASSERT(secp256k1_xonly_pubkey_serialize(ctx, ser, &ka.agg_pubkey),
+                    "xonly ser");
+        unsigned char tweak[32];
+        sha256_tagged("TapTweak", ser, 32, tweak);
+        secp256k1_pubkey tweaked_pk;
+        TEST_ASSERT(secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tweaked_pk,
+                                                             &ka.cache, tweak),
+                    "musig tweak");
+        secp256k1_xonly_pubkey fund_tw;
+        TEST_ASSERT(secp256k1_xonly_pubkey_from_pubkey(ctx, &fund_tw, NULL,
+                                                         &tweaked_pk),
+                    "xonly tw");
+        build_p2tr_script_pubkey(fund_spk, &fund_tw);
+    }
+
+    unsigned char fake_txid[32];
+    memset(fake_txid, 0xBE, 32);
+
+    factory_t *f = (factory_t *)calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+    factory_init(f, ctx, kps, 5, 6, 10);
+    factory_set_arity(f, FACTORY_ARITY_PS);
+    factory_set_ps_subfactory_arity(f, 2);   /* k=2 -> 4 clients per leaf */
+    factory_set_funding(f, fake_txid, 0, 2000000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(f), "build k**2=4 PS tree");
+    TEST_ASSERT(factory_sign_all(f), "sign chain[0]");
+
+    size_t leaf_idx = f->leaf_node_indices[0];
+    factory_node_t *leaf = &f->nodes[leaf_idx];
+    int sub0_node_idx = leaf->subfactory_node_indices[0];
+    TEST_ASSERT(sub0_node_idx >= 0, "sub0 wired");
+    factory_node_t *sub = &f->nodes[sub0_node_idx];
+    TEST_ASSERT_EQ((long)sub->n_outputs, 3, "sub has k+1=3 outputs");
+
+    /* Trigger chain advance: client A buys 50000 from sales-stock. */
+    uint64_t delta = 50000;
+    TEST_ASSERT_EQ(
+        factory_subfactory_chain_advance_unsigned(f, 0, 0, 0, delta),
+        1, "chain advance ok");
+    TEST_ASSERT_EQ(sub->ps_chain_len, 1, "chain_len=1");
+    TEST_ASSERT_EQ((long)sub->ps_n_prev_outputs, 3, "captured 3 prev outputs");
+
+    size_t n_inp = sub->ps_n_prev_outputs;
+    size_t sstock_idx = n_inp - 1;
+
+    /* Driver: per-input ceremony.  Channel inputs sign 2-of-2; sales-stock
+       signs N-of-N (= node->n_signers). */
+    secp256k1_musig_secnonce secnonces[3][FACTORY_MAX_SIGNERS];
+    memset(secnonces, 0, sizeof(secnonces));
+
+    /* Round 1: init + nonces. */
+    for (size_t i = 0; i < n_inp; i++) {
+        TEST_ASSERT(factory_session_init_node_input(f, (size_t)sub0_node_idx, i),
+                    "init per-input session");
+
+        /* Verify per-input metadata after init. */
+        if (i == sstock_idx) {
+            TEST_ASSERT_EQ((long)sub->input_n_signers[i],
+                            (long)sub->n_signers,
+                            "sales-stock n_signers = node N-of-N");
+        } else {
+            TEST_ASSERT_EQ((long)sub->input_n_signers[i], 2,
+                            "channel n_signers = 2-of-2");
+            /* Slot 0 = client_i (signer_indices[i+1]); slot 1 = LSP. */
+            TEST_ASSERT_EQ(
+                (long)sub->input_signer_indices[i][0],
+                (long)sub->signer_indices[i + 1],
+                "channel slot 0 = client_i");
+            TEST_ASSERT_EQ((long)sub->input_signer_indices[i][1], 0,
+                            "channel slot 1 = LSP");
+        }
+
+        size_t this_n = sub->input_n_signers[i];
+        for (size_t s = 0; s < this_n; s++) {
+            uint32_t participant = sub->input_signer_indices[i][s];
+            unsigned char seckey[32];
+            secp256k1_pubkey pk;
+            TEST_ASSERT(secp256k1_keypair_sec(ctx, seckey, &kps[participant]),
+                        "kp sec");
+            TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[participant]),
+                        "kp pub");
+            secp256k1_musig_pubnonce pubnonce;
+            TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[i][s], &pubnonce,
+                                               seckey, &pk,
+                                               &sub->input_keyaggs[i].cache),
+                        "gen nonce per-input");
+            TEST_ASSERT(factory_session_set_nonce_input(
+                            f, (size_t)sub0_node_idx, i, s, &pubnonce),
+                        "set nonce per-input");
+            memset(seckey, 0, 32);
+        }
+        TEST_ASSERT(factory_session_finalize_node_input(
+                        f, (size_t)sub0_node_idx, i),
+                    "finalize per-input");
+    }
+
+    /* Round 2: partial sigs. */
+    for (size_t i = 0; i < n_inp; i++) {
+        size_t this_n = sub->input_n_signers[i];
+        for (size_t s = 0; s < this_n; s++) {
+            uint32_t participant = sub->input_signer_indices[i][s];
+            secp256k1_musig_partial_sig psig;
+            TEST_ASSERT(musig_create_partial_sig(
+                            ctx, &psig, &secnonces[i][s], &kps[participant],
+                            &sub->input_signing_sessions[i]),
+                        "create per-input psig");
+            TEST_ASSERT(factory_session_set_partial_sig_input(
+                            f, (size_t)sub0_node_idx, i, s, &psig),
+                        "set per-input psig");
+        }
+        TEST_ASSERT(factory_session_complete_node_input(
+                        f, (size_t)sub0_node_idx, i),
+                    "complete per-input");
+    }
+
+    TEST_ASSERT(factory_session_assemble_signed_tx_multi(
+                    f, (size_t)sub0_node_idx),
+                "assemble multi-witness signed_tx");
+    TEST_ASSERT(sub->is_signed, "sub signed");
+    TEST_ASSERT(sub->signed_tx.len > 100, "signed_tx populated");
+
+    /* Extract per-input Schnorr sigs and verify each against the recorded
+       prev-output SPK (i.e., what bitcoind will check on broadcast). */
+    for (size_t i = 0; i < n_inp; i++) {
+        unsigned char sig64[64];
+        TEST_ASSERT(extract_input_sig(sub->signed_tx.data, sub->signed_tx.len,
+                                       n_inp, sub->n_outputs, i, sig64),
+                    "extract per-input sig");
+
+        /* Recompute the per-input BIP-341 sighash via the same helper the
+           library uses for finalize. */
+        unsigned char sighash[32];
+        const unsigned char *spks[FACTORY_MAX_OUTPUTS];
+        uint32_t seqs[FACTORY_MAX_OUTPUTS];
+        for (size_t j = 0; j < n_inp; j++) {
+            spks[j] = sub->ps_prev_spks[j];
+            seqs[j] = sub->nsequence;
+        }
+        TEST_ASSERT(compute_taproot_sighash_multi(sighash,
+                        sub->unsigned_tx.data, sub->unsigned_tx.len,
+                        (uint32_t)i, n_inp, spks, sub->ps_prev_spk_lens,
+                        sub->ps_prev_amounts, seqs),
+                    "recompute per-input sighash");
+
+        TEST_ASSERT_EQ((long)sub->ps_prev_spk_lens[i], 34,
+                        "prev SPK is P2TR (34 bytes)");
+        secp256k1_xonly_pubkey xonly;
+        TEST_ASSERT(secp256k1_xonly_pubkey_parse(ctx, &xonly,
+                                                   sub->ps_prev_spks[i] + 2),
+                    "parse prev SPK xonly");
+        int ok = secp256k1_schnorrsig_verify(ctx, sig64, sighash, 32, &xonly);
+        char msg[64];
+        snprintf(msg, sizeof(msg), "schnorrsig_verify input %zu", i);
+        TEST_ASSERT(ok, msg);
+    }
+
+    /* Per-input signer-slot helpers. */
+    for (size_t i = 0; i < n_inp; i++) {
+        TEST_ASSERT(factory_session_input_signs(f, (size_t)sub0_node_idx, i, 0),
+                    "LSP signs every input");
+    }
+    uint32_t client0 = sub->signer_indices[1];
+    uint32_t client1 = sub->signer_indices[2];
+    TEST_ASSERT(factory_session_input_signs(f, (size_t)sub0_node_idx, 0, client0),
+                "client0 signs channel 0");
+    TEST_ASSERT(!factory_session_input_signs(f, (size_t)sub0_node_idx, 0, client1),
+                "client1 does NOT sign channel 0");
+    TEST_ASSERT(factory_session_input_signs(f, (size_t)sub0_node_idx, 1, client1),
+                "client1 signs channel 1");
+    TEST_ASSERT(!factory_session_input_signs(f, (size_t)sub0_node_idx, 1, client0),
+                "client0 does NOT sign channel 1");
+    TEST_ASSERT(factory_session_input_signs(f, (size_t)sub0_node_idx, sstock_idx, client0),
+                "client0 signs sales-stock");
+    TEST_ASSERT(factory_session_input_signs(f, (size_t)sub0_node_idx, sstock_idx, client1),
+                "client1 signs sales-stock");
+
+    factory_free(f);
+    free(f);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -101,6 +101,7 @@ extern int test_factory_advance(void);
 extern int test_factory_sign_split_round_step_by_step(void);
 extern int test_factory_split_round_with_pool(void);
 extern int test_factory_advance_split_round(void);
+extern int test_factory_multi_input_keyagg(void);
 extern int test_regtest_factory_tree(void);
 
 extern int test_bip158_backend_init(void);
@@ -1995,6 +1996,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_sign_split_round_step_by_step);
     RUN_TEST(test_factory_split_round_with_pool);
     RUN_TEST(test_factory_advance_split_round);
+    RUN_TEST(test_factory_multi_input_keyagg);
 
     printf("\n=== BIP 158 Compact Block Filters ===\n");
     RUN_TEST(test_bip158_backend_init);

--- a/tools/superscalar_lsp_post_daemon_tests.inc
+++ b/tools/superscalar_lsp_post_daemon_tests.inc
@@ -846,9 +846,11 @@
          - Legacy path (default)
          - Phase 1c new path (when SS_MUSIG_STATELESS=1) */
     if (test_wire_leaf_advance && channels_active) {
-        const char *stateless = getenv("SS_MUSIG_STATELESS");
+        /* Phase 2 (#272): stateless is default-on; report 0 only if
+           SS_MUSIG_LEGACY=1 forces a fallback. */
+        const char *legacy = getenv("SS_MUSIG_LEGACY");
         printf("\n=== POST-DAEMON WIRE LEAF ADVANCE TEST (stateless=%s) ===\n",
-               (stateless && stateless[0] == '1') ? "1" : "0");
+               (legacy && legacy[0] == '1') ? "0" : "1");
         fflush(stdout);
         int adv_rc = lsp_channels_advance_ps_leaf(mgr, lsp_p, 0);
         if (adv_rc == 1) {

--- a/tools/test_multiprocess_subfactory_advance.sh
+++ b/tools/test_multiprocess_subfactory_advance.sh
@@ -234,7 +234,7 @@ while [ "$WAITED" -lt 600 ]; do
         break
     fi
     if [ $((WAITED % 20)) -eq 0 ]; then
-        SUB_PROGRESS=$(grep -c "sub-factory.*chain extended\|PS K² SUB-FACTORY TEST" "$LSP_LOG" 2>/dev/null || echo 0)
+        SUB_PROGRESS=$(grep -cE "sub-factory.*chain extended|LSP-stateless subfactory MULTI-INPUT advance.*DONE|PS K² SUB-FACTORY TEST" "$LSP_LOG" 2>/dev/null || echo 0)
         echo "  ... ${WAITED}s elapsed, sub-factory markers in LSP log: $SUB_PROGRESS"
     fi
     sleep 2
@@ -271,12 +271,12 @@ if ! grep -q "PS K² SUB-FACTORY CHAIN EXTENSION TEST" "$LSP_LOG"; then
 fi
 echo "  test header present"
 
-if ! grep -q "sub-factory.*chain extended" "$LSP_LOG"; then
+if ! grep -qE "sub-factory.*chain extended|LSP-stateless subfactory MULTI-INPUT advance.*DONE" "$LSP_LOG"; then
     echo "FAIL: sub-factory chain extension never fired"
     tail -80 "$LSP_LOG"
     exit 1
 fi
-CE_LINE=$(grep "sub-factory.*chain extended" "$LSP_LOG" | head -1)
+CE_LINE=$(grep -E "sub-factory.*chain extended|LSP-stateless subfactory MULTI-INPUT advance.*DONE" "$LSP_LOG" | head -1)
 echo "  $CE_LINE"
 
 if ! grep -q "PS K² SUB-FACTORY TEST: PASS" "$LSP_LOG"; then
@@ -314,9 +314,9 @@ for i in $(seq 0 $((N_CLIENTS - 1))); do
     # multi-input ceremony (#142 SF-A) which logs "advanced (MULTI) to
     # chain_len".  Sub-factories with ps_chain_len>0 + n_prev_outputs>1
     # use the multi-input MuSig fork added in PR #270.
-    if grep -qE "sub-factory.*advanced( \(MULTI\))? to chain_len" "$LOG" 2>/dev/null; then
+    if grep -qE "sub-factory.*advanced( \(MULTI\))? to chain_len|Client-stateless subfactory MULTI-INPUT [0-9]+: advance done" "$LOG" 2>/dev/null; then
         PARTICIPATED=$((PARTICIPATED + 1))
-        SA=$(grep -E "sub-factory.*advanced( \(MULTI\))? to chain_len" "$LOG" | head -1)
+        SA=$(grep -E "sub-factory.*advanced( \(MULTI\))? to chain_len|Client-stateless subfactory MULTI-INPUT [0-9]+: advance done" "$LOG" | head -1)
         echo "  client[$i]: participated — $SA"
     else
         echo "  client[$i]: no sub-factory advance marker (may be in different sub-factory)"


### PR DESCRIPTION
## Summary

**MUSIG-PHASE-2 (#272):** flips MuSig2 stateless to the default behavior and renames the opt-out to `SS_MUSIG_LEGACY=1`. Mechanical changes at 7 read sites; legacy fall-through paths preserved unchanged (deleted in Phase 3).

## Context

The BIP-327 stateless MuSig2 signer (introduced in #271 / #330) has been fully validated through:
- Complete ceremony set merged (#333 / #334 / #336)
- Hardening tests (#338 — poison restart + multi-input breach)
- Nonce-safety invariant in CI (#337 — 1475/1475 unit tests)
- Cheat-engine parity (#339 — CL7 wire-up)
- Full observability journals (#340 — Tier B signing_rounds + participants + pre-rotation snapshot)
- Wallet-team v34 API parity (#341 — factory creation ceremonies + ceremony_participants)

Everything that needs to be true for stateless to be the production-shape default is now true.

## Changes

7 sites mechanically transformed from "if `SS_MUSIG_STATELESS=1` then stateless else legacy" to "if `SS_MUSIG_LEGACY=1` then legacy else stateless":

- `src/client.c` × 2 (factory creation client dispatch + leaf advance dispatch)
- `src/lsp_channels.c` × 3 (leaf advance + state advance + sub-factory chain advance)
- `src/lsp.c` × 1 (factory creation LSP dispatch)
- `tools/superscalar_lsp_post_daemon_tests.inc` × 1 (test logging)

Legacy fall-through paths unchanged — they're deleted in Phase 3.

## Migration

- **No action needed** if you want the new stateless behavior — it is the default.
- Set `SS_MUSIG_LEGACY=1` in the LSP environment to opt back into the legacy nonce-pool path. This option is removed in Phase 3.
- The opt-in `SS_MUSIG_STATELESS=1` env var becomes a no-op. Existing test scripts that still set it continue to work but the variable has no effect.

## Validation (regtest)

| | EXIT | stateless markers in LSP log |
|---|---|---|
| `test_regtest_tier_b_rollover_ps` (no env, default) | **0** | **1** ✓ stateless is default |
| `test_regtest_tier_b_rollover_ps` (`SS_MUSIG_LEGACY=1`) | **0** | **0** ✓ legacy fallback works |

Plus full unit suite: **1475/1475** pass.

CHANGELOG entry added under Unreleased.
