### PR TITLE
docs: link deployment-coordination.md from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See [`docs/testing-guide.md`](docs/testing-guide.md) for the full test taxonomy.
 | Rotation ceremony | [`docs/rotation-ceremony.md`](docs/rotation-ceremony.md) |
 | JIT channels + rollback | [`docs/jit-and-rollback.md`](docs/jit-and-rollback.md) |
 | LSP operator guide | [`docs/lsp-operator-guide.md`](docs/lsp-operator-guide.md) |
+| Multi-party deployment coordination | [`docs/deployment-coordination.md`](docs/deployment-coordination.md) |
 | Mainnet runbook | [`docs/mainnet-runbook.md`](docs/mainnet-runbook.md) |
 | Client / user guide | [`docs/client-user-guide.md`](docs/client-user-guide.md) |
 | Testnet4 quickstart | [`docs/testnet4-quickstart.md`](docs/testnet4-quickstart.md) |


### PR DESCRIPTION
## Summary

Surfaces the multi-party deployment-coordination guide that already exists in `docs/` but was orphaned (not linked from README).

Placed between LSP operator guide and Mainnet runbook in the Documentation table:
- LSP operator guide → solo LSP ops
- **Multi-party deployment coordination** → multi-machine "LSP + N users" flow (new link)
- Mainnet runbook → mainnet production

Resolves the orphan flagged in PR #376's audit follow-up.

## Test plan
- [x] 1-line addition
- [x] Linked file exists (docs/deployment-coordination.md, 364 lines)