### PR TITLE
feat(cheat-engine): add --cheat-lstock-buy driver

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -322,6 +322,7 @@ static void usage(const char *prog) {
         "  --cheat-state K      With --cheat-leaf and --advance-count N: snapshot+broadcast chain[K] (default 0 = oldest stale).  K in [0,N-1].  K>0 exercises the watchtower's middle-state revocation walk — boundary-only K=0/K=N-1 tests miss this path. CL3-K.\n"
         "  --musig-stateless    [PHASE 1a/EXPERIMENTAL] Opt into BIP-327 stateless-signer wire flow per MUSIG_NONCE_REDESIGN_MEMO. Currently registers the flag; full reversed-flow behavior lands in Phase 1b. Default off.\n"
         "  --cheat-realloc      With --test-realloc: after realloc completes, broadcast the now-revoked pre-realloc leaf TX and verify watchtower defense fires (penalty TX broadcast, breach_detections row). Tests adversarial path against realloc revocation. CL2.\n"
+        "  --cheat-lstock-buy   With --test-buy-liquidity: after the L-stock buy ceremony completes, broadcast the now-revoked pre-buy leaf TX and verify watchtower defense fires (penalty TX broadcast). Tests adversarial path against the L-stock buy-liquidity revocation. SF-CHEAT-LSTOCK-BUY (#255).\n"
         "  --kill-after-state-advance Clean exit immediately after first state-advance ceremony completes (post MSG_PATH_SIGN_DONE). Drives restart-harness tests verifying persistence + revocation_secrets survive. CL5.\n"
         "  --ps-subfactory-arity K  PS sub-factory arity k (canonical k² PS shape from t/1242).  k=1 (default) = 1-client-per-PS-leaf; k>1 = k clients per sub-factory, k sub-factories per leaf, k² clients per leaf.\n"
         "  --test-partial-rotation After demo: 1 client goes offline, partial rotation with 3/4, dist TX on old factory\n"
@@ -1340,6 +1341,10 @@ int main(int argc, char *argv[]) {
                                   -Werror to keep the build green until then. */
     (void)cheat_leaf_side;
     int cheat_realloc = 0;
+    int cheat_lstock_buy = 0;           /* SF-CHEAT-LSTOCK-BUY (#255): when set, after
+                                  --test-buy-liquidity completes the honest L-stock
+                                  buy ceremony, broadcast the pre-buy leaf signed_tx
+                                  (now revoked) and verify the watchtower defense path. */
     secp256k1_pubkey _bridge_pubkey_arg;
     int _has_bridge_pubkey_arg = 0;     /* CL2: when set, after --test-realloc completes,
                                   broadcast the pre-realloc leaf signed_tx (now revoked)
@@ -1829,6 +1834,16 @@ int main(int argc, char *argv[]) {
         else if (strcmp(argv[i], "--cheat-realloc") == 0) {
             /* CL2: enable post-finalize cheat broadcast against --test-realloc. */
             cheat_realloc = 1;
+        }
+        else if (strcmp(argv[i], "--cheat-lstock-buy") == 0) {
+            /* SF-CHEAT-LSTOCK-BUY (#255): after --test-buy-liquidity completes the
+               honest L-stock buy ceremony (which mutates the leaf signed_tx to the
+               post-buy state), broadcast the snapshotted pre-buy leaf TX and verify
+               the watchtower detects + responds with the penalty TX.
+               Mirrors the established cheat-engine pattern (--cheat-realloc / CL2). */
+            cheat_lstock_buy = 1;
+            test_buy_liquidity = 1;
+            setenv("SS_CHEAT_LSTOCK_BUY", "1", 1);
         }
         else if (strcmp(argv[i], "--test-dual-factory") == 0)
             test_dual_factory = 1;

--- a/tools/superscalar_lsp_post_daemon_tests.inc
+++ b/tools/superscalar_lsp_post_daemon_tests.inc
@@ -1372,16 +1372,34 @@
 
             /* Record pre-buy state */
             size_t leaf_node_idx = lsp_p->factory.leaf_node_indices[0];
-            uint64_t pre_lstock = lsp_p->factory.nodes[leaf_node_idx].outputs[2].amount_sats;
-            uint64_t pre_client = lsp_p->factory.nodes[leaf_node_idx].outputs[0].amount_sats;
+            factory_node_t *buy_leaf_node = &lsp_p->factory.nodes[leaf_node_idx];
+            uint64_t pre_lstock = buy_leaf_node->outputs[2].amount_sats;
+            uint64_t pre_client = buy_leaf_node->outputs[0].amount_sats;
+
+            /* SF-CHEAT-LSTOCK-BUY (#255): snapshot the pre-buy leaf signed_tx
+               BEFORE lsp_channels_buy_liquidity mutates the node (via internal
+               lsp_realloc_leaf).  After the honest ceremony completes, this
+               snapshotted tx is the revoked pre-buy state we will broadcast.
+               Mirrors the CL2 cheat-realloc pattern (see line 1066 above). */
+            tx_buf_t cl_lsb_pre_buy_tx;
+            tx_buf_init(&cl_lsb_pre_buy_tx, 0);
+            if (cheat_lstock_buy &&
+                buy_leaf_node->is_signed && buy_leaf_node->signed_tx.len > 0) {
+                tx_buf_init(&cl_lsb_pre_buy_tx, (int)buy_leaf_node->signed_tx.len);
+                memcpy(cl_lsb_pre_buy_tx.data, buy_leaf_node->signed_tx.data,
+                       buy_leaf_node->signed_tx.len);
+                cl_lsb_pre_buy_tx.len = buy_leaf_node->signed_tx.len;
+                printf("CL?-CHEAT-LSTOCK-BUY: snapshotted pre-buy leaf tx (%zu bytes)\n",
+                       (size_t)cl_lsb_pre_buy_tx.len);
+            }
 
             if (!lsp_channels_buy_liquidity(mgr, lsp_p, 0, buy_amount)) {
                 printf("  buy_liquidity FAILED\n");
                 buy_pass = 0;
             } else {
                 /* Verify L-stock decreased and client output increased */
-                uint64_t post_lstock = lsp_p->factory.nodes[leaf_node_idx].outputs[2].amount_sats;
-                uint64_t post_client = lsp_p->factory.nodes[leaf_node_idx].outputs[0].amount_sats;
+                uint64_t post_lstock = buy_leaf_node->outputs[2].amount_sats;
+                uint64_t post_client = buy_leaf_node->outputs[0].amount_sats;
 
                 printf("  L-stock: %llu → %llu (-%llu)\n",
                        (unsigned long long)pre_lstock, (unsigned long long)post_lstock,
@@ -1395,6 +1413,77 @@
                     buy_pass = 0;
                 }
             }
+
+            /* SF-CHEAT-LSTOCK-BUY (#255): adversarial broadcast + WT assertion.
+               At this point the honest L-stock buy ceremony has completed and
+               buy_leaf_node->signed_tx now contains the POST-BUY state.  The
+               watchtower has registered the new state via lsp_realloc_leaf's
+               revocation path.  Now broadcast the snapshotted PRE-BUY tx (the
+               revoked state) and assert WT detects + responds.  Same trick as
+               CL2 cheat-realloc: temporarily set is_signed=0 on the buy leaf
+               so broadcast_factory_tree_any_network lands the parent without
+               the post-buy leaf, then broadcast the pre-buy snapshot. */
+            if (buy_pass && cheat_lstock_buy && cl_lsb_pre_buy_tx.len > 0) {
+                printf("\n--- CL?-CHEAT-LSTOCK-BUY: broadcasting parent factory tree (skipping post-buy leaf) ---\n");
+                fflush(stdout);
+                int saved_leaf_is_signed = buy_leaf_node->is_signed;
+                buy_leaf_node->is_signed = 0;
+                int parent_tree_ok = broadcast_factory_tree_any_network(
+                    &lsp_p->factory, &rt, mine_addr, is_regtest,
+                    confirm_timeout_secs);
+                buy_leaf_node->is_signed = saved_leaf_is_signed;
+                if (!parent_tree_ok) {
+                    fprintf(stderr,
+                            "CL?-CHEAT-LSTOCK-BUY: parent tree broadcast failed — cannot test stale broadcast\n");
+                    buy_pass = 0;
+                    goto cl_lstock_buy_cleanup;
+                }
+                printf("CL?-CHEAT-LSTOCK-BUY: parent tree on-chain; broadcasting revoked pre-buy leaf\n");
+
+                char *cheat_hex = malloc((size_t)cl_lsb_pre_buy_tx.len * 2 + 1);
+                char cheat_txid_str[65] = {0};
+                int sent = 0;
+                if (cheat_hex) {
+                    hex_encode(cl_lsb_pre_buy_tx.data,
+                               (size_t)cl_lsb_pre_buy_tx.len, cheat_hex);
+                    sent = regtest_send_raw_tx(&rt, cheat_hex, cheat_txid_str);
+                    if (g_db)
+                        persist_log_broadcast(g_db,
+                            sent ? cheat_txid_str : "?",
+                            "cheat_lstock_buy_stale",
+                            cheat_hex,
+                            sent ? "ok" : "failed");
+                    free(cheat_hex);
+                }
+                if (!sent) {
+                    fprintf(stderr, "CL?-CHEAT-LSTOCK-BUY: stale broadcast failed\n");
+                    buy_pass = 0;
+                } else {
+                    printf("CL?-CHEAT-LSTOCK-BUY: revoked tx broadcast txid=%s\n",
+                           cheat_txid_str);
+                    if (is_regtest) regtest_mine_blocks(&rt, 1, mine_addr);
+                    watchtower_t *wt_lsb = mgr->watchtower;
+                    if (!wt_lsb) {
+                        fprintf(stderr,
+                                "CL?-CHEAT-LSTOCK-BUY: no watchtower configured — cannot assert defense\n");
+                        buy_pass = 0;
+                    } else {
+                        int detected = watchtower_check(wt_lsb);
+                        if (detected > 0) {
+                            printf("CL?-CHEAT-LSTOCK-BUY: BREACH DETECTED! Watchtower broadcast %d penalty tx(s)\n",
+                                   detected);
+                            if (is_regtest) regtest_mine_blocks(&rt, 1, mine_addr);
+                        } else {
+                            fprintf(stderr,
+                                    "CL?-CHEAT-LSTOCK-BUY: watchtower did NOT detect revoked broadcast (defense MISS)\n");
+                            buy_pass = 0;
+                        }
+                    }
+                }
+            }
+        cl_lstock_buy_cleanup:
+            tx_buf_free(&cl_lsb_pre_buy_tx);
+
             printf("BUY LIQUIDITY TEST: %s\n", buy_pass ? "PASS" : "FAIL");
         }
         fflush(stdout);

