### PR TITLE
Revocation verification standard: durable, fail-closed, symmetric

### DIFF
--- a/doc/revocation-verification-standard.md
+++ b/doc/revocation-verification-standard.md
@@ -1,0 +1,111 @@
+# Revocation Verification Standard
+
+**Status:** design → implementation (branch `fix/revocation-verify-standard`)
+**Class:** fund-safety correctness (BOLT-2 conformance)
+**Origin:** present since the repo root commit `a1b5e0f` (2026-05-16) — an original design gap, not a regression.
+
+## 1. The principle
+
+> Every piece of counterparty-supplied secret material that gates fund safety MUST
+> be cryptographically verified, at a single choke point, against durable state,
+> BEFORE it is trusted or stored. Unverifiable material is rejected and the channel
+> is treated as breached. "Don't trust — verify" is an enforced invariant, not a
+> per-call-site convention.
+
+## 2. The problem this fixes
+
+Counterparty **revocation secrets** (per-commitment secrets revealed in `revoke_and_ack`)
+are accepted and stored through several paths with inconsistent verification:
+
+| Path | Today |
+|---|---|
+| `lsp_channels.c` payment handlers (961/1240/5355) | verify, but **fail OPEN** when the committed PCP isn't in the 2-slot window |
+| `htlc_commit.c` BOLT-2 handler (153/665) | **no verification** — stores `peer_pcs` straight off the wire |
+| `client.c` LSP-revoke handler (`0x50`) | **no verification** (the user's side of trustlessness) |
+
+A wrong/garbage secret that is stored arms the watchtower's penalty with a bad key
+(`channel_build_penalty_tx` is built from the stored secret; nothing re-verifies it at
+breach time). Result: when the counterparty later broadcasts that revoked state, the
+penalty TX is invalid → **the breach is unpunishable → the honest party loses the
+clawback.** This breaks the trustless guarantee in BOTH directions; the client side is
+the more important half because the user is exposed to the LSP.
+
+## 3. What the spec requires
+
+- **BOLT-2** (`revoke_and_ack`): the receiver MUST check the `per_commitment_secret`
+  generates the expected `per_commitment_point`; on mismatch the channel SHOULD/MAY
+  fail. There is no "accept on trust."
+- **BOLT-3**: received per-commitment secrets are stored compactly in a **shachain**
+  (O(log N)), inserted in order with a built-in consistency check.
+
+SuperScalar uses `shachain_from_seed` only to GENERATE its own secrets; received
+secrets go into a fixed 512-entry flat array + a lossy 2-slot remote-PCP window, with
+verification bolted onto some call sites and absent from others.
+
+## 4. Root cause
+
+Verification lives at *call sites* and depends on *lossy in-memory state* (the 2-slot
+PCP window evicts old commitments). When the committed point isn't in the window, the
+code cannot verify, and chose to ACCEPT rather than REJECT. The durable `remote_pcps`
+table exists but (a) is written at revoke time, not commitment creation, and (b) is
+never consulted by the verifier.
+
+## 5. The design
+
+Move verification to the **storage choke point**, back it with **durable** state, make
+it **fail-closed**, and make it **symmetric**.
+
+1. **One shared verifier.** Promote `verify_revocation_secret` out of `lsp_channels.c`
+   (static) into `channel.c` as public `channel_verify_revocation_secret(ch, cn, secret)`,
+   used by LSP and client alike.
+2. **Durable committed-PCP.** Persist the remote PCP at **commitment creation**, and have
+   `channel_get_remote_pcp` fall back to `persist_load_remote_pcp(ch->persist_db, …)` when
+   the in-memory window misses. The committed point is then always retrievable for the
+   life of a revocable commitment.
+3. **Verify at the choke point.** `channel_receive_revocation[_flat]` verifies internally
+   and returns failure if the secret can't be verified — so NO path (htlc_commit, lsp
+   handlers, client, bridge) can store an unverified secret. Callers must handle failure.
+4. **Fail closed.** On mismatch or genuinely-missing committed point, reject and fail the
+   channel (BOLT-2). Never store-on-trust.
+5. **Symmetric.** Because the choke point is shared `channel.c`, both the LSP verifying the
+   client and the client verifying the LSP are covered by the same code.
+6. **Completeness guard.** A test asserts the verifier is the only way secrets enter
+   storage (no direct flat-array writes bypass it), so the standard cannot silently
+   regress.
+7. **(Optional, deferred) BOLT-3 shachain receiver storage** to replace the 512-flat-array
+   with compact, uncapped, self-consistent storage. Separable from the correctness fix.
+
+### Safety: detect-then-enforce
+Because this is payment-hot and some paths verify nothing today, flipping straight to
+strict could surface a latent ordering bug and halt payments. Within this PR we prove
+correctness with tests rather than a production soak: legitimate flows (incl.
+restart-then-revoke) verify and pass; injected garbage secrets are rejected in both
+directions; the penalty/breach matrix stays green. A loud log remains on the
+(now-should-be-unreachable) reject path as a tripwire.
+
+## 6. Phases
+
+- **Phase 1 — Durable shared verifier (no enforcement change).** Move verifier to
+  `channel.c`; persist committed PCP at creation; `get_remote_pcp` consults the DB.
+  Unit tests for verify match/mismatch + durable lookup. Build green.
+- **Phase 2 — Centralize + fail-closed.** Verification moves INTO
+  `channel_receive_revocation[_flat]`; callers fail-close on failure; accept-on-trust →
+  reject. Unit tests for reject-on-mismatch/missing.
+- **Phase 3 — Symmetric + integration.** Confirm/route the client path through the
+  verifying choke point. Regtest drills: payment happy path, restart-then-revoke,
+  cheating-client garbage secret rejected, cheating-LSP garbage rejected client-side;
+  penalty/breach matrix green.
+- **Phase 4 — (optional) shachain receiver storage.** Deferrable follow-up.
+- **Phase 5 — PR.** This doc + tests + completeness guard; open PR vs `main`.
+
+## 7. Before / after (plain terms)
+
+**Before:** the other side says "here's the secret that retires our old state," and we
+mostly take their word for it — and in some paths don't check at all. A bogus secret gets
+filed away; if they later cheat by publishing that old state, our punishment is built from
+the bogus secret and bounces — they keep money they shouldn't.
+
+**After:** every revocation secret — us checking the client, the client checking us — is
+mathematically verified against the exact state it claims to retire, using a record
+written durably to disk. If it doesn't verify, we refuse it and treat the channel as
+breached. A valid punishment can always be built; neither side can cheat the other.

--- a/doc/revocation-verification-standard.md
+++ b/doc/revocation-verification-standard.md
@@ -109,3 +109,47 @@ the bogus secret and bounces — they keep money they shouldn't.
 mathematically verified against the exact state it claims to retire, using a record
 written durably to disk. If it doesn't verify, we refuse it and treat the channel as
 breached. A valid punishment can always be built; neither side can cheat the other.
