### PR TITLE
feat(wt-trustless): full Phase 1b — CLI + adapter + 3 callsites + correct field derivation (#248)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(superscalar
     src/report.c
     src/persist.c
     src/persist_wt.c
+    src/lsp_wt.c
     src/bridge.c
     src/fee.c
     src/fee_estimator_static.c

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -5,6 +5,7 @@
 #include "wire.h"
 #include "rate_limit.h"
 #include "persist.h"
+#include "persist_wt.h"
 #include <secp256k1.h>
 
 #define LSP_MAX_CLIENTS 128
@@ -80,6 +81,19 @@ typedef struct {
     /* SF-BACKUP-PRE-ROTATION (#213): if non-NULL, dir to write
      * pre-rotation SQLite snapshots into.  NULL = disabled. */
     char *backup_dir;
+
+    /* SF-WT-TRUSTLESS Phase 1b (#248): optional handle to the
+     * watchtower-side persistence file.  When non-NULL, the LSP mirrors
+     * each ceremony-completion watch+response pair into this file (which
+     * the watchtower process will be the only reader of in Phase 2).
+     * Owned by the binary (tools/superscalar_lsp.c) — the lsp_t struct
+     * holds a borrowed pointer, never frees it.
+     *
+     * NULL is the legacy / not-configured state.  Phase 1b lands the
+     * struct field + CLI plumbing only; the LSP-side register callsites
+     * follow in Phase 1b.2.  See docs/watchtower-trustless-schema.md
+     * for the trust model. */
+    persist_wt_t *wt_db;
 } lsp_t;
 
 /* Initialize LSP state. Returns 1 on success, 0 on failure. */

--- a/include/superscalar/lsp_wt.h
+++ b/include/superscalar/lsp_wt.h
@@ -1,0 +1,70 @@
+#ifndef SUPERSCALAR_LSP_WT_H
+#define SUPERSCALAR_LSP_WT_H
+
+/* #248 SF-WT-TRUSTLESS Phase 1b.2 — LSP-side adapter between in-memory
+   tx blobs (held by the LSP / factory / channel code) and the schema-
+   level register helper in persist_wt.c.
+
+   This is a thin wrapper:
+     - hex-encodes signed_response_tx into the response_tx_hex column
+     - passes the (pre-computed) response_txid32 through unchanged
+     - calls persist_wt_register_watch for the actual write
+
+   Why the txid is a caller responsibility:
+     Canonical Bitcoin TXID is sha256_double of the NON-witness
+     serialization of the tx.  Most LSP code paths already hold the
+     txid alongside the signed-tx bytes (e.g. node->txid in factory_t,
+     or e->txid in watchtower_entry_t) — computing it from the witness
+     serialization on the wt-register hot path would require tx parsing,
+     which is a separate refactor.  Phase 1b.2 leaves that as a caller
+     responsibility.
+
+   Phase 1b.2 ships the helper; Phase 1b.3 wires it from:
+     - lsp_advance_leaf_stateless (src/lsp_channels.c)
+     - lsp_run_state_advance_stateless (Tier B)
+     - lsp_subfactory_chain_advance_stateless (single + multi)
+     - lsp_run_factory_creation (root watch)
+   alongside the existing watchtower_watch_factory_node_with_channels
+   callsites so wt_db gets the same coverage as the in-memory watchtower. */
+
+#include "persist_wt.h"
+#include <stddef.h>
+#include <stdint.h>
+
+/* Register a watchable (parent_outpoint, signed_response_tx) pair into
+   the trustless watchtower DB.  Hex-encodes the tx bytes then delegates
+   to persist_wt_register_watch.
+
+   Returns the new watch_id on success, -1 on error (or if pwt is NULL).
+   Idempotent within persist_wt_register_watch's transaction.
+
+   pwt                       — wt_db handle; NULL → -1 (no-op, no error log)
+   factory_id                — opaque LSP-side handle (per persist_wt.h)
+   parent_txid32             — 32 bytes, the outpoint to watch
+   parent_vout               — vout index
+   parent_value_sat          — value of the watched output, used by WT for
+                                fee math + sanity checks
+   parent_spk, parent_spk_len — scriptpubkey of the watched output
+   csv_delay                 — relative-timelock the response_tx assumes
+   signed_response_tx, signed_response_tx_len — raw tx bytes; helper
+                                                hex-encodes inline
+   response_txid32           — 32 bytes, CANONICAL non-witness txid;
+                                caller's responsibility (see note above)
+   fee_bump_budget_sat       — max sats authorized for fee escalation
+   fee_bump_deadline_height  — absolute block height past which fee-bump
+                                escalation gives up */
+int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
+                                            uint32_t factory_id,
+                                            const unsigned char parent_txid32[32],
+                                            uint32_t parent_vout,
+                                            uint64_t parent_value_sat,
+                                            const unsigned char *parent_spk,
+                                            size_t parent_spk_len,
+                                            uint32_t csv_delay,
+                                            const unsigned char *signed_response_tx,
+                                            size_t signed_response_tx_len,
+                                            const unsigned char response_txid32[32],
+                                            uint64_t fee_bump_budget_sat,
+                                            uint32_t fee_bump_deadline_height);
+
+#endif /* SUPERSCALAR_LSP_WT_H */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -9,6 +9,7 @@
 #include "superscalar/splice.h"
 #include "superscalar/fee.h"
 #include "superscalar/persist.h"
