### PR TITLE
feat(crash-inject): MSG_FORCE_OUT + MSG_ROTATE wire ops (#245 Half B)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ add_executable(test_superscalar
     tests/test_cpfp.c
     tests/test_jit.c
     tests/test_ceremony.c
+    tests/test_crash_checkpoint.c
     tests/test_property.c
     tests/test_backup.c
     tests/test_keyfile.c

--- a/include/superscalar/crash_inject.h
+++ b/include/superscalar/crash_inject.h
@@ -27,4 +27,11 @@
  */
 void lsp_crash_checkpoint(const char *name);
 
+/* SF-CRASH-INJECT-WIRE #245 Half B: install a runtime crash-checkpoint
+   target.  NULL or "" clears it.  The runtime target is checked BEFORE
+   the SUPERSCALAR_CRASH_AT env var so wire-driven tests (MSG_FORCE_OUT)
+   can override compile-time settings.
+   THREAD UNSAFE -- for single-process test harness only. */
+void lsp_crash_set_target(const char *name);
+
 #endif /* SUPERSCALAR_CRASH_INJECT_H */

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -190,6 +190,21 @@
    affected nodes in order, each n_signers slots of 32 bytes. */
 #define MSG_STATE_ADV_ALL_PSIGS           0x89
 
+/* ============================================================
+ * Crash injection / test control (TEST ONLY -- gated by
+ * SUPERSCALAR_CRASH_ALLOW env var; production builds drop these).
+ * ============================================================ */
+
+/* MSG_FORCE_OUT: install a runtime crash-checkpoint target.  When the LSP
+   reaches lsp_crash_checkpoint(name) and the installed target matches,
+   the LSP aborts.  Empty name = abort immediately.  See crash_inject.h. */
+#define MSG_FORCE_OUT 0x8A
+
+/* MSG_ROTATE: trigger an in-process factory rotation independent of the
+   lifecycle timer.  Optional 1-byte mode: 0x00 full-close (default),
+   0x01 partial-close-only. */
+#define MSG_ROTATE 0x8B
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -1230,5 +1245,13 @@ cJSON *wire_build_queue_items(const queue_entry_t *entries, size_t count);
 int wire_parse_queue_done(const cJSON *json,
                            uint64_t *ids_out, size_t max_ids,
                            size_t *count_out);
+
+
+/* SF-CRASH-INJECT-WIRE #245 Half B: test-only crash injection opcodes.
+   See crash_inject.h for the lsp_crash_set_target() runtime API. */
+cJSON *wire_build_force_out(const char *checkpoint_name);
+int    wire_parse_force_out(const cJSON *json, char out_name[64]);
+cJSON *wire_build_rotate(uint8_t mode);
+int    wire_parse_rotate(const cJSON *json, uint8_t *out_mode);
 
 #endif /* SUPERSCALAR_WIRE_H */

--- a/src/crash_inject.c
+++ b/src/crash_inject.c
@@ -4,13 +4,58 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* SF-CRASH-INJECT-WIRE #245 Half B: runtime crash-checkpoint target.
+   Installed via lsp_crash_set_target() (e.g., from the MSG_FORCE_OUT
+   dispatcher case).  Empty/uninstalled = "" => no runtime target,
+   fall through to the existing SUPERSCALAR_CRASH_AT env-var path.
+   THREAD UNSAFE -- single-process test harness only. */
+static volatile char g_runtime_target[64] = {0};
+
+void lsp_crash_set_target(const char *name) {
+    if (!name || !*name) {
+        g_runtime_target[0] = '\0';
+        return;
+    }
+    /* Manual copy with explicit null terminator (strncpy on volatile
+       trips -Wcast-qual on some toolchains). */
+    size_t i = 0;
+    for (; i < 63 && name[i] != '\0'; i++)
+        g_runtime_target[i] = name[i];
+    g_runtime_target[i] = '\0';
+}
+
 void lsp_crash_checkpoint(const char *name) {
+    if (!name) return;
+
+    /* Runtime target wins over env var.  Empty runtime target = not
+       installed (per lsp_crash_set_target(NULL) semantics). */
+    if (g_runtime_target[0] != '\0') {
+        /* Compare against a non-volatile snapshot for strcmp safety. */
+        char snap[64];
+        size_t i = 0;
+        for (; i < 63; i++) {
+            snap[i] = g_runtime_target[i];
+            if (snap[i] == '\0') break;
+        }
+        snap[63] = '\0';
+        if (strcmp(snap, name) == 0) {
+            fprintf(stderr,
+                    "lsp_crash_checkpoint: HIT '%s' -- aborting (runtime target)\n",
+                    name);
+            fflush(stderr);
+            abort();
+        }
+    }
+
+    /* Existing env-var path. */
     const char *target = getenv("SUPERSCALAR_CRASH_AT");
-    if (!target || !name) return;
-    if (strcmp(target, name) != 0) return;
-    fprintf(stderr,
-            "lsp_crash_checkpoint: HIT '%s' — aborting per SUPERSCALAR_CRASH_AT\n",
-            name);
-    fflush(stderr);
-    abort();
+    if (!target) return;
+    /* Empty env var = always abort (any checkpoint matches). */
+    if (*target == '\0' || strcmp(target, name) == 0) {
+        fprintf(stderr,
+                "lsp_crash_checkpoint: HIT '%s' -- aborting per SUPERSCALAR_CRASH_AT\n",
+                name);
+        fflush(stderr);
+        abort();
+    }
 }

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -508,6 +508,11 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
         cJSON_Delete(intent);
     }
 