+
+## 8. All three actors must verify at every step
+
+The shared verifier (`channel_verify_revocation_secret` in `channel.c`) + the choke point
+(`channel_receive_revocation_flat`) give **all three actors the capability** to verify.
+Status of each, as of this branch:
+
+| Step | LSP | Client (user) | Watchtower |
+|---|---|---|---|
+| Counterparty commitment signature | ✅ | ✅ `channel_verify_and_aggregate_commitment_sig` | n/a (pre-signed) |
+| **Counterparty revocation secret** | ✅ Phase 2, fail-closed | ❌ **drops `0x50`**, no LSP-PCP tracking past cn 0/1 | ✅ transitive — only ever reads secrets verified at store time; hydrate uses pre-signed penalty TXs, never raw secrets |
+| Funding on-chain | gated | warn + hard-gated on prod (#197) | (uses pre-signed) |
+| Ceremony / MuSig | ✅ | ✅ (participates) | n/a |
+
+**LSP — done.** Verifies client revocations at the choke point, fail-closed (Phases 1–2,
+tested green).
+
+**Watchtower — covered (transitive), no change needed.** Post-Phase-2 every secret in
+`received_revocations` was verified when stored; the standalone WT hydrate path
+(`wt_hydrate_row_cb`) loads pre-signed penalty TXs, so it never trusts a raw, unverified
+secret. (A belt-and-suspenders verify-on-ingest is a possible hardening, not a gap.)
+
+**Client — the remaining gap.** It holds the verification capability and verifies the LSP's
+commitment *signatures*, but it **discards the LSP's `revoke_and_ack` (`0x50`)** and tracks
+the LSP's per-commitment point only for commitments 0 and 1. So today the client cannot
+itself detect an LSP breach — that protection lives entirely in the standalone watchtower +
+self-exit.
+
+### Client implementation plan (focused next piece)
+1. Add `client_handle_lsp_revoke_and_ack(ch, ctx, msg)` mirroring the LSP handler:
+   parse → `channel_verify_revocation_secret(ch, cn-1, secret)` → on fail, reject + fail the
+   channel (BOLT-2) → `channel_receive_revocation` (store) → set the LSP's next per-commitment
+   point from the message (enabling ongoing tracking; the message already carries it — the
+   client currently throws it away).
+2. **Map the client's real payment commitment flow first.** `client_handle_commitment_signed`
+   is only called on reconnect (`client_reconnect.c:327`); the normal path is LSP-driven and
+   multi-loop, and `0x50` is intentionally skipped in the setup/ceremony loops. The handler
+   must be wired into the actual payment exchange, not the setup loops — this needs the client
+   message architecture mapped before touching it (delicate; mis-wiring risks breaking
+   payments).
+3. Tests: client rejects a garbage LSP revocation (fail-closed) and retains/verifies a correct
+   one across many commitments; existing client/reconnect suites stay green.
+4. Design note: the client retaining LSP revocations enables self-detection; whether it
+   self-penalizes or hands secrets to its watchtower is a separate (existing) concern.

--- a/include/superscalar/channel.h
+++ b/include/superscalar/channel.h
@@ -280,6 +280,15 @@ void channel_set_remote_pcp(channel_t *ch, uint64_t commitment_num,
 int channel_get_remote_pcp(const channel_t *ch, uint64_t commitment_num,
                             secp256k1_pubkey *pcp_out);
 
+/* Revocation-verification standard (shared by LSP and client): verify a revealed
+   per-commitment secret matches the per-commitment point the peer committed to
+   (secret*G == committed_PCP), using channel_get_remote_pcp (which consults the
+   durable DB record). Returns 1 if valid, 0 if demonstrably wrong. NOTE: in the
+   current phase this still returns 1 when no committed point can be found at all
+   (legacy accept-on-trust); that branch flips to fail-closed in a later phase. */
+int channel_verify_revocation_secret(const channel_t *ch, uint64_t commitment_num,
+                                     const unsigned char *secret32);
+
 /* Store a received revocation secret at flat index. */
 int channel_receive_revocation_flat(channel_t *ch, uint64_t commitment_num,
                                       const unsigned char *secret32);

--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -136,6 +136,16 @@ int client_handle_commitment_signed(int fd, channel_t *ch,
                                       secp256k1_context *ctx,
                                       const wire_msg_t *msg);
 
+/* Revocation-verification standard (client side): verify the LSP's revealed
+   per-commitment secret against the LSP's committed per-commitment point, then
+   retain it (so the user can detect an LSP breach) and track the LSP's next
+   point. Mirrors the LSP-side handler. Returns 1 on success (verified+stored, or
+   nothing to revoke yet at commitment 0); 0 if the secret is invalid (caller
+   should fail the channel) or the message is malformed. See
+   doc/revocation-verification-standard.md. */
+int client_handle_lsp_revoke_and_ack(channel_t *ch, secp256k1_context *ctx,
+                                       const wire_msg_t *msg);
+
 /* Handle incoming ADD_HTLC from LSP (we are the payee).
    Returns 1 on success. */
 int client_handle_add_htlc(channel_t *ch, const wire_msg_t *msg);

--- a/include/superscalar/crash_inject.h
+++ b/include/superscalar/crash_inject.h
@@ -34,4 +34,16 @@ void lsp_crash_checkpoint(const char *name);
    THREAD UNSAFE -- for single-process test harness only. */
 void lsp_crash_set_target(const char *name);
 
+/* #9 cheat-gate: defense-BYPASS cheats (e.g. SS_CHEAT_DUST_RACE, which strands
+   counterparty HTLCs to absorb them at force-close) must NEVER fire on a real
+   network. The binary calls superscalar_set_cheat_gate(is_regtest) at startup;
+   library cheat sites call superscalar_cheat_allowed() IN ADDITION to their
+   env-var check, so a directly-set SS_CHEAT_* env var is inert unless the node
+   runs on regtest. Default (gate never set) is 0 = NOT allowed (fail-safe).
+   Detection-only cheats (broadcast-revoked-state, self-harming) are handled
+   separately by refusing the cheat/test scaffolding flags on mainnet at
+   arg-parse. */
+void superscalar_set_cheat_gate(int is_regtest);
+int  superscalar_cheat_allowed(void);
+
 #endif /* SUPERSCALAR_CRASH_INJECT_H */

--- a/src/channel.c
+++ b/src/channel.c
@@ -602,8 +602,16 @@ int channel_verify_revocation_secret(const channel_t *ch, uint64_t commitment_nu
         return 0;  /* not a valid scalar — always reject */
 
     secp256k1_pubkey committed;
-    if (!channel_get_remote_pcp(ch, commitment_num, &committed))
-        return 1;  /* PHASE 1: no committed PCP retrievable — accept on trust */
+    if (!channel_get_remote_pcp(ch, commitment_num, &committed)) {
+        /* PHASE 2 — fail closed: a revocation we cannot check against a committed
+           point is never trusted (storing it would arm a broken penalty). Phase 1
+           durable persistence ensures a legitimate revocation always has a
+           retrievable point, so this branch means a protocol desync or an attack. */
+        fprintf(stderr, "channel: revocation for commitment %llu has no retrievable "
+                "committed point — refusing (fail-closed)\n",
+                (unsigned long long)commitment_num);
+        return 0;
+    }
 
     unsigned char d_ser[33], c_ser[33];
     size_t dlen = 33, clen = 33;
@@ -616,6 +624,17 @@ int channel_verify_revocation_secret(const channel_t *ch, uint64_t commitment_nu
 
 int channel_receive_revocation_flat(channel_t *ch, uint64_t commitment_num,
                                       const unsigned char *secret32) {
+    /* Revocation-verification standard (choke point): EVERY received revocation
+       secret — via any path (LSP handlers, htlc_commit, client, bridge) — is
+       verified here against the peer's committed point before it is stored. A
+       secret that doesn't match is rejected and NOT stored, so a broken penalty
+       can never be armed and the caller can fail the channel (BOLT-2). */
+    if (!channel_verify_revocation_secret(ch, commitment_num, secret32)) {
+        fprintf(stderr, "channel: REJECTED revocation secret for commitment %llu "
+                "(does not match committed point) — not stored\n",
+                (unsigned long long)commitment_num);
+        return 0;
+    }
     if (!channel_ensure_revocations_cap(ch, (size_t)(commitment_num + 1))) return 0;
     memcpy(ch->received_revocations[commitment_num], secret32, 32);
     ch->received_revocation_valid[commitment_num] = 1;

--- a/src/channel.c
+++ b/src/channel.c
@@ -505,39 +505,56 @@ void channel_set_local_pcs(channel_t *ch, uint64_t commitment_num,
 
 void channel_set_remote_pcp(channel_t *ch, uint64_t commitment_num,
                              const secp256k1_pubkey *pcp) {
-    /* Check if this commitment_num already occupies a slot */
-    for (int i = 0; i < 2; i++) {
+    /* Update the in-memory 2-slot window (matches a slot, fills an empty one,
+       or evicts the lower commitment_num). */
+    int placed = 0;
+    for (int i = 0; i < 2 && !placed; i++) {
         if (ch->remote_pcp_valid[i] && ch->remote_pcp_nums[i] == commitment_num) {
             ch->remote_pcps[i] = *pcp;
-            return;
+            placed = 1;
         }
     }
-    /* Find an empty slot */
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < 2 && !placed; i++) {
         if (!ch->remote_pcp_valid[i]) {
             ch->remote_pcps[i] = *pcp;
             ch->remote_pcp_nums[i] = commitment_num;
             ch->remote_pcp_valid[i] = 1;
-            return;
+            placed = 1;
         }
     }
-    /* Both slots occupied — evict the one with the smaller commitment_num */
-    int evict = (ch->remote_pcp_nums[0] <= ch->remote_pcp_nums[1]) ? 0 : 1;
-    ch->remote_pcps[evict] = *pcp;
-    ch->remote_pcp_nums[evict] = commitment_num;
-    ch->remote_pcp_valid[evict] = 1;
+    if (!placed) {
+        int evict = (ch->remote_pcp_nums[0] <= ch->remote_pcp_nums[1]) ? 0 : 1;
+        ch->remote_pcps[evict] = *pcp;
+        ch->remote_pcp_nums[evict] = commitment_num;
+        ch->remote_pcp_valid[evict] = 1;
+    }
+
+    /* Revocation-verification standard: persist the committed per-commitment
+       point immediately, keyed by commitment_num, so it is durably retrievable
+       for revocation verification even after the 2-slot window evicts it or the
+       process restarts. The in-memory window stays as a fast cache; the DB is
+       the authoritative, complete record (channel_get_remote_pcp falls back to
+       it). Non-fatal on failure — the cache still serves the common case. */
+    if (ch->persist_db) {
+        unsigned char ser[33];
+        size_t slen = 33;
+        secp256k1_ec_pubkey_serialize(ch->ctx, ser, &slen, pcp,
+                                       SECP256K1_EC_COMPRESSED);
+        (void)persist_save_remote_pcp((persist_t *)ch->persist_db,
+                                      ch->persist_channel_id, commitment_num, ser);
+    }
 }
 
 int channel_get_remote_pcp(const channel_t *ch, uint64_t commitment_num,
                             secp256k1_pubkey *pcp_out) {
-    /* Check both stored slots */
+    /* 1. in-memory 2-slot window (fast path) */
     for (int i = 0; i < 2; i++) {
         if (ch->remote_pcp_valid[i] && ch->remote_pcp_nums[i] == commitment_num) {
             *pcp_out = ch->remote_pcps[i];
             return 1;
         }
     }
-    /* For old commitments, derive from received revocation secret */
+    /* 2. for old commitments, derive from an already-received revocation secret */
     uint64_t max_stored = 0;
     for (int i = 0; i < 2; i++) {
         if (ch->remote_pcp_valid[i] && ch->remote_pcp_nums[i] > max_stored)
@@ -545,13 +562,56 @@ int channel_get_remote_pcp(const channel_t *ch, uint64_t commitment_num,
     }
     if (commitment_num < max_stored) {
         unsigned char secret[32];
-        if (!channel_get_received_revocation(ch, commitment_num, secret))
-            return 0;
-        int ok = secp256k1_ec_pubkey_create(ch->ctx, pcp_out, secret);
-        secure_zero(secret, 32);
-        return ok;
+        if (channel_get_received_revocation(ch, commitment_num, secret)) {
+            int ok = secp256k1_ec_pubkey_create(ch->ctx, pcp_out, secret);
+            secure_zero(secret, 32);
+            if (ok) return 1;
+        }
+    }
+    /* 3. durable committed-PCP from the DB — the authoritative, complete record
+       (keyed by commitment_num). This survives 2-slot eviction and restarts, so
+       a revocation can be verified against what the peer actually committed to
+       rather than skipped. */
+    if (ch->persist_db) {
+        unsigned char ser[33];
+        if (persist_load_remote_pcp((persist_t *)ch->persist_db,
+                                    ch->persist_channel_id, commitment_num, ser) &&
+            secp256k1_ec_pubkey_parse(ch->ctx, pcp_out, ser, 33)) {
+            return 1;
+        }
     }
     return 0;
+}
+
+/* Revocation-verification standard (shared by LSP and client). Verify that a
+   revealed per-commitment secret matches the per-commitment point the peer
+   committed to for `commitment_num`: secret*G == committed_PCP. Uses
+   channel_get_remote_pcp, which now consults the durable DB record, so a
+   legitimate revocation can always be checked.
+
+   PHASE 1 (this commit) preserves the historical behavior of accepting when no
+   committed point can be found anywhere (returns 1) so this is a pure,
+   behavior-neutral relocation + durability upgrade. PHASE 2 flips that branch to
+   fail-closed (return 0) once the choke-point + tests prove no legitimate
+   revocation lands without a retrievable point. */
+int channel_verify_revocation_secret(const channel_t *ch, uint64_t commitment_num,
+                                     const unsigned char *secret32) {
+    if (!ch || !secret32) return 0;
+    secp256k1_pubkey derived;
+    if (!secp256k1_ec_pubkey_create(ch->ctx, &derived, secret32))
+        return 0;  /* not a valid scalar — always reject */
+
+    secp256k1_pubkey committed;
+    if (!channel_get_remote_pcp(ch, commitment_num, &committed))
+        return 1;  /* PHASE 1: no committed PCP retrievable — accept on trust */
+
+    unsigned char d_ser[33], c_ser[33];
+    size_t dlen = 33, clen = 33;
+    secp256k1_ec_pubkey_serialize(ch->ctx, d_ser, &dlen, &derived,
+                                   SECP256K1_EC_COMPRESSED);
+    secp256k1_ec_pubkey_serialize(ch->ctx, c_ser, &clen, &committed,
+                                   SECP256K1_EC_COMPRESSED);
+    return memcmp(d_ser, c_ser, 33) == 0;
 }
 
 int channel_receive_revocation_flat(channel_t *ch, uint64_t commitment_num,

--- a/src/client.c
+++ b/src/client.c
@@ -405,6 +405,45 @@ int client_handle_commitment_signed(int fd, channel_t *ch,
     return ok;
 }
 
+int client_handle_lsp_revoke_and_ack(channel_t *ch, secp256k1_context *ctx,
+                                       const wire_msg_t *msg) {
+    if (!ch || !msg) return 0;
+    uint32_t cid;
+    unsigned char rev_secret[32], next_point[33];
+    if (!wire_parse_revoke_and_ack(msg->json, &cid, rev_secret, next_point))
+        return 0;
+
+    /* At commitment 0 there is no prior LSP commitment to revoke yet. */
+    if (ch->commitment_number == 0) {
+        volatile unsigned char *z = (volatile unsigned char *)rev_secret;
+        for (int i = 0; i < 32; i++) z[i] = 0;
+        return 1;
+    }
+
+    uint64_t old_cn = ch->commitment_number - 1;
+    /* Verify the LSP's secret against the LSP's committed point (secret*G ==
+       committed_PCP). channel_verify_revocation_secret consults the durable
+       record, and the choke point re-verifies on store — fail closed. */
+    if (!channel_verify_revocation_secret(ch, old_cn, rev_secret)) {
+        fprintf(stderr, "Client: INVALID LSP revocation secret (commitment %llu) "
+                "— rejecting (fail-closed)\n", (unsigned long long)old_cn);
+        volatile unsigned char *z = (volatile unsigned char *)rev_secret;
+        for (int i = 0; i < 32; i++) z[i] = 0;
+        return 0;
+    }
+    channel_receive_revocation(ch, old_cn, rev_secret);
+    { volatile unsigned char *z = (volatile unsigned char *)rev_secret;
+      for (int i = 0; i < 32; i++) z[i] = 0; }
+
+    /* Track the LSP's NEXT per-commitment point (carried in this message) so
+       subsequent LSP revocations remain verifiable. The client used to discard
+       this. */
+    secp256k1_pubkey next_pcp;
+    if (secp256k1_ec_pubkey_parse(ctx, &next_pcp, next_point, 33))
+        channel_set_remote_pcp(ch, ch->commitment_number + 1, &next_pcp);
+    return 1;
+}
+
 int client_handle_add_htlc(channel_t *ch, const wire_msg_t *msg) {
     uint64_t htlc_id, amount_msat;
     unsigned char payment_hash[32];

--- a/src/crash_inject.c
+++ b/src/crash_inject.c
@@ -59,3 +59,16 @@ void lsp_crash_checkpoint(const char *name) {
         abort();
     }
 }
+
+/* #9 cheat-gate. Default 0 = cheats NOT allowed (fail-safe: a binary that never
+   calls superscalar_set_cheat_gate, or runs on any non-regtest network, cannot
+   fire a defense-bypass cheat even if the SS_CHEAT_* env var is set). */
+static int g_cheat_gate_regtest = 0;
+
+void superscalar_set_cheat_gate(int is_regtest) {
+    g_cheat_gate_regtest = is_regtest ? 1 : 0;
+}
+
+int superscalar_cheat_allowed(void) {
+    return g_cheat_gate_regtest;
+}

--- a/src/htlc_commit.c
+++ b/src/htlc_commit.c
@@ -17,6 +17,7 @@
 
 #include "superscalar/htlc_commit.h"
 #include "superscalar/channel.h"
+#include "superscalar/crash_inject.h"   /* #9 superscalar_cheat_allowed() */
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -368,7 +369,10 @@ int htlc_commit_recv_update_fee(channel_t *ch,
        the HTLC into commit fees at force-close. This MUST only fire in
        cheat-engine test runs (env var gated). Markers: LSP-CHEAT-DUST. */
     const char *cheat = getenv("SS_CHEAT_DUST_RACE");
-    int cheat_active = (cheat && cheat[0] && cheat[0] != '0');
+    /* #9 cheat-gate: this is a defense BYPASS (strands counterparty HTLC sweeps
+       below dust so the LSP absorbs them). Honor it ONLY on regtest — even a
+       directly-set env var is inert on signet/testnet/mainnet (gate default 0). */
+    int cheat_active = (cheat && cheat[0] && cheat[0] != '0') && superscalar_cheat_allowed();
 
     for (size_t i = 0; i < ch->n_htlcs; i++) {
         if (ch->htlcs[i].state != HTLC_STATE_ACTIVE) continue;

--- a/src/htlc_commit.c
+++ b/src/htlc_commit.c
@@ -149,8 +149,11 @@ static int recv_revoke_and_ack(peer_mgr_t *mgr, int peer_idx,
     const unsigned char *peer_pcs      = buf + 34; /* after type(2) + channel_id(32) */
     const unsigned char *next_pcp_wire = buf + 66; /* after + pcs(32) */
 
-    if (ch->commitment_number > 0)
-        channel_receive_revocation_flat(ch, ch->commitment_number - 1, peer_pcs);
+    if (ch->commitment_number > 0 &&
+        !channel_receive_revocation_flat(ch, ch->commitment_number - 1, peer_pcs)) {
+        fprintf(stderr, "htlc_commit: peer revocation failed verification — failing update\n");
+        return 0;
+    }
 
     secp256k1_pubkey next_pcp;
     if (!secp256k1_ec_pubkey_parse(ctx, &next_pcp, next_pcp_wire, 33)) return 0;
@@ -661,9 +664,12 @@ int htlc_commit_dispatch(peer_mgr_t *mgr, int peer_idx,
         const unsigned char *peer_pcs      = payload + 32;
         const unsigned char *next_pcp_wire = payload + 64;
 
-        if (ch->commitment_number > 0)
-            channel_receive_revocation_flat(ch, ch->commitment_number - 1,
-                                             peer_pcs);
+        if (ch->commitment_number > 0 &&
+            !channel_receive_revocation_flat(ch, ch->commitment_number - 1,
+                                             peer_pcs)) {
+            fprintf(stderr, "htlc_commit: peer revocation failed verification — failing update\n");
+            return -1;
+        }
 
         secp256k1_pubkey next_pcp;
         if (!secp256k1_ec_pubkey_parse(ctx, &next_pcp, next_pcp_wire, 33))

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -41,29 +41,9 @@
    The LSP caller passes its own pubkey as "my", the client's as "peer";
    the returned my_signer_idx indicates LSP's position in the keyagg. */
 
-/* Verify that a revocation secret matches the per-commitment point stored for
-   the given commitment number.  Returns 1 if valid (or if no stored PCP to
-   check against), 0 if the secret is demonstrably wrong. */
-static int verify_revocation_secret(const secp256k1_context *ctx,
-                                     const channel_t *ch,
-                                     uint64_t commitment_num,
-                                     const unsigned char *secret32) {
-    secp256k1_pubkey derived;
-    if (!secp256k1_ec_pubkey_create(ctx, &derived, secret32))
-        return 0;  /* not a valid scalar */
-
-    secp256k1_pubkey stored;
-    if (!channel_get_remote_pcp(ch, commitment_num, &stored))
-        return 1;  /* no PCP stored — can't verify, accept on trust */
-
-    unsigned char d_ser[33], s_ser[33];
-    size_t dlen = 33, slen = 33;
-    secp256k1_ec_pubkey_serialize(ctx, d_ser, &dlen, &derived,
-                                   SECP256K1_EC_COMPRESSED);
-    secp256k1_ec_pubkey_serialize(ctx, s_ser, &slen, &stored,
-                                   SECP256K1_EC_COMPRESSED);
-    return memcmp(d_ser, s_ser, 33) == 0;
-}
+/* Revocation-secret verification now lives in channel.c as the shared
+   channel_verify_revocation_secret() (used by both LSP and client) — see
+   doc/revocation-verification-standard.md. */
 
 /* Detect single-process mode: returns 1 only when f->keypairs[i] holds a
    real seckey for every signer in `node` (LSP + every non-LSP signer).
@@ -958,7 +938,7 @@ static int handle_add_htlc(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         if (wire_parse_revoke_and_ack(ack_msg.json, &ack_chan_id,
                                         rev_secret, next_point)) {
             uint64_t old_cn = sender_ch->commitment_number - 1;
-            if (!verify_revocation_secret(mgr->ctx, sender_ch, old_cn, rev_secret)) {
+            if (!channel_verify_revocation_secret(sender_ch, old_cn, rev_secret)) {
                 fprintf(stderr, "LSP: INVALID revocation secret from sender %zu "
                         "(commitment %lu) — rejecting\n",
                         sender_idx, (unsigned long)old_cn);
@@ -1237,7 +1217,7 @@ static int handle_add_htlc(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         if (wire_parse_revoke_and_ack(ack_msg.json, &ack_chan_id,
                                         rev_secret, next_point)) {
             uint64_t old_cn = dest_ch->commitment_number - 1;
-            if (!verify_revocation_secret(mgr->ctx, dest_ch, old_cn, rev_secret)) {
+            if (!channel_verify_revocation_secret(dest_ch, old_cn, rev_secret)) {
                 fprintf(stderr, "LSP: INVALID revocation secret from dest %zu "
                         "(commitment %lu) — rejecting\n",
                         dest_idx, (unsigned long)old_cn);
@@ -5352,7 +5332,7 @@ static void replay_pending_htlcs(lsp_channel_mgr_t *mgr, lsp_t *lsp, size_t reco
                 if (wire_parse_revoke_and_ack(ack_msg.json, &ack_chan_id,
                                                 rev_secret, next_point)) {
                     uint64_t old_cn = dest_ch->commitment_number - 1;
-                    if (!verify_revocation_secret(mgr->ctx, dest_ch, old_cn, rev_secret)) {
+                    if (!channel_verify_revocation_secret(dest_ch, old_cn, rev_secret)) {
                         fprintf(stderr, "LSP: INVALID revocation secret from reconnected "
                                 "client %zu (commitment %lu)\n",
                                 reconnected_idx, (unsigned long)old_cn);

--- a/tests/test_channel.c
+++ b/tests/test_channel.c
@@ -1774,6 +1774,10 @@ int test_htlc_penalty(void) {
     unsigned char secret0[32];
     TEST_ASSERT(channel_get_revocation_secret(&local_ch, 1, secret0),
                 "get revocation secret");  /* commitment #1 which was the HTLC commit */
+    /* revocation-verify: committed point for cn #1 (= secret0*G) must be in-window */
+    secp256k1_pubkey rvp1;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &rvp1, secret0), "rvp1");
+    channel_set_remote_pcp(&remote_ch, 1, &rvp1);
     TEST_ASSERT(channel_receive_revocation(&remote_ch, 1, secret0),
                 "remote receive revocation");
 
@@ -4299,6 +4303,10 @@ int test_channel_dynamic_growth(void) {
 
     /* Verify revocations grow too */
     unsigned char rev_secret[32] = { [0 ... 31] = 0xAA };
+    /* revocation-verify: committed point for cn 600 (= rev_secret*G) in-window */
+    secp256k1_pubkey rvp600;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &rvp600, rev_secret), "rvp600");
+    channel_set_remote_pcp(&ch, 600, &rvp600);
     TEST_ASSERT(channel_receive_revocation_flat(&ch, 600, rev_secret),
                 "receive revocation at 600");
     TEST_ASSERT(ch.revocations_cap >= 1024, "rev cap grew to >= 1024");

--- a/tests/test_cpfp.c
+++ b/tests/test_cpfp.c
@@ -130,7 +130,15 @@ int test_penalty_tx_has_anchor(void) {
     unsigned char lsp_secret0[32], client_secret0[32];
     channel_get_revocation_secret(&lsp_ch, 0, lsp_secret0);
     channel_get_revocation_secret(&client_ch, 0, client_secret0);
+    /* revocation-verify: the committed point (secret*G) for cn #0 was evicted
+       from the 2-slot window by setting pcp #2 above; restore it so the receive
+       can verify. (Production attaches a DB and never needs this re-set.) */
+    secp256k1_pubkey rvp;
+    secp256k1_ec_pubkey_create(ctx, &rvp, client_secret0);
+    channel_set_remote_pcp(&lsp_ch, 0, &rvp);
     channel_receive_revocation(&lsp_ch, 0, client_secret0);
+    secp256k1_ec_pubkey_create(ctx, &rvp, lsp_secret0);
+    channel_set_remote_pcp(&client_ch, 0, &rvp);
     channel_receive_revocation(&client_ch, 0, lsp_secret0);
 
     /* Build local commitment #0 to get to_local SPK */
@@ -247,7 +255,14 @@ int test_htlc_penalty_tx_has_anchor(void) {
     unsigned char lsp_secret0[32], client_secret0[32];
     channel_get_revocation_secret(&lsp_ch, 0, lsp_secret0);
     channel_get_revocation_secret(&client_ch, 0, client_secret0);
+    /* revocation-verify: restore the committed point (secret*G) for cn #0,
+       evicted from the 2-slot window by pcp #2 above, so the receive verifies. */
+    secp256k1_pubkey rvp;
+    secp256k1_ec_pubkey_create(ctx, &rvp, client_secret0);
+    channel_set_remote_pcp(&lsp_ch, 0, &rvp);
     channel_receive_revocation(&lsp_ch, 0, client_secret0);
+    secp256k1_ec_pubkey_create(ctx, &rvp, lsp_secret0);
+    channel_set_remote_pcp(&client_ch, 0, &rvp);
     channel_receive_revocation(&client_ch, 0, lsp_secret0);
 
     /* Get the HTLC output info from the old commitment.

--- a/tests/test_dust_recovery.c
+++ b/tests/test_dust_recovery.c
@@ -37,6 +37,7 @@
 
 #include "superscalar/htlc_commit.h"
 #include "superscalar/channel.h"
+#include "superscalar/crash_inject.h"   /* #9 cheat-gate: cheats are inert unless armed */
 
 #include <string.h>
 #include <stdio.h>
@@ -148,6 +149,10 @@ int test_dust_race_defense_rejects_ptlc(void) {
 /* DR3 — SS_CHEAT_DUST_RACE=1 ACCEPTS the otherwise-rejected feerate   */
 /* ------------------------------------------------------------------ */
 int test_dust_race_cheat_bypass(void) {
+    /* #9: defense-bypass cheats require BOTH the env flag AND the regtest
+       cheat-gate. This test exercises the cheat's bypass behavior, so it must
+       arm the gate (as the regtest binary does); it is reset before return. */
+    superscalar_set_cheat_gate(1);
     setenv("SS_CHEAT_DUST_RACE", "1", 1);
 
     channel_t ch;
@@ -173,6 +178,7 @@ int test_dust_race_cheat_bypass(void) {
            "DR3: fee_rate updated to attacker-chosen ceiling");
 
     unsetenv("SS_CHEAT_DUST_RACE");
+    superscalar_set_cheat_gate(0);
     return 1;
 }
 
@@ -255,6 +261,10 @@ int test_dust_race_boundary_accept(void) {
 /* DR6 — cheat does NOT bypass floor/ceiling checks                    */
 /* ------------------------------------------------------------------ */
 int test_dust_race_cheat_does_not_bypass_floor(void) {
+    /* #9: arm the cheat-gate so the cheat is genuinely active — proving the
+       floor/ceiling bounds hold EVEN against an armed cheat (not trivially
+       because the cheat was inert). */
+    superscalar_set_cheat_gate(1);
     setenv("SS_CHEAT_DUST_RACE", "1", 1);
 
     channel_t ch;
@@ -290,6 +300,7 @@ int test_dust_race_cheat_does_not_bypass_floor(void) {
     ASSERT(ch.fee_rate_sat_per_kvb == 1000, "DR6: fee_rate unchanged");
 
     unsetenv("SS_CHEAT_DUST_RACE");
+    superscalar_set_cheat_gate(0);
     return 1;
 }
 
@@ -297,6 +308,8 @@ int test_dust_race_cheat_does_not_bypass_floor(void) {
 /* DR7 — cheat applies per-HTLC and still updates ch->fee_rate          */
 /* ------------------------------------------------------------------ */
 int test_dust_race_cheat_per_htlc(void) {
+    /* #9: arm the regtest cheat-gate so the bypass behavior is reachable. */
+    superscalar_set_cheat_gate(1);
     setenv("SS_CHEAT_DUST_RACE", "1", 1);
 
     channel_t ch;
@@ -327,5 +340,6 @@ int test_dust_race_cheat_per_htlc(void) {
            "DR7: fee_rate updated to attacker-chosen ceiling");
 
     unsetenv("SS_CHEAT_DUST_RACE");
+    superscalar_set_cheat_gate(0);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1229,6 +1229,7 @@ extern int test_persist_revocation_round_trip(void);
 extern int test_channel_revocation_durable_pcp_verify(void);  /* revocation-verify Phase 1 */
 extern int test_channel_revocation_failclosed(void);          /* revocation-verify Phase 2 */
 extern int test_client_verifies_lsp_revocation(void);         /* revocation-verify client side */
+extern int test_cheat_gate(void);                             /* #9 cheat-gate */
 extern int test_persist_watchtower_hydrate_round_trip(void);
 extern int test_persist_htlc_round_trip(void);
 extern int test_persist_htlc_delete(void);
@@ -3110,6 +3111,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_channel_revocation_durable_pcp_verify);
     RUN_TEST(test_channel_revocation_failclosed);
     RUN_TEST(test_client_verifies_lsp_revocation);
+    RUN_TEST(test_cheat_gate);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);
     RUN_TEST(test_persist_htlc_round_trip);
     RUN_TEST(test_persist_htlc_delete);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1226,6 +1226,7 @@ extern int test_persist_wt_no_secrets_in_schema(void);
 extern int test_persist_old_commitment_ptlcs_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
+extern int test_channel_revocation_durable_pcp_verify(void);  /* revocation-verify Phase 1 */
 extern int test_persist_watchtower_hydrate_round_trip(void);
 extern int test_persist_htlc_round_trip(void);
 extern int test_persist_htlc_delete(void);
@@ -3104,6 +3105,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_old_commitment_ptlcs_round_trip);
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
+    RUN_TEST(test_channel_revocation_durable_pcp_verify);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);
     RUN_TEST(test_persist_htlc_round_trip);
     RUN_TEST(test_persist_htlc_delete);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1227,6 +1227,7 @@ extern int test_persist_old_commitment_ptlcs_round_trip(void);
 extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_channel_revocation_durable_pcp_verify(void);  /* revocation-verify Phase 1 */
+extern int test_channel_revocation_failclosed(void);          /* revocation-verify Phase 2 */
 extern int test_persist_watchtower_hydrate_round_trip(void);
 extern int test_persist_htlc_round_trip(void);
 extern int test_persist_htlc_delete(void);
@@ -3106,6 +3107,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_channel_round_trip);
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_channel_revocation_durable_pcp_verify);
+    RUN_TEST(test_channel_revocation_failclosed);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);
     RUN_TEST(test_persist_htlc_round_trip);
     RUN_TEST(test_persist_htlc_delete);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1228,6 +1228,7 @@ extern int test_persist_channel_round_trip(void);
 extern int test_persist_revocation_round_trip(void);
 extern int test_channel_revocation_durable_pcp_verify(void);  /* revocation-verify Phase 1 */
 extern int test_channel_revocation_failclosed(void);          /* revocation-verify Phase 2 */
+extern int test_client_verifies_lsp_revocation(void);         /* revocation-verify client side */
 extern int test_persist_watchtower_hydrate_round_trip(void);
 extern int test_persist_htlc_round_trip(void);
 extern int test_persist_htlc_delete(void);
@@ -3108,6 +3109,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_revocation_round_trip);
     RUN_TEST(test_channel_revocation_durable_pcp_verify);
     RUN_TEST(test_channel_revocation_failclosed);
+    RUN_TEST(test_client_verifies_lsp_revocation);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);
     RUN_TEST(test_persist_htlc_round_trip);
     RUN_TEST(test_persist_htlc_delete);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -18,6 +18,7 @@
 #include "superscalar/dw_state.h"
 #include "superscalar/client.h"   /* client_handle_lsp_revoke_and_ack (revocation-verify) */
 #include "superscalar/wire.h"     /* wire_build_revoke_and_ack, wire_msg_t */
+#include "superscalar/crash_inject.h"  /* #9 cheat-gate */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -5134,6 +5135,18 @@ int test_client_verifies_lsp_revocation(void) {
     free(ch.received_revocations);  free(ch.received_revocation_valid);
     free(ch2.received_revocations); free(ch2.received_revocation_valid);
     secp256k1_context_destroy(ctx);
+    return 1;
+}
+
+/* #9 cheat-gate: defense-bypass cheats are inert by default (fail-safe) and
+   only allowed when the gate is set for regtest. */
+int test_cheat_gate(void) {
+    superscalar_set_cheat_gate(0);
+    TEST_ASSERT(superscalar_cheat_allowed() == 0, "gate off -> cheats not allowed");
+    superscalar_set_cheat_gate(1);
+    TEST_ASSERT(superscalar_cheat_allowed() == 1, "gate on (regtest) -> cheats allowed");
+    superscalar_set_cheat_gate(0);
+    TEST_ASSERT(superscalar_cheat_allowed() == 0, "gate reset -> cheats not allowed");
     return 1;
 }
 

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -651,7 +651,13 @@ int test_persist_watchtower_hydrate_round_trip(void) {
     unsigned char rev0[32], rev1[32];
     memset(rev0, 0x55, 32);
     memset(rev1, 0x66, 32);
+    /* revocation-verify: committed points (secret*G) must match the secrets */
+    secp256k1_pubkey hvp;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &hvp, rev0), "hvp0");
+    channel_set_remote_pcp(&ch, 0, &hvp);
     TEST_ASSERT(channel_receive_revocation(&ch, 0, rev0), "recv rev0");
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &hvp, rev1), "hvp1");
+    channel_set_remote_pcp(&ch, 1, &hvp);
     TEST_ASSERT(channel_receive_revocation(&ch, 1, rev1), "recv rev1");
 
     /* persist_list_channel_ids finds our saved channel */

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -5050,4 +5050,41 @@ int test_channel_revocation_durable_pcp_verify(void) {
     return 1;
 }
 
+/* Phase 2: verification is enforced at the choke point and fails closed —
+   unverifiable/mismatched secrets are rejected and never stored. */
+int test_channel_revocation_failclosed(void) {
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    channel_t ch;
+    memset(&ch, 0, sizeof ch);
+    ch.ctx = ctx;   /* no persist_db, no window — no committed point anywhere */
+
+    unsigned char any[32]; memset(any, 7, 32);
+    /* (1) no committed point -> verifier fails closed (was: accept-on-trust) */
+    TEST_ASSERT(channel_verify_revocation_secret(&ch, 0, any) == 0, "no PCP -> fail closed");
+    /* (2) choke point refuses to store an unverifiable secret */
+    TEST_ASSERT(channel_receive_revocation_flat(&ch, 0, any) == 0, "choke point rejects unverifiable");
+    TEST_ASSERT(channel_get_received_revocation(&ch, 0, any) == 0, "nothing stored");
+
+    /* (3) with a committed point for cn=3: wrong rejected (not stored), correct stored */
+    unsigned char s3[32]; memset(s3, 0, 32); s3[31] = 3;
+    secp256k1_pubkey p3;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &p3, s3), "p3");
+    channel_set_remote_pcp(&ch, 3, &p3);
+
+    unsigned char wrong[32]; memset(wrong, 0xcd, 32);
+    TEST_ASSERT(channel_receive_revocation_flat(&ch, 3, wrong) == 0, "wrong secret rejected at choke point");
+    unsigned char got[32];
+    TEST_ASSERT(channel_get_received_revocation(&ch, 3, got) == 0, "wrong secret NOT stored");
+
+    TEST_ASSERT(channel_receive_revocation_flat(&ch, 3, s3) == 1, "correct secret accepted");
+    TEST_ASSERT(channel_get_received_revocation(&ch, 3, got) == 1 && memcmp(got, s3, 32) == 0,
+                "correct secret stored");
+
+    free(ch.received_revocations);
+    free(ch.received_revocation_valid);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
 /* === End revocation verification standard tests =========================== */

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -4994,3 +4994,60 @@ int test_ceremony_helpers_aggregate_hard_guard(void) {
 }
 
 /* === End SF-CEREMONY-HELPERS tests ======================================== */
+
+/* === Revocation verification standard (Phase 1: durable committed-PCP) ===== */
+
+/* A committed remote per-commitment point must stay verifiable after it is
+   evicted from the 2-slot in-memory window — via the durable DB record — and a
+   wrong secret must NOT verify against it. This is the durability that lets
+   Phase 2 safely fail-closed. */
+int test_channel_revocation_durable_pcp_verify(void) {
+    const char *path = "/tmp/test_ss_revverify.db";
+    unlink(path);
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, path), "open");
+
+    channel_t ch;
+    memset(&ch, 0, sizeof ch);
+    ch.ctx = ctx;
+    ch.persist_db = &db;
+    ch.persist_channel_id = 7;
+
+    /* commitment 5: committed PCP = secret5*G */
+    unsigned char secret5[32]; memset(secret5, 0, 32); secret5[31] = 5;
+    secp256k1_pubkey pcp5;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &pcp5, secret5), "pcp5");
+    channel_set_remote_pcp(&ch, 5, &pcp5);            /* in-memory + persisted */
+
+    /* evict 5 from the 2-slot window with two newer commitments */
+    unsigned char s6[32] = {0}, s7[32] = {0}; s6[31] = 6; s7[31] = 7;
+    secp256k1_pubkey p6, p7;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &p6, s6), "p6");
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &p7, s7), "p7");
+    channel_set_remote_pcp(&ch, 6, &p6);
+    channel_set_remote_pcp(&ch, 7, &p7);              /* window {6,7}; 5 evicted */
+
+    /* durable fallback: PCP for 5 is still retrievable (from DB) and correct */
+    secp256k1_pubkey got;
+    TEST_ASSERT(channel_get_remote_pcp(&ch, 5, &got), "PCP 5 retrievable after eviction");
+    unsigned char a[33], b[33]; size_t al = 33, bl = 33;
+    secp256k1_ec_pubkey_serialize(ctx, a, &al, &got,  SECP256K1_EC_COMPRESSED);
+    secp256k1_ec_pubkey_serialize(ctx, b, &bl, &pcp5, SECP256K1_EC_COMPRESSED);
+    TEST_ASSERT(memcmp(a, b, 33) == 0, "durable PCP matches committed");
+
+    /* verification against the durable record: correct accepted, wrong rejected */
+    TEST_ASSERT(channel_verify_revocation_secret(&ch, 5, secret5) == 1,
+                "correct secret verifies against durable PCP");
+    unsigned char wrong[32]; memset(wrong, 0xab, 32);
+    TEST_ASSERT(channel_verify_revocation_secret(&ch, 5, wrong) == 0,
+                "wrong secret rejected (durable PCP present)");
+
+    persist_close(&db);
+    secp256k1_context_destroy(ctx);
+    unlink(path);
+    return 1;
+}
+
+/* === End revocation verification standard tests =========================== */

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -16,6 +16,8 @@
 #include "superscalar/channel.h"
 #include "superscalar/lsp_channels.h"
 #include "superscalar/dw_state.h"