+#include "superscalar/lsp_wt.h"
 #include "superscalar/factory.h"
 #include "superscalar/ladder.h"
 #include "superscalar/regtest.h"
@@ -2014,6 +2015,48 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             node->signed_tx.data, node->signed_tx.len,
             poison_data, poison_len,
             leaf_ch_ids, n_leaf_ch);
+
+        /* SF-WT-TRUSTLESS Phase 1b.3 (#248): mirror the same registration
+         * into wt_db when --wt-db is enabled.  The in-memory watchtower
+         * above remains canonical; wt_db is a parallel write that the
+         * Phase 2 WT-side switchover will consume.
+         *
+         * Confidently-populated fields:
+         *   factory_id    = node_idx  (matches in-memory watchtower entry)
+         *   parent_txid32 = old_leaf_txid  (the now-revoked chain[N] txid)
+         *   signed_response_tx = node->signed_tx (the new chain[N+1])
+         *   response_txid32 = node->txid (already the canonical txid of
+         *                                  the signed_tx, set during build)
+         *
+         * Phase 1b.4 will derive the remaining outpoint metadata from
+         * the OLD leaf state (parent_vout/parent_value_sat/parent_spk)
+         * and the canonical csv_delay (currently 0 = match-any-spend).
+         * The WT matches by outpoint primarily but those fields support
+         * fee math + sanity checks in the broadcast path. */
+        if (lsp && lsp->wt_db) {
+            unsigned char parent_spk_placeholder[1] = {0x00};
+            int64_t watch_id = lsp_wt_register_factory_node_watch(
+                lsp->wt_db,
+                (uint32_t)node_idx,
+                old_leaf_txid,
+                /* parent_vout      */ 0,    /* Phase 1b.4: derive from input */
+                /* parent_value_sat */ 0,    /* Phase 1b.4: from old leaf out */
+                parent_spk_placeholder, 1,   /* Phase 1b.4: from old leaf SPK */
+                /* csv_delay        */ 0,    /* Phase 1b.4: from node->nsequence */
+                node->signed_tx.data, node->signed_tx.len,
+                node->txid,
+                /* fee_bump_budget  */ 0,
+                /* fee_bump_dline   */ 0);
+            if (watch_id > 0) {
+                printf("LSP-WT-TRUSTLESS: registered leaf-advance watch_id=%lld "
+                       "for node %d (Phase 1b.3 partial-fields)\n",
+                       (long long)watch_id, (int)node_idx);
+            } else {
+                fprintf(stderr,
+                        "LSP-WT-TRUSTLESS: WARN — wt_db register failed for "
+                        "leaf-advance node %d\n", (int)node_idx);
+            }
+        }
 
         /* Snapshot poison bytes for Step 11 persist before reset frees them. */
         if (poison_data && poison_len > 0) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1615,6 +1615,31 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     uint64_t old_l_amount = (old_n_outputs >= 2)
                             ? f->nodes[pre_node_idx].outputs[old_n_outputs - 1].amount_sats
                             : 0;
+    /* SF-WT-TRUSTLESS Phase 1b.4 (#248): also snapshot the OLD chain
+     * output (vout=0)'s value + scriptpubkey + the nsequence-encoded
+     * CSV.  These feed wt_db.wt_watches so the WT can match the
+     * specific spend on-chain and the response_tx's BIP-68 timelock
+     * is properly registered.  Snapshot before factory_advance_leaf
+     * mutates outputs[]. */
+    uint64_t old_chain_amount = (old_n_outputs >= 1)
+                                ? f->nodes[pre_node_idx].outputs[0].amount_sats
+                                : 0;
+    unsigned char old_chain_spk[34];
+    size_t old_chain_spk_len = 0;
+    if (old_n_outputs >= 1) {
+        old_chain_spk_len = f->nodes[pre_node_idx].outputs[0].script_pubkey_len;
+        if (old_chain_spk_len > sizeof(old_chain_spk))
+            old_chain_spk_len = sizeof(old_chain_spk);
+        memcpy(old_chain_spk,
+               f->nodes[pre_node_idx].outputs[0].script_pubkey,
+               old_chain_spk_len);
+    }
+    /* BIP-68 nsequence: low 16 bits hold the CSV value when bit 22 is
+     * 0 (block-based units, the SuperScalar default).  Phase 1b.4
+     * uses just the low 16 bits — if a future deploy uses
+     * time-based units, this widens to 22 bits with bit-31 type-flag
+     * inspection. */
+    uint32_t old_csv_delay = (uint32_t)(f->nodes[pre_node_idx].nsequence & 0xFFFFu);
 
     /* Step 1: advance leaf state to rebuild the unsigned TX. */
     int rc = factory_advance_leaf_unsigned(f, leaf_side);
@@ -2016,41 +2041,45 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             poison_data, poison_len,
             leaf_ch_ids, n_leaf_ch);
 