--- a/tools/test_regtest_cheat_lstock_buy.sh
+++ b/tools/test_regtest_cheat_lstock_buy.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# test_regtest_cheat_lstock_buy.sh — SF-CHEAT-LSTOCK-BUY (#255) adversarial test on regtest.
+#
+# Validates --cheat-lstock-buy: after the LSP completes an honest L-stock
+# buy-liquidity ceremony (which mutates the leaf signed_tx via lsp_realloc_leaf),
+# it broadcasts the now-revoked pre-buy leaf TX, and the watchtower must
+# detect + respond with a penalty TX (BUY LIQUIDITY TEST PASS path).
+#
+# Source: docs/cheat-engine-catalog (SF-CHEAT-LSTOCK-BUY).
+# Mirrors tools/test_regtest_cheat_realloc.sh.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+# --test-buy-liquidity requires arity=2 (per the SKIP gate in
+# superscalar_lsp_post_daemon_tests.inc). Use N=2 (minimum).
+N_CLIENTS=2
+FUNDING_SATS=200000
+LSP_PORT=29958                    # distinct from sibling cheat tests
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+
+. "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
+
+TMPDIR=$(mktemp -d /tmp/ss-cheat-lstock-buy.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"
+LSP_LOG="$TMPDIR/lsp.log"
+
+PIDS=()
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    cp "$LSP_LOG" /tmp/cheat_lstock_buy_last_lsp.log 2>/dev/null || true
+    cp "$LSP_DB"  /tmp/cheat_lstock_buy_last_lsp.db  2>/dev/null || true
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        cp "$TMPDIR/client_${i}.log" "/tmp/cheat_lstock_buy_last_client_${i}.log" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR"
+    echo "  preserved: /tmp/cheat_lstock_buy_last_lsp.{log,db}, /tmp/cheat_lstock_buy_last_client_{0..$((N_CLIENTS - 1))}.log"
+}
+trap cleanup EXIT
+
+echo "=== L-STOCK BUY-LIQUIDITY CHEAT (SF-CHEAT-LSTOCK-BUY #255, regtest) ==="
+echo "  build dir   : $BUILD_DIR"
+echo "  N clients   : $N_CLIENTS"
+echo "  funding     : $FUNDING_SATS sats"
+echo "  bitcoind    : $REGTEST_CONF"
+echo
+echo "  Test will:"
+echo "    1. Build arity=2 factory with 2 clients (3-of-3 leaf)"
+echo "    2. LSP runs honest L-stock buy ceremony (1000 sats to client 0)"
+echo "    3. LSP snapshots pre-buy leaf TX, broadcasts after buy completes"
+echo "    4. LSP-internal watchtower_check fires"
+echo "    5. PASS = penalty TX broadcast + BUY LIQUIDITY TEST: PASS"
+
+# --- bitcoind check ---
+echo
+echo "--- bitcoind regtest check ---"
+if ! $BCLI getblockchaininfo >/dev/null 2>&1; then
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+    for i in $(seq 1 30); do
+        sleep 1
+        $BCLI getblockchaininfo >/dev/null 2>&1 && break
+    done
+fi
+echo "  bitcoind reachable, chain at height $($BCLI getblockcount)"
+
+REORG_LOG="$TMPDIR/reorg.log"
+REORG_PID=$(start_reorg_watcher "$REORG_LOG")
+PIDS+=($REORG_PID)
+echo "  reorg watcher PID=$REORG_PID"
+$BCLI -named createwallet wallet_name=ss_cheat_lstock_miner load_on_startup=false 2>&1 | head -2 || true
+$BCLI loadwallet ss_cheat_lstock_miner 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=ss_cheat_lstock_miner -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+echo "  miner wallet ready, 101 fresh blocks"
+
+# --- LSP ---
+echo
+echo "--- LSP daemon (--demo --test-buy-liquidity --cheat-lstock-buy) ---"
+ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+"$LSP_BIN" \
+    --network regtest \
+    --port $LSP_PORT \
+    --clients $N_CLIENTS \
+    --arity 2 \
+    --amount $FUNDING_SATS \
+    --fee-rate 1000 \
+    --confirm-timeout 600 \
+    --active-blocks 6 \
+    --dying-blocks 4 \
+    --step-blocks 1 \
+    --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser ${RPCUSER:-rpcuser} \
+    --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet ss_cheat_lstock_miner \
+    --db "$LSP_DB" \
+    --demo --cheat-lstock-buy \
+    --lsp-balance-pct 50 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+PIDS+=($LSP_PID)
+
+for i in $(seq 1 60); do
+    sleep 1
+    if grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null; then
+        echo "  LSP listening (PID=$LSP_PID, port=$LSP_PORT)"
+        break
+    fi
+    if ! kill -0 $LSP_PID 2>/dev/null; then
+        echo "FAIL: LSP died before listening"
+        tail -20 "$LSP_LOG"
+        exit 1
+    fi
+done
+
+# --- Clients ---
+echo
+echo "--- Starting $N_CLIENTS clients ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+    "$CLIENT_BIN" \
+        --network regtest \
+        --host 127.0.0.1 --port $LSP_PORT \
+        --seckey "${CLIENT_SECKEYS[$i]}" \
+        --fee-rate 1000 \
+        --lsp-pubkey "$LSP_PUBKEY" \
+        --participant-id $((i + 1)) \
+        --daemon \
+        --rpcuser ${RPCUSER:-rpcuser} \
+        --rpcpassword ${RPCPASSWORD:-rpcpass} \
+        --wallet ss_cheat_lstock_miner \
+        --db "$TMPDIR/client_${i}.db" \
+        > "$TMPDIR/client_${i}.log" 2>&1 &
+    CLIENT_PID=$!
+    PIDS+=($CLIENT_PID)
+    echo "  client[$i] PID=$CLIENT_PID"
+    sleep 0.5
+done
+
+# --- Background miner ---
+(
+    while kill -0 $LSP_PID 2>/dev/null; do
+        "$BCLI" generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1
+        sleep 2
+    done
+) &
+MINE_PID=$!
+PIDS+=($MINE_PID)
+
+# --- Wait for outcome ---
+echo
+echo "--- Waiting for BUY LIQUIDITY TEST: PASS|FAIL (timeout 600s) ---"
+for i in $(seq 1 300); do
+    sleep 2
+    if grep -qE "BUY LIQUIDITY TEST: (PASS|FAIL|SKIP)" "$LSP_LOG" 2>/dev/null; then
+        break
+    fi
+    if [ $((i % 15)) -eq 0 ]; then
+        M=$(grep -cE "CL\?-CHEAT-LSTOCK-BUY|watchtower_check|BREACH" "$LSP_LOG" 2>/dev/null || echo 0)
+        echo "  ... ${i}s elapsed, SF-CHEAT-LSTOCK-BUY markers in LSP log: $M"
+    fi
+    kill -0 $LSP_PID 2>/dev/null || { echo "  LSP exited at iter $i"; break; }
+done
+
+LSP_EXIT=0
+wait $LSP_PID 2>/dev/null || LSP_EXIT=$?
+echo "--- LSP exit=$LSP_EXIT ---"
+
+# --- Verification ---
+echo
+echo "=== SF-CHEAT-LSTOCK-BUY markers ==="
+grep -E "CL\?-CHEAT-LSTOCK-BUY|watchtower_check" "$LSP_LOG" | head -15 || echo "  (none)"
+echo
+echo "=== broadcast_log entries ==="
+sqlite3 "$LSP_DB" "SELECT id, source, result, substr(txid,1,32) FROM broadcast_log WHERE source LIKE '%lstock%' OR source LIKE '%poison%' OR source LIKE '%penalty%' OR source LIKE '%response%' ORDER BY id;" 2>/dev/null
+echo
+echo "=== breach_detections rows ==="
+sqlite3 "$LSP_DB" "SELECT * FROM breach_detections ORDER BY id DESC LIMIT 5;" 2>/dev/null
+echo
+echo "=== Final result ==="
+# PASS criterion: the WT must have DETECTED the cheat broadcast (FACTORY
+# BREACH or BREACH DETECTED line) AND broadcast at least one defense TX
+# (poison/penalty/response).  Detection can fire either via the
+# watchtower_check() call from the test scaffold OR the WT's main-loop
+# block scan -- both count.
+BREACH_DETECTED=$(grep -E "FACTORY BREACH on node|CL\?-CHEAT-LSTOCK-BUY: BREACH DETECTED" "$LSP_LOG" 2>/dev/null | wc -l)
+POISON_BROADCAST=$(grep -E "L-stock burn tx broadcast|poison TX broadcast|penalty.*broadcast|response_tx.*broadcast" "$LSP_LOG" 2>/dev/null | wc -l)
+
+if [ "$BREACH_DETECTED" -ge 1 ] && [ "$POISON_BROADCAST" -ge 1 ]; then
+    echo "  PASS: WT detected breach (x$BREACH_DETECTED) + broadcast poison (x$POISON_BROADCAST)"
+    grep -E "FACTORY BREACH|L-stock burn|response_tx|watchtower registered OLD" "$LSP_LOG" | head -10
+    exit 0
+fi
+
+echo "  FAIL: BREACH_DETECTED=$BREACH_DETECTED POISON_BROADCAST=$POISON_BROADCAST"
+echo "  LSP log tail:"
+tail -40 "$LSP_LOG"
+exit 1


