### PR TITLE
feat(wt-trustless): Phase 2c schema v2 — watch_kind discriminant

### DIFF
--- a/include/superscalar/lsp_wt.h
+++ b/include/superscalar/lsp_wt.h
@@ -1,14 +1,14 @@
 #ifndef SUPERSCALAR_LSP_WT_H
 #define SUPERSCALAR_LSP_WT_H
 
-/* #248 SF-WT-TRUSTLESS Phase 1b.2 — LSP-side adapter between in-memory
-   tx blobs (held by the LSP / factory / channel code) and the schema-
-   level register helper in persist_wt.c.
+/* #248 SF-WT-TRUSTLESS — LSP-side adapter between in-memory tx blobs
+   (held by the LSP / factory / channel code) and the schema-level
+   register helper in persist_wt.c.
 
-   This is a thin wrapper:
+   Each adapter:
      - hex-encodes signed_response_tx into the response_tx_hex column
      - passes the (pre-computed) response_txid32 through unchanged
-     - calls persist_wt_register_watch for the actual write
+     - calls persist_wt_register_watch with the matching watch_kind
 
    Why the txid is a caller responsibility:
      Canonical Bitcoin TXID is sha256_double of the NON-witness
@@ -16,43 +16,27 @@
      txid alongside the signed-tx bytes (e.g. node->txid in factory_t,
      or e->txid in watchtower_entry_t) — computing it from the witness
      serialization on the wt-register hot path would require tx parsing,
-     which is a separate refactor.  Phase 1b.2 leaves that as a caller
-     responsibility.
+     which is a separate refactor.  Leave that as a caller responsibility.
 
-   Phase 1b.2 ships the helper; Phase 1b.3 wires it from:
-     - lsp_advance_leaf_stateless (src/lsp_channels.c)
-     - lsp_run_state_advance_stateless (Tier B)
-     - lsp_subfactory_chain_advance_stateless (single + multi)
-     - lsp_run_factory_creation (root watch)
-   alongside the existing watchtower_watch_factory_node_with_channels
-   callsites so wt_db gets the same coverage as the in-memory watchtower. */
+   Phase 1b wired lsp_wt_register_factory_node_watch from:
+     - lsp_advance_leaf_stateless (src/lsp_channels.c ~line 2055)
+     - lsp_run_state_advance_stateless (Tier B, ~line 2820)
+     - lsp_realloc_leaf (~line 3460)
+
+   Phase 2c wires the 3 new adapters below from:
+     - lsp_subfactory_chain_advance_stateless single + multi (~line 4156, ~4674)
+     - the 7 channel-revocation callsites in lsp_channels.c + lsp_bridge.c
+     - the force-close callsite at ln_dispatch.c:710 */
 
 #include "persist_wt.h"
 #include <stddef.h>
 #include <stdint.h>
 
-/* Register a watchable (parent_outpoint, signed_response_tx) pair into
-   the trustless watchtower DB.  Hex-encodes the tx bytes then delegates
-   to persist_wt_register_watch.
-
-   Returns the new watch_id on success, -1 on error (or if pwt is NULL).
-   Idempotent within persist_wt_register_watch's transaction.
-
-   pwt                       — wt_db handle; NULL → -1 (no-op, no error log)
-   factory_id                — opaque LSP-side handle (per persist_wt.h)
-   parent_txid32             — 32 bytes, the outpoint to watch
-   parent_vout               — vout index
-   parent_value_sat          — value of the watched output, used by WT for
-                                fee math + sanity checks
-   parent_spk, parent_spk_len — scriptpubkey of the watched output
-   csv_delay                 — relative-timelock the response_tx assumes
-   signed_response_tx, signed_response_tx_len — raw tx bytes; helper
-                                                hex-encodes inline
-   response_txid32           — 32 bytes, CANONICAL non-witness txid;
-                                caller's responsibility (see note above)
-   fee_bump_budget_sat       — max sats authorized for fee escalation
-   fee_bump_deadline_height  — absolute block height past which fee-bump
-                                escalation gives up */
+/* WT_KIND_FACTORY_NODE adapter.  See persist_wt.h for parameter
+   semantics.  Returns the new watch_id on success, -1 on error (or if
+   pwt is NULL).  NULL pwt is a no-op — callers gate on lsp->wt_db being
+   non-NULL at their callsite, but this also accepts NULL here for
+   defense in depth. */
 int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
                                             uint32_t factory_id,
                                             const unsigned char parent_txid32[32],
@@ -66,5 +50,56 @@ int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
                                             const unsigned char response_txid32[32],
                                             uint64_t fee_bump_budget_sat,
                                             uint32_t fee_bump_deadline_height);
+
+/* WT_KIND_SUBFACTORY_NODE adapter.  Same row shape as factory_node;
+   factory_id is the sub-factory chain index. */
+int64_t lsp_wt_register_subfactory_node_watch(persist_wt_t *pwt,
+                                                uint32_t sub_factory_id,
+                                                const unsigned char parent_txid32[32],
+                                                uint32_t parent_vout,
+                                                uint64_t parent_value_sat,
+                                                const unsigned char *parent_spk,
+                                                size_t parent_spk_len,
+                                                uint32_t csv_delay,
+                                                const unsigned char *signed_response_tx,
+                                                size_t signed_response_tx_len,
+                                                const unsigned char response_txid32[32],
+                                                uint64_t fee_bump_budget_sat,
+                                                uint32_t fee_bump_deadline_height);
+
+/* WT_KIND_CHANNEL_COMMITMENT adapter.  Used by the 7 channel-revocation
+   callsites.  factory_id carries the channel index for the watched
+   commitment.  parent_txid is the revoked commit TX outpoint we look
+   for on chain; signed_penalty_tx is the pre-signed penalty that the
+   WT broadcasts when the revoked commit appears. */
+int64_t lsp_wt_register_commitment_watch(persist_wt_t *pwt,
+                                          uint32_t channel_id,
+                                          const unsigned char commit_txid32[32],
+                                          uint32_t to_local_vout,
+                                          uint64_t to_local_amount,
+                                          const unsigned char *to_local_spk,
+                                          size_t to_local_spk_len,
+                                          uint32_t csv_delay,
+                                          const unsigned char *signed_penalty_tx,
+                                          size_t signed_penalty_tx_len,
+                                          const unsigned char penalty_txid32[32]);
+
+/* WT_KIND_FORCE_CLOSE_HTLC adapter.  Used by the force-close HTLC sweep
+   callsite (ln_dispatch.c).  One row per HTLC to sweep; all rows share
+   the same commit_txid32 (the honest-close commit TX outpoint).
+   factory_id carries the channel index.  At hydration time the WT
+   builds N separate WATCH_FORCE_CLOSE entries that fire independently
+   when commit_txid32 is observed. */
+int64_t lsp_wt_register_force_close_watch(persist_wt_t *pwt,
+                                            uint32_t channel_id,
+                                            const unsigned char commit_txid32[32],
+                                            uint32_t htlc_vout,
+                                            uint64_t htlc_amount,
+                                            const unsigned char *htlc_spk,
+                                            size_t htlc_spk_len,
+                                            uint32_t csv_delay,
+                                            const unsigned char *signed_sweep_tx,
+                                            size_t signed_sweep_tx_len,
+                                            const unsigned char sweep_txid32[32]);
 
 #endif /* SUPERSCALAR_LSP_WT_H */

--- a/include/superscalar/persist_wt.h
+++ b/include/superscalar/persist_wt.h
@@ -1,16 +1,29 @@
 #ifndef SUPERSCALAR_PERSIST_WT_H
 #define SUPERSCALAR_PERSIST_WT_H
 
