### PR TITLE
fix(factory): bump FACTORY_MAX_SIGNERS 128 -> 256, fixes N=128 LSP crash (#303)

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -19,7 +19,12 @@
  * 8 × tx_output_t to 16 × tx_output_t; at 506 nodes (max PS factory at
  * N=128) that's ~50KB extra per factory_t — acceptable. */
 #define FACTORY_MAX_OUTPUTS 16
-#define FACTORY_MAX_SIGNERS 128
+/* FACTORY_MAX_SIGNERS = max participants in a MuSig2 group = 1 LSP + up to
+ * N clients.  Was 128 (= LSP + 127 clients).  Bumped to 256 in #303 fix
+ * because N=128 clients + LSP = 129 signers overflowed the previous cap by
+ * exactly one pubkey slot — release build's stack canary caught the overrun
+ * on the all_pubkeys array in lsp.c:275.  256 gives headroom up to N=255. */
+#define FACTORY_MAX_SIGNERS 256
 #define FACTORY_MAX_LEAVES  128
 
 #define NSEQUENCE_DISABLE_BIP68 0xFFFFFFFFu


### PR DESCRIPTION
## Summary

Fixes #303 SF-N128-SIGNET-CRASH. Root cause: `FACTORY_MAX_SIGNERS = 128` caps the MuSig group at 128 participants. N=128 clients + 1 LSP = 129 signers → 1-pubkey overrun on `all_pubkeys[FACTORY_MAX_SIGNERS]` stack array in `lsp.c:275`. Release build's `-fstack-protector-strong` canary detected it and aborted with SIGABRT. Debug build's looser canary settings missed it (which is why this only surfaced on real-chain signet runs against the release binary).

## Fix

Bump `FACTORY_MAX_SIGNERS` from 128 to 256 in `include/superscalar/factory.h:22`. Now supports up to 255 clients + LSP = 256 signers.

## Validation on signet (real chain, 0.1 sat/vB)

After rebuilding `build-release` with the new constant:

```
LSP: listening on port 9951, waiting for 128 clients...
LSP: deterministic ordering applied via slot_hints  ← previously crashed HERE
LSP: all 128 clients connected
LSP: funding address: tb1pjejupc...
LSP: wallet balance: 0.04000000 BTC (sufficient)
LSP: funding TX broadcast at fee_rate=100 sat/kvB (0.1000 sat/vB)
```

LSP alive, 129/129 procs running (LSP + 128 clients), factory funding TX in signet mempool. Full lifecycle continuing.

## Memory cost

Each FACTORY_MAX_SIGNERS-sized array in factory_t doubles. Per-factory struct grows by ~30KB. Acceptable for runtime savings of N>=128 support.

## Test plan
- [x] Source change reviewed (single constant)
- [x] No literal `128` substitutions needed (other 128 uses are unrelated string/charset buffers)
- [x] Rebuild on VPS: cmake --build build-release --target superscalar_lsp superscalar_client_bin
- [x] Re-run N=128 signet test: LSP launches + 128 clients connect + ceremony advances past crash point + factory funding TX broadcast
- [x] No SIGABRT, no stack canary trip
- [ ] Wait for N=128 signet lifecycle to complete end-to-end (~5-8 hr per signet block tempo)