### PR TITLE
fix(tests): add --lsp-balance-pct 50 to 9 scripts hit by PR #370 hard-error

### DIFF
--- a/tools/test_multiprocess_musig_n8.sh
+++ b/tools/test_multiprocess_musig_n8.sh
@@ -211,7 +211,7 @@ stdbuf -oL "$LSP_BIN" \
     "${SNR_ARGS[@]}" \
     --amount "$FUNDING_SATS" \
     --step-blocks 1 \
-    --demo \
+    --demo --lsp-balance-pct 50 \
     --force-close \
     --db "$LSP_DB" \
     --cli-path "$(which bitcoin-cli)" \

--- a/tools/test_multiprocess_subfactory_advance.sh
+++ b/tools/test_multiprocess_subfactory_advance.sh
@@ -161,7 +161,7 @@ stdbuf -oL "$LSP_BIN" \
     --ps-subfactory-arity "$PS_SUB_ARITY" \
     --amount "$FUNDING_SATS" \
     --step-blocks 1 \
-    --demo \
+    --demo --lsp-balance-pct 50 \
     --test-subfactory-advance \
     --force-close \
     --db "$LSP_DB" \

--- a/tools/test_multiprocess_tier_b_rollover.sh
+++ b/tools/test_multiprocess_tier_b_rollover.sh
@@ -166,7 +166,7 @@ stdbuf -oL "$LSP_BIN" \
     --states-per-layer "$STATES_PER_LAYER" \
     --amount "$FUNDING_SATS" \
     --step-blocks 1 \
-    --demo \
+    --demo --lsp-balance-pct 50 \
     --test-tier-b-rollover \
     --force-close \
     --db "$LSP_DB" \

--- a/tools/test_regtest_cheat_daemon_subfactory.sh
+++ b/tools/test_regtest_cheat_daemon_subfactory.sh
@@ -125,7 +125,7 @@ env $SS_ASAN_ENV "$LSP_BIN" \
     --wallet $MINER_WALLET \
     --db "$LSP_DB" \
     --cli-path "$(which bitcoin-cli)" \
-    --demo --cheat-daemon-sub \
+    --demo --lsp-balance-pct 50 --cheat-daemon-sub \
     > "$LSP_LOG" 2>&1 &
 LSP_PID=$!; PIDS+=($LSP_PID)
 

--- a/tools/test_regtest_k2_subfactory_breach.sh
+++ b/tools/test_regtest_k2_subfactory_breach.sh
@@ -164,7 +164,7 @@ env $SS_ASAN_ENV "$LSP_BIN" \
     --amount "$FUNDING_SATS" \
     --step-blocks 1 \
     --max-conn-rate 1000 --max-handshakes 256 \
-    --demo \
+    --demo --lsp-balance-pct 50 \
     --cheat-subfactory \
     --db "$LSP_DB" \
     --cli-path "$(which bitcoin-cli)" \

--- a/tools/test_regtest_k2_subfactory_breach_multi.sh
+++ b/tools/test_regtest_k2_subfactory_breach_multi.sh
@@ -101,7 +101,7 @@ env $SS_ASAN_ENV SS_MUSIG_STATELESS="${SS_MUSIG_STATELESS:-1}" "$LSP_BIN" \
     --amount "$FUNDING_SATS" \
     --step-blocks 1 \
     --max-conn-rate 1000 --max-handshakes 256 \
-    --demo --test-subfactory-advance-multi --cheat-subfactory \
+    --demo --lsp-balance-pct 50 --test-subfactory-advance-multi --cheat-subfactory \
     --db "$LSP_DB" \
     --cli-path "$(which bitcoin-cli)" \
     --rpcuser rpcuser --rpcpassword rpcpass \

--- a/tools/test_regtest_rebroadcast_recovery.sh
+++ b/tools/test_regtest_rebroadcast_recovery.sh
@@ -119,7 +119,7 @@ ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
     --seckey "$LSP_SECKEY" \
     --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
     --wallet $MINER_WALLET --db "$LSP_DB" \
-    --demo \
+    --demo --lsp-balance-pct 50 \
     > "$LSP_LOG" 2> "$LSP_ERR" &
 LSP_PID=$!
 PIDS+=($LSP_PID)

--- a/tools/test_regtest_subfactory_chain_advance_multi.sh
+++ b/tools/test_regtest_subfactory_chain_advance_multi.sh
@@ -166,7 +166,7 @@ env $SS_ASAN_ENV "$LSP_BIN" \
     --amount "$FUNDING_SATS" \
     --step-blocks 1 \
     --max-conn-rate 1000 --max-handshakes 256 \
-    --demo \
+    --demo --lsp-balance-pct 50 \
     --test-subfactory-advance-multi \
     --db "$LSP_DB" \
     --cli-path "$(which bitcoin-cli)" \

--- a/tools/test_regtest_subfactory_poison_restart.sh
+++ b/tools/test_regtest_subfactory_poison_restart.sh
@@ -104,7 +104,7 @@ env $SS_ASAN_ENV SS_MUSIG_STATELESS="${SS_MUSIG_STATELESS:-1}" "$LSP_BIN" \
     --amount "$FUNDING_SATS" \
     --step-blocks 1 \
     --max-conn-rate 1000 --max-handshakes 256 \
-    --demo --test-subfactory-advance \
+    --demo --lsp-balance-pct 50 --test-subfactory-advance \
     --db "$LSP_DB" \
     --cli-path "$(which bitcoin-cli)" \
     --rpcuser rpcuser --rpcpassword rpcpass \


### PR DESCRIPTION
## Summary

PR #370 added a hard-error to the LSP that rejects \`--demo\` with \`--lsp-balance-pct\` in {0, 100}.  9 test scripts were launching the LSP with just \`--demo\` (no explicit balance-pct, defaulting to 100), tripping the new hard-error and breaking CI.

Specifically, the \`Multi-process k² sub-factory advance (under ASan+LSan)\` job on main went red after PR #373 merged.  Root cause: \`tools/test_multiprocess_subfactory_advance.sh\` (which CI runs) hit the hard-error.

## Fix

Insert \`--lsp-balance-pct 50\` right after \`--demo\` on each LSP cmdline.  Single sed across all 9 scripts.

## Test plan
- [x] Single mechanical change per file (9 files × 1 line each)
- [x] All 9 patched lines verified by grep
- [x] Pattern matches canonical usage in already-passing scripts (crash_drill_matrix, n64_ps_lifecycle, etc.)
- [ ] CI green (Multi-Process ASan job specifically) after merge