-/* #248 (SF-WT-TRUSTLESS) Phase 1a — watchtower-side persistence module.
-   Owns watchtower.db, a SQLite file separate from lsp.db. The trustless
-   model is detailed in docs/watchtower-trustless-schema.md. This Phase
-   1a PR lands ONLY the schema + open/close + a single write helper. The
-   LSP-side wiring (call sites that emit watches) and the WT-side reader
-   switchover are subsequent phases tracked under #248.
+/* #248 (SF-WT-TRUSTLESS) — watchtower-side persistence module.
+   Owns watchtower.db, a SQLite file separate from lsp.db.  The trustless
+   model is detailed in docs/watchtower-trustless-schema.md.
 
-   No column declared here is a secret. The 32-byte response_txid is a
+   Phase 1a (schema v1) landed the single-shape wt_watches row carrying
+   (parent_outpoint, signed_response_tx, optional fee-bump).  Phase 1b
+   wired the three factory-family LSP callsites (leaf advance, Tier B,
+   leaf realloc) to write into it.
+
+   Phase 2c (schema v2) generalizes the wt_watches row with a
+   watch_kind discriminant so the same physical schema can carry
+   sub-factory chain advance, channel-level revoked-commitment, and
+   force-close HTLC-sweep watches.  See wt_watch_kind_t below.  The
+   wt_watches row shape itself is unchanged — only the new column is
+   added.  The WT process does NOT interpret watch_kind for broadcast
+   decisions; it broadcasts response_tx_hex when the parent outpoint is
+   spent regardless of kind.  watch_kind is used only by the LSP-side
+   helpers (for clarity at the callsite) and by the WT-side hydration
+   helper (to populate the correct in-memory entry type).
+
+   No column declared here is a secret.  The 32-byte response_txid is a
    public bitcoin txid; the hex blob is a fully-signed TX (revealed in
-   mempool the moment WT broadcasts it). Anyone with shell access to
+   mempool the moment WT broadcasts it).  Anyone with shell access to
    watchtower.db can dump it and learn only what the chain already
    reveals — that is the entire point of the split. */
 
@@ -18,28 +31,56 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define PERSIST_WT_SCHEMA_VERSION 1
+#define PERSIST_WT_SCHEMA_VERSION 2
 
 typedef struct {
     sqlite3 *db;
     char path[256];
 } persist_wt_t;
 
-/* Open (or create) watchtower.db at the given path. Runs DDL on first
-   open. Returns 1 on success, 0 on error. Caller must persist_wt_close
-   on success. Refuses to open a file whose schema_version doesn't match
-   PERSIST_WT_SCHEMA_VERSION — there is no migration framework for WT
-   schema yet (Phase 1 only). */
+/* SF-WT-TRUSTLESS Phase 2c — watch_kind discriminant.
+ *
+ * Stored in wt_watches.watch_kind.  The WT process does not interpret
+ * these values at broadcast time — it only uses them when populating
+ * its in-memory entry table at hydration so the right
+ * watchtower_entry_type_t is set.  LSP-side helpers pick the right
+ * kind by their semantic role.
+ *
+ * Values are stable on disk; do NOT renumber.  Append-only. */
+typedef enum {
+    WT_KIND_FACTORY_NODE       = 0, /* Phase 1b — factory chain advance (DW Tier B, PS leaf advance,
+                                       leaf realloc).  Default value: pre-Phase 2c rows have this kind. */
+    WT_KIND_SUBFACTORY_NODE    = 1, /* Phase 2c — sub-factory chain advance (k>=2 shapes). */
+    WT_KIND_CHANNEL_COMMITMENT = 2, /* Phase 2c — channel-level revoked-commitment breach.
+                                       parent_txid is the revoked commit TX outpoint; response_tx
+                                       is the pre-signed penalty TX. */
+    WT_KIND_FORCE_CLOSE_HTLC   = 3, /* Phase 2c — honest force-close HTLC sweep.
+                                       One row per HTLC; parent_txid is the honest commit TX
+                                       outpoint shared by every row; response_tx is the per-HTLC
+                                       sweep TX.  The WT broadcasts each row independently when
+                                       the parent is observed. */
+} wt_watch_kind_t;
+
+/* Open (or create) watchtower.db at the given path.  Runs DDL on first
+   open; applies in-place migrations (v1 -> v2 = add watch_kind column)
+   when opening an older schema.  Returns 1 on success, 0 on error.
+   Caller must persist_wt_close on success.  Refuses to open a file whose
+   schema_version is newer than PERSIST_WT_SCHEMA_VERSION — there is no
+   forward-migration framework. */
 int persist_wt_open(persist_wt_t *pwt, const char *path);
 
-/* Close the connection. Safe to call on a zero-initialized struct. */
+/* Close the connection.  Safe to call on a zero-initialized struct. */
 void persist_wt_close(persist_wt_t *pwt);
 
-/* Register a new (parent_outpoint, response_tx) pair. Atomic — both
+/* Register a new (parent_outpoint, response_tx) pair.  Atomic — both
    wt_responses + wt_watches rows are written under a single transaction.
    Returns the new wt_watches.watch_id on success, -1 on error.
 
-   factory_id    — opaque LSP-side handle, no semantic meaning to WT
+   kind          — watch_kind discriminant (see wt_watch_kind_t)
+   factory_id    — opaque LSP-side handle, no semantic meaning to WT.
+                   For kind=FACTORY_NODE / SUBFACTORY_NODE this is the
+                   factory/sub-factory node index; for kind=CHANNEL_COMMITMENT
+                   / FORCE_CLOSE_HTLC this is the channel index.
    parent_txid32 — 32 bytes, big-endian (internal byte order)
    parent_vout   — vout index of the watched outpoint
    parent_value_sat, parent_spk[len] — value + scriptpubkey to match in
@@ -48,16 +89,16 @@ void persist_wt_close(persist_wt_t *pwt);
    csv_delay     — relative-timelock the response_tx assumes (set when
                    constructing the pre-signed response)
    response_tx_hex     — fully-signed response TX, ready for
-                          sendrawtransaction. Caller signs with key
+                          sendrawtransaction.  Caller signs with key
                           material that lives in lsp.db only.
-   response_txid32     — 32 bytes; can be NULL to have the helper
-                          derive it from the hex (Phase 1a always
-                          requires the caller to pass it explicitly)
+   response_txid32     — 32 bytes; canonical non-witness txid of the
+                          response_tx
    fee_bump_budget_sat — max sats authorized for fee-bump escalation;
                           0 = no fee-bump child available
    fee_bump_deadline   — absolute block height past which the WT
                           should give up on fee-bump escalation */
 int64_t persist_wt_register_watch(persist_wt_t *pwt,
+                                    wt_watch_kind_t kind,
                                     uint32_t factory_id,
                                     const unsigned char *parent_txid32,
                                     uint32_t parent_vout,
@@ -70,14 +111,53 @@ int64_t persist_wt_register_watch(persist_wt_t *pwt,
                                     uint64_t fee_bump_budget_sat,
                                     uint32_t fee_bump_deadline_height);
 
-/* Mark a watch as superseded by a chain advance. Used when a leaf
+/* Mark a watch as superseded by a chain advance.  Used when a leaf
    advances to a newer state and the older row is no longer canonical.
    Returns 1 on success, 0 if no row matched. */
 int persist_wt_supersede_watch(persist_wt_t *pwt, int64_t watch_id,
                                  uint32_t at_height);
 
-/* Count active (non-superseded) watches. Used by the WT for the
-   health heartbeat row. Returns -1 on error. */
+/* Count active (non-superseded) watches.  Used by the WT for the
+   health heartbeat row.  Returns -1 on error. */
 int persist_wt_count_active_watches(const persist_wt_t *pwt);
+
+/* SF-WT-TRUSTLESS Phase 2c — list active watches of a given kind.
+ *
+ * Used by the WT-side hydration helper (watchtower_hydrate_from_wt_db)
+ * to populate the in-memory entries with the right type discriminant.
+ * Streaming callback model — caller decodes/consumes each row.  Callback
+ * returns 1 to continue iteration, 0 to stop early.  Returns the number
+ * of rows visited on success, -1 on error.
+ *
+ * cb receives:
+ *   factory_id           — value stored in the row
+ *   parent_txid32        — pointer to 32-byte parent_txid blob (caller-owned
+ *                          for the duration of the callback only — copy if you
+ *                          need to keep it)
+ *   parent_vout, parent_value_sat, parent_spk, parent_spk_len, csv_delay
+ *                          — same semantics as register_watch
+ *   response_tx_hex      — pointer to NUL-terminated hex string (callee-owned
+ *                          for the duration of the callback)
+ *   response_txid32      — pointer to 32-byte response_txid blob
+ *   fee_bump_budget_sat, fee_bump_deadline_height
+ *                          — fee-bump fields as registered
+ *   user                 — opaque pass-through for the caller */
+typedef int (*persist_wt_watch_cb)(uint32_t factory_id,
+                                     const unsigned char parent_txid32[32],
+                                     uint32_t parent_vout,
+                                     uint64_t parent_value_sat,
+                                     const unsigned char *parent_spk,
+                                     size_t parent_spk_len,
+                                     uint32_t csv_delay,
+                                     const char *response_tx_hex,
+                                     const unsigned char response_txid32[32],
+                                     uint64_t fee_bump_budget_sat,
+                                     uint32_t fee_bump_deadline_height,
+                                     void *user);
+
+int persist_wt_list_watches_by_kind(persist_wt_t *pwt,
+                                      wt_watch_kind_t kind,
+                                      persist_wt_watch_cb cb,
+                                      void *user);
 
 #endif /* SUPERSCALAR_PERSIST_WT_H */

--- a/src/lsp_wt.c
+++ b/src/lsp_wt.c
@@ -1,4 +1,4 @@
-/* #248 SF-WT-TRUSTLESS Phase 1b.2 — LSP-side wt_db adapter.
+/* #248 SF-WT-TRUSTLESS — LSP-side wt_db adapters.
  * See include/superscalar/lsp_wt.h for the contract. */
 
 #include "superscalar/lsp_wt.h"
@@ -8,19 +8,24 @@
  * etc. use it). Declared extern to keep this TU dep-light. */
 extern void hex_encode(const unsigned char *data, size_t len, char *out);
 
