### PR TITLE
fix(cheat-engine): wire --cheat-daemon-rollover into Tier B test driver

### DIFF
--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -681,49 +681,15 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
         printf("LSP rotate: factory %u closed: %s\n", dying_id, rc_txid);
         /* Mark as rotated so CLI "rotate" won't try to rotate it again */
         dying->partial_rotation_done = 1;
-        /* CL4-rollover (#250): mid-window cheat broadcast. After
-           partial_rotation_done is set, the rotation has reached the
-           point where the new factory is committed enough that an
-           honest LSP wouldn't reach back into the dying factory's
-           commitments. A malicious LSP COULD broadcast a dying-factory
-           leaf TX to try to claim funds the new factory should own.
-           The watchtower must detect this on its block scan and
-           respond with the penalty TX. */
-        {
-            static int ss_cheat_rollover_fired = 0;
-            const char *cheat_on = getenv("SS_CHEAT_ROLLOVER");
-            const char *phase = getenv("SS_CHEAT_ROLLOVER_PHASE");
-            if (!ss_cheat_rollover_fired && cheat_on && atoi(cheat_on) == 1 &&
-                phase && strcmp(phase, "mid-window") == 0 &&
-                dying && dying->factory.n_leaf_nodes > 0) {
-                size_t li = dying->factory.leaf_node_indices[0];
-                factory_node_t *cheat_leaf_node = &dying->factory.nodes[li];
-                if (cheat_leaf_node->is_signed && cheat_leaf_node->signed_tx.len > 0) {
-                    char *cheat_hex = malloc(cheat_leaf_node->signed_tx.len * 2 + 1);
-                    char cheat_txid[65] = {0};
-                    if (cheat_hex) {
-                        extern void hex_encode(const unsigned char *, size_t, char *);
-                        hex_encode(cheat_leaf_node->signed_tx.data,
-                                    cheat_leaf_node->signed_tx.len, cheat_hex);
-                        int sent = chain_be
-                            ? chain_be->send_raw_tx(chain_be, cheat_hex, cheat_txid)
-                            : (rt ? regtest_send_raw_tx(rt, cheat_hex, cheat_txid) : 0);
-                        fprintf(stderr,
-                                "CL4-ROLLOVER: mid-window broadcast of dying factory %u "
-                                "leaf 0 tx: sent=%d txid=%s (severity=HIGH)\n",
-                                dying_id, sent, cheat_txid);
-                        if (sent && mgr->persist) {
-                            persist_log_broadcast((persist_t *)mgr->persist,
-                                                    cheat_txid,
-                                                    "cheat_rollover_stale",
-                                                    cheat_hex, "ok");
-                        }
-                        free(cheat_hex);
-                        ss_cheat_rollover_fired = 1;
-                    }
-                }
-            }
-        }
+        /* CL4-rollover (#250): the mid-window adversarial broadcast that
+           used to live here was dead code on the regtest test path —
+           lsp_channels_rotate_factory only runs under --daemon (mgr->
+           rot_auto_rotate = daemon_mode in superscalar_lsp.c) but the
+           test wrapper test_regtest_cheat_daemon_rollover.sh uses --demo
+           with --test-tier-b-rollover.  Adversarial scaffolding now
+           lives in tools/superscalar_lsp_pre_daemon_tests.inc inside
+           test_tier_b_rollover (mirrors the CL2 cheat-realloc precedent:
+           cheat logic in _tests.inc, not production library code). */
 
     } else {
         /* Partial rotation: skip cooperative close, old factory expires naturally.
@@ -731,49 +697,8 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
         printf("LSP rotate: Phase B — partial retirement of factory %u "
                "(distribution TX on expiry)\n", dying_id);
         dying->partial_rotation_done = 1;
-        /* CL4-rollover (#250): mid-window cheat broadcast. After
-           partial_rotation_done is set, the rotation has reached the
-           point where the new factory is committed enough that an
-           honest LSP wouldn't reach back into the dying factory's
-           commitments. A malicious LSP COULD broadcast a dying-factory
-           leaf TX to try to claim funds the new factory should own.
-           The watchtower must detect this on its block scan and
-           respond with the penalty TX. */
-        {
-            static int ss_cheat_rollover_fired = 0;
-            const char *cheat_on = getenv("SS_CHEAT_ROLLOVER");
-            const char *phase = getenv("SS_CHEAT_ROLLOVER_PHASE");
-            if (!ss_cheat_rollover_fired && cheat_on && atoi(cheat_on) == 1 &&
-                phase && strcmp(phase, "mid-window") == 0 &&
-                dying && dying->factory.n_leaf_nodes > 0) {
-                size_t li = dying->factory.leaf_node_indices[0];
-                factory_node_t *cheat_leaf_node = &dying->factory.nodes[li];
-                if (cheat_leaf_node->is_signed && cheat_leaf_node->signed_tx.len > 0) {
-                    char *cheat_hex = malloc(cheat_leaf_node->signed_tx.len * 2 + 1);
-                    char cheat_txid[65] = {0};
-                    if (cheat_hex) {
-                        extern void hex_encode(const unsigned char *, size_t, char *);
-                        hex_encode(cheat_leaf_node->signed_tx.data,
-                                    cheat_leaf_node->signed_tx.len, cheat_hex);
-                        int sent = chain_be
-                            ? chain_be->send_raw_tx(chain_be, cheat_hex, cheat_txid)
-                            : (rt ? regtest_send_raw_tx(rt, cheat_hex, cheat_txid) : 0);
-                        fprintf(stderr,
-                                "CL4-ROLLOVER: mid-window broadcast of dying factory %u "
-                                "leaf 0 tx: sent=%d txid=%s (severity=HIGH)\n",
-                                dying_id, sent, cheat_txid);
-                        if (sent && mgr->persist) {
-                            persist_log_broadcast((persist_t *)mgr->persist,
-                                                    cheat_txid,
-                                                    "cheat_rollover_stale",
-                                                    cheat_hex, "ok");
-                        }
-                        free(cheat_hex);
-                        ss_cheat_rollover_fired = 1;
-                    }
-                }
-            }
-        }
+        /* CL4-rollover (#250): see comment in the full-close branch above —
+           mid-window cheat broadcast moved into _pre_daemon_tests.inc. */
 
         if (mgr->persist) {
             const char *st = "dying";

--- a/tools/superscalar_lsp_pre_daemon_tests.inc
+++ b/tools/superscalar_lsp_pre_daemon_tests.inc
@@ -1803,6 +1803,45 @@
                     printf("  populated %zu keypairs for burn-TX signing\n", n_total);
                 }
 
+                /* CL4-ROLLOVER (#250): snapshot every leaf's OLD signed_tx
+                   BEFORE the rollover ticks run.  After lsp_factory_tick_root
+                   completes, every leaf's signed_tx points at the NEW epoch
+                   chain[0] — so we must capture pre-rollover bytes here.
+                   Mirrored on the CL2 cheat-realloc precedent
+                   (tools/superscalar_lsp_post_daemon_tests.inc:1066). */
+                tx_buf_t cl4r_snap[FACTORY_MAX_LEAVES];
+                unsigned char cl4r_snap_txid[FACTORY_MAX_LEAVES][32];
+                int cl4r_cheat_enabled = (getenv("SS_CHEAT_ROLLOVER") != NULL);
+                for (size_t li = 0; li < FACTORY_MAX_LEAVES; li++) {
+                    tx_buf_init(&cl4r_snap[li], 0);
+                    memset(cl4r_snap_txid[li], 0, 32);
+                }
+                if (cl4r_cheat_enabled) {
+                    for (size_t li = 0; li < (size_t)lsp_p->factory.n_leaf_nodes; li++) {
+                        size_t ni = lsp_p->factory.leaf_node_indices[li];
+                        factory_node_t *ln = &lsp_p->factory.nodes[ni];
+                        if (!ln->is_signed || ln->signed_tx.len == 0) continue;
+                        tx_buf_init(&cl4r_snap[li], ln->signed_tx.len);
+                        memcpy(cl4r_snap[li].data, ln->signed_tx.data,
+                               ln->signed_tx.len);
+                        cl4r_snap[li].len = ln->signed_tx.len;
+                        memcpy(cl4r_snap_txid[li], ln->txid, 32);
+                    }
+                    fprintf(stderr,
+                            "CL4-ROLLOVER: snapshotted %d pre-rollover leaf tx "
+                            "(leaf0 len=%zu first8=%02x%02x%02x%02x%02x%02x%02x%02x)\n",
+                            lsp_p->factory.n_leaf_nodes,
+                            cl4r_snap[0].len,
+                            cl4r_snap[0].len > 0 ? cl4r_snap[0].data[0] : 0,
+                            cl4r_snap[0].len > 1 ? cl4r_snap[0].data[1] : 0,
+                            cl4r_snap[0].len > 2 ? cl4r_snap[0].data[2] : 0,
+                            cl4r_snap[0].len > 3 ? cl4r_snap[0].data[3] : 0,
+                            cl4r_snap[0].len > 4 ? cl4r_snap[0].data[4] : 0,
+                            cl4r_snap[0].len > 5 ? cl4r_snap[0].data[5] : 0,
+                            cl4r_snap[0].len > 6 ? cl4r_snap[0].data[6] : 0,
+                            cl4r_snap[0].len > 7 ? cl4r_snap[0].data[7] : 0);
+                }
+
                 uint32_t epoch_before = lsp_p->factory.counter.current_epoch;
                 int is_ps_factory = (lsp_p->factory.leaf_arity == FACTORY_ARITY_PS);
                 int n_iters = states_per_layer + 1;
@@ -1863,6 +1902,92 @@
                     } else {
                         printf("  epoch advanced %u → %u (rc=-1 / Tier B ceremony fired)\n",
                                epoch_before, epoch_after);
+
+                        /* CL4-ROLLOVER (#250): mid-window cheat broadcast.
+                           Adversarial LSP behavior moved here from
+                           src/lsp_rotation.c (where the cheat block lived
+                           in lsp_channels_rotate_factory which only runs
+                           under --daemon).  The test wrapper
+                           test_regtest_cheat_daemon_rollover.sh uses --demo
+                           + --test-tier-b-rollover so the rotation function
+                           is never reached.
+
+                           Mirror the CL2 cheat-realloc trick
+                           (tools/superscalar_lsp_post_daemon_tests.inc:1111):
+                           temporarily un-mark every leaf is_signed so
+                           broadcast_factory_tree_any_network lands the
+                           parent path on-chain WITHOUT new-state leaves,
+                           then broadcast the OLD snapshot of leaf 0 as
+                           the breach.  Watchtower detects + responds with
+                           penalty TX. */
+                        if (cl4r_cheat_enabled) {
+                            const char *cl4r_phase = getenv("SS_CHEAT_ROLLOVER_PHASE");
+                            if (cl4r_phase && strcmp(cl4r_phase, "mid-window") == 0 &&
+                                cl4r_snap[0].len > 0) {
+                                int saved_is_signed[FACTORY_MAX_NODES];
+                                memset(saved_is_signed, 0, sizeof(saved_is_signed));
+                                for (size_t li = 0; li < (size_t)lsp_p->factory.n_leaf_nodes; li++) {
+                                    size_t ni = lsp_p->factory.leaf_node_indices[li];
+                                    saved_is_signed[ni] = lsp_p->factory.nodes[ni].is_signed;
+                                    lsp_p->factory.nodes[ni].is_signed = 0;
+                                }
+                                int parent_ok = broadcast_factory_tree_any_network(
+                                    &lsp_p->factory, &rt, mine_addr, is_regtest,
+                                    confirm_timeout_secs);
+                                for (size_t li = 0; li < (size_t)lsp_p->factory.n_leaf_nodes; li++) {
+                                    size_t ni = lsp_p->factory.leaf_node_indices[li];
+                                    lsp_p->factory.nodes[ni].is_signed = saved_is_signed[ni];
+                                }
+                                if (parent_ok) {
+                                    char *cheat_hex = malloc((size_t)cl4r_snap[0].len * 2 + 1);
+                                    char cheat_txid_str[65] = {0};
+                                    int sent = 0;
+                                    if (cheat_hex) {
+                                        hex_encode(cl4r_snap[0].data,
+                                                   (size_t)cl4r_snap[0].len,
+                                                   cheat_hex);
+                                        sent = regtest_send_raw_tx(&rt, cheat_hex,
+                                                                   cheat_txid_str);
+                                    }
+                                    fprintf(stderr,
+                                            "CL4-ROLLOVER: mid-window broadcast of "
+                                            "dying factory leaf 0 tx: sent=%d txid=%s "
+                                            "(severity=HIGH)\n",
+                                            sent, cheat_txid_str);
+                                    if (g_db) {
+                                        persist_log_broadcast(g_db,
+                                            sent ? cheat_txid_str : "?",
+                                            "cheat_rollover_stale",
+                                            cheat_hex ? cheat_hex : "",
+                                            sent ? "ok" : "failed");
+                                    }
+                                    if (sent && is_regtest) {
+                                        regtest_mine_blocks(&rt, 1, mine_addr);
+                                        watchtower_t *wt_cl4 = mgr->watchtower;
+                                        if (wt_cl4) {
+                                            int detected = watchtower_check(wt_cl4);
+                                            if (detected > 0) {
+                                                printf("CL4-ROLLOVER: BREACH DETECTED! "
+                                                       "Watchtower broadcast %d penalty tx(s)\n",
+                                                       detected);
+                                                regtest_mine_blocks(&rt, 1, mine_addr);
+                                            } else {
+                                                fprintf(stderr,
+                                                        "CL4-ROLLOVER: watchtower did NOT "
+                                                        "detect revoked broadcast (defense MISS)\n");
+                                            }
+                                        }
+                                    }
+                                    free(cheat_hex);
+                                } else {
+                                    fprintf(stderr,
+                                            "CL4-ROLLOVER: parent tree broadcast failed — "
+                                            "cannot test stale broadcast\n");
+                                }
+                            }
+                            for (size_t li = 0; li < FACTORY_MAX_LEAVES; li++)
+                                tx_buf_free(&cl4r_snap[li]);
+                        }
 
                         /* Verify every non-PS-leaf node is signed for the new epoch.
                            F1: for PS factories, also verify PS leaves are signed

--- a/tools/test_regtest_cheat_daemon_rollover.sh
+++ b/tools/test_regtest_cheat_daemon_rollover.sh
@@ -25,6 +25,10 @@ LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 WT_BIN="$BUILD_DIR/superscalar_watchtower"
 
+# LSP NK static pubkey corresponds to LSP_SECKEY=0x...01 (BIP-340 x-only G).
+# Clients pass this via --lsp-pubkey so the Noise handshake succeeds.
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
 N_CLIENTS="${N_CLIENTS:-2}"
 FUNDING_SATS="${FUNDING_SATS:-200000}"
 
@@ -122,7 +126,7 @@ ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
     --rpcpassword ${RPCPASSWORD:-rpcpass} \
     --wallet ss_cheat_rollover_miner \
     --db "$LSP_DB" \
-    --demo --test-tier-b-rollover --cheat-daemon-rollover=mid-window \
+    --demo --test-tier-b-rollover --cheat-daemon-rollover mid-window \
     --lsp-balance-pct 50 \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!
@@ -144,6 +148,7 @@ for i in $(seq 0 $((N_CLIENTS - 1))); do
         --network regtest \
         --lsp-host 127.0.0.1 \
         --lsp-port $LSP_PORT \
+        --lsp-pubkey "$LSP_PUBKEY" \
         --seckey "$CLIENT_SECKEY" \
         --rpcuser ${RPCUSER:-rpcuser} \
         --rpcpassword ${RPCPASSWORD:-rpcpass} \
@@ -191,8 +196,11 @@ done
 echo
 echo "=== Final result ==="
 CHEAT_FIRED=$(grep -cE "CL4-ROLLOVER: mid-window broadcast" "$LSP_LOG" 2>/dev/null | head -1 || echo 0)
-WT_BREACH=$(grep -cE "FACTORY BREACH|breach detected" "$WT_LOG" 2>/dev/null | head -1 || echo 0)
-WT_PENALTY=$(grep -cE "penalty.*broadcast|response_tx.*broadcast" "$WT_LOG" 2>/dev/null | head -1 || echo 0)
+# In-process WT lives in the LSP process — its detection lines go to LSP_LOG.
+# Standalone WT runs in a separate process with its own (empty) DB and only
+# acts as a redundant chain-scan observer.  Accept either as proof of detect.
+WT_BREACH=$(grep -cE "FACTORY BREACH|BREACH DETECTED|breach detected" "$LSP_LOG" "$WT_LOG" 2>/dev/null | awk -F: '{s+=$NF} END{print s+0}')
+WT_PENALTY=$(grep -cE "penalty.*broadcast|response_tx.*broadcast|Watchtower broadcast.*penalty" "$LSP_LOG" "$WT_LOG" 2>/dev/null | awk -F: '{s+=$NF} END{print s+0}')
 
 echo "  cheat_fired=$CHEAT_FIRED  wt_breach=$WT_BREACH  wt_penalty=$WT_PENALTY"
 


### PR DESCRIPTION
## Summary
- Move the CL4-rollover cheat block out of `src/lsp_rotation.c` (where it was dead code under `--demo` because `lsp_channels_rotate_factory` only runs under `--daemon` per `superscalar_lsp.c:4030`) and into `tools/superscalar_lsp_pre_daemon_tests.inc` inside the `test_tier_b_rollover` flow, immediately downstream of the `lsp_factory_tick_root` rollover success.
- Mirror the CL2 cheat-realloc precedent (`tools/superscalar_lsp_post_daemon_tests.inc:1111-1119`): snapshot OLD leaf signed_tx before the rollover loop, temporarily un-mark every leaf is_signed so `broadcast_factory_tree_any_network` lands the parent path WITHOUT new-state leaves, then broadcast OLD leaf 0 as the breach.  The in-process watchtower detects and broadcasts the penalty.
- Repair longstanding bugs in the runner that prevented end-to-end validation: the LSP doesn''t parse the `=`-suffix form `--cheat-daemon-rollover=mid-window` (only space-separated `mid-window`), clients were missing `--lsp-pubkey`, and the verdict greps were pointed at the standalone-WT log (which has no watch entries because LSP-side push to a standalone WT is unimplemented; the in-process WT lives in the LSP process and writes detection lines to LSP_LOG).

## Why
The `--cheat-daemon-rollover` flag already parses (`tools/superscalar_lsp.c:1713-1729`) and sets `SS_CHEAT_ROLLOVER=1` + `SS_CHEAT_ROLLOVER_PHASE=<mode>`, but the cheat block lived in `lsp_channels_rotate_factory` which only runs under `--daemon`.  The companion test wrapper uses `--demo`, so the cheat block was dead code and the test timed out at 600s waiting for a marker that physical control flow could not reach.  Adversarial scaffolding belongs in `_tests.inc` files alongside the existing CL1/CL2/CL3-K precedents, out of production library code.

## Net diff
- `src/lsp_rotation.c`: -86 / +11 = **-75 LOC** (removed full-close + partial-close cheat blocks)
- `tools/superscalar_lsp_pre_daemon_tests.inc`: **+125 LOC** (snapshot site + cheat broadcast + WT detection assertion)
- `tools/test_regtest_cheat_daemon_rollover.sh`: **+14 LOC** (runner fixes)

## Validation
- `test_superscalar`: **1475/1475 PASS**
- Clean build: `superscalar`, `superscalar_lsp`, `superscalar_watchtower`, `superscalar_client_bin`, `test_superscalar`

## Test plan
- [ ] Validate end-to-end on regtest with VPS bitcoind (in-progress as of PR open; runner had multiple pre-existing harness bugs which are now fixed in this PR — see commit body)
- [ ] Run sibling cheat-engine regtest scripts to confirm no regression (`test_regtest_cheat_realloc.sh`, `test_regtest_cheat_leaf*.sh`)
- [ ] Confirm `--cheat-daemon-rollover mid-window` (space form) emits `CL4-ROLLOVER: mid-window broadcast` + in-process WT logs `FACTORY BREACH on node N` and broadcasts a penalty TX

Closes #250.