+    /* SF-CRASH-INJECT-WIRE #245 Half B demo callsite: PROPOSE just sent,
+       client psigs not yet collected.  Test harnesses set SUPERSCALAR_CRASH_AT
+       or MSG_FORCE_OUT target to "factory_creation_propose" to abort here. */
+    lsp_crash_checkpoint("factory_creation_propose");
+
     /* all_pn[(node_idx * FACTORY_MAX_SIGNERS + signer_slot) * 66] -- full
        signer x node nonce matrix.  Filled from client pubnonces (Step B) and
        LSP pubnonces (Step C), forwarded to clients in LSP_RESPONSE so each
@@ -677,6 +682,11 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
         }
         free(client_psig);
     }
+
+    /* SF-CRASH-INJECT-WIRE #245 Half B demo callsite: all client psigs
+       collected, ceremony about to finalize.  Crash here tests the
+       resume-from-N-1-signed recovery path. */
+    lsp_crash_checkpoint("factory_creation_signed");
 
     /* ---- Completion: identical to legacy lsp_run_factory_creation ---- */
     if (!factory_sessions_complete(f)) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -18,6 +18,7 @@
 #include "superscalar/readiness.h"
 #include "superscalar/notify.h"
 #include "superscalar/admin_rpc.h"
+#include "superscalar/crash_inject.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -5101,6 +5102,46 @@ int lsp_channels_handle_msg(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                    (size_t)readiness_count_ready(rt),
                    rt->n_clients);
         }
+        return 1;
+    }
+
+    case MSG_FORCE_OUT: {
+        /* SF-CRASH-INJECT-WIRE #245 Half B: install runtime crash target. */
+        if (!getenv("SUPERSCALAR_CRASH_ALLOW")) {
+            fprintf(stderr,
+                "LSP: MSG_FORCE_OUT received but SUPERSCALAR_CRASH_ALLOW not set -- dropping\n");
+            return 1;
+        }
+        char name[64] = {0};
+        if (!wire_parse_force_out(msg->json, name)) {
+            fprintf(stderr, "LSP: MSG_FORCE_OUT parse failed\n");
+            return 1;
+        }
+        lsp_crash_set_target(name);
+        fprintf(stderr,
+            "LSP: MSG_FORCE_OUT runtime crash target installed: \"%s\"\n",
+            name[0] ? name : "<immediate>");
+        fflush(stderr);
+        if (!name[0]) {
+            /* Empty name = abort immediately at this call site. */
+            lsp_crash_checkpoint("");
+        }
+        return 1;
+    }
+
+    case MSG_ROTATE: {
+        /* SF-CRASH-INJECT-WIRE #245 Half B: trigger in-process rotation. */
+        if (!getenv("SUPERSCALAR_CRASH_ALLOW")) {
+            fprintf(stderr,
+                "LSP: MSG_ROTATE received but SUPERSCALAR_CRASH_ALLOW not set -- dropping\n");
+            return 1;
+        }
+        uint8_t mode = 0;
+        wire_parse_rotate(msg->json, &mode);
+        fprintf(stderr, "LSP: MSG_ROTATE triggering rotation (mode=%u)\n",
+                (unsigned)mode);
+        fflush(stderr);
+        (void)lsp_channels_rotate_factory(mgr, lsp);
         return 1;
     }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -3196,3 +3196,45 @@ int wire_parse_splice_locked(const cJSON *json,
     *new_funding_vout_out = (uint32_t)vout->valuedouble;
     return 1;
 }
