### PR TITLE
feat(wt-trustless): PR-C.2 — wire commitment revocation (7 sites via 1 edit)

### DIFF
--- a/include/superscalar/watchtower.h
+++ b/include/superscalar/watchtower.h
@@ -144,6 +144,12 @@ typedef struct {
     wallet_source_t *wallet;       /* UTXO selection + signing for CPFP (may be NULL) */
     wallet_source_rpc_t _wallet_rpc_default; /* auto-init'd when rt != NULL */
     persist_t *db;
+    /* SF-WT-TRUSTLESS Phase 2c (#248): trustless wt_db handle.  Optional;
+       when non-NULL, watchtower_watch_revoked_commitment also writes the
+       pre-built penalty TX bytes into wt_db so a standalone trustless WT
+       (started with --wt-db only) can broadcast on breach without ever
+       opening lsp.db.  Set via watchtower_set_wt_db after watchtower_init. */
+    persist_wt_t *wt_db;
 
     /* P2A anchor SPK for CPFP fee bumping (anyone-can-spend, no keys needed) */
     unsigned char anchor_spk[P2A_SPK_LEN];
@@ -249,6 +255,13 @@ void watchtower_watch_revoked_commitment_oracular(watchtower_t *wt, channel_t *c
 
 /* Remove entries for a channel (e.g., after cooperative close). */
 void watchtower_remove_channel(watchtower_t *wt, uint32_t channel_id);
+
+/* SF-WT-TRUSTLESS Phase 2c (#248): attach an optional trustless wt_db
+   handle.  Once set, every subsequent watchtower_watch_revoked_commitment
+   call also writes a kind=WT_KIND_CHANNEL_COMMITMENT row carrying the
+   pre-built penalty TX bytes.  NULL clears the handle (no-op state).
+   Safe to call before or after watchtower entries exist. */
+void watchtower_set_wt_db(watchtower_t *wt, persist_wt_t *wt_db);
 
 /* Watch for an old factory state node. If detected, broadcast latest state tx
    and burn tx (if provided). Both are copied (caller can free theirs).

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -15,6 +15,7 @@ extern void chain_backend_regtest_init(chain_backend_t *backend, regtest_t *rt);
 extern void hex_encode(const unsigned char *data, size_t len, char *out);
 extern int hex_decode(const char *hex, unsigned char *out, size_t out_len);
 extern void reverse_bytes(unsigned char *data, size_t len);
+extern void sha256_double(const unsigned char *data, size_t len, unsigned char *out32);
 
 /* Authoritative check: does this serialised penalty TX contain a P2A anchor
  * at vout 1?  The build-time `use_anchor` decision (fee_should_use_anchor at
@@ -536,6 +537,61 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
                                 persist_save_old_commitment_witness(
                                     wt->db, channel_id, old_commit_num,
                                     penalty.data, penalty.len);
+
+                            /* SF-WT-TRUSTLESS Phase 2c (#248): mirror penalty
+                               into wt_db for trustless WT consumption.  The
+                               penalty was just built using channel secrets;
+                               wt_db never sees the secrets, only the signed
+                               bytes that the WT broadcasts on breach. */
+                            if (wt->wt_db && wt->wt_db->db) {
+                                /* response_txid = wtxid of the signed penalty
+                                   (sha256d of full bytes).  Not the canonical
+                                   non-witness txid; wt_db uses it for
+                                   observability + indexing only, not for
+                                   chain matching (chain matching keys off
+                                   parent_txid). */
+                                unsigned char resp_txid[32];
+                                sha256_double(penalty.data, penalty.len,
+                                              resp_txid);
+                                /* hex-encode the bytes for storage. */
+                                size_t hex_buf_len = penalty.len * 2 + 1;
+                                char *hex = (char *)malloc(hex_buf_len);
+                                if (hex) {
+                                    hex_encode(penalty.data, penalty.len, hex);
+                                    int64_t wid = persist_wt_register_watch(
+                                        wt->wt_db,
+                                        WT_KIND_CHANNEL_COMMITMENT,
+                                        channel_id,
+                                        old_txid,
+                                        /* parent_vout      */ 0,
+                                        /* parent_value_sat */ old_remote,
+                                        to_local_spk,
+                                        /* parent_spk_len   */ 34,
+                                        /* csv_delay        */ ch->to_self_delay,
+                                        hex,
+                                        resp_txid,
+                                        /* fee_bump_budget  */ 0,
+                                        /* fee_bump_dline   */ 0);
+                                    free(hex);
+                                    if (wid > 0) {
+                                        fprintf(stderr,
+                                            "LSP-WT-TRUSTLESS: registered "
+                                            "commitment watch_id=%lld for "
+                                            "channel %u (commit_num=%llu, "
+                                            "to_local=%llu sats)\n",
+                                            (long long)wid, channel_id,
+                                            (unsigned long long)old_commit_num,
+                                            (unsigned long long)old_remote);
+                                    } else {
+                                        fprintf(stderr,
+                                            "LSP-WT-TRUSTLESS: WARN — wt_db "
+                                            "commitment register failed for "
+                                            "channel %u (commit_num=%llu)\n",
+                                            channel_id,
+                                            (unsigned long long)old_commit_num);
+                                    }
+                                }
+                            }
                         }
                     }
                     tx_buf_free(&penalty);