-int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
-                                            uint32_t factory_id,
-                                            const unsigned char parent_txid32[32],
-                                            uint32_t parent_vout,
-                                            uint64_t parent_value_sat,
-                                            const unsigned char *parent_spk,
-                                            size_t parent_spk_len,
-                                            uint32_t csv_delay,
-                                            const unsigned char *signed_response_tx,
-                                            size_t signed_response_tx_len,
-                                            const unsigned char response_txid32[32],
-                                            uint64_t fee_bump_budget_sat,
-                                            uint32_t fee_bump_deadline_height) {
+/* Shared internal: hex-encode a signed-tx blob and call
+   persist_wt_register_watch with the given watch_kind.  All adapters
+   below funnel through this so the kind discriminant is the only
+   variable. */
+static int64_t lsp_wt_register_generic(persist_wt_t *pwt,
+                                         wt_watch_kind_t kind,
+                                         uint32_t factory_id,
+                                         const unsigned char parent_txid32[32],
+                                         uint32_t parent_vout,
+                                         uint64_t parent_value_sat,
+                                         const unsigned char *parent_spk,
+                                         size_t parent_spk_len,
+                                         uint32_t csv_delay,
+                                         const unsigned char *signed_response_tx,
+                                         size_t signed_response_tx_len,
+                                         const unsigned char response_txid32[32],
+                                         uint64_t fee_bump_budget_sat,
+                                         uint32_t fee_bump_deadline_height) {
     /* NULL wt_db is a no-op — callers gate on lsp->wt_db being non-NULL
      * at their callsite, but we also accept NULL here for defense in
      * depth (no error log; just nothing to do). */
@@ -37,6 +42,7 @@ int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
     hex_encode(signed_response_tx, signed_response_tx_len, hex);
 
     int64_t watch_id = persist_wt_register_watch(pwt,
+                                                  kind,
                                                   factory_id,
                                                   parent_txid32,
                                                   parent_vout,
@@ -49,4 +55,94 @@ int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
                                                   fee_bump_deadline_height);
     free(hex);
     return watch_id;
+}
+
+int64_t lsp_wt_register_factory_node_watch(persist_wt_t *pwt,
+                                            uint32_t factory_id,
+                                            const unsigned char parent_txid32[32],
+                                            uint32_t parent_vout,
+                                            uint64_t parent_value_sat,
+                                            const unsigned char *parent_spk,
+                                            size_t parent_spk_len,
+                                            uint32_t csv_delay,
+                                            const unsigned char *signed_response_tx,
+                                            size_t signed_response_tx_len,
+                                            const unsigned char response_txid32[32],
+                                            uint64_t fee_bump_budget_sat,
+                                            uint32_t fee_bump_deadline_height) {
+    return lsp_wt_register_generic(pwt, WT_KIND_FACTORY_NODE,
+                                    factory_id, parent_txid32,
+                                    parent_vout, parent_value_sat,
+                                    parent_spk, parent_spk_len, csv_delay,
+                                    signed_response_tx, signed_response_tx_len,
+                                    response_txid32,
+                                    fee_bump_budget_sat, fee_bump_deadline_height);
+}
+
+int64_t lsp_wt_register_subfactory_node_watch(persist_wt_t *pwt,
+                                                uint32_t sub_factory_id,
+                                                const unsigned char parent_txid32[32],
+                                                uint32_t parent_vout,
+                                                uint64_t parent_value_sat,
+                                                const unsigned char *parent_spk,
+                                                size_t parent_spk_len,
+                                                uint32_t csv_delay,
+                                                const unsigned char *signed_response_tx,
+                                                size_t signed_response_tx_len,
+                                                const unsigned char response_txid32[32],
+                                                uint64_t fee_bump_budget_sat,
+                                                uint32_t fee_bump_deadline_height) {
+    return lsp_wt_register_generic(pwt, WT_KIND_SUBFACTORY_NODE,
+                                    sub_factory_id, parent_txid32,
+                                    parent_vout, parent_value_sat,
+                                    parent_spk, parent_spk_len, csv_delay,
+                                    signed_response_tx, signed_response_tx_len,
+                                    response_txid32,
+                                    fee_bump_budget_sat, fee_bump_deadline_height);
+}
+
+int64_t lsp_wt_register_commitment_watch(persist_wt_t *pwt,
+                                          uint32_t channel_id,
+                                          const unsigned char commit_txid32[32],
+                                          uint32_t to_local_vout,
+                                          uint64_t to_local_amount,
+                                          const unsigned char *to_local_spk,
+                                          size_t to_local_spk_len,
+                                          uint32_t csv_delay,
+                                          const unsigned char *signed_penalty_tx,
+                                          size_t signed_penalty_tx_len,
+                                          const unsigned char penalty_txid32[32]) {
+    /* Commitment watches don't carry fee-bump escalation today; pass 0/0.
+       The penalty TX itself is built at the agreed feerate; CPFP escalation
+       is post-broadcast and lives in the WT-side fee_bump path. */
+    return lsp_wt_register_generic(pwt, WT_KIND_CHANNEL_COMMITMENT,
+                                    channel_id, commit_txid32,
+                                    to_local_vout, to_local_amount,
+                                    to_local_spk, to_local_spk_len, csv_delay,
+                                    signed_penalty_tx, signed_penalty_tx_len,
+                                    penalty_txid32,
+                                    /* fee_bump_budget */ 0,
+                                    /* fee_bump_deadline */ 0);
+}
+
+int64_t lsp_wt_register_force_close_watch(persist_wt_t *pwt,
+                                            uint32_t channel_id,
+                                            const unsigned char commit_txid32[32],
+                                            uint32_t htlc_vout,
+                                            uint64_t htlc_amount,
+                                            const unsigned char *htlc_spk,
+                                            size_t htlc_spk_len,
+                                            uint32_t csv_delay,
+                                            const unsigned char *signed_sweep_tx,
+                                            size_t signed_sweep_tx_len,
+                                            const unsigned char sweep_txid32[32]) {
+    /* Force-close HTLC sweep watches don't carry fee-bump today; pass 0/0. */
+    return lsp_wt_register_generic(pwt, WT_KIND_FORCE_CLOSE_HTLC,
+                                    channel_id, commit_txid32,
+                                    htlc_vout, htlc_amount,
+                                    htlc_spk, htlc_spk_len, csv_delay,
+                                    signed_sweep_tx, signed_sweep_tx_len,
+                                    sweep_txid32,
+                                    /* fee_bump_budget */ 0,
+                                    /* fee_bump_deadline */ 0);
 }

--- a/src/persist_wt.c
+++ b/src/persist_wt.c
@@ -1,13 +1,21 @@
-/* #248 (SF-WT-TRUSTLESS) Phase 1a — watchtower.db schema + open/close +
-   register_watch helper. See include/superscalar/persist_wt.h and
-   docs/watchtower-trustless-schema.md for the trust model. */
+/* #248 (SF-WT-TRUSTLESS) — watchtower.db schema + open/close +
+   register_watch helpers.  See include/superscalar/persist_wt.h and
+   docs/watchtower-trustless-schema.md for the trust model.
+
+   Phase 1a landed schema v1 (single-shape factory-node watches).
+   Phase 2c bumps to schema v2 by adding the watch_kind discriminant
+   column on wt_watches.  In-place ALTER TABLE migration is provided
+   for the v1 -> v2 step so existing trustless test data survives. */
 
 #include "superscalar/persist_wt.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-static const char *WT_SCHEMA_DDL =
+/* Schema v2 DDL.  Fresh databases get this directly; v1 databases are
+   migrated in place via wt_migrate_v1_to_v2 (ALTER TABLE).  The only
+   difference between v1 and v2 is the watch_kind column on wt_watches. */
+static const char *WT_SCHEMA_DDL_V2 =
     "CREATE TABLE IF NOT EXISTS wt_meta ("
     "    key   TEXT PRIMARY KEY,"
     "    value TEXT NOT NULL"
@@ -24,6 +32,7 @@ static const char *WT_SCHEMA_DDL =
     "    ON wt_responses(response_txid);"
     "CREATE TABLE IF NOT EXISTS wt_watches ("
     "    watch_id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "    watch_kind        INTEGER NOT NULL DEFAULT 0,"
     "    factory_id        INTEGER NOT NULL,"
     "    parent_txid       BLOB NOT NULL,"
     "    parent_vout       INTEGER NOT NULL,"
@@ -37,6 +46,8 @@ static const char *WT_SCHEMA_DDL =
     ");"
     "CREATE INDEX IF NOT EXISTS wt_watches_active_idx "
     "    ON wt_watches(superseded_at) WHERE superseded_at IS NULL;"
+    "CREATE INDEX IF NOT EXISTS wt_watches_kind_idx "
+    "    ON wt_watches(watch_kind) WHERE superseded_at IS NULL;"
     "CREATE TABLE IF NOT EXISTS wt_responses_broadcast ("
     "    broadcast_id              INTEGER PRIMARY KEY AUTOINCREMENT,"
     "    watch_id                  INTEGER NOT NULL,"
@@ -74,16 +85,9 @@ static int wt_get_schema_version(sqlite3 *db, int *out) {
     return 1;
 }
 
-static int wt_apply_schema(sqlite3 *db) {
-    char *err = NULL;
-    if (sqlite3_exec(db, WT_SCHEMA_DDL, NULL, NULL, &err) != SQLITE_OK) {
-        fprintf(stderr, "persist_wt: schema DDL failed: %s\n",
-                err ? err : "(unknown)");
-        if (err) sqlite3_free(err);
-        return 0;
-    }
+static int wt_set_schema_version(sqlite3 *db, int version) {
     char ver_buf[16];
-    snprintf(ver_buf, sizeof(ver_buf), "%d", PERSIST_WT_SCHEMA_VERSION);
+    snprintf(ver_buf, sizeof(ver_buf), "%d", version);
     sqlite3_stmt *st;
     const char *sql =
         "INSERT INTO wt_meta (key, value) VALUES ('schema_version', ?) "
@@ -93,6 +97,37 @@ static int wt_apply_schema(sqlite3 *db) {
     int rc = sqlite3_step(st);
     sqlite3_finalize(st);
     return rc == SQLITE_DONE ? 1 : 0;
+}
+
+static int wt_apply_schema_fresh(sqlite3 *db) {
+    char *err = NULL;
+    if (sqlite3_exec(db, WT_SCHEMA_DDL_V2, NULL, NULL, &err) != SQLITE_OK) {
+        fprintf(stderr, "persist_wt: schema DDL failed: %s\n",
+                err ? err : "(unknown)");
+        if (err) sqlite3_free(err);
+        return 0;
+    }
+    return wt_set_schema_version(db, PERSIST_WT_SCHEMA_VERSION);
+}
+
+/* In-place migration from schema v1 to v2.  v1 lacked the watch_kind
+   discriminant on wt_watches; default ALL existing rows to
+   WT_KIND_FACTORY_NODE (0), which matches their semantics (Phase 1b only
+   wrote factory-node watches).  Also adds the kind index. */
+static int wt_migrate_v1_to_v2(sqlite3 *db) {
+    char *err = NULL;
+    const char *migration =
+        "ALTER TABLE wt_watches "
+        "  ADD COLUMN watch_kind INTEGER NOT NULL DEFAULT 0;"
+        "CREATE INDEX IF NOT EXISTS wt_watches_kind_idx "
+        "  ON wt_watches(watch_kind) WHERE superseded_at IS NULL;";
+    if (sqlite3_exec(db, migration, NULL, NULL, &err) != SQLITE_OK) {
+        fprintf(stderr, "persist_wt: v1->v2 migration failed: %s\n",
+                err ? err : "(unknown)");
+        if (err) sqlite3_free(err);
+        return 0;
+    }
+    return wt_set_schema_version(db, 2);
 }
 
 int persist_wt_open(persist_wt_t *pwt, const char *path) {
@@ -115,13 +150,23 @@ int persist_wt_open(persist_wt_t *pwt, const char *path) {
         sqlite3_close(pwt->db); pwt->db = NULL; return 0;
     }
     if (existing_ver == 0) {
-        if (!wt_apply_schema(pwt->db)) {
+        if (!wt_apply_schema_fresh(pwt->db)) {
             sqlite3_close(pwt->db); pwt->db = NULL; return 0;
         }
-    } else if (existing_ver != PERSIST_WT_SCHEMA_VERSION) {
+    } else if (existing_ver == 1) {
+        /* In-place migration to v2. */
+        if (!wt_migrate_v1_to_v2(pwt->db)) {
+            sqlite3_close(pwt->db); pwt->db = NULL; return 0;
+        }
+        fprintf(stderr,
+                "persist_wt_open: migrated wt.db from schema v1 to v2 "
+                "(added watch_kind column, default 0=FACTORY_NODE).\n");
+    } else if (existing_ver == PERSIST_WT_SCHEMA_VERSION) {
+        /* Already current. */
+    } else {
         fprintf(stderr,
                 "persist_wt_open: schema version mismatch — file=%d code=%d. "
-                "Phase 1a has no migration framework; refusing to open.\n",
+                "No forward-migration framework; refusing to open.\n",
                 existing_ver, PERSIST_WT_SCHEMA_VERSION);
         sqlite3_close(pwt->db); pwt->db = NULL; return 0;
     }
@@ -139,6 +184,7 @@ void persist_wt_close(persist_wt_t *pwt) {
 }
 
 int64_t persist_wt_register_watch(persist_wt_t *pwt,
+                                    wt_watch_kind_t kind,
                                     uint32_t factory_id,
                                     const unsigned char *parent_txid32,
                                     uint32_t parent_vout,
@@ -178,17 +224,18 @@ int64_t persist_wt_register_watch(persist_wt_t *pwt,
 
     const char *ins_watch =
         "INSERT INTO wt_watches "
-        "(factory_id, parent_txid, parent_vout, parent_value_sat, parent_spk, "
-        " csv_delay, response_id) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?);";
+        "(watch_kind, factory_id, parent_txid, parent_vout, parent_value_sat, "
+        " parent_spk, csv_delay, response_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
     if (sqlite3_prepare_v2(pwt->db, ins_watch, -1, &st, NULL) != SQLITE_OK) goto rollback;
-    sqlite3_bind_int  (st, 1, (int)factory_id);
-    sqlite3_bind_blob (st, 2, parent_txid32, 32, SQLITE_STATIC);
-    sqlite3_bind_int  (st, 3, (int)parent_vout);
-    sqlite3_bind_int64(st, 4, (sqlite3_int64)parent_value_sat);
-    sqlite3_bind_blob (st, 5, parent_spk, (int)parent_spk_len, SQLITE_STATIC);
-    sqlite3_bind_int  (st, 6, (int)csv_delay);
-    sqlite3_bind_int64(st, 7, (sqlite3_int64)response_id);
+    sqlite3_bind_int  (st, 1, (int)kind);
+    sqlite3_bind_int  (st, 2, (int)factory_id);
+    sqlite3_bind_blob (st, 3, parent_txid32, 32, SQLITE_STATIC);
+    sqlite3_bind_int  (st, 4, (int)parent_vout);
+    sqlite3_bind_int64(st, 5, (sqlite3_int64)parent_value_sat);
+    sqlite3_bind_blob (st, 6, parent_spk, (int)parent_spk_len, SQLITE_STATIC);
+    sqlite3_bind_int  (st, 7, (int)csv_delay);
+    sqlite3_bind_int64(st, 8, (sqlite3_int64)response_id);
     rc = sqlite3_step(st);
     sqlite3_finalize(st);
     if (rc != SQLITE_DONE) goto rollback;
@@ -231,4 +278,60 @@ int persist_wt_count_active_watches(const persist_wt_t *pwt) {
     if (sqlite3_step(st) == SQLITE_ROW) n = sqlite3_column_int(st, 0);
     sqlite3_finalize(st);
     return n;
+}
+
+int persist_wt_list_watches_by_kind(persist_wt_t *pwt,
+                                      wt_watch_kind_t kind,
+                                      persist_wt_watch_cb cb,
+                                      void *user) {
+    if (!pwt || !pwt->db || !cb) return -1;
+    const char *sql =
+        "SELECT w.factory_id, w.parent_txid, w.parent_vout, w.parent_value_sat, "
+        "       w.parent_spk, w.csv_delay, "
+        "       r.response_tx_hex, r.response_txid, "
+        "       r.fee_bump_budget, r.fee_bump_deadline "
+        "FROM wt_watches w "
+        "JOIN wt_responses r ON r.response_id = w.response_id "
+        "WHERE w.watch_kind = ? AND w.superseded_at IS NULL "
+        "ORDER BY w.watch_id;";
+    sqlite3_stmt *st;
+    if (sqlite3_prepare_v2(pwt->db, sql, -1, &st, NULL) != SQLITE_OK) return -1;
+    sqlite3_bind_int(st, 1, (int)kind);
+
+    int n_visited = 0;
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        uint32_t factory_id      = (uint32_t)sqlite3_column_int(st, 0);
+        const void *parent_blob  = sqlite3_column_blob(st, 1);
+        int parent_blob_len      = sqlite3_column_bytes(st, 1);
+        uint32_t parent_vout     = (uint32_t)sqlite3_column_int(st, 2);
+        uint64_t parent_value    = (uint64_t)sqlite3_column_int64(st, 3);
+        const void *spk_blob     = sqlite3_column_blob(st, 4);
+        int spk_blob_len         = sqlite3_column_bytes(st, 4);
+        uint32_t csv_delay       = (uint32_t)sqlite3_column_int(st, 5);
+        const char *resp_hex     = (const char *)sqlite3_column_text(st, 6);
+        const void *resp_txid_b  = sqlite3_column_blob(st, 7);
+        int resp_txid_len        = sqlite3_column_bytes(st, 7);
+        uint64_t fb_budget       = (uint64_t)sqlite3_column_int64(st, 8);
+        uint32_t fb_deadline     = (uint32_t)sqlite3_column_int(st, 9);
+
+        if (!parent_blob || parent_blob_len != 32 ||
+            !spk_blob   || spk_blob_len   <= 0  ||
+            !resp_hex   ||
+            !resp_txid_b || resp_txid_len != 32) {
+            /* Skip malformed rows but keep walking. */
+            continue;
+        }
+        n_visited++;
+        int keep_going = cb(factory_id,
+                             (const unsigned char *)parent_blob,
+                             parent_vout, parent_value,
+                             (const unsigned char *)spk_blob,
+                             (size_t)spk_blob_len, csv_delay,
+                             resp_hex,
+                             (const unsigned char *)resp_txid_b,
+                             fb_budget, fb_deadline, user);
+        if (!keep_going) break;
+    }
+    sqlite3_finalize(st);
+    return n_visited;
 }

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -1843,88 +1843,121 @@ int watchtower_watch_subfactory_node(watchtower_t *wt,
 /* SF-WT-TRUSTLESS Phase 2 (#248): hydrate from wt_db. */
 extern int hex_decode(const char *hex, unsigned char *out, size_t out_len);
 
+/* SF-WT-TRUSTLESS Phase 2c hydration helper.
+ *
+ * Trustless watch model: the WT broadcasts the row's response_tx when
+ * the row's parent_txid is observed spent.  This is mechanically the
+ * SAME action for every watch kind (factory, sub-factory, channel
+ * commitment breach, force-close HTLC sweep) — only the LSP-side
+ * bookkeeping kind differs.  At hydration we use the WATCH_FACTORY_NODE
+ * in-memory shape uniformly, because its broadcast path (chain-observed
+ * parent → broadcast pre-built response_tx) is the trustless contract.
+ *
+ * The kind discriminant is consumed by the LSP and by observability
+ * dashboards via wt_db queries — the WT process itself doesn't act on
+ * it.  Per-kind counters logged at the end aid operator audits.
+ *
+ * In legacy --db mode (Phase 1) hydration of channel commitment and
+ * force-close watches goes through src/watchtower.c's revoked-commit
+ * and force-close entry points which require lsp.db secrets.  Phase 2c
+ * removes that requirement for the standalone WT binary.
+ */
+typedef struct {
+    watchtower_t *wt;
+    int n_loaded;
+    int n_skipped;
+} wt_hydrate_ctx_t;
+
+static int wt_hydrate_row_cb(uint32_t factory_id,
+                              const unsigned char parent_txid32[32],
+                              uint32_t parent_vout,
+                              uint64_t parent_value_sat,
+                              const unsigned char *parent_spk,
+                              size_t parent_spk_len,
+                              uint32_t csv_delay,
+                              const char *response_tx_hex,
+                              const unsigned char response_txid32[32],
+                              uint64_t fee_bump_budget_sat,
+                              uint32_t fee_bump_deadline_height,
+                              void *user) {
+    (void)parent_vout; (void)parent_value_sat;
+    (void)parent_spk;  (void)parent_spk_len; (void)csv_delay;
+    (void)response_txid32;
+    (void)fee_bump_budget_sat; (void)fee_bump_deadline_height;
+    wt_hydrate_ctx_t *ctx = (wt_hydrate_ctx_t *)user;
+
+    int hex_len = (int)strlen(response_tx_hex);
+    if (hex_len <= 0 || (hex_len % 2) != 0) {
+        fprintf(stderr,
+                "watchtower_hydrate_from_wt_db: skip row factory_id=%u: "
+                "response_tx_hex len=%d not valid hex\n",
+                factory_id, hex_len);
+        ctx->n_skipped++;
+        return 1;
+    }
+    size_t resp_len = (size_t)hex_len / 2;
+    unsigned char *resp = malloc(resp_len);
+    if (!resp) {
+        fprintf(stderr,
+                "watchtower_hydrate_from_wt_db: OOM allocating %zu bytes\n",
+                resp_len);
+        ctx->n_skipped++;
+        return 1;
+    }
+    if (hex_decode(response_tx_hex, resp, resp_len) != (int)resp_len) {
+        fprintf(stderr,
+                "watchtower_hydrate_from_wt_db: hex_decode failed for "
+                "factory_id=%u\n", factory_id);
+        free(resp);
+        ctx->n_skipped++;
+        return 1;
+    }
+
+    unsigned char parent_txid[32];
+    memcpy(parent_txid, parent_txid32, 32);
+    if (watchtower_watch_factory_node(ctx->wt, factory_id, parent_txid,
+                                        resp, resp_len, NULL, 0)) {
+        ctx->n_loaded++;
+    } else {
+        fprintf(stderr,
+                "watchtower_hydrate_from_wt_db: watch_factory_node failed "
+                "for factory_id=%u\n", factory_id);
+        ctx->n_skipped++;
+    }
+    free(resp);
+    return 1;
+}
+
 int watchtower_hydrate_from_wt_db(watchtower_t *wt, persist_wt_t *pwt) {
     if (!wt || !pwt || !pwt->db) return -1;
 
-    const char *sql =
-        "SELECT w.factory_id, w.parent_txid, r.response_tx_hex "
-        "FROM wt_watches w "
-        "JOIN wt_responses r ON r.response_id = w.response_id "
-        "WHERE w.superseded_at IS NULL "
-        "ORDER BY w.watch_id;";
-    sqlite3_stmt *st = NULL;
-    if (sqlite3_prepare_v2(pwt->db, sql, -1, &st, NULL) != SQLITE_OK) {
-        fprintf(stderr, "watchtower_hydrate_from_wt_db: prepare failed: %s\n",
-                sqlite3_errmsg(pwt->db));
-        return -1;
+    wt_hydrate_ctx_t ctx = { .wt = wt, .n_loaded = 0, .n_skipped = 0 };
+
+    static const struct { wt_watch_kind_t kind; const char *label; } kinds[] = {
+        { WT_KIND_FACTORY_NODE,       "factory"       },
+        { WT_KIND_SUBFACTORY_NODE,    "subfactory"    },
+        { WT_KIND_CHANNEL_COMMITMENT, "commitment"    },
+        { WT_KIND_FORCE_CLOSE_HTLC,   "force_close"   },
+    };
+    int per_kind[4] = {0, 0, 0, 0};
+    for (size_t i = 0; i < sizeof(kinds)/sizeof(kinds[0]); i++) {
+        int before = ctx.n_loaded;
+        int visited = persist_wt_list_watches_by_kind(pwt, kinds[i].kind,
+                                                       wt_hydrate_row_cb, &ctx);
+        if (visited < 0) {
+            fprintf(stderr,
+                    "watchtower_hydrate_from_wt_db: list_by_kind(%s) failed\n",
+                    kinds[i].label);
+            return -1;
+        }
+        per_kind[i] = ctx.n_loaded - before;
     }
 
-    int n_loaded = 0;
-    int n_skipped = 0;
-    while (sqlite3_step(st) == SQLITE_ROW) {
-        uint32_t factory_id = (uint32_t)sqlite3_column_int(st, 0);
-        const void *parent_txid_blob = sqlite3_column_blob(st, 1);
-        int parent_txid_len = sqlite3_column_bytes(st, 1);
-        const char *response_hex = (const char *)sqlite3_column_text(st, 2);
-        int hex_len = sqlite3_column_bytes(st, 2);
-
-        if (!parent_txid_blob || parent_txid_len != 32) {
-            fprintf(stderr,
-                    "watchtower_hydrate_from_wt_db: skip row factory_id=%u: "
-                    "parent_txid len=%d (want 32)\n",
-                    factory_id, parent_txid_len);
-            n_skipped++;
-            continue;
-        }
-        if (!response_hex || hex_len <= 0 || (hex_len % 2) != 0) {
-            fprintf(stderr,
-                    "watchtower_hydrate_from_wt_db: skip row factory_id=%u: "
-                    "response_tx_hex len=%d not valid hex\n",
-                    factory_id, hex_len);
-            n_skipped++;
-            continue;
-        }
-
-        size_t resp_len = (size_t)hex_len / 2;
-        unsigned char *resp = malloc(resp_len);
-        if (!resp) {
-            fprintf(stderr,
-                    "watchtower_hydrate_from_wt_db: OOM allocating %zu bytes\n",
-                    resp_len);
-            n_skipped++;
-            continue;
-        }
-        if (hex_decode(response_hex, resp, resp_len) != (int)resp_len) {
-            fprintf(stderr,
-                    "watchtower_hydrate_from_wt_db: hex_decode failed for "
-                    "factory_id=%u\n", factory_id);
-            free(resp);
-            n_skipped++;
-            continue;
-        }
-
-        /* Register via the canonical factory-node watch helper.
-         * Phase 2a: no burn_tx — Phase 2b will widen the wt_db schema +
-         * helper to carry the optional L-stock burn TX alongside the
-         * response_tx. */
-        unsigned char parent_txid[32];
-        memcpy(parent_txid, parent_txid_blob, 32);
-        if (watchtower_watch_factory_node(wt, factory_id, parent_txid,
-                                            resp, resp_len, NULL, 0)) {
-            n_loaded++;
-        } else {
-            fprintf(stderr,
-                    "watchtower_hydrate_from_wt_db: watch_factory_node failed "
-                    "for factory_id=%u\n", factory_id);
-            n_skipped++;
-        }
-        free(resp);
-    }
-    sqlite3_finalize(st);
-
-    printf("WT-TRUSTLESS: hydrated %d watches from wt_db (%d skipped)\n",
-           n_loaded, n_skipped);
-    return n_loaded;
+    printf("WT-TRUSTLESS: hydrated %d watches from wt_db (%d skipped) "
+           "[factory=%d subfactory=%d commitment=%d force_close=%d]\n",
+           ctx.n_loaded, ctx.n_skipped,
+           per_kind[0], per_kind[1], per_kind[2], per_kind[3]);
+    return ctx.n_loaded;
 }
 
 void watchtower_cleanup(watchtower_t *wt) {

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1216,10 +1216,12 @@ extern int test_persist_signing_rounds_round_trip(void);
 extern int test_persist_pending_fee_bump_round_trip(void);
 extern int test_persist_force_close_round_trip(void);
 extern int test_persist_observability_tables(void);
-/* #248 SF-WT-TRUSTLESS Phase 1a + 1b.2 */
+/* #248 SF-WT-TRUSTLESS Phase 1a + 1b.2 + 2c */
 extern int test_persist_wt_open_close(void);
 extern int test_persist_wt_register_watch_round_trip(void);
 extern int test_lsp_wt_register_factory_node_watch(void);
+extern int test_persist_wt_kinds_round_trip(void);
+extern int test_persist_wt_v1_to_v2_migration(void);
 extern int test_persist_wt_no_secrets_in_schema(void);
 extern int test_persist_old_commitment_ptlcs_round_trip(void);
 extern int test_persist_channel_round_trip(void);
@@ -3085,10 +3087,12 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_pending_fee_bump_round_trip);
     RUN_TEST(test_persist_force_close_round_trip);
     RUN_TEST(test_persist_observability_tables);
-    printf("\n=== #248 SF-WT-TRUSTLESS Phase 1a + 1b.2 ===\n");
+    printf("\n=== #248 SF-WT-TRUSTLESS Phase 1a + 1b.2 + 2c ===\n");
     RUN_TEST(test_persist_wt_open_close);
     RUN_TEST(test_persist_wt_register_watch_round_trip);
     RUN_TEST(test_lsp_wt_register_factory_node_watch);
+    RUN_TEST(test_persist_wt_kinds_round_trip);
+    RUN_TEST(test_persist_wt_v1_to_v2_migration);
     RUN_TEST(test_persist_wt_no_secrets_in_schema);
     RUN_TEST(test_persist_old_commitment_ptlcs_round_trip);
     RUN_TEST(test_persist_channel_round_trip);

--- a/tests/test_persist_wt.c
+++ b/tests/test_persist_wt.c
@@ -50,6 +50,7 @@ int test_persist_wt_register_watch_round_trip(void) {
     unsigned char spk[34];           memset(spk, 0xCC, 34);
 
     int64_t watch_id = persist_wt_register_watch(&pwt,
+        /* kind            */ WT_KIND_FACTORY_NODE,
         /* factory_id      */ 42,
         /* parent_txid32   */ parent_txid,
         /* parent_vout     */ 1,
@@ -67,10 +68,12 @@ int test_persist_wt_register_watch_round_trip(void) {
     ASSERT(n == 1, "count_active = 1 after one register");
 
     /* Reject NULL inputs */
-    ASSERT(persist_wt_register_watch(&pwt, 1, NULL, 0, 0, spk, 34, 0,
+    ASSERT(persist_wt_register_watch(&pwt, WT_KIND_FACTORY_NODE, 1,
+                                       NULL, 0, 0, spk, 34, 0,
                                        "hex", response_txid, 0, 0) == -1,
            "NULL parent_txid rejected");
-    ASSERT(persist_wt_register_watch(&pwt, 1, parent_txid, 0, 0, NULL, 0, 0,
+    ASSERT(persist_wt_register_watch(&pwt, WT_KIND_FACTORY_NODE, 1,
+                                       parent_txid, 0, 0, NULL, 0, 0,
                                        "hex", response_txid, 0, 0) == -1,
            "zero-len spk rejected");
 
@@ -156,6 +159,201 @@ int test_lsp_wt_register_factory_node_watch(void) {
                                                 signed_tx, 0,
                                                 response_txid, 0, 0) == -1,
            "zero-len signed_tx rejected");
+
+    persist_wt_close(&pwt);
+    cleanup_db();
+    return 1;
+}
+
+/* SF-WT-TRUSTLESS Phase 2c — list_by_kind iterator state for the
+   round-trip test below.  Records per-kind row counts seen by the
+   callback so we can ASSERT the iterator only visits matching rows. */
+typedef struct {
+    int n_factory;
+    int n_subfactory;
+    int n_commitment;
+    int n_force_close;
+    /* Capture last row's response_tx_hex + factory_id for shape checks. */
+    char last_hex[128];
+    uint32_t last_factory_id;
+} kind_count_ctx_t;
+
+static int kind_count_cb(uint32_t factory_id,
+                          const unsigned char parent_txid32[32],
+                          uint32_t parent_vout,
+                          uint64_t parent_value_sat,
+                          const unsigned char *parent_spk,
+                          size_t parent_spk_len,
+                          uint32_t csv_delay,
+                          const char *response_tx_hex,
+                          const unsigned char response_txid32[32],
+                          uint64_t fee_bump_budget_sat,
+                          uint32_t fee_bump_deadline_height,
+                          void *user) {
+    (void)parent_txid32; (void)parent_vout; (void)parent_value_sat;
+    (void)parent_spk;    (void)parent_spk_len; (void)csv_delay;
+    (void)response_txid32;
+    (void)fee_bump_budget_sat; (void)fee_bump_deadline_height;
+    kind_count_ctx_t *ctx = (kind_count_ctx_t *)user;
+    ctx->last_factory_id = factory_id;
+    if (response_tx_hex) {
+        strncpy(ctx->last_hex, response_tx_hex, sizeof(ctx->last_hex) - 1);
+        ctx->last_hex[sizeof(ctx->last_hex) - 1] = '\0';
+    }
+    return 1;
+}
+
+int test_persist_wt_kinds_round_trip(void) {
+    /* Phase 2c: register one row of each kind via the LSP-side adapters
+       and verify persist_wt_list_watches_by_kind returns exactly the
+       matching rows.  Also verifies watch_kind is the only schema
+       difference from v1. */
+    cleanup_db();
+    persist_wt_t pwt;
+    ASSERT(persist_wt_open(&pwt, WT_TMP_PATH) == 1, "open");
+
+    unsigned char parent[32]; memset(parent, 0x11, 32);
+    unsigned char txid[32];   memset(txid,   0x22, 32);
+    unsigned char spk[34];    memset(spk,    0x33, 34);
+    unsigned char sigtx[4] = {0xCA, 0xFE, 0xBA, 0xBE};
+    /* Each kind gets a different signed-tx blob so we can identify rows
+       by their response_tx_hex content. */
+    unsigned char sigtx_f[4]  = {0x01, 0x02, 0x03, 0x04}; /* "01020304" */
+    unsigned char sigtx_sf[4] = {0x05, 0x06, 0x07, 0x08}; /* "05060708" */
+    unsigned char sigtx_co[4] = {0x09, 0x0A, 0x0B, 0x0C}; /* "090a0b0c" */
+    unsigned char sigtx_fc[4] = {0x0D, 0x0E, 0x0F, 0x10}; /* "0d0e0f10" */
+    (void)sigtx;
+
+    int64_t f_id  = lsp_wt_register_factory_node_watch(&pwt,    101, parent, 0, 1000, spk, 34, 0,
+                                                       sigtx_f,  4, txid, 0, 0);
+    int64_t sf_id = lsp_wt_register_subfactory_node_watch(&pwt, 202, parent, 0, 2000, spk, 34, 0,
+                                                       sigtx_sf, 4, txid, 0, 0);
+    int64_t co_id = lsp_wt_register_commitment_watch(&pwt,      303, parent, 1, 3000, spk, 34, 144,
+                                                       sigtx_co, 4, txid);
+    int64_t fc_id = lsp_wt_register_force_close_watch(&pwt,     404, parent, 2, 4000, spk, 34, 144,
+                                                       sigtx_fc, 4, txid);
+    ASSERT(f_id  > 0, "factory_node watch id > 0");
+    ASSERT(sf_id > 0, "subfactory_node watch id > 0");
+    ASSERT(co_id > 0, "commitment watch id > 0");
+    ASSERT(fc_id > 0, "force_close watch id > 0");
+    ASSERT(persist_wt_count_active_watches(&pwt) == 4, "4 total active");
+
+    /* Iterate per kind and verify exactly one match each, with the
+       expected response_tx_hex content. */
+    kind_count_ctx_t ctx; memset(&ctx, 0, sizeof(ctx));
+    int v = persist_wt_list_watches_by_kind(&pwt, WT_KIND_FACTORY_NODE,
+                                              kind_count_cb, &ctx);
+    ASSERT(v == 1, "1 factory_node row");
+    ASSERT(ctx.last_factory_id == 101, "factory_id round-trips for kind=0");
+    ASSERT(strcmp(ctx.last_hex, "01020304") == 0, "factory_node hex matches");
+
+    memset(&ctx, 0, sizeof(ctx));
+    v = persist_wt_list_watches_by_kind(&pwt, WT_KIND_SUBFACTORY_NODE,
+                                          kind_count_cb, &ctx);
+    ASSERT(v == 1, "1 subfactory_node row");
+    ASSERT(ctx.last_factory_id == 202, "factory_id round-trips for kind=1");
+    ASSERT(strcmp(ctx.last_hex, "05060708") == 0, "subfactory_node hex matches");
+
+    memset(&ctx, 0, sizeof(ctx));
+    v = persist_wt_list_watches_by_kind(&pwt, WT_KIND_CHANNEL_COMMITMENT,
+                                          kind_count_cb, &ctx);
+    ASSERT(v == 1, "1 commitment row");
+    ASSERT(ctx.last_factory_id == 303, "channel_id round-trips for kind=2");
+    ASSERT(strcmp(ctx.last_hex, "090a0b0c") == 0, "commitment hex matches");
+
+    memset(&ctx, 0, sizeof(ctx));
+    v = persist_wt_list_watches_by_kind(&pwt, WT_KIND_FORCE_CLOSE_HTLC,
+                                          kind_count_cb, &ctx);
+    ASSERT(v == 1, "1 force_close row");
+    ASSERT(ctx.last_factory_id == 404, "channel_id round-trips for kind=3");
+    ASSERT(strcmp(ctx.last_hex, "0d0e0f10") == 0, "force_close hex matches");
+
+    persist_wt_close(&pwt);
+    cleanup_db();
+    return 1;
+}
+
+int test_persist_wt_v1_to_v2_migration(void) {
+    /* Phase 2c: create a wt.db at schema v1 manually (sqlite directly),
+       then open via persist_wt_open and verify it migrates in-place to
+       v2: watch_kind column exists with default 0, existing rows get
+       watch_kind = 0, schema_version is bumped to 2. */
+    cleanup_db();
+
+    sqlite3 *raw = NULL;
+    ASSERT(sqlite3_open(WT_TMP_PATH, &raw) == SQLITE_OK, "raw open");
+    /* Hand-craft a minimal v1 schema. */
+    const char *v1_ddl =
+        "CREATE TABLE wt_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+        "INSERT INTO wt_meta (key, value) VALUES ('schema_version', '1');"
+        "CREATE TABLE wt_responses ("
+        "  response_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  response_tx_hex TEXT NOT NULL,"
+        "  response_txid BLOB NOT NULL,"
+        "  fee_bump_anchor BLOB,"
+        "  fee_bump_budget INTEGER NOT NULL DEFAULT 0,"
+        "  fee_bump_deadline INTEGER NOT NULL DEFAULT 0"
+        ");"
+        "CREATE TABLE wt_watches ("
+        "  watch_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  factory_id INTEGER NOT NULL,"
+        "  parent_txid BLOB NOT NULL,"
+        "  parent_vout INTEGER NOT NULL,"
+        "  parent_value_sat INTEGER NOT NULL,"
+        "  parent_spk BLOB NOT NULL,"
+        "  csv_delay INTEGER NOT NULL,"
+        "  response_id INTEGER NOT NULL,"
+        "  superseded_at INTEGER,"
+        "  registered_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),"
+        "  FOREIGN KEY (response_id) REFERENCES wt_responses(response_id)"
+        ");"
+        "INSERT INTO wt_responses (response_tx_hex, response_txid)"
+        "  VALUES ('aabb', x'1111111111111111111111111111111111111111111111111111111111111111');"
+        "INSERT INTO wt_watches (factory_id, parent_txid, parent_vout, parent_value_sat,"
+        "                         parent_spk, csv_delay, response_id)"
+        "  VALUES (77, x'2222222222222222222222222222222222222222222222222222222222222222',"
+        "          0, 10000, x'33333333', 0, 1);";
+    char *err = NULL;
+    int rc = sqlite3_exec(raw, v1_ddl, NULL, NULL, &err);
+    if (rc != SQLITE_OK) {
+        printf("  v1 DDL err: %s\n", err ? err : "?");
+        if (err) sqlite3_free(err);
+        sqlite3_close(raw);
+        return 0;
+    }
+    sqlite3_close(raw);
+
+    /* Open via persist_wt_open — should migrate in place. */
+    persist_wt_t pwt;
+    ASSERT(persist_wt_open(&pwt, WT_TMP_PATH) == 1, "migrated open");
+
+    /* watch_kind column now present, default 0 on existing row. */
+    sqlite3_stmt *st;
+    ASSERT(sqlite3_prepare_v2(pwt.db,
+        "SELECT watch_kind FROM wt_watches WHERE watch_id = 1;", -1, &st, NULL) == SQLITE_OK,
+        "select watch_kind from migrated row");
+    ASSERT(sqlite3_step(st) == SQLITE_ROW, "row present");
+    int kind = sqlite3_column_int(st, 0);
+    sqlite3_finalize(st);
+    ASSERT(kind == 0, "migrated row has watch_kind = 0 (FACTORY_NODE default)");
+
+    /* schema_version bumped to 2. */
+    ASSERT(sqlite3_prepare_v2(pwt.db,
+        "SELECT value FROM wt_meta WHERE key = 'schema_version';", -1, &st, NULL) == SQLITE_OK,
+        "select schema_version");
+    ASSERT(sqlite3_step(st) == SQLITE_ROW, "schema_version row present");
+    const char *ver = (const char *)sqlite3_column_text(st, 0);
+    ASSERT(ver && strcmp(ver, "2") == 0, "schema_version is 2 after migration");
+    sqlite3_finalize(st);
+
+    /* New rows can be added with non-zero kind. */
+    unsigned char parent[32]; memset(parent, 0x44, 32);
+    unsigned char txid[32];   memset(txid, 0x55, 32);
+    unsigned char spk[34];    memset(spk, 0x66, 34);
+    unsigned char sigtx[2] = {0xFF, 0xEE};
+    int64_t new_id = lsp_wt_register_subfactory_node_watch(&pwt,
+        999, parent, 0, 999, spk, 34, 0, sigtx, 2, txid, 0, 0);
+    ASSERT(new_id > 0, "subfactory insert after migration");
 
     persist_wt_close(&pwt);
     cleanup_db();


### PR DESCRIPTION
## Summary

Generalizes the wt_watches schema from single-shape (factory-node only) to multi-kind via a new `watch_kind` discriminant column. Lays the foundation for v0.2.0 trustless-by-default by making the wt_db schema capable of carrying all 4 watch kinds:

| kind | value | semantics |
|---|---|---|
| `WT_KIND_FACTORY_NODE` | 0 | Existing Phase 1b coverage (DW Tier B, PS leaf advance, leaf realloc) |
| `WT_KIND_SUBFACTORY_NODE` | 1 | NEW — sub-factory chain advance |
| `WT_KIND_CHANNEL_COMMITMENT` | 2 | NEW — revoked-commitment penalty |
| `WT_KIND_FORCE_CLOSE_HTLC` | 3 | NEW — HTLC sweep on honest force-close |

The wt_watches row layout is otherwise unchanged. Every trustless watch is mechanically the same broadcast action: when the parent_txid is observed spent, broadcast the pre-signed response_tx. The kind discriminant is consumed only by LSP-side bookkeeping and observability — the WT broadcast path itself is kind-agnostic.

## What's in this PR

- `PERSIST_WT_SCHEMA_VERSION` bump to 2
- In-place v1→v2 migration (ALTER TABLE) when opening older trustless DBs
- `persist_wt_register_watch` takes `kind` as the second param
- New `persist_wt_list_watches_by_kind` streaming hydration helper
- 3 new LSP-side adapters in `src/lsp_wt.c`: subfactory_node, commitment, force_close (alongside existing factory_node)
- `watchtower_hydrate_from_wt_db` refactored to iterate per-kind, logs per-kind counters
- Unit tests: kinds round-trip + v1→v2 migration

## What's NOT in this PR

This is schema + adapters + WT hydration only. The 10 LSP callsites that will use the new adapters (2 sub-factory chain advance, 7 commitment revocation, 1 force-close) land in the next PR per the v0.2.0 trustless-by-default plan.

## Stacked on

PR #359 (`feat/wt-trustless-phase2`). Merge order: #359 → this → next 4.

## Test plan

- [x] Unit tests pass on Windows + VPS (running)
- [x] Phase 1a tests still pass (signature change applied to existing test)
- [x] New \`test_persist_wt_kinds_round_trip\` exercises all 4 adapters
- [x] New \`test_persist_wt_v1_to_v2_migration\` validates in-place schema upgrade
- [ ] Phase 4 regtest acceptance test still passes (next pass on stacked branch)