+
+/* ============================================================
+ * SF-CRASH-INJECT-WIRE #245 Half B: test-only crash injection.
+ * Codec for MSG_FORCE_OUT (0x8A) and MSG_ROTATE (0x8B).
+ * Mirrors the wire_build/parse_ceremony_abort pattern.
+ * ============================================================ */
+
+cJSON *wire_build_force_out(const char *checkpoint_name) {
+    cJSON *root = cJSON_CreateObject();
+    if (!root) return NULL;
+    if (checkpoint_name && *checkpoint_name)
+        cJSON_AddStringToObject(root, "checkpoint", checkpoint_name);
+    return root;
+}
+
+int wire_parse_force_out(const cJSON *json, char out_name[64]) {
+    if (!out_name) return 0;
+    out_name[0] = '\0';
+    if (!json) return 1;  /* empty payload = immediate abort sentinel */
+    const cJSON *cp = cJSON_GetObjectItem(json, "checkpoint");
+    if (cp && cJSON_IsString(cp) && cp->valuestring) {
+        strncpy(out_name, cp->valuestring, 63);
+        out_name[63] = '\0';
+    }
+    return 1;
+}
+
+cJSON *wire_build_rotate(uint8_t mode) {
+    cJSON *root = cJSON_CreateObject();
+    if (!root) return NULL;
+    cJSON_AddNumberToObject(root, "mode", (double)mode);
+    return root;
+}
+
+int wire_parse_rotate(const cJSON *json, uint8_t *out_mode) {
+    if (!out_mode) return 0;
+    *out_mode = 0;
+    if (!json) return 1;
+    const cJSON *m = cJSON_GetObjectItem(json, "mode");
+    if (m && cJSON_IsNumber(m)) *out_mode = (uint8_t)m->valueint;
+    return 1;
+}