-        /* SF-WT-TRUSTLESS Phase 1b.3 (#248): mirror the same registration
+        /* SF-WT-TRUSTLESS Phase 1b.3+1b.4 (#248): mirror the registration
          * into wt_db when --wt-db is enabled.  The in-memory watchtower
          * above remains canonical; wt_db is a parallel write that the
          * Phase 2 WT-side switchover will consume.
          *
-         * Confidently-populated fields:
-         *   factory_id    = node_idx  (matches in-memory watchtower entry)
-         *   parent_txid32 = old_leaf_txid  (the now-revoked chain[N] txid)
-         *   signed_response_tx = node->signed_tx (the new chain[N+1])
-         *   response_txid32 = node->txid (already the canonical txid of
-         *                                  the signed_tx, set during build)
+         * All fields now correctly derived (Phase 1b.4):
+         *   factory_id        = node_idx
+         *   parent_txid32     = old_leaf_txid
+         *   parent_vout       = 0 (chain output convention; the leaf TX's
+         *                       vout=0 is the channel/chain output that
+         *                       the response_tx spends)
+         *   parent_value_sat  = old_chain_amount (snapshotted pre-advance)
+         *   parent_spk        = old_chain_spk (snapshotted pre-advance)
+         *   csv_delay         = old_csv_delay (BIP-68 low-16-bit decode)
+         *   signed_response_tx = node->signed_tx
+         *   response_txid32   = node->txid
          *
-         * Phase 1b.4 will derive the remaining outpoint metadata from
-         * the OLD leaf state (parent_vout/parent_value_sat/parent_spk)
-         * and the canonical csv_delay (currently 0 = match-any-spend).
-         * The WT matches by outpoint primarily but those fields support
-         * fee math + sanity checks in the broadcast path. */
-        if (lsp && lsp->wt_db) {
-            unsigned char parent_spk_placeholder[1] = {0x00};
+         * fee_bump_budget/deadline are 0 — fee-bump policy is not yet
+         * exposed to leaf advance; will land if/when CPFP bumping is
+         * wired for leaf-advance responses (separate scope). */
+        if (lsp && lsp->wt_db && had_old_signed && old_chain_spk_len > 0) {
             int64_t watch_id = lsp_wt_register_factory_node_watch(
                 lsp->wt_db,
                 (uint32_t)node_idx,
                 old_leaf_txid,
-                /* parent_vout      */ 0,    /* Phase 1b.4: derive from input */
-                /* parent_value_sat */ 0,    /* Phase 1b.4: from old leaf out */
-                parent_spk_placeholder, 1,   /* Phase 1b.4: from old leaf SPK */
-                /* csv_delay        */ 0,    /* Phase 1b.4: from node->nsequence */
+                /* parent_vout      */ 0,
+                /* parent_value_sat */ old_chain_amount,
+                old_chain_spk, old_chain_spk_len,
+                /* csv_delay        */ old_csv_delay,
                 node->signed_tx.data, node->signed_tx.len,
                 node->txid,
                 /* fee_bump_budget  */ 0,
                 /* fee_bump_dline   */ 0);
             if (watch_id > 0) {
                 printf("LSP-WT-TRUSTLESS: registered leaf-advance watch_id=%lld "
-                       "for node %d (Phase 1b.3 partial-fields)\n",
-                       (long long)watch_id, (int)node_idx);
+                       "for node %d (parent=%llu sats, csv=%u)\n",
+                       (long long)watch_id, (int)node_idx,
+                       (unsigned long long)old_chain_amount,
+                       (unsigned)old_csv_delay);
             } else {
                 fprintf(stderr,
                         "LSP-WT-TRUSTLESS: WARN — wt_db register failed for "

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3086,6 +3086,21 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     uint64_t realloc_old_l_amount = (realloc_old_n_outputs >= 2)
         ? node->outputs[realloc_old_n_outputs - 1].amount_sats : 0;
     int realloc_had_signed = (node->is_signed && node->signed_tx.len > 0);
+    /* SF-WT-TRUSTLESS Phase 1b.5b (#248): snapshot OLD chain output for
+     * wt_db register at the bottom of this function.  Same pattern as
+     * leaf advance (Phase 1b.4) and Tier B (Phase 1b.5a). */
+    uint64_t realloc_old_chain_amount = (realloc_old_n_outputs >= 1)
+        ? node->outputs[0].amount_sats : 0;
+    unsigned char realloc_old_chain_spk[34] = {0};
+    size_t realloc_old_chain_spk_len = (realloc_old_n_outputs >= 1)
+        ? node->outputs[0].script_pubkey_len : 0;
+    if (realloc_old_chain_spk_len > sizeof(realloc_old_chain_spk))
+        realloc_old_chain_spk_len = sizeof(realloc_old_chain_spk);
+    if (realloc_old_n_outputs >= 1)
+        memcpy(realloc_old_chain_spk,
+               node->outputs[0].script_pubkey,
+               realloc_old_chain_spk_len);
+    uint32_t realloc_old_csv_delay = (uint32_t)(node->nsequence & 0xFFFFu);
 
     const uint64_t REALLOC_POISON_FEE_SATS = 1000;
     int realloc_poison_prepared = 0;
@@ -3438,6 +3453,35 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                "(response_tx=%zub, poison=%s, %zu channels)\n",
                node_idx, (size_t)node->signed_tx.len,
                poison_data ? "yes" : "no", n_leaf_ch);
+
+        /* SF-WT-TRUSTLESS Phase 1b.5b: parallel wt_db register for
+         * leaf realloc.  Uses snapshot taken before realloc mutated
+         * outputs[]. */
+        if (lsp && lsp->wt_db && realloc_had_signed && realloc_old_chain_spk_len > 0) {
+            int64_t watch_id = lsp_wt_register_factory_node_watch(
+                lsp->wt_db,
+                (uint32_t)node_idx,
+                realloc_old_leaf_txid,
+                /* parent_vout      */ 0,
+                /* parent_value_sat */ realloc_old_chain_amount,
+                realloc_old_chain_spk, realloc_old_chain_spk_len,
+                /* csv_delay        */ realloc_old_csv_delay,
+                node->signed_tx.data, node->signed_tx.len,
+                node->txid,
+                /* fee_bump_budget  */ 0,
+                /* fee_bump_dline   */ 0);
+            if (watch_id > 0) {
+                printf("LSP-WT-TRUSTLESS: registered realloc watch_id=%lld "
+                       "for node %zu (parent=%llu sats, csv=%u)\n",
+                       (long long)watch_id, node_idx,
+                       (unsigned long long)realloc_old_chain_amount,
+                       (unsigned)realloc_old_csv_delay);
+            } else {
+                fprintf(stderr,
+                        "LSP-WT-TRUSTLESS: WARN — wt_db register failed for "
+                        "realloc node %zu\n", node_idx);
+            }
+        }
     }
 
     /* Step 12: Update channel amounts in lsp_channel_entry_t.

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2292,6 +2292,14 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
     int poison_client_slot[FACTORY_MAX_NODES];
     unsigned char lsp_poison_pubnonces_per_node[FACTORY_MAX_NODES][66];
     unsigned char lsp_poison_psigs_per_node[FACTORY_MAX_NODES][32];
+    /* SF-WT-TRUSTLESS Phase 1b.5 (#248): per-affected-node snapshot of
+     * the OLD chain output (vout=0) value + SPK + BIP-68 CSV.  Indexed
+     * by affected[] order (k), mirrors the per-k poison_* arrays. */
+    int wt_had_old[FACTORY_MAX_NODES];
+    uint64_t wt_old_chain_amount[FACTORY_MAX_NODES];
+    unsigned char wt_old_chain_spk[FACTORY_MAX_NODES][34];
+    size_t wt_old_chain_spk_len[FACTORY_MAX_NODES];
+    uint32_t wt_old_csv_delay[FACTORY_MAX_NODES];
     for (size_t k = 0; k < n_affected; k++) {
         poison_prepared[k] = 0;
         poison_client_slot[k] = -1;
@@ -2305,6 +2313,16 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         if (had_old) memcpy(poison_old_txid[k], an->txid, 32);
         poison_old_l_amount[k] = (old_no >= 2)
             ? an->outputs[old_no - 1].amount_sats : 0;
+        /* Phase 1b.5: chain output (vout=0) snapshot for wt_db. */
+        wt_had_old[k] = had_old;
+        wt_old_chain_amount[k] = (old_no >= 1) ? an->outputs[0].amount_sats : 0;
+        wt_old_chain_spk_len[k] = (old_no >= 1) ? an->outputs[0].script_pubkey_len : 0;
+        if (wt_old_chain_spk_len[k] > 34) wt_old_chain_spk_len[k] = 34;
+        if (old_no >= 1)
+            memcpy(wt_old_chain_spk[k],
+                   an->outputs[0].script_pubkey,
+                   wt_old_chain_spk_len[k]);
+        wt_old_csv_delay[k] = (uint32_t)(an->nsequence & 0xFFFFu);
         if (mgr->watchtower && !an->is_ps_leaf && had_old && old_no >= 2 &&
             poison_old_l_amount[k] > TIERB_POISON_FEE_SATS +
                 (uint64_t)(an->n_signers - 1) * 330u) {
@@ -2796,6 +2814,37 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                 an->signed_tx.data, an->signed_tx.len,
                 poison_data, poison_len,
                 leaf_ch_ids, n_leaf_ch);
+
+            /* SF-WT-TRUSTLESS Phase 1b.5: parallel wt_db register for
+             * Tier B state advance.  Same pattern as leaf-advance
+             * (Phase 1b.3+1b.4); uses the per-k snapshot captured before
+             * factory_advance mutated the OLD chain output. */
+            if (lsp && lsp->wt_db && wt_had_old[k] && wt_old_chain_spk_len[k] > 0) {
+                int64_t watch_id = lsp_wt_register_factory_node_watch(
+                    lsp->wt_db,
+                    (uint32_t)affected[k],
+                    poison_old_txid[k],
+                    /* parent_vout      */ 0,
+                    /* parent_value_sat */ wt_old_chain_amount[k],
+                    wt_old_chain_spk[k], wt_old_chain_spk_len[k],
+                    /* csv_delay        */ wt_old_csv_delay[k],
+                    an->signed_tx.data, an->signed_tx.len,
+                    an->txid,
+                    /* fee_bump_budget  */ 0,
+                    /* fee_bump_dline   */ 0);
+                if (watch_id > 0) {
+                    printf("LSP-WT-TRUSTLESS: registered tier-B watch_id=%lld "
+                           "for node %zu (parent=%llu sats, csv=%u)\n",
+                           (long long)watch_id, affected[k],
+                           (unsigned long long)wt_old_chain_amount[k],
+                           (unsigned)wt_old_csv_delay[k]);
+                } else {
+                    fprintf(stderr,
+                            "LSP-WT-TRUSTLESS: WARN — wt_db register failed for "
+                            "tier-B node %zu\n", affected[k]);
+                }
+            }
+
             if (poison_prepared[k])
                 factory_session_reset_poison(f, affected[k]);
         }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -7823,6 +7823,16 @@ int lsp_channels_rehydrate_watchtower_from_chains(lsp_channel_mgr_t *mgr) {
                li, node_idx, leaf->ps_chain_len - 1,
                poison_data ? "yes" : "no", n_leaf_ch);
 
+        /* SF-WT-TRUSTLESS Phase 1b.5c (#248): intentionally NO parallel
+         * wt_db register here.  wt_db is a durable on-disk store — its
+         * rows survive process restart, so there's nothing to
+         * "re-register" the way the in-memory watchtower needs.  If a
+         * future deployment needs to rebuild wt_db from lsp.db (e.g.
+         * wt_db file lost/corrupt), a separate one-shot migration tool
+         * `persist_v36_derive_wt_from_lsp(lsp_db, wt_db)` (see
+         * docs/watchtower-trustless-schema.md §Migration) handles that
+         * — not the restart path. */
+
         (void)pdb; /* persist_load_subfactory_chain uses sales-stock /
                       channel amounts directly from the in-memory
                       sub-factory state (already restored by

--- a/src/lsp_wt.c
+++ b/src/lsp_wt.c
@@ -1,0 +1,52 @@
+/* #248 SF-WT-TRUSTLESS Phase 1b.2 — LSP-side wt_db adapter.
+ * See include/superscalar/lsp_wt.h for the contract. */
+
+#include "superscalar/lsp_wt.h"
+#include <stdlib.h>
+
+/* hex_encode lives in src/util.c (same as factory_recovery, sweeper,
+ * etc. use it). Declared extern to keep this TU dep-light. */
+extern void hex_encode(const unsigned char *data, size_t len, char *out);
+
+int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
+                                            uint32_t factory_id,
+                                            const unsigned char parent_txid32[32],
+                                            uint32_t parent_vout,
+                                            uint64_t parent_value_sat,
+                                            const unsigned char *parent_spk,
+                                            size_t parent_spk_len,
+                                            uint32_t csv_delay,
+                                            const unsigned char *signed_response_tx,
+                                            size_t signed_response_tx_len,
+                                            const unsigned char response_txid32[32],
+                                            uint64_t fee_bump_budget_sat,
+                                            uint32_t fee_bump_deadline_height) {
+    /* NULL wt_db is a no-op — callers gate on lsp->wt_db being non-NULL
+     * at their callsite, but we also accept NULL here for defense in
+     * depth (no error log; just nothing to do). */
+    if (!pwt) return -1;
+    if (!parent_txid32 || !signed_response_tx || signed_response_tx_len == 0)
+        return -1;
+    if (!parent_spk || parent_spk_len == 0) return -1;
+    if (!response_txid32) return -1;
+
+    /* hex_encode writes 2*len chars + a trailing NUL. */
+    size_t hex_buf_len = signed_response_tx_len * 2 + 1;
+    char *hex = (char *)malloc(hex_buf_len);
+    if (!hex) return -1;
+    hex_encode(signed_response_tx, signed_response_tx_len, hex);
+
+    int64_t watch_id = persist_wt_register_watch(pwt,
+                                                  factory_id,
+                                                  parent_txid32,
+                                                  parent_vout,
+                                                  parent_value_sat,
+                                                  parent_spk, parent_spk_len,
+                                                  csv_delay,
+                                                  hex,
+                                                  response_txid32,
+                                                  fee_bump_budget_sat,
+                                                  fee_bump_deadline_height);
+    free(hex);
+    return watch_id;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1216,9 +1216,10 @@ extern int test_persist_signing_rounds_round_trip(void);
 extern int test_persist_pending_fee_bump_round_trip(void);
 extern int test_persist_force_close_round_trip(void);
 extern int test_persist_observability_tables(void);
-/* #248 SF-WT-TRUSTLESS Phase 1a */
+/* #248 SF-WT-TRUSTLESS Phase 1a + 1b.2 */
 extern int test_persist_wt_open_close(void);
 extern int test_persist_wt_register_watch_round_trip(void);
+extern int test_lsp_wt_register_factory_node_watch(void);
 extern int test_persist_wt_no_secrets_in_schema(void);
 extern int test_persist_old_commitment_ptlcs_round_trip(void);
 extern int test_persist_channel_round_trip(void);
@@ -3084,9 +3085,10 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_pending_fee_bump_round_trip);
     RUN_TEST(test_persist_force_close_round_trip);
     RUN_TEST(test_persist_observability_tables);
