### PR TITLE
feat(cheat-engine): --cheat-dust-race driver against HTLC-dust-bump race

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ add_executable(test_superscalar
     tests/test_stateless_invoice.c
     tests/test_onion_msg_relay.c
     tests/test_htlc_fee_bump.c
+    tests/test_dust_recovery.c
     tests/test_bolt4_failure.c
     tests/test_payment_uri.c
     tests/test_trampoline.c

--- a/src/htlc_commit.c
+++ b/src/htlc_commit.c
@@ -358,10 +358,30 @@ int htlc_commit_recv_update_fee(channel_t *ch,
     uint64_t new_kvb = (uint64_t)feerate * 4;
     uint64_t htlc_sweep_fee = (new_kvb * 180 + 999) / 1000;
     uint64_t htlc_safe_floor = htlc_sweep_fee + CHANNEL_DUST_LIMIT_SATS;
+
+    /* #257 SF-CHEAT-DUST-RACE: when SS_CHEAT_DUST_RACE is set, an attacker
+       LSP bypasses the dust-race defense above. The accepted feerate then
+       strands counterparty HTLC sweeps below dust, letting the LSP absorb
+       the HTLC into commit fees at force-close. This MUST only fire in
+       cheat-engine test runs (env var gated). Markers: LSP-CHEAT-DUST. */
+    const char *cheat = getenv("SS_CHEAT_DUST_RACE");
+    int cheat_active = (cheat && cheat[0] && cheat[0] != '0');
+
     for (size_t i = 0; i < ch->n_htlcs; i++) {
         if (ch->htlcs[i].state != HTLC_STATE_ACTIVE) continue;
         if (ch->htlcs[i].amount_sats < CHANNEL_DUST_LIMIT_SATS) continue; /* already trimmed */
         if (ch->htlcs[i].amount_sats < htlc_safe_floor) {
+            if (cheat_active) {
+                fprintf(stderr,
+                        "LSP-CHEAT-DUST: bypass HTLC[%zu] amount=%llu sats — "
+                        "feerate %u sat/kw would strand sweep (sweep_fee=%llu, "
+                        "dust=%u). Cheat accepts; HTLC will be absorbed into "
+                        "commit fees at force-close.\n",
+                        i, (unsigned long long)ch->htlcs[i].amount_sats,
+                        feerate, (unsigned long long)htlc_sweep_fee,
+                        (unsigned int)CHANNEL_DUST_LIMIT_SATS);
+                continue;
+            }
             fprintf(stderr,
                     "htlc_commit_recv_update_fee: REJECT feerate %u sat/kw — "
                     "HTLC[%zu] amount=%llu sats would yield sweep amount below dust "
@@ -377,6 +397,17 @@ int htlc_commit_recv_update_fee(channel_t *ch,
         if (ch->ptlcs[i].state != PTLC_STATE_ACTIVE) continue;
         if (ch->ptlcs[i].amount_sats < CHANNEL_DUST_LIMIT_SATS) continue;
         if (ch->ptlcs[i].amount_sats < htlc_safe_floor) {
+            if (cheat_active) {
+                fprintf(stderr,
+                        "LSP-CHEAT-DUST: bypass PTLC[%zu] amount=%llu sats — "
+                        "feerate %u sat/kw would strand sweep (sweep_fee=%llu, "
+                        "dust=%u). Cheat accepts; PTLC will be absorbed into "
+                        "commit fees at force-close.\n",
+                        i, (unsigned long long)ch->ptlcs[i].amount_sats,
+                        feerate, (unsigned long long)htlc_sweep_fee,
+                        (unsigned int)CHANNEL_DUST_LIMIT_SATS);
+                continue;
+            }
             fprintf(stderr,
                     "htlc_commit_recv_update_fee: REJECT feerate %u sat/kw — "
                     "PTLC[%zu] amount=%llu sats would yield sweep amount below dust "
@@ -389,6 +420,11 @@ int htlc_commit_recv_update_fee(channel_t *ch,
         }
     }
 
+    if (cheat_active) {
+        fprintf(stderr,
+                "LSP-CHEAT-DUST: accept feerate %u sat/kw (dust-race defense "
+                "bypassed)\n", feerate);
+    }
     ch->fee_rate_sat_per_kvb = new_kvb;
     return 1;
 }

--- a/tests/test_dust_recovery.c
+++ b/tests/test_dust_recovery.c
@@ -1,0 +1,331 @@
+/*
+ * test_dust_recovery.c — #257 SF-CHEAT-DUST-RACE unit suite
+ *
+ * Validates both halves of the dust-race contract:
+ *
+ *   DR1: htlc_commit_recv_update_fee REJECTS feerates that would push an
+ *        active above-dust HTLC's sweep amount below CHANNEL_DUST_LIMIT_SATS.
+ *        This is the honest defense — without it, a peer can strand the
+ *        counterparty's HTLC at force-close.
+ *
+ *   DR2: htlc_commit_recv_update_fee REJECTS feerates that would push an
+ *        active PTLC's sweep amount below dust (PTLC counterpart of DR1).
+ *
+ *   DR3: With SS_CHEAT_DUST_RACE=1 in the environment, the same abusive
+ *        feerate is ACCEPTED. This is the SF-CHEAT-DUST-RACE bypass: an
+ *        attacker LSP turns off the defense and the strand-the-sweep theft
+ *        becomes possible. Used by tools/test_regtest_cheat_dust_race.sh.
+ *
+ *   DR4: With SS_CHEAT_DUST_RACE=0 (explicit disable), the defense fires
+ *        normally — proves the env var is opt-in, not opt-out.
+ *
+ *   DR5: Boundary — exactly at htlc_safe_floor (sweep_fee + dust) is
+ *        accepted by the defense (the check is strict <, not <=).
+ *
+ *   DR6: Cheat bypass DOES NOT mask the basic floor/ceiling checks — a
+ *        below-floor feerate is still rejected even with cheat armed.
+ *
+ *   DR7: With cheat armed, a feerate that is safe for one HTLC but unsafe
+ *        for a second smaller HTLC still updates ch->fee_rate_sat_per_kvb
+ *        (verifying that the cheat applies per-HTLC and reaches the final
+ *        commit-assignment).
+ *
+ * These tests do NOT exercise on-chain TX construction — that path is
+ * covered by the regtest script. They exercise the wire-level decision
+ * point where the cheat is wired.
+ */
+
+#include "superscalar/htlc_commit.h"
+#include "superscalar/channel.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d): %s\n", __func__, __LINE__, (msg)); \
+        return 0; \
+    } \
+} while (0)
+
+/* Local big-endian write helpers (avoid name collision with test_htlc_commit). */
+static void dr_wr16(unsigned char *b, uint16_t v) {
+    b[0] = (unsigned char)(v >> 8); b[1] = (unsigned char)v;
+}
+static void dr_wr32(unsigned char *b, uint32_t v) {
+    b[0] = (unsigned char)(v >> 24); b[1] = (unsigned char)(v >> 16);
+    b[2] = (unsigned char)(v >> 8);  b[3] = (unsigned char)v;
+}
+
+static void dr_build_update_fee(unsigned char msg[38], uint32_t feerate) {
+    memset(msg, 0, 38);
+    dr_wr16(msg, BOLT2_UPDATE_FEE);
+    dr_wr32(msg + 34, feerate);
+}
+
+/* ------------------------------------------------------------------ */
+/* Borderline HTLC fixture                                             */
+/* ------------------------------------------------------------------ */
+/*
+ * Pick an HTLC amount that is safely above dust at the channel's starting
+ * 1000 sat/kvb but stranded at BOLT2_UPDATE_FEE_CEILING.
+ *
+ * htlc_sweep_fee at 1000 sat/kvb     = (1000*180+999)/1000 = 180
+ * htlc_safe_floor at 1000 sat/kvb    = 180 + 546 = 726
+ * htlc_sweep_fee at ceiling (4*ceiling) = ((BOLT2_UPDATE_FEE_CEILING*4)*180+999)/1000
+ * htlc_safe_floor at ceiling         = sweep_fee + 546
+ *
+ * We pick amount = 5000 sat: well above 726 (safe at 1000 sat/kvb), well
+ * below htlc_safe_floor at ceiling (which approaches 72546 for the test's
+ * BOLT2_UPDATE_FEE_CEILING). This mirrors HC16 in test_htlc_commit.c.
+ */
+#define BORDERLINE_HTLC_AMOUNT 5000ULL
+
+/* ------------------------------------------------------------------ */
+/* DR1 — honest defense rejects abusive HTLC feerate                   */
+/* ------------------------------------------------------------------ */
+int test_dust_race_defense_rejects_htlc(void) {
+    /* Make sure cheat is OFF for this test, regardless of process env. */
+    unsetenv("SS_CHEAT_DUST_RACE");
+
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    htlc_t htlcs[1];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = BORDERLINE_HTLC_AMOUNT;
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 1;
+
+    unsigned char msg[38];
+    dr_build_update_fee(msg, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "DR1: defense rejects abusive feerate against borderline HTLC");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000,
+           "DR1: fee_rate unchanged after rejection");
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* DR2 — honest defense rejects abusive PTLC feerate                   */
+/* ------------------------------------------------------------------ */
+int test_dust_race_defense_rejects_ptlc(void) {
+    unsetenv("SS_CHEAT_DUST_RACE");
+
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    ptlc_t ptlcs[1];
+    memset(ptlcs, 0, sizeof(ptlcs));
+    ptlcs[0].state = PTLC_STATE_ACTIVE;
+    ptlcs[0].direction = PTLC_OFFERED;
+    ptlcs[0].amount_sats = BORDERLINE_HTLC_AMOUNT;
+    ch.ptlcs = ptlcs;
+    ch.n_ptlcs = 1;
+
+    unsigned char msg[38];
+    dr_build_update_fee(msg, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "DR2: defense rejects abusive feerate against borderline PTLC");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000,
+           "DR2: fee_rate unchanged after PTLC rejection");
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* DR3 — SS_CHEAT_DUST_RACE=1 ACCEPTS the otherwise-rejected feerate   */
+/* ------------------------------------------------------------------ */
+int test_dust_race_cheat_bypass(void) {
+    setenv("SS_CHEAT_DUST_RACE", "1", 1);
+
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    htlc_t htlcs[1];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = BORDERLINE_HTLC_AMOUNT;
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 1;
+
+    unsigned char msg[38];
+    dr_build_update_fee(msg, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 1, "DR3: cheat ACCEPTS abusive feerate");
+    ASSERT(ch.fee_rate_sat_per_kvb == (uint64_t)BOLT2_UPDATE_FEE_CEILING * 4,
+           "DR3: fee_rate updated to attacker-chosen ceiling");
+
+    unsetenv("SS_CHEAT_DUST_RACE");
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* DR4 — SS_CHEAT_DUST_RACE=0 explicitly disabled → defense fires      */
+/* ------------------------------------------------------------------ */
+int test_dust_race_cheat_disabled_explicit(void) {
+    setenv("SS_CHEAT_DUST_RACE", "0", 1);
+
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    htlc_t htlcs[1];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = BORDERLINE_HTLC_AMOUNT;
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 1;
+
+    unsigned char msg[38];
+    dr_build_update_fee(msg, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "DR4: explicit '0' is opt-out; defense still rejects");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000, "DR4: fee_rate unchanged");
+
+    unsetenv("SS_CHEAT_DUST_RACE");
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* DR5 — boundary: amount == htlc_safe_floor is ACCEPTED               */
+/* ------------------------------------------------------------------ */
+int test_dust_race_boundary_accept(void) {
+    unsetenv("SS_CHEAT_DUST_RACE");
+
+    /* Compute exact htlc_safe_floor at the ceiling. */
+    uint64_t kvb = (uint64_t)BOLT2_UPDATE_FEE_CEILING * 4;
+    uint64_t sweep_fee = (kvb * 180 + 999) / 1000;
+    uint64_t safe_floor = sweep_fee + CHANNEL_DUST_LIMIT_SATS;
+
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    htlc_t htlcs[1];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = safe_floor;  /* exactly at the boundary */
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 1;
+
+    unsigned char msg[38];
+    dr_build_update_fee(msg, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 1, "DR5: HTLC exactly at safe_floor is accepted (strict < check)");
+    ASSERT(ch.fee_rate_sat_per_kvb == kvb,
+           "DR5: fee_rate updated when exactly at boundary");
+
+    /* One sat below the boundary is rejected. */
+    ch.fee_rate_sat_per_kvb = 1000;
+    htlcs[0].amount_sats = safe_floor - 1;
+    ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                      BOLT2_UPDATE_FEE_FLOOR,
+                                      BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "DR5: one sat below safe_floor is rejected");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000, "DR5: fee_rate unchanged on reject");
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* DR6 — cheat does NOT bypass floor/ceiling checks                    */
+/* ------------------------------------------------------------------ */
+int test_dust_race_cheat_does_not_bypass_floor(void) {
+    setenv("SS_CHEAT_DUST_RACE", "1", 1);
+
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    htlc_t htlcs[1];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = BORDERLINE_HTLC_AMOUNT;
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 1;
+
+    /* Build a below-floor feerate. */
+    uint32_t below_floor = (BOLT2_UPDATE_FEE_FLOOR > 0)
+                           ? (BOLT2_UPDATE_FEE_FLOOR - 1) : 0;
+    unsigned char msg[38];
+    dr_build_update_fee(msg, below_floor);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "DR6: cheat does not bypass below-floor feerate rejection");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000, "DR6: fee_rate unchanged");
+
+    /* Above-ceiling should also be rejected with cheat armed. */
+    dr_build_update_fee(msg, BOLT2_UPDATE_FEE_CEILING + 1);
+    ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                      BOLT2_UPDATE_FEE_FLOOR,
+                                      BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 0, "DR6: cheat does not bypass above-ceiling rejection");
+    ASSERT(ch.fee_rate_sat_per_kvb == 1000, "DR6: fee_rate unchanged");
+
+    unsetenv("SS_CHEAT_DUST_RACE");
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* DR7 — cheat applies per-HTLC and still updates ch->fee_rate          */
+/* ------------------------------------------------------------------ */
+int test_dust_race_cheat_per_htlc(void) {
+    setenv("SS_CHEAT_DUST_RACE", "1", 1);
+
+    channel_t ch;
+    memset(&ch, 0, sizeof(ch));
+    ch.fee_rate_sat_per_kvb = 1000;
+
+    /* Two HTLCs: one large (safe at ceiling), one small (would normally be
+       rejected). With cheat armed, both pass and ch->fee_rate updates. */
+    htlc_t htlcs[2];
+    memset(htlcs, 0, sizeof(htlcs));
+    htlcs[0].state = HTLC_STATE_ACTIVE;
+    htlcs[0].direction = HTLC_OFFERED;
+    htlcs[0].amount_sats = 500000;  /* safely above any reachable sweep_fee */
+    htlcs[1].state = HTLC_STATE_ACTIVE;
+    htlcs[1].direction = HTLC_RECEIVED;
+    htlcs[1].amount_sats = BORDERLINE_HTLC_AMOUNT;  /* would be stranded */
+    ch.htlcs = htlcs;
+    ch.n_htlcs = 2;
+
+    unsigned char msg[38];
+    dr_build_update_fee(msg, BOLT2_UPDATE_FEE_CEILING);
+
+    int ok = htlc_commit_recv_update_fee(&ch, msg, sizeof(msg),
+                                          BOLT2_UPDATE_FEE_FLOOR,
+                                          BOLT2_UPDATE_FEE_CEILING);
+    ASSERT(ok == 1, "DR7: cheat accepts even with one borderline + one safe HTLC");
+    ASSERT(ch.fee_rate_sat_per_kvb == (uint64_t)BOLT2_UPDATE_FEE_CEILING * 4,
+           "DR7: fee_rate updated to attacker-chosen ceiling");
+
+    unsetenv("SS_CHEAT_DUST_RACE");
+    return 1;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -789,6 +789,14 @@ extern int test_hfb_blocks_remaining(void);
 extern int test_hfb_confirm(void);
 extern int test_hfb_budget_limits_max(void);
 extern int test_hfb_null_safety(void);
+/* #257 SF-CHEAT-DUST-RACE: HTLC dust-bump force-close race */
+extern int test_dust_race_defense_rejects_htlc(void);
+extern int test_dust_race_defense_rejects_ptlc(void);
+extern int test_dust_race_cheat_bypass(void);
+extern int test_dust_race_cheat_disabled_explicit(void);
+extern int test_dust_race_boundary_accept(void);
+extern int test_dust_race_cheat_does_not_bypass_floor(void);
+extern int test_dust_race_cheat_per_htlc(void);
 /* PR #50: BOLT #4 Onion Failure Message Parser */
 extern int test_bf_temporary_channel_failure(void);
 extern int test_bf_channel_disabled(void);
@@ -2727,6 +2735,15 @@ static void run_unit_tests(void) {
     RUN_TEST(test_hfb_confirm);
     RUN_TEST(test_hfb_budget_limits_max);
     RUN_TEST(test_hfb_null_safety);
+
+    printf("\n=== #257 SF-CHEAT-DUST-RACE: HTLC dust-bump force-close race ===\n");
+    RUN_TEST(test_dust_race_defense_rejects_htlc);
+    RUN_TEST(test_dust_race_defense_rejects_ptlc);
+    RUN_TEST(test_dust_race_cheat_bypass);
+    RUN_TEST(test_dust_race_cheat_disabled_explicit);
+    RUN_TEST(test_dust_race_boundary_accept);
+    RUN_TEST(test_dust_race_cheat_does_not_bypass_floor);
+    RUN_TEST(test_dust_race_cheat_per_htlc);
 
     printf("\n=== PR #50: BOLT #4 Onion Failure Message Parser ===\n");
     RUN_TEST(test_bf_temporary_channel_failure);

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -322,6 +322,7 @@ static void usage(const char *prog) {
         "  --cheat-state K      With --cheat-leaf and --advance-count N: snapshot+broadcast chain[K] (default 0 = oldest stale).  K in [0,N-1].  K>0 exercises the watchtower's middle-state revocation walk — boundary-only K=0/K=N-1 tests miss this path. CL3-K.\n"
         "  --musig-stateless    [PHASE 1a/EXPERIMENTAL] Opt into BIP-327 stateless-signer wire flow per MUSIG_NONCE_REDESIGN_MEMO. Currently registers the flag; full reversed-flow behavior lands in Phase 1b. Default off.\n"
         "  --cheat-realloc      With --test-realloc: after realloc completes, broadcast the now-revoked pre-realloc leaf TX and verify watchtower defense fires (penalty TX broadcast, breach_detections row). Tests adversarial path against realloc revocation. CL2.\n"
+        "  --cheat-dust-race    SF-CHEAT-DUST-RACE (#257): bypass the dust-race defense in htlc_commit_recv_update_fee. The LSP accepts peer feerate bumps that strand counterparty HTLC sweeps below the 546-sat dust limit, demonstrating the absorbed-HTLC theft path. Markers: LSP-CHEAT-DUST. Test: tools/test_regtest_cheat_dust_race.sh.\n"
         "  --kill-after-state-advance Clean exit immediately after first state-advance ceremony completes (post MSG_PATH_SIGN_DONE). Drives restart-harness tests verifying persistence + revocation_secrets survive. CL5.\n"
         "  --ps-subfactory-arity K  PS sub-factory arity k (canonical k² PS shape from t/1242).  k=1 (default) = 1-client-per-PS-leaf; k>1 = k clients per sub-factory, k sub-factories per leaf, k² clients per leaf.\n"
         "  --test-partial-rotation After demo: 1 client goes offline, partial rotation with 3/4, dist TX on old factory\n"
@@ -1829,6 +1830,18 @@ int main(int argc, char *argv[]) {
         else if (strcmp(argv[i], "--cheat-realloc") == 0) {
             /* CL2: enable post-finalize cheat broadcast against --test-realloc. */
             cheat_realloc = 1;
+        }
+        else if (strcmp(argv[i], "--cheat-dust-race") == 0) {
+            /* #257 SF-CHEAT-DUST-RACE: bypass the dust-race defense in
+               htlc_commit_recv_update_fee.  An accepted peer update_fee that
+               strands a counterparty HTLC sweep below the 546-sat dust limit
+               normally returns 0 (REJECT).  With this flag, the LSP accepts
+               the bump and emits LSP-CHEAT-DUST markers — at force-close the
+               affected HTLC is absorbed into commit fees instead of being
+               claimable by the counterparty.  Test:
+                 tools/test_regtest_cheat_dust_race.sh */
+            setenv("SS_CHEAT_DUST_RACE", "1", 1);
+            fprintf(stderr, "LSP-CHEAT-DUST: armed (dust-race defense bypass enabled)\n");
         }
         else if (strcmp(argv[i], "--test-dual-factory") == 0)
             test_dual_factory = 1;

--- a/tools/test_regtest_cheat_dust_race.sh
+++ b/tools/test_regtest_cheat_dust_race.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# test_regtest_cheat_dust_race.sh — #257 SF-CHEAT-DUST-RACE smoke test.
+#
+# Validates --cheat-dust-race on regtest:
+#
+#   1. LSP arms the cheat at startup ("LSP-CHEAT-DUST: armed" marker).
+#   2. SS_CHEAT_DUST_RACE env var propagates to libsuperscalar (verified by
+#      running the matching unit subset under the env override and observing
+#      the LSP-CHEAT-DUST bypass markers in test_superscalar stderr).
+#   3. The honest defense still rejects abusive feerates without the flag.
+#
+# The on-chain dance (set up borderline-amount HTLC, push update_fee, force
+# close, watch the HTLC absorbed into commit fees) requires a multi-binary
+# choreography that the existing regtest harness does not yet expose to
+# external drivers. The cheat-engine harness lands here as the
+# arm-and-validate-wiring smoke; the deep on-chain behavior is exercised
+# by the DR1-DR7 unit suite (tests/test_dust_recovery.c) which directly
+# drives htlc_commit_recv_update_fee with and without the env override.
+#
+# When the on-chain hook lands in a follow-up, this script's step (3) will
+# be replaced by an LSP --demo --cheat-dust-race run that exercises the
+# full force-close path.
+#
+# Usage: bash tools/test_regtest_cheat_dust_race.sh [BUILD_DIR]
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar-dust-race-impl/build-release}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+TEST_BIN="$BUILD_DIR/test_superscalar"
+
+if [ ! -x "$LSP_BIN" ]; then
+    echo "FAIL: superscalar_lsp not found at $LSP_BIN"
+    exit 1
+fi
+if [ ! -x "$TEST_BIN" ]; then
+    echo "FAIL: test_superscalar not found at $TEST_BIN"
+    exit 1
+fi
+
+TMPDIR=$(mktemp -d /tmp/ss-cheat-dust-race.XXXXXX)
+LSP_LOG="$TMPDIR/lsp.log"
+UNIT_LOG="$TMPDIR/unit.log"
+
+cleanup() {
+    cp "$LSP_LOG"  /tmp/cheat_dust_race_last_lsp.log  2>/dev/null || true
+    cp "$UNIT_LOG" /tmp/cheat_dust_race_last_unit.log 2>/dev/null || true
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "=== SF-CHEAT-DUST-RACE (#257) regtest smoke ==="
+echo "  BUILD_DIR : $BUILD_DIR"
+echo "  LSP_BIN   : $LSP_BIN"
+echo "  TEST_BIN  : $TEST_BIN"
+echo
+
+# ----------------------------------------------------------------------
+# Step 1: --cheat-dust-race emits the arm marker
+# ----------------------------------------------------------------------
+echo "--- Step 1: --cheat-dust-race arms the cheat (stderr marker) ---"
+# Use --help so the LSP exits immediately after arg parsing, then look for
+# the arm marker.  --cheat-dust-race calls setenv + fprintf during arg
+# parsing — the marker fires before the help text is printed.
+"$LSP_BIN" --cheat-dust-race --help 2>"$LSP_LOG" 1>/dev/null || true
+
+if grep -q "LSP-CHEAT-DUST: armed" "$LSP_LOG"; then
+    echo "  PASS: arm marker present"
+else
+    echo "  FAIL: arm marker missing"
+    echo "  LSP stderr (first 20 lines):"
+    head -20 "$LSP_LOG"
+    exit 1
+fi
+
+# ----------------------------------------------------------------------
+# Step 2: --cheat-dust-race appears in --help
+# ----------------------------------------------------------------------
+echo
+echo "--- Step 2: --cheat-dust-race appears in --help ---"
+HELP_OUT=$("$LSP_BIN" --help 2>&1)
+if grep -q "cheat-dust-race" <<<"$HELP_OUT"; then
+    echo "  PASS: flag documented in --help"
+else
+    echo "  FAIL: flag missing from --help"
+    exit 1
+fi
+
+# ----------------------------------------------------------------------
+# Step 3: Unit suite under SS_CHEAT_DUST_RACE=1 emits bypass markers
+# ----------------------------------------------------------------------
+echo
+echo "--- Step 3: htlc_commit cheat path emits LSP-CHEAT-DUST markers ---"
+"$TEST_BIN" 2>"$UNIT_LOG" 1>"$TMPDIR/unit.out" || true
+
+if grep -q "Results: " "$TMPDIR/unit.out"; then
+    LINE=$(grep "Results: " "$TMPDIR/unit.out" | tail -1)
+    echo "  unit results: $LINE"
+fi
+
+DR_BYPASS=$(grep -c "LSP-CHEAT-DUST: bypass" "$UNIT_LOG" || true)
+DR_ACCEPT=$(grep -c "LSP-CHEAT-DUST: accept feerate" "$UNIT_LOG" || true)
+DR_REJECT=$(grep -c "htlc_commit_recv_update_fee: REJECT" "$UNIT_LOG" || true)
+
+echo "  LSP-CHEAT-DUST bypass markers   : $DR_BYPASS"
+echo "  LSP-CHEAT-DUST accept markers   : $DR_ACCEPT"
+echo "  honest REJECT markers (defense) : $DR_REJECT"
+
+if [ "$DR_BYPASS" -ge 1 ] && [ "$DR_ACCEPT" -ge 1 ] && [ "$DR_REJECT" -ge 1 ]; then
+    echo "  PASS: both cheat-bypass AND honest-reject paths exercised"
+else
+    echo "  FAIL: missing markers; saw bypass=$DR_BYPASS accept=$DR_ACCEPT reject=$DR_REJECT"
+    echo "  unit stderr tail:"
+    tail -40 "$UNIT_LOG"
+    exit 1
+fi
+
+# ----------------------------------------------------------------------
+# Step 4: The dust-recovery unit subset must report all PASS
+# ----------------------------------------------------------------------
+echo
+echo "--- Step 4: dust-race unit suite (DR1-DR7) ---"
+if grep -q "#257 SF-CHEAT-DUST-RACE" "$TMPDIR/unit.out"; then
+    # Count the OK after each test_dust_race_ line.
+    PASS=$(grep -c "test_dust_race_.* OK" "$TMPDIR/unit.out" || true)
+    echo "  DR tests PASS: $PASS / 7"
+    if [ "$PASS" -ge 7 ]; then
+        echo "  PASS: all 7 dust-race units green"
+    else
+        echo "  FAIL: dust-race unit count $PASS < 7"
+        grep -A2 "test_dust_race_" "$TMPDIR/unit.out" | head -40
+        exit 1
+    fi
+else
+    echo "  FAIL: SF-CHEAT-DUST-RACE section not found in unit output"
+    exit 1
+fi
+
+echo
+echo "=== SF-CHEAT-DUST-RACE smoke: PASS ==="
+exit 0


### PR DESCRIPTION
## Summary

- Adds `--cheat-dust-race` cheat-engine driver (#257 SF-CHEAT-DUST-RACE) — adversarial LSP that bypasses the dust-race defense in `htlc_commit_recv_update_fee` to demonstrate the HTLC-absorbed-into-commit-fee theft path.
- Env-gated (`SS_CHEAT_DUST_RACE=1`): the honest path is unchanged; the cheat fires only when the flag is set, emitting `LSP-CHEAT-DUST:` markers at every bypass + final acceptance.
- New unit suite `tests/test_dust_recovery.c` (DR1-DR7) covers the defense, the cheat bypass, env opt-out (`SS_CHEAT_DUST_RACE=0`), the safe-floor boundary, and the cheat's interaction with floor/ceiling rejection.

## How the cheat works

The dust-race defense lives in `src/htlc_commit.c::htlc_commit_recv_update_fee` — it refuses any peer-proposed feerate that would push a counterparty's above-dust HTLC's sweep amount below `CHANNEL_DUST_LIMIT_SATS` (546). Without this defense, a malicious peer can push a borderline HTLC into dust right before force-close, causing the HTLC output to be absorbed into the commit fee (no output → no sweep → stolen).

With `--cheat-dust-race`, the LSP sets `SS_CHEAT_DUST_RACE=1`; `htlc_commit_recv_update_fee` then logs `LSP-CHEAT-DUST: bypass HTLC[i] ...` and accepts the unsafe rate. The downstream commit-tx assignment uses the attacker-chosen feerate and the stranded HTLC disappears at force-close.

## Files

- `src/htlc_commit.c` — env-gated bypass + markers
- `tools/superscalar_lsp.c` — `--cheat-dust-race` flag (sets env + arm marker)
- `tests/test_dust_recovery.c` — 331-line DR1-DR7 unit suite
- `tests/test_main.c`, `CMakeLists.txt` — wire the new suite
- `tools/test_regtest_cheat_dust_race.sh` — arm-and-marker smoke

## Test plan

- [x] Unit suite: `./build-release/test_superscalar` -> **1482/1482 PASS** (was 1475 before; +7 DR1-DR7)
- [x] Regtest smoke: `bash tools/test_regtest_cheat_dust_race.sh build-release` -> **PASS** (arm marker, --help, bypass + accept + reject markers from the unit run, DR1-DR7 all green)
- [x] `--help` documents the flag
- [x] HC16/HC17 in `test_htlc_commit.c` still pass (defense unchanged when env unset)

## Complexity notes

The on-chain HTLC-dust dance (set up borderline-amount HTLC, peer-side `update_fee`, force-close, watch the HTLC absorbed into commit fees) requires a multi-binary choreography that the existing regtest harness does not yet expose to external cheat drivers. This PR lands the cheat at the wire-decision layer (where the dust-race defense lives) and validates both halves of the contract through the DR1-DR7 unit suite. A follow-up can extend `--demo --cheat-dust-race` to drive the full on-chain force-close once that scaffold exists.

Closes #257.