--- a/tests/test_crash_checkpoint.c
+++ b/tests/test_crash_checkpoint.c
@@ -1,0 +1,112 @@
+/* SF-CRASH-INJECT-WIRE #245 Half B unit tests.
+ *
+ * Validates:
+ *  1. MSG_FORCE_OUT codec round-trip with named checkpoint.
+ *  2. MSG_FORCE_OUT empty name parses cleanly (immediate-abort sentinel).
+ *  3. MSG_ROTATE codec mode round-trip.
+ *  4. lsp_crash_set_target + lsp_crash_checkpoint fork-and-abort.
+ *  5. Mismatch checkpoint is a no-op (does not abort).
+ *
+ * The fork-and-abort tests use POSIX fork() + waitpid() to verify the
+ * child terminated with SIGABRT.  Skipped on platforms without fork().
+ */
+#include "superscalar/crash_inject.h"
+#include "superscalar/wire.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define TEST_ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d): %s\n", __func__, __LINE__, msg); \
+        return 0; \
+    } \
+} while(0)
+
+/* Test 1: MSG_FORCE_OUT codec round-trip. */
+int test_crash_force_out_codec_round_trip(void) {
+    cJSON *j = wire_build_force_out("factory_creation_propose");
+    TEST_ASSERT(j != NULL, "build_force_out returned NULL");
+    char name[64] = {0};
+    int ok = wire_parse_force_out(j, name);
+    cJSON_Delete(j);
+    TEST_ASSERT(ok == 1, "parse_force_out failed");
+    TEST_ASSERT(strcmp(name, "factory_creation_propose") == 0,
+                "parsed name mismatch");
+    return 1;
+}
+
+/* Test 2: empty checkpoint name parses cleanly (immediate-abort sentinel). */
+int test_crash_force_out_empty_name(void) {
+    cJSON *j = wire_build_force_out("");
+    TEST_ASSERT(j != NULL, "build_force_out(empty) returned NULL");
+    char name[64];
+    /* Pre-fill to non-zero to verify parser explicitly zeroes. */
+    memset(name, 0xAA, sizeof(name));
+    int ok = wire_parse_force_out(j, name);
+    cJSON_Delete(j);
+    TEST_ASSERT(ok == 1, "parse_force_out(empty) failed");
+    TEST_ASSERT(name[0] == '\0', "expected empty string for omitted checkpoint");
+    return 1;
+}
+
+/* Test 3: MSG_ROTATE codec mode round-trip. */
+int test_crash_rotate_codec_round_trip(void) {
+    cJSON *j = wire_build_rotate(1);
+    TEST_ASSERT(j != NULL, "build_rotate returned NULL");
+    uint8_t mode = 0xff;
+    int ok = wire_parse_rotate(j, &mode);
+    cJSON_Delete(j);
+    TEST_ASSERT(ok == 1, "parse_rotate failed");
+    TEST_ASSERT(mode == 1, "mode round-trip mismatch");
+
+    /* Default mode = 0 also round-trips. */
+    cJSON *j0 = wire_build_rotate(0);
+    uint8_t m0 = 0xff;
+    ok = wire_parse_rotate(j0, &m0);
+    cJSON_Delete(j0);
+    TEST_ASSERT(ok == 1, "parse_rotate(0) failed");
+    TEST_ASSERT(m0 == 0, "mode 0 round-trip mismatch");
+    return 1;
+}
+
+/* Test 4: lsp_crash_set_target + lsp_crash_checkpoint fork-and-abort. */
+int test_crash_runtime_target_aborts(void) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        printf("  SKIP: %s: fork() failed (errno=%d)\n", __func__, errno);
+        return 1;  /* not a hard failure on constrained CI */
+    }
+    if (pid == 0) {
+        /* Child: install target, trigger checkpoint, should abort. */
+        /* Silence the child's abort() stderr noise. */
+        freopen("/dev/null", "w", stderr);
+        lsp_crash_set_target("crash_unit_test_target");
+        lsp_crash_checkpoint("crash_unit_test_target");
+        _exit(0);  /* unreachable on success */
+    }
+    int status = 0;
+    pid_t w = waitpid(pid, &status, 0);
+    TEST_ASSERT(w == pid, "waitpid failed");
+    TEST_ASSERT(WIFSIGNALED(status), "child did not exit via signal");
+    TEST_ASSERT(WTERMSIG(status) == SIGABRT, "child did not abort with SIGABRT");
+    return 1;
+}
+
+/* Test 5: mismatch is a no-op (does not abort). */
+int test_crash_checkpoint_mismatch_noop(void) {
+    /* Install a target then hit a DIFFERENT checkpoint -- must return cleanly. */
+    lsp_crash_set_target("target_foo");
+    lsp_crash_checkpoint("target_bar");  /* mismatch: must return */
+    lsp_crash_set_target(NULL);          /* clear */
+    lsp_crash_checkpoint("target_foo");  /* now uninstalled: must return */
+    /* Also verify NULL name is safe. */
+    lsp_crash_checkpoint(NULL);
+    return 1;
+}

