### PR TITLE
fix: hard-error at LSP startup on --demo + bad --lsp-balance-pct + N=64 runner config

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -1385,7 +1385,6 @@ int main(int argc, char *argv[]) {
     const char *funding_txid_override = NULL; /* --funding-txid: skip wallet funding, use existing UTXO */
     uint64_t routing_fee_ppm = 0;    /* 0 = zero-fee (no routing fee) */
     uint16_t lsp_balance_pct = 100;  /* 100 = LSP retains all capacity (production default) */
-    int lsp_balance_pct_explicit = 0; /* 1 if user passed --lsp-balance-pct */
     int accept_risk = 0;             /* --i-accept-the-risk for mainnet */
     int placement_mode_arg = 3;      /* 0=sequential, 1=inward, 2=outward, 3=timezone-cluster */
     int economic_mode_arg = 0;       /* 0=lsp-takes-all, 1=profit-shared */
@@ -1961,7 +1960,6 @@ int main(int argc, char *argv[]) {
             routing_fee_ppm = (uint64_t)strtoull(argv[++i], NULL, 10);
         else if (strcmp(argv[i], "--lsp-balance-pct") == 0 && i + 1 < argc) {
             lsp_balance_pct = (uint16_t)atoi(argv[++i]);
-            lsp_balance_pct_explicit = 1;
             if (lsp_balance_pct > 100) {
                 fprintf(stderr, "Error: --lsp-balance-pct must be 0-100\n");
                 return 1;

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2289,18 +2289,25 @@ int main(int argc, char *argv[]) {
 
     /* --- BIP39 Test placeholder (moved after key init) --- */
 
-    /* No --demo override of lsp_balance_pct.  The production-safe default
-       (100 = LSP retains all capacity) applies to demo mode too — silently
-       handing 50% of the funding to clients was a footgun: cheat/defense
-       tests that forgot to pass --lsp-balance-pct 100 explicitly would
-       invisibly run with the wrong economics.  If you want demo payments
-       from clients (which requires them to have a balance), pass
-       --lsp-balance-pct 50 explicitly. */
-    if (demo_mode && !lsp_balance_pct_explicit && lsp_balance_pct == 100) {
+    /* --demo runs client-initiated routed payments and requires BOTH the LSP
+       and clients to hold balance on every channel.  Refuse to start when
+       the configuration makes payments structurally impossible — fail fast
+       at startup rather than burn fees on factory funding + N channels just
+       to surface "channel_add_htlc: refused" mid-flight.  Production-safe
+       default of 100% is fine for non-demo runs; explicit 0 / 100 with
+       --demo is a footgun (e.g. the N=64 testnet4 runner that this guard
+       catches).  Acceptable demo range is (0, 100) — both sides non-zero. */
+    if (demo_mode && (lsp_balance_pct == 0 || lsp_balance_pct == 100)) {
         fprintf(stderr,
-            "LSP: --demo with default --lsp-balance-pct 100 — clients will\n"
-            "     have 0 sats and any demo payment FROM a client will fail.\n"
-            "     Pass --lsp-balance-pct 50 if you want demo payments to work.\n");
+            "Error: --demo with --lsp-balance-pct %u makes routed payments\n"
+            "       structurally impossible:\n"
+            "         100 = LSP holds 100%%, clients have 0 — clients can't\n"
+            "               offer HTLCs (channel_add_htlc refuses unbacked).\n"
+            "           0 = clients hold 100%%, LSP has 0 — LSP can't route.\n"
+            "       Use --lsp-balance-pct in (0, 100); 50 is canonical for\n"
+            "       demo flows where both sides must transact.\n",
+            (unsigned)lsp_balance_pct);
+        return 1;
     }
 
     /* Mainnet safety guard: refuse unless explicitly acknowledged */

--- a/tools/test_testnet4_n64_ps_lifecycle.sh
+++ b/tools/test_testnet4_n64_ps_lifecycle.sh
@@ -84,7 +84,7 @@ nohup "$LSP_BIN" \
     --amount "$AMOUNT" \
     --active-blocks 50 --dying-blocks 20 \
     --step-blocks 5 --states-per-layer 2 \
-    --fee-rate "$FEE_RATE" --lsp-balance-pct 100 \
+    --fee-rate "$FEE_RATE" --lsp-balance-pct 50 \
     --confirm-timeout 86400 \
     --max-conn-rate 400 --max-handshakes 80 \
     --seckey "$LSP_SECKEY" \
@@ -108,7 +108,7 @@ for i in $(seq 1 $N_CLIENTS); do
     SK=$(printf '%064x' $((i + 1)))  # 0x02 .. 0x41
     nohup "$CLIENT_BIN" \
         --network "$NETWORK" --host 127.0.0.1 --port "$PORT" --daemon \
-        --seckey "$SK" --fee-rate "$FEE_RATE" --lsp-balance-pct 100 \
+        --seckey "$SK" --fee-rate "$FEE_RATE" --lsp-balance-pct 50 \
         --lsp-pubkey "$LSP_PUBKEY" --participant-id $i \
         --rpcuser "$RPCUSER" --rpcpassword "$RPCPASS" --rpcport "$RPCPORT" \
         --wallet "$WALLET" --db "/tmp/ss_t4_${TAG}_c${SK:60:4}.db" \


### PR DESCRIPTION
## Summary

Two related fixes for the dust-corner failure that surfaced on the in-flight N=64 testnet4 run:

> \`channel_add_htlc: refused — RECEIVED amount 1000 > remote_amount 0\`

### 1. Test runner config (test_testnet4_n64_ps_lifecycle.sh)
Switch from \`--lsp-balance-pct 100\` to \`--lsp-balance-pct 50\` on both LSP and client launch lines. 100% LSP balance leaves clients at 0 sats, so the demo's client→client payments are structurally impossible — no client has balance to offer the HTLC.

### 2. LSP startup validation (superscalar_lsp.c)
The channel_add_htlc validator is correct (it refuses unbacked HTLCs), but it only fires AFTER the factory is funded and N channels created. By then sats are spent. Tighten the existing soft warning to a hard refusal at startup:

```
Error: --demo with --lsp-balance-pct 100 makes routed payments
       structurally impossible:
         100 = LSP holds 100%, clients have 0 — clients can't
               offer HTLCs (channel_add_htlc refuses unbacked).
           0 = clients hold 100%, LSP has 0 — LSP can't route.
       Use --lsp-balance-pct in (0, 100); 50 is canonical for
       demo flows where both sides must transact.
```

Catches the N=64 runner config (and any future runner that hits the same footgun) before any sats are spent. Non-demo runs are unaffected — \`--lsp-balance-pct 100\` remains the production-safe default when no payments are being driven.

## Verified

Regtest smoke test on VPS:

| Config | Expected | Actual |
|---|---|---|
| \`--demo --lsp-balance-pct 100\` | hard error, exit non-zero | ✅ exits with full error message, no DB/socket created |
| \`--demo --lsp-balance-pct 0\` | hard error | (re-running) |
| \`--demo --lsp-balance-pct 50\` | normal startup → listening | (re-running) |
| \`--lsp-balance-pct 100\` (no --demo) | normal startup (production case) | (re-running) |

## Why this isn't a Lightning bug

LN channel routing requires the sender side to have outbound balance. With \`--lsp-balance-pct 100\` every channel has client_local = 0, so no client can initiate an HTLC. The channel_add_htlc validator refusing this is **correct** — it's the same check Lightning peers use to reject unbacked HTLCs.

The "bug" was the test config + demo mode combination producing a configuration where payments are impossible by construction. The fix makes that impossibility visible at startup rather than mid-run.

## Test plan

- [ ] CI green
- [ ] Smoke tests (above) all pass on VPS regtest
- [ ] Next N=64 launch after this merges runs demo payments successfully before force-close