@@ -1958,6 +2014,11 @@ int watchtower_hydrate_from_wt_db(watchtower_t *wt, persist_wt_t *pwt) {
            ctx.n_loaded, ctx.n_skipped,
            per_kind[0], per_kind[1], per_kind[2], per_kind[3]);
     return ctx.n_loaded;
+}
+
+void watchtower_set_wt_db(watchtower_t *wt, persist_wt_t *wt_db) {
+    if (!wt) return;
+    wt->wt_db = wt_db;
 }
 
 void watchtower_cleanup(watchtower_t *wt) {

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2855,6 +2855,11 @@ int main(int argc, char *argv[]) {
             watchtower_init(&rec_wt, mgr->n_channels, &rt, fee_est, &db);
             /* watchtower_set_channel loop dropped in #208 A3.2 — penalty
                bytes are pre-built at revocation receive time. */
+            /* SF-WT-TRUSTLESS Phase 2c (#248): attach wt_db on the
+               recovery-path watchtower too so post-restart breaches are
+               also trustlessly observable. */
+            if (use_wt_db)
+                watchtower_set_wt_db(&rec_wt, &wt_db);
             mgr->watchtower = &rec_wt;
 
             if (bump_budget_pct > 0) rec_wt.bump_budget_pct = bump_budget_pct;
@@ -3287,6 +3292,11 @@ accept_new_factory:
 
             /* Watchtower: init and wire into dispatch */
             watchtower_init(&g_watchtower, g_channel_mgr->n_channels, NULL, fee_est, g_db);
+            /* SF-WT-TRUSTLESS Phase 2c (#248): attach the global wt_db handle
+               (g_wt_db) so the dispatch-path watchtower mirrors penalty TXs
+               into wt_db for trustless WT consumption. */
+            if (g_wt_db)
+                watchtower_set_wt_db(&g_watchtower, g_wt_db);
 
             if (bump_budget_pct > 0) g_watchtower.bump_budget_pct = bump_budget_pct;
             if (max_bump_fee > 0) g_watchtower.max_bump_fee_sat = max_bump_fee;
@@ -4129,6 +4139,13 @@ accept_new_factory:
                           use_db ? &db : NULL);
         /* watchtower_set_channel loop dropped in #208 A3.2 — penalty
            bytes are pre-built at revocation receive time. */
+        /* SF-WT-TRUSTLESS Phase 2c (#248): attach the trustless wt_db
+           handle so watchtower_watch_revoked_commitment mirrors each
+           pre-built penalty TX into wt_db (kind=2 row).  Standalone
+           trustless WT then broadcasts from wt_db alone without ever
+           opening lsp.db. */
+        if (use_wt_db)
+            watchtower_set_wt_db(&wt, &wt_db);
         mgr->watchtower = &wt;
 
             if (bump_budget_pct > 0) wt.bump_budget_pct = bump_budget_pct;


### PR DESCRIPTION
## Summary

Covers all 7 channel-revocation callsites in trustless mode via a **single edit inside `watchtower_watch_revoked_commitment`**, not 7 callsite-level changes.

The legacy function already pre-builds the penalty TX at registration time (#208 A3.1b — channel secrets are in scope right after rev_secret arrives) and stashes them on the in-memory entry plus \`lsp.db.old_commitments_witness\`. This PR adds one more write at the same spot: mirror the bytes into wt_db as a \`WT_KIND_CHANNEL_COMMITMENT\` row.

Every existing caller benefits automatically:

| Callsite | File:line |
|---|---|
| sender dispatch | \`lsp_channels.c:1195\` |
| dest dispatch | \`lsp_channels.c:1486\` |
| single-channel ack | \`lsp_channels.c:4868\` |
| sender replay | \`lsp_channels.c:5006\` |
| reconnect replay | \`lsp_channels.c:5464\` |
| bridge dest revocation | \`lsp_bridge.c:332\` |
| bridge sender revocation | \`lsp_bridge.c:474\` |

## Plumbing

\`watchtower_t\` gains a \`persist_wt_t *wt_db\` field + \`watchtower_set_wt_db\` setter. All 3 \`watchtower_init\` sites in \`superscalar_lsp.c\` (main, recovery, dispatch) now call the setter with the LSP's wt_db handle.

## response_txid note

The \`response_txid\` column stores \`sha256d(penalty.data, penalty.len)\` — that's the **wtxid**, not the canonical non-witness txid. \`wt_db\` uses response_txid for observability + indexing only; chain matching keys off \`parent_txid\` (the watched commit TX outpoint). Documented inline.

## Coverage after this PR

| Kind | Status |
|---|---|
| \`WT_KIND_FACTORY_NODE\` | ✅ Phase 1b |
| \`WT_KIND_SUBFACTORY_NODE\` | ✅ PR-C.1 |
| \`WT_KIND_CHANNEL_COMMITMENT\` | ✅ **this PR** |
| \`WT_KIND_FORCE_CLOSE_HTLC\` | 🟡 PR-C.3 next |

## Stacked on

PR-C.1 (sub-factory).

## Test plan

- [x] VPS build (in flight)
- [ ] Unit tests pass
- [ ] cheat_leaf regtest still passes (sanity check on commitment-revocation path)
- [ ] wt_db kind=2 row count > 0 after a revocation