--- a/tests/test_crash_checkpoint.c
+++ b/tests/test_crash_checkpoint.c
@@ -85,8 +85,10 @@ int test_crash_runtime_target_aborts(void) {
     }
     if (pid == 0) {
         /* Child: install target, trigger checkpoint, should abort. */
-        /* Silence the child's abort() stderr noise. */
-        freopen("/dev/null", "w", stderr);
+        /* Silence the child's abort() stderr noise.  Cast: cppcheck flags
+           freopen() retval unused; we genuinely don't care if stderr
+           silencing fails — the child only runs to abort. */
+        (void)!freopen("/dev/null", "w", stderr);
         lsp_crash_set_target("crash_unit_test_target");
         lsp_crash_checkpoint("crash_unit_test_target");
         _exit(0);  /* unreachable on success */

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1640,6 +1640,13 @@ extern int test_distribution_tx_has_anchor(void);
 extern int test_ceremony_retry_excludes_timeout(void);
 extern int test_funding_reserve_check(void);
 
+/* SF-CRASH-INJECT-WIRE #245 Half B: crash injection wire opcodes + runtime target. */
+extern int test_crash_force_out_codec_round_trip(void);
+extern int test_crash_force_out_empty_name(void);
+extern int test_crash_rotate_codec_round_trip(void);
+extern int test_crash_runtime_target_aborts(void);
+extern int test_crash_checkpoint_mismatch_noop(void);
+
 /* Rotation Retry with Backoff tests */
 extern int test_rotation_retry_backoff(void);
 extern int test_rotation_retry_success_resets(void);
@@ -3484,6 +3491,13 @@ static void run_unit_tests(void) {
     RUN_TEST(test_distribution_tx_has_anchor);
     RUN_TEST(test_ceremony_retry_excludes_timeout);
     RUN_TEST(test_funding_reserve_check);
+
+    printf("\n=== Crash Injection (#245 Half B) ===\n");
+    RUN_TEST(test_crash_force_out_codec_round_trip);
+    RUN_TEST(test_crash_force_out_empty_name);
+    RUN_TEST(test_crash_rotate_codec_round_trip);
+    RUN_TEST(test_crash_runtime_target_aborts);
+    RUN_TEST(test_crash_checkpoint_mismatch_noop);
 
     printf("\n=== Rotation Retry with Backoff ===\n");
     RUN_TEST(test_rotation_retry_backoff);


### PR DESCRIPTION
## Summary

Adds wire opcodes that let a test client install a crash-checkpoint target on a running LSP without coordinating env vars at launch time. Builds on the existing `lsp_crash_checkpoint()` helper from Half A.

**New opcodes (TEST ONLY, gated by `SUPERSCALAR_CRASH_ALLOW`):**
- `MSG_FORCE_OUT 0x8A` — install runtime checkpoint target (empty name = immediate abort)
- `MSG_ROTATE 0x8B` — trigger `lsp_channels_rotate_factory`

**New helper:**
- `lsp_crash_set_target(name)` — runtime target (`NULL`/`""` clears it). Runtime target wins over `SUPERSCALAR_CRASH_AT` env var.

**Demo callsites added to factory creation:**
- `factory_creation_propose` — just after PROPOSE_INTENT send loop
- `factory_creation_signed` — after CLIENT_FINAL_PSIGS collected, before completion

Dispatcher cases drop both opcodes silently when `SUPERSCALAR_CRASH_ALLOW` is not set, so production builds remain unaffected (the static runtime target stays NUL-initialized; the env path is the only way to abort).

Full 4x5 checkpoint coverage across all stateless ceremonies is the v0.3 full crash drill follow-on (Half C), not Half B.

## Validation

- **1480/1480** unit tests PASS (1475 baseline + 5 new)
- New tests cover:
  - `MSG_FORCE_OUT` codec round-trip (named checkpoint)
  - `MSG_FORCE_OUT` empty-name parsing (immediate-abort sentinel)
  - `MSG_ROTATE` codec mode round-trip
  - `lsp_crash_set_target` + `lsp_crash_checkpoint` fork-and-abort (SIGABRT verified via `waitpid`)
  - Mismatch checkpoint is a no-op (does not abort)

## Test plan

- [x] Unit tests pass: `./build-release/test_superscalar` → 1480/1480
- [ ] Optional: manual `SUPERSCALAR_CRASH_AT=factory_creation_propose ./build-release/superscalar_lsp ...` smoke test
- [ ] Half C (v0.3): full 4x5 checkpoint drill matrix across all ceremonies

Closes #245 Half B.