### PR DESCRIPTION
## Summary

Adversarial test against the L-stock (sales-stock) buy-liquidity ceremony, closing #255.

- `--cheat-lstock-buy` flag in `superscalar_lsp.c`: sets `SS_CHEAT_LSTOCK_BUY=1` and auto-enables `--test-buy-liquidity`.
- Injection in `tools/superscalar_lsp_post_daemon_tests.inc` inside the BUY LIQUIDITY TEST block: snapshot pre-buy leaf signed_tx, run honest `lsp_channels_buy_liquidity` (which mutates leaf via internal `lsp_realloc_leaf` so WT registers post-buy state), then broadcast parent tree skipping the buy'd leaf and broadcast the snapshotted pre-buy tx, then `watchtower_check()` should fire breach detection + L-stock burn TX.
- `tools/test_regtest_cheat_lstock_buy.sh` companion regtest wrapper, mirrors `test_regtest_cheat_realloc.sh`.

Mirrors the established cheat-engine pattern (#347 `--cheat-daemon-rollover`, CL2 `--cheat-realloc`).

## Validation

- 1475/1475 unit PASS (baseline, no regression).
- Regtest PASS: `CL?-CHEAT-LSTOCK-BUY: snapshotted pre-buy leaf tx (248 bytes)` → `parent tree on-chain` → `revoked tx broadcast txid=...` → `FACTORY BREACH on node 1` → `L-stock burn tx broadcast: ...` → `breach_detections` row written → `BUY LIQUIDITY TEST: PASS`.

## Test plan

- [x] cmake --build build-release -j2 succeeds (no -Werror regressions).
- [x] ./build-release/test_superscalar — 1475/1475 PASS.
- [x] tools/test_regtest_cheat_lstock_buy.sh build-release — PASS (WT detected breach + broadcast poison).
- [x] --help shows the new flag.