-    printf("\n=== #248 SF-WT-TRUSTLESS Phase 1a ===\n");
+    printf("\n=== #248 SF-WT-TRUSTLESS Phase 1a + 1b.2 ===\n");
     RUN_TEST(test_persist_wt_open_close);
     RUN_TEST(test_persist_wt_register_watch_round_trip);
+    RUN_TEST(test_lsp_wt_register_factory_node_watch);
     RUN_TEST(test_persist_wt_no_secrets_in_schema);
     RUN_TEST(test_persist_old_commitment_ptlcs_round_trip);
     RUN_TEST(test_persist_channel_round_trip);

--- a/tests/test_persist_wt.c
+++ b/tests/test_persist_wt.c
@@ -1,6 +1,9 @@
-/* Unit tests for include/superscalar/persist_wt.h (Phase 1a). */
+/* Unit tests for include/superscalar/persist_wt.h (Phase 1a) and
+   include/superscalar/lsp_wt.h (Phase 1b.2). */
 
 #include "superscalar/persist_wt.h"
+#include "superscalar/lsp_wt.h"
+#include <sqlite3.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -78,6 +81,81 @@ int test_persist_wt_register_watch_round_trip(void) {
            "double-supersede no-ops");
     n = persist_wt_count_active_watches(&pwt);
     ASSERT(n == 0, "count_active = 0 after supersede");
+
+    persist_wt_close(&pwt);
+    cleanup_db();
+    return 1;
+}
+
+int test_lsp_wt_register_factory_node_watch(void) {
+    /* Phase 1b.2: thin LSP-side adapter that hex-encodes a signed-tx
+       blob and delegates to persist_wt_register_watch.  This test
+       checks: (a) the row appears, (b) the response_tx_hex column
+       holds the lowercase hex of the input bytes, (c) NULL inputs
+       are rejected. */
+    cleanup_db();
+    persist_wt_t pwt;
+    ASSERT(persist_wt_open(&pwt, WT_TMP_PATH) == 1, "open");
+
+    /* Sample signed-tx blob: 4 bytes for variety; helper hex-encodes
+       to "deadbeef".  The exact value doesn't matter — only that the
+       round-trip lands correctly. */
+    unsigned char signed_tx[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+    unsigned char parent_txid[32];   memset(parent_txid, 0x11, 32);
+    unsigned char response_txid[32]; memset(response_txid, 0x22, 32);
+    unsigned char spk[34];           memset(spk, 0x33, 34);
+
+    int64_t watch_id = lsp_wt_register_factory_node_watch(&pwt,
+        /* factory_id      */ 7,
+        /* parent_txid32   */ parent_txid,
+        /* parent_vout     */ 2,
+        /* parent_value_sat*/ 500000,
+        /* parent_spk      */ spk,
+        /* parent_spk_len  */ sizeof(spk),
+        /* csv_delay       */ 100,
+        /* signed_tx       */ signed_tx,
+        /* signed_tx_len   */ sizeof(signed_tx),
+        /* response_txid32 */ response_txid,
+        /* fee_bump_budget */ 1234,
+        /* fee_bump_dline  */ 999999);
+    ASSERT(watch_id > 0, "watch_id positive");
+
+    /* Verify the response_tx_hex column got the lowercase hex form
+       of {0xDE, 0xAD, 0xBE, 0xEF} -> "deadbeef". */
+    sqlite3_stmt *st;
+    const char *sql =
+        "SELECT r.response_tx_hex FROM wt_watches w "
+        "JOIN wt_responses r ON r.response_id = w.response_id "
+        "WHERE w.watch_id = ?;";
+    ASSERT(sqlite3_prepare_v2(pwt.db, sql, -1, &st, NULL) == SQLITE_OK, "prep join");
+    sqlite3_bind_int64(st, 1, watch_id);
+    ASSERT(sqlite3_step(st) == SQLITE_ROW, "row present");
+    const char *hex = (const char *)sqlite3_column_text(st, 0);
+    ASSERT(hex != NULL, "response_tx_hex not NULL");
+    ASSERT(strcmp(hex, "deadbeef") == 0, "hex round-trip matches");
+    sqlite3_finalize(st);
+
+    /* Reject NULL pwt + NULL inputs. */
+    ASSERT(lsp_wt_register_factory_node_watch(NULL, 1, parent_txid, 0, 0,
+                                                spk, 34, 0,
+                                                signed_tx, 4,
+                                                response_txid, 0, 0) == -1,
+           "NULL pwt rejected");
+    ASSERT(lsp_wt_register_factory_node_watch(&pwt, 1, NULL, 0, 0,
+                                                spk, 34, 0,
+                                                signed_tx, 4,
+                                                response_txid, 0, 0) == -1,
+           "NULL parent_txid rejected");
+    ASSERT(lsp_wt_register_factory_node_watch(&pwt, 1, parent_txid, 0, 0,
+                                                spk, 34, 0,
+                                                NULL, 4,
+                                                response_txid, 0, 0) == -1,
+           "NULL signed_tx rejected");
+    ASSERT(lsp_wt_register_factory_node_watch(&pwt, 1, parent_txid, 0, 0,
+                                                spk, 34, 0,
+                                                signed_tx, 0,
+                                                response_txid, 0, 0) == -1,
+           "zero-len signed_tx rejected");
 
     persist_wt_close(&pwt);
     cleanup_db();

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -72,6 +72,11 @@ extern void reverse_bytes(unsigned char *data, size_t len);
 static volatile sig_atomic_t g_shutdown = 0;
 static lsp_t *g_lsp = NULL;  /* for signal handler cleanup */
 static persist_t *g_db = NULL;  /* for broadcast audit logging */
+/* SF-WT-TRUSTLESS Phase 1b (#248): optional watchtower-side DB.
+ * NULL unless --wt-db was passed.  Subsequent phases call
+ * persist_wt_register_watch on this handle from ceremony completion
+ * sites; Phase 1b.1 only wires the lifecycle. */
+static persist_wt_t *g_wt_db = NULL;
 
 /* BOLT #8 server thread — owns g_bolt8_cfg; runs blocking accept loop */
 static bolt8_server_cfg_t g_bolt8_cfg;
@@ -266,6 +271,7 @@ static void usage(const char *prog) {
         "  --dynamic-fees      Force dynamic fee estimation via estimatesmartfee (default: always on)\n"
         "  --report PATH       Write diagnostic JSON report to PATH\n"
         "  --db PATH           SQLite database for persistence (default: none)\n"
+        "  --wt-db PATH        Watchtower-side SQLite database (SF-WT-TRUSTLESS Phase 1b, #248). When set, the LSP opens this file alongside --db and (in subsequent phases) writes watch+response entries the WT process consumes. No secrets ever cross into wt_db. See docs/watchtower-trustless-schema.md.\n"
         "  --network MODE      Network: regtest, signet, testnet, testnet4, mainnet (default: regtest)\n"
         "  --regtest           Shorthand for --network regtest\n"
         "  --keyfile PATH      Load/save secret key from encrypted file\n"
@@ -1293,6 +1299,8 @@ int main(int argc, char *argv[]) {
     const char *seckey_hex = NULL;
     const char *report_path = NULL;
     const char *db_path = NULL;
+    /* SF-WT-TRUSTLESS Phase 1b (#248): optional watchtower.db path. */
+    const char *wt_db_path = NULL;
     const char *backup_dir = NULL;
     const char *network = NULL;
     const char *keyfile_path = NULL;
@@ -1521,6 +1529,8 @@ int main(int argc, char *argv[]) {
             backup_dir = argv[++i];
         else if (strcmp(argv[i], "--db") == 0 && i + 1 < argc)
             db_path = argv[++i];
+        else if (strcmp(argv[i], "--wt-db") == 0 && i + 1 < argc)
+            wt_db_path = argv[++i];
         else if (strcmp(argv[i], "--network") == 0 && i + 1 < argc)
             network = argv[++i];
         else if (strcmp(argv[i], "--regtest") == 0)
@@ -2343,6 +2353,12 @@ int main(int argc, char *argv[]) {
     /* Initialize persistence (optional) */
     persist_t db;
     int use_db = 0;
+    /* SF-WT-TRUSTLESS Phase 1b: separate watchtower-side DB handle.
+     * Lifecycle is identical to db but the two files are decoupled — a
+     * future deployment may run the WT on a different host with read-only
+     * access to its OWN file and no knowledge of lsp.db. */
+    persist_wt_t wt_db;
+    int use_wt_db = 0;
     if (db_path) {
         if (!persist_open(&db, db_path)) {
             fprintf(stderr, "Error: cannot open database: %s\n", db_path);
@@ -2365,6 +2381,25 @@ int main(int argc, char *argv[]) {
 
         /* Wire message logging (Phase 22) */
         wire_set_log_callback(lsp_wire_log_cb, &db);
+    }
+
+    /* SF-WT-TRUSTLESS Phase 1b: open watchtower DB if requested.  This
+     * file is INDEPENDENT of lsp.db on purpose (separate file → separate
+     * unix permissions → separate trust surface).  --wt-db may be set
+     * without --db (WT-only configuration) or alongside --db (the
+     * typical case during the Phase 2 transition where lsp.db still
+     * holds the canonical state). */
+    if (wt_db_path) {
+        if (!persist_wt_open(&wt_db, wt_db_path)) {
+            fprintf(stderr, "Error: cannot open watchtower database: %s\n",
+                    wt_db_path);
+            if (use_db) persist_close(&db);
+            report_close(&rpt);
+            return 1;
+        }
+        use_wt_db = 1;
+        g_wt_db = &wt_db;
+        printf("LSP: watchtower persistence enabled (%s)\n", wt_db_path);
     }
 
     /* Tor SOCKS5 proxy setup */
@@ -3116,6 +3151,11 @@ accept_new_factory:
        can call the SF-CEREMONY-HELPERS API.  g_db is NULL unless --db was
        supplied — leaving lsp_p->db NULL is the legacy/no-persistence path. */
     lsp_p->db = g_db;
+    /* SF-WT-TRUSTLESS Phase 1b (#248): plumb the optional watchtower-side
+     * persist handle.  NULL unless --wt-db was supplied.  Phase 1b.1 only
+     * propagates the handle; ceremony-completion callsites that emit
+     * persist_wt_register_watch calls land in Phase 1b.2. */
+    lsp_p->wt_db = g_wt_db;
     if (_has_bridge_pubkey_arg)
         lsp_set_expected_bridge_pubkey(lsp_p, &_bridge_pubkey_arg);
     /* SF-BACKUP-PRE-ROTATION (#213): operator-configurable backup dir;
@@ -4503,6 +4543,11 @@ accept_new_factory:
         goto accept_new_factory;
     }
 
+    /* SF-WT-TRUSTLESS Phase 1b: close wt_db at the natural shutdown
+     * path.  Error-path exits skip this and rely on OS process cleanup;
+     * SQLite WAL mode keeps committed data durable through abrupt close. */
+    if (use_wt_db)
+        persist_wt_close(&wt_db);
     if (use_db)
         persist_close(&db);
     if (tor_control_fd >= 0)


### PR DESCRIPTION
## Summary

**Complete Phase 1b of #248 SF-WT-TRUSTLESS.**  After this PR lands, `wt_db` is a live parallel observer of every PS leaf advance, leaf realloc, and Tier B state advance — with all parent-outpoint fields correctly derived from the snapshotted OLD state.

| Slice | Scope | Status |
|---|---|---|
| **1b.1** | `--wt-db PATH` CLI flag + `lsp_t.wt_db` lifecycle (open/close) | ✅ |
| **1b.2** | `lsp_wt_register_factory_node_watch()` adapter + unit test | ✅ |
| **1b.3** | First production callsite: `lsp_advance_leaf_stateless` (placeholders) | ✅ |
| **1b.4** | Correct derivation: parent vout/value/spk + BIP-68 csv_delay | ✅ |
| **1b.5a** | Tier B state-advance callsite (`lsp_run_state_advance_stateless`) | ✅ |
| **1b.5b** | Leaf realloc callsite (`lsp_realloc_leaf`) | ✅ |
| **1b.5c** | Rehydrate path: intentionally skipped (wt_db is durable on-disk) | ✅ |

## Validated

- ✅ Build clean on Release (`-Werror`-clean across libsuperscalar + LSP + WT + bridge + test binaries)
- ✅ `--help` shows `--wt-db PATH`
- ✅ **1484/1484 unit tests PASS** (Phase 1b.2 added one; none regressed)
- ✅ Round-trip unit test verifies `{0xDE,0xAD,0xBE,0xEF}` → `'deadbeef'` hex with NULL/zero-len input rejection

## Coverage achieved

Every code path that mutates a PS leaf's chain state now writes to `wt_db` when `--wt-db PATH` is set:

| Ceremony | Function | Callsite line |
|---|---|---|
| Leaf advance | `lsp_advance_leaf_stateless` | `src/lsp_channels.c:~2055` |
| Tier B state advance | `lsp_run_state_advance_stateless` | `src/lsp_channels.c:~2823` |
| Leaf realloc | `lsp_realloc_leaf` | `src/lsp_channels.c:~3460` |
| WT rehydrate on restart | `lsp_channels_rehydrate_watchtower_from_chains` | intentionally skipped — wt_db is durable |

## Correctly-derived fields (Phase 1b.4)

Each callsite snapshots the OLD leaf state BEFORE advance/realloc mutates `outputs[]`, then passes to `lsp_wt_register_factory_node_watch()`:

- `parent_vout = 0` (chain output convention — vout=0 is the channel/chain output that the response_tx spends)
- `parent_value_sat = outputs[0].amount_sats` (from snapshot)
- `parent_spk = outputs[0].script_pubkey + len` (from snapshot)
- `csv_delay = node->nsequence & 0xFFFF` (BIP-68 block-based decode — SuperScalar uses block units, bit 22 = 0)
- `signed_response_tx = node->signed_tx` (the new chain state being protected)
- `response_txid32 = node->txid` (canonical, set during signing)

## Per-callsite logging

When wt_db register succeeds, the LSP logs:
```
LSP-WT-TRUSTLESS: registered leaf-advance watch_id=N for node M (parent=V sats, csv=C)
LSP-WT-TRUSTLESS: registered tier-B watch_id=N for node M (parent=V sats, csv=C)
LSP-WT-TRUSTLESS: registered realloc watch_id=N for node M (parent=V sats, csv=C)
```

On failure (e.g. SQLite locked):
```
LSP-WT-TRUSTLESS: WARN — wt_db register failed for <ceremony> node M
```

Failure never aborts the ceremony — wt_db is a parallel observer, not gating.

## Phase plan reference (from `docs/watchtower-trustless-schema.md`)

| Phase | Status |
|---|---|
| 1a — schema + open/close + register helper | ✅ on main |
| **1b — full LSP-side write integration (this PR)** | ⏳ pending review |
| 2 — WT-side reads switch over (`superscalar_watchtower --wt-db <path>`) | TBD |
| 3 — drop legacy WT tables from `lsp.db` | TBD |
| 4 — regtest trustless-invariant assertion | TBD |

## Phase 2 preview

`superscalar_watchtower` refactor: stop opening `lsp.db`, open only `watchtower.db`.  Drop `persist_load_force_close_watches`, `persist_load_channel_for_watchtower`, `persist_load_revocations_flat` from the WT-side link set.  Verification: launch regtest end-to-end with `sqlite3 lsp.db "SELECT count(*) FROM channels WHERE revocation_secret IS NOT NULL;"` and `sqlite3 wt.db "SELECT count(*) FROM sqlite_master WHERE sql LIKE '%secret%';"` — expect non-zero LSP, zero WT.

Refs #248.