+#include "superscalar/client.h"   /* client_handle_lsp_revoke_and_ack (revocation-verify) */
+#include "superscalar/wire.h"     /* wire_build_revoke_and_ack, wire_msg_t */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -5089,6 +5091,48 @@ int test_channel_revocation_failclosed(void) {
 
     free(ch.received_revocations);
     free(ch.received_revocation_valid);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
+/* The CLIENT (user) verifies the LSP's revocation at the revocation step:
+   a correct LSP secret is verified + retained; a garbage one is rejected and
+   never stored. Proves the user's side of "verify everything". */
+int test_client_verifies_lsp_revocation(void) {
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    /* LSP's committed point for commitment 0 = lsp_secret0 * G */
+    unsigned char lsp_secret0[32]; memset(lsp_secret0, 0, 32); lsp_secret0[31] = 9;
+    secp256k1_pubkey lsp_pcp0;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &lsp_pcp0, lsp_secret0), "lsp_pcp0");
+    unsigned char nx[32]; memset(nx, 0, 32); nx[31] = 11;
+    secp256k1_pubkey next_pcp;
+    TEST_ASSERT(secp256k1_ec_pubkey_create(ctx, &next_pcp, nx), "next_pcp");
+
+    /* (1) correct LSP revocation -> verified + retained */
+    channel_t ch; memset(&ch, 0, sizeof ch); ch.ctx = ctx; ch.commitment_number = 1;
+    channel_set_remote_pcp(&ch, 0, &lsp_pcp0);
+    cJSON *good = wire_build_revoke_and_ack(7, lsp_secret0, ctx, &next_pcp);
+    wire_msg_t m; m.msg_type = MSG_LSP_REVOKE_AND_ACK; m.json = good;
+    TEST_ASSERT(client_handle_lsp_revoke_and_ack(&ch, ctx, &m) == 1, "correct LSP revocation accepted");
+    cJSON_Delete(good);
+    unsigned char got[32];
+    TEST_ASSERT(channel_get_received_revocation(&ch, 0, got) == 1 && memcmp(got, lsp_secret0, 32) == 0,
+                "LSP secret retained");
+
+    /* (2) garbage LSP revocation -> rejected (fail-closed), never stored */
+    channel_t ch2; memset(&ch2, 0, sizeof ch2); ch2.ctx = ctx; ch2.commitment_number = 1;
+    channel_set_remote_pcp(&ch2, 0, &lsp_pcp0);
+    unsigned char garbage[32]; memset(garbage, 0xde, 32);
+    cJSON *bad = wire_build_revoke_and_ack(7, garbage, ctx, &next_pcp);
+    wire_msg_t mb; mb.msg_type = MSG_LSP_REVOKE_AND_ACK; mb.json = bad;
+    TEST_ASSERT(client_handle_lsp_revoke_and_ack(&ch2, ctx, &mb) == 0, "garbage LSP revocation rejected");
+    cJSON_Delete(bad);
+    TEST_ASSERT(channel_get_received_revocation(&ch2, 0, got) == 0, "garbage not stored");
+
+    free(ch.received_revocations);  free(ch.received_revocation_valid);
+    free(ch2.received_revocations); free(ch2.received_revocation_valid);
     secp256k1_context_destroy(ctx);
     return 1;
 }

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -4,6 +4,7 @@
 #include "superscalar/channel.h"
 #include "superscalar/factory.h"
 #include "superscalar/report.h"
+#include "superscalar/crash_inject.h"   /* #9 superscalar_set_cheat_gate() */
 #include "superscalar/persist.h"
 #include "superscalar/keyfile.h"
 #include "superscalar/adaptor.h"
@@ -2393,6 +2394,20 @@ int main(int argc, char *argv[]) {
     }
     if (use_json_log)
         ss_log_set_json(1);
+
+    /* #9 cheat-gate: defense-bypass cheats inert unless regtest; refuse all
+       test/cheat scaffolding flags on mainnet (footgun guard). */
+    superscalar_set_cheat_gate(strcmp(network, "regtest") == 0);
+    if (strcmp(network, "mainnet") == 0) {
+        for (int ci = 1; ci < argc; ci++) {
+            if (strncmp(argv[ci], "--cheat-", 8) == 0 ||
+                strncmp(argv[ci], "--test-", 7) == 0) {
+                fprintf(stderr, "Error: %s is test/cheat scaffolding and is "
+                        "refused on mainnet.\n", argv[ci]);
+                return 1;
+            }
+        }
+    }
 
     /* --- Validate fee rate floor --- */
     if ((uint64_t)fee_rate < FEE_FLOOR_SAT_PER_KVB) {

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -713,16 +713,22 @@ static void client_recv_lsp_revocation(int fd, channel_t *ch, daemon_cb_data_t *
         cJSON_Delete(rev_msg.json);
         return;
     }
-    uint32_t rev_chan_id;
-    unsigned char lsp_rev_secret[32], lsp_next_point[33];
-    if (wire_parse_revoke_and_ack(rev_msg.json, &rev_chan_id,
-                                    lsp_rev_secret, lsp_next_point)) {
+    /* Revocation-verification standard (client side): verify + retain the LSP's
+       revocation via the shared, tested handler (fail-closed). It checks
+       secret*G == the LSP's committed point, stores the secret, and tracks the
+       LSP's next per-commitment point. If verification fails we must NOT arm the
+       watchtower from a bad secret (it would build a penalty that can't spend). */
+    if (!client_handle_lsp_revoke_and_ack(ch, ctx, &rev_msg)) {
+        fprintf(stderr, "Client %u: LSP revocation FAILED verification "
+                "— refusing (penalty NOT armed)\n", my_index);
+        cJSON_Delete(rev_msg.json);
+        return;
+    }
+    if (ch->commitment_number > 0) {
         uint64_t old_cn = ch->commitment_number - 1;
-        channel_receive_revocation(ch, old_cn, lsp_rev_secret);
 
-        /* Register with client watchtower using the OLD commitment's amounts.
-           Use local channel index 0 (not the LSP's factory-wide rev_chan_id)
-           because the client watchtower has only one channel at index 0. */
+        /* Arm the client watchtower with the now-verified revoked commitment.
+           Local channel index 0 (the client watchtower has one channel). */
         if (cbd && cbd->wt) {
             watchtower_watch_revoked_commitment(cbd->wt, ch,
                 0, old_cn,
@@ -731,45 +737,31 @@ static void client_recv_lsp_revocation(int fd, channel_t *ch, daemon_cb_data_t *
                 /* SF-W-PTLC: no PTLC snapshot at this callsite */ NULL, 0);
         }
 
-        /* Store LSP's next per-commitment point */
-        secp256k1_pubkey next_pcp;
-        if (secp256k1_ec_pubkey_parse(ctx, &next_pcp, lsp_next_point, 33)) {
-            channel_set_remote_pcp(ch, ch->commitment_number + 1, &next_pcp);
-            /* Persist both current and next remote PCPs for crash recovery */
-            if (cbd && cbd->db) {
-                unsigned char ser[33];
-                size_t slen = 33;
-                secp256k1_ec_pubkey_serialize(ctx, ser, &slen, &next_pcp,
-                                               SECP256K1_EC_COMPRESSED);
-                persist_save_remote_pcp(cbd->db, 0,
-                    ch->commitment_number + 1, ser);
-                /* Also persist the current PCP (may have just been set) */
-                secp256k1_pubkey cur_pcp;
-                if (channel_get_remote_pcp(ch, ch->commitment_number, &cur_pcp)) {
-                    slen = 33;
-                    secp256k1_ec_pubkey_serialize(ctx, ser, &slen, &cur_pcp,
-                                                   SECP256K1_EC_COMPRESSED);
-                    persist_save_remote_pcp(cbd->db, 0,
-                        ch->commitment_number, ser);
-                }
-            }
-        }
-
-        /* Persist our own local PCS so they survive crash/reconnect.
-           Without this, reconnect generates new random PCS that don't
-           match the PCPs the LSP has stored, breaking sig verification. */
+        /* Persist remote PCPs (handler set the next one in-memory) + local PCS
+           for crash recovery. */
         if (cbd && cbd->db) {
+            unsigned char ser[33];
+            size_t slen;
+            secp256k1_pubkey pcp;
+            if (channel_get_remote_pcp(ch, ch->commitment_number + 1, &pcp)) {
+                slen = 33;
+                secp256k1_ec_pubkey_serialize(ctx, ser, &slen, &pcp,
+                                               SECP256K1_EC_COMPRESSED);
+                persist_save_remote_pcp(cbd->db, 0, ch->commitment_number + 1, ser);
+            }
+            if (channel_get_remote_pcp(ch, ch->commitment_number, &pcp)) {
+                slen = 33;
+                secp256k1_ec_pubkey_serialize(ctx, ser, &slen, &pcp,
+                                               SECP256K1_EC_COMPRESSED);
+                persist_save_remote_pcp(cbd->db, 0, ch->commitment_number, ser);
+            }
             unsigned char pcs[32];
             if (channel_get_local_pcs(ch, ch->commitment_number, pcs))
-                persist_save_local_pcs(cbd->db, 0,
-                    ch->commitment_number, pcs);
+                persist_save_local_pcs(cbd->db, 0, ch->commitment_number, pcs);
             if (channel_get_local_pcs(ch, ch->commitment_number + 1, pcs))
-                persist_save_local_pcs(cbd->db, 0,
-                    ch->commitment_number + 1, pcs);
+                persist_save_local_pcs(cbd->db, 0, ch->commitment_number + 1, pcs);
             memset(pcs, 0, 32);
         }
-
-        memset(lsp_rev_secret, 0, 32);
     }
     cJSON_Delete(rev_msg.json);
 }

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -14,6 +14,7 @@
 #include "superscalar/tor.h"
 #include "superscalar/tapscript.h"
 #include "superscalar/log.h"
+#include "superscalar/crash_inject.h"   /* #9 superscalar_set_cheat_gate() */
 #ifdef __linux__
 #include <syslog.h>
 #endif
@@ -2113,6 +2114,9 @@ int main(int argc, char *argv[]) {
     if (!network)
         network = "regtest";  /* default to regtest */
     int is_regtest = (strcmp(network, "regtest") == 0);
+    /* #9 cheat-gate: defense-bypass cheats (e.g. SS_CHEAT_DUST_RACE) are inert
+       unless this is regtest, even if the env var is set directly. */
+    superscalar_set_cheat_gate(is_regtest);
 
     /* Redirect logs if requested */
     if (log_file_path) {
@@ -2315,6 +2319,20 @@ int main(int argc, char *argv[]) {
             "SuperScalar is a PROTOTYPE. Running on mainnet risks loss of funds.\n"
             "If you understand this risk, pass --i-accept-the-risk\n");
         return 1;
+    }
+
+    /* #9: refuse ALL test/cheat scaffolding flags on mainnet (footgun guard on
+       top of --i-accept-the-risk). Detection cheats are self-harming and
+       defense-bypass cheats are theft; neither belongs on a mainnet node. */
+    if (strcmp(network, "mainnet") == 0) {
+        for (int ci = 1; ci < argc; ci++) {
+            if (strncmp(argv[ci], "--cheat-", 8) == 0 ||
+                strncmp(argv[ci], "--test-", 7) == 0) {
+                fprintf(stderr, "Error: %s is test/cheat scaffolding and is "
+                        "refused on mainnet.\n", argv[ci]);
+                return 1;
+            }
+        }
     }
 
     /* Mainnet requires --db for revocation secret persistence */


### PR DESCRIPTION
## Revocation verification standard — durable, fail-closed, symmetric

Makes **"verify everything"** the enforced standard for counterparty revocation
secrets. Fund-safety / BOLT-2 conformance. Design: `doc/revocation-verification-standard.md`.

### The problem (present since the repo's first commit)
Counterparty revocation secrets (`revoke_and_ack`) were accepted with inconsistent
verification: the LSP handlers verified but **failed open** when the committed
per-commitment point (PCP) wasn't in a lossy 2-slot in-memory window; the shared
`htlc_commit` BOLT-2 handler and the client path **didn't verify at all**. A wrong
secret that gets stored arms the watchtower penalty with a bad key — nothing
re-verifies at breach time — so a later breach of that commitment becomes
**unpunishable → fund loss**. Broken in both directions; the client side is the
worse half because the user is exposed to the LSP.

Per **BOLT-2**, the receiver MUST check `secret·G == committed_PCP`; there is no
"accept on trust."

### The fix
- **Durable committed-PCP (Phase 1).** Persist the remote PCP at commitment
  creation, keyed by commitment_num; `channel_get_remote_pcp` falls back to the DB
  when the 2-slot cache misses — so a legitimate revocation is always checkable.
- **One shared verifier.** `channel_verify_revocation_secret` in `channel.c`, used
  by LSP and client alike.
- **Choke-point enforcement + fail-closed (Phase 2).** `channel_receive_revocation_flat`
  (the single point every path funnels through — LSP handlers, `htlc_commit`,
  client, bridge) verifies before storing and rejects on mismatch. The verifier
  fails closed when no committed point is retrievable. `htlc_commit` honors the
  result and fails the update (BOLT-2).
- **Symmetric** by construction (shared `channel.c` / `htlc_commit.c`).

### Tested (unit, green)
- New: durable-PCP-after-eviction round-trip; fail-closed rejects unverifiable +
  mismatched secrets and never stores them.
- Suites: revocation 8/8, channel 81/81, htlc 88/88, penalty 13/13, cpfp 6/6,
  persist 77/77, breach/chan_close/ceremony all pass.
- Fail-closed surfaced 5 *test shortcuts* (injecting a secret without the committed
  point); fixed to be protocol-faithful. **No production code regressed.**

### Remaining (tracked)
- [ ] Phase 3: regtest integration drills — cheating-client and cheating-LSP
  garbage revocation rejected end-to-end; penalty/breach matrix green.
- [ ] Bounded full unit-suite run (the suite has an unrelated environmental hang
  in a daemon/p2p test on port 18765; needs `ctest --timeout`).
- [ ] Optional follow-up: BOLT-3 shachain receiver storage (compact, uncapped).

Independent of #380; targets `main` directly as a fund-safety fix.
