### PR TITLE
Item-1 escalation policy + adversarial live-drill (revocation-forgery response)

### DIFF
--- a/doc/adversarial-verification-matrix.md
+++ b/doc/adversarial-verification-matrix.md
@@ -53,13 +53,18 @@ fail-open.
   (the harness clients run the daemon loop even under `--send`/`--recv`). The
   legacy bare-`--channels` consume (`scripted_consume_lsp_revoke`) was also
   hardened to verify (defense-in-depth; it previously stored blindly).
-- **Phase 4 follow-up — detect → ESCALATE** ⏳ (open hardening): the client
-  correctly DETECTS + REFUSES a cheating LSP's forged revocation, but currently
-  CONTINUES the session (payments still settle). A client that cannot obtain a
-  valid LSP revocation holds an un-penalizable old LSP state; the fund-safe
-  response is to halt + cooperatively/force-close on the last fully-verified
-  state rather than keep building states it cannot protect. Detection is wired;
-  response is the next layer. Tracked.
+- **Phase 4 follow-up — detect → ESCALATE** ✅: the client now has a selectable
+  response to a detected forgery (`--on-lsp-forgery continue|halt|close`,
+  default `halt`; see `doc/revocation-verification-standard.md` §9). Proven live
+  across all modes on the N=4 daemon harness (`ON_LSP_FORGERY` selects the mode):
+    - `continue` — 24/24 forged `0x50` refused, session continues, payments settle.
+    - `halt` (default) — refuse + **halt the daemon loop, 4/4 clients**, no reconnect.
+    - `close` — refuse + **force-close on the last verified state, 4/4 clients**
+      (`factory_recovery_run` "broadcast 3 TXs (run=1)").
+    - happy-path control (honest LSP, default `halt`) — **0** false halts, settles.
+  Parser unit-tested (`test_lsp_forgery_response_parse`). PS leaves are CLTV-gated
+  (less severe); the policy is applied uniformly today (per-leaf-type is a future
+  refinement, not a gap).
 - **Phase 5 — PTLC adaptor pre-sig + HTLC provenance** ⏳: PTLC (off-by-default)
   already verifies the turnover binding (#196); a cryptographic adaptor-pre-sig
   verify needs an adaptor-verify primitive. Client receiver-side HTLC invoice

--- a/doc/adversarial-verification-matrix.md
+++ b/doc/adversarial-verification-matrix.md
@@ -24,7 +24,7 @@ fail-open.
 | Cheat gate | `SS_CHEAT_*` set, network≠regtest | inert | `test_persist.c` (`test_cheat_gate`) ✅ |
 | **WT false-positive** | revoked commitment NOT on-chain | no penalty (non-vacuous: WT did query chain) | `test_client_watchtower.c` (`test_adversarial_wt_no_false_penalty`) ✅ |
 | **Reconnect stale-claim** | LSP `RECONNECT_ACK` claims a different commitment number | keep own DB state + loud SECURITY alert | code `client_reconnect.c` + reconnect suite green; dedicated drill ⏳ |
-| Item-1 live (routed payment) | cheating LSP sends bad `0x50` mid-payment | client refuses, no WT-arm | adversarial **unit-proven** (`test_client_verifies_lsp_revocation`); live regtest drill ⏳ (needs PR #380 routed-payment harness) |
+| Item-1 live (routed payment) | cheating LSP forges every `0x50` mid-payment (`SS_CHEAT_LSP_BAD_REVOCATION`) | client refuses all, no WT-arm | **live regtest drill ✅** — N=4 daemon payment harness: LSP forged 24 revocations → clients refused **24/24** fail-closed (two ways: point-mismatch, then "no retrievable committed point" once the PCP chain breaks); happy-path control = **0** false-rejects + full settlement |
 
 ## Phases
 - **Phase 1 — unit forgery suite** (`tests/test_adversarial_verify.c`): keyagg
@@ -36,10 +36,30 @@ fail-open.
   `RECONNECT_ACK` commitment claim; keeps its own persisted state (fund-safe) and
   raises a SECURITY alert (AHEAD = forged/stale injection, BEHIND = replay). ✅
   (reconnect 13/13).
-- **Phase 4 — item-1 routed-payment drill** ⏳: the adversarial assertion (client
-  rejects a forged `0x50`) is already unit-proven; the live happy-path empirical
-  gate needs the daemon `--send`/`--recv` routed-payment harness that currently
-  lives on PR #380, not on `main`. Tracked.
+- **Phase 4 — item-1 routed-payment drill** ✅: overcome by building an
+  integration tree that stacks the #380 routed-payment harness + #381 revocation
+  verification + #382 adversarial work (`integration/security-e2e`), then running
+  the daemon `--send`/`--recv` payment harness (`test_regtest_n64_payments.sh`) on
+  regtest at N=4 with two configs:
+    - **happy-path control** (no cheat): payments settle end-to-end, cooperative
+      close confirmed on-chain, sats conserved to the sat, LSP wt.db armed (24
+      kind=2 watches), standalone secret-less WT hydrated all 24, and **0**
+      client revocation rejections — legit `0x50`s VERIFY and are accepted.
+    - **adversarial** (`SS_CHEAT_LSP_BAD_REVOCATION=1`, regtest-gated): the LSP
+      forged all 24 revocations (`LSP-CHEAT-BADREV` ×24); every client refused
+      every one (`INVALID LSP revocation secret` / `refusing (penalty NOT armed)`
+      ×24) fail-closed and armed no watchtower from a forgery.
+  Production path = `client_recv_lsp_revocation` → `client_handle_lsp_revoke_and_ack`
+  (the harness clients run the daemon loop even under `--send`/`--recv`). The
+  legacy bare-`--channels` consume (`scripted_consume_lsp_revoke`) was also
+  hardened to verify (defense-in-depth; it previously stored blindly).
+- **Phase 4 follow-up — detect → ESCALATE** ⏳ (open hardening): the client
+  correctly DETECTS + REFUSES a cheating LSP's forged revocation, but currently
+  CONTINUES the session (payments still settle). A client that cannot obtain a
+  valid LSP revocation holds an un-penalizable old LSP state; the fund-safe
+  response is to halt + cooperatively/force-close on the last fully-verified
+  state rather than keep building states it cannot protect. Detection is wired;
+  response is the next layer. Tracked.
 - **Phase 5 — PTLC adaptor pre-sig + HTLC provenance** ⏳: PTLC (off-by-default)
   already verifies the turnover binding (#196); a cryptographic adaptor-pre-sig
   verify needs an adaptor-verify primitive. Client receiver-side HTLC invoice

--- a/doc/revocation-verification-standard.md
+++ b/doc/revocation-verification-standard.md
@@ -119,7 +119,7 @@ Status of each, as of this branch:
 | Step | LSP | Client (user) | Watchtower |
 |---|---|---|---|
 | Counterparty commitment signature | ✅ | ✅ `channel_verify_and_aggregate_commitment_sig` | n/a (pre-signed) |
-| **Counterparty revocation secret** | ✅ Phase 2, fail-closed | ❌ **drops `0x50`**, no LSP-PCP tracking past cn 0/1 | ✅ transitive — only ever reads secrets verified at store time; hydrate uses pre-signed penalty TXs, never raw secrets |
+| **Counterparty revocation secret** | ✅ Phase 2, fail-closed | ✅ `client_handle_lsp_revoke_and_ack` — verifies `0x50` fail-closed + tracks the LSP's next PCP; on a detected forgery applies the **escalation policy** (§9) | ✅ transitive — only ever reads secrets verified at store time; hydrate uses pre-signed penalty TXs, never raw secrets |
 | Funding on-chain | gated | warn + hard-gated on prod (#197) | (uses pre-signed) |
 | Ceremony / MuSig | ✅ | ✅ (participates) | n/a |
 
@@ -131,11 +131,15 @@ tested green).
 (`wt_hydrate_row_cb`) loads pre-signed penalty TXs, so it never trusts a raw, unverified
 secret. (A belt-and-suspenders verify-on-ingest is a possible hardening, not a gap.)
 
-**Client — the remaining gap.** It holds the verification capability and verifies the LSP's
-commitment *signatures*, but it **discards the LSP's `revoke_and_ack` (`0x50`)** and tracks
-the LSP's per-commitment point only for commitments 0 and 1. So today the client cannot
-itself detect an LSP breach — that protection lives entirely in the standalone watchtower +
-self-exit.
+**Client — closed.** `client_handle_lsp_revoke_and_ack` now verifies the LSP's `0x50`
+fail-closed (`secret*G == committed PCP`), stores the secret only on success, and tracks the
+LSP's *next* per-commitment point so the chain stays verifiable past cn 0/1. Wired into the
+production daemon loop (`client_recv_lsp_revocation`) and the legacy bare-`--channels`
+consume. Proven live: an honest LSP's revocations are accepted (0 false-rejects across a
+routed-payment drill); a cheating LSP that forges every `0x50` is refused 24/24 fail-closed
+with no watchtower armed from a forgery (see `doc/adversarial-verification-matrix.md`). The
+client can now itself detect an LSP breach attempt at the revocation step — and respond to
+it per the policy in §9.
 
 ### Client implementation plan (focused next piece)
 1. Add `client_handle_lsp_revoke_and_ack(ch, ctx, msg)` mirroring the LSP handler:
@@ -153,3 +157,50 @@ self-exit.
    one across many commitments; existing client/reconnect suites stay green.
 4. Design note: the client retaining LSP revocations enables self-detection; whether it
    self-penalizes or hands secrets to its watchtower is a separate (existing) concern.
+
+## 9. Detection → Response: the escalation policy (`--on-lsp-forgery`)
+
+Verification (§5–§8) tells the client *that* the LSP forged a revocation. It does **not**
+by itself decide what to do next. Detection is necessary but not sufficient: a client that
+cannot obtain a *valid* LSP revocation is holding an **un-penalizable old LSP state** — if
+the LSP later broadcasts that revoked state, the client cannot build a valid penalty and is
+exposed (the receiver of a payment is most exposed, having gained balance). So continuing to
+build new states the client cannot protect is the riskiest choice.
+
+The client exposes a selectable response, applied at the detection point
+(`client_recv_lsp_revocation` → on a fail-closed verify), via `--on-lsp-forgery MODE`:
+
+| Mode | Behaviour on a detected forged `0x50` | When to use |
+|---|---|---|
+| `continue` | Refuse the bad secret, arm no watchtower from it, **keep the session** (legacy). | Testing / maximum tolerance; leaves the exposure open. |
+| `halt` (**default**) | Refuse + **stop accepting further commitments** + CRITICAL alert + do not reconnect to the proven-cheating LSP. No on-chain action. | Default: stops the exposure without surprise on-chain spends; operator decides whether to close. |
+| `close` | `halt` + **force-close on the last fully-verified state** (reuses the #313 self-custody `factory_recovery_run` from the persisted DB + broadcasts the last signed commitment). | Maximum fund-safety; accepts the on-chain cost. |
+
+In **every** mode the forged secret is refused and no watchtower is armed from it — the modes
+differ only in what happens *after* detection. The default is `halt`, **not** the legacy
+`continue`: it only ever triggers on a genuinely detected forgery (an honest LSP's
+revocations verify — proven by 0 false-rejects on the happy-path drill), so honest operation
+is unaffected while the exposure is closed by default.
+
+**Wiring.** `lsp_forgery_response_t` enum + `client_parse_forgery_response` (`src/client.c`,
+unit-tested by `test_lsp_forgery_response_parse`); `daemon_cb_data_t` carries the policy +
+`lsp_forgery_detected` + `force_close_requested`; the daemon loop breaks on detection (both
+the `--daemon` and scripted `--send`/`--recv` paths); `client_force_close_from_db` performs
+the `close`-mode recovery after the loop.
+
+**PS-leaf-type nuance.** Pseudo-Spilman (PS) leaves are **CLTV-gated**, not revocation-gated,
+so a forged LSP revocation is *less* severe on a PS leaf (funds are protected by the timeout,
+not by the ability to penalize) than on a revocation-gated leaf. The policy is applied
+**uniformly** today; a per-leaf-type response (e.g. tolerate on PS, force-close on
+revocation-gated) is a possible future refinement, not a current gap.
+
+**Live evidence (regtest, N=4 daemon payment harness; `ON_LSP_FORGERY` selects the mode):**
+
+| Drill | Config | Observed |
+|---|---|---|
+| happy-path control | no cheat, default (`halt`) | **PASS** — payments settle e2e, cooperative close confirmed on-chain, sats conserved; **0** forgery refusals, **0** halts (an honest LSP never trips the policy — the default is safe) |
+| `continue` | cheat + `continue` | **24/24** forged `0x50` refused fail-closed; session continues; payments still settle (legacy behaviour, exposure left open) |
+| `halt` (default) | cheat + `halt` | clients refuse the forgery, log `CRITICAL`, and **halt the daemon loop (4/4 clients)** without reconnecting — no further commitments accepted, no on-chain action |
+| `close` | cheat + `close` | clients refuse + **force-close on the last verified state (4/4 clients)** via the #313 self-custody `factory_recovery_run` — `CLOSE policy force-close: factory 0 (state=active): broadcast 3 TXs (run=1)` |
+
+The refusal counts differ by design: `continue` processes all 24 forged revocations (it never stops), while `halt`/`close` stop at the first detection (≈1 per client) — both refuse every forgery they see, fail-closed, before acting.

--- a/doc/revocation-verification-standard.md
+++ b/doc/revocation-verification-standard.md
@@ -204,3 +204,27 @@ revocation-gated) is a possible future refinement, not a current gap.
 | `close` | cheat + `close` | clients refuse + **force-close on the last verified state (4/4 clients)** via the #313 self-custody `factory_recovery_run` — `CLOSE policy force-close: factory 0 (state=active): broadcast 3 TXs (run=1)` |
 
 The refusal counts differ by design: `continue` processes all 24 forged revocations (it never stops), while `halt`/`close` stop at the first detection (≈1 per client) — both refuse every forgery they see, fail-closed, before acting.
+
+### 9.1 Refinements
+
+- **Config-file** — `on-lsp-forgery` (and `on-lsp-forgery-ps`) are honoured in the
+  JSON `--config` file; CLI overrides config.
+- **Poisoned-LSP marker** — on a `halt`/`close` detection the client writes a
+  sentinel (`<db>.lsp_poisoned`) and, on a later start, **refuses to reconnect** to
+  the proven-cheating LSP. `--force-close` still works (it is handled before the
+  connect path); deleting the marker re-enables connecting. (File sentinel — no
+  schema change.)
+- **Per-leaf-type response (`--on-lsp-forgery-ps`)** — PS leaves are CLTV-gated, so a
+  forged revocation *may* be less severe than on a revocation-gated leaf. The client
+  **detects + reports** the leaf type in the alert and lets an operator set a
+  *separate* PS-leaf policy. **It defaults to "inherit" (uniform) and never
+  auto-downgrades** — PS leaf *chaining* does not by itself prove the channel-level
+  revocation is non-load-bearing. **Open security-model question:** confirm whether a
+  PS leaf's channel commitments still depend on revocation before recommending a more
+  lenient PS policy; until then the safe default is to respond uniformly (over-respond
+  rather than under-respond).
+- **Surgical close** — already per-client: `close` runs `factory_recovery_run` for the
+  client's *own* factory + broadcasts only the client's *own* signed commitment. The
+  shared tree nodes (root/intermediates) are architecturally required to reach any
+  leaf; a client never publishes another client's leaf commitment. So the close is as
+  surgical as the factory construction allows.

--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -146,6 +146,25 @@ int client_handle_commitment_signed(int fd, channel_t *ch,
 int client_handle_lsp_revoke_and_ack(channel_t *ch, secp256k1_context *ctx,
                                        const wire_msg_t *msg);
 
+/* Item-1 escalation policy: how the client responds once it DETECTS a forged LSP
+   revocation (i.e. client_handle_lsp_revoke_and_ack returned 0 — fail-closed). In
+   every mode the bad secret is refused and NO watchtower is armed from it; the
+   modes differ only in what the client does NEXT. A client that cannot obtain a
+   valid LSP revocation holds an un-penalizable old LSP state, so continuing to
+   build new states is the riskiest choice. Selectable via --on-lsp-forgery.
+   NOTE: PS (Pseudo-Spilman) leaves are CLTV-gated rather than revocation-gated,
+   so a forged LSP revocation is less severe on a PS leaf than on a revocation-
+   gated leaf; the policy is applied uniformly today (see doc). */
+typedef enum {
+    LSP_FORGERY_CONTINUE = 0,  /* refuse + no WT-arm, keep the session (legacy)   */
+    LSP_FORGERY_HALT     = 1,  /* + stop accepting new commitments, CRITICAL alert*/
+    LSP_FORGERY_CLOSE    = 2,  /* + force-close on the last fully-verified state   */
+} lsp_forgery_response_t;
+
+/* Parse an --on-lsp-forgery argument ("continue"|"halt"|"close") into the enum;
+   returns -1 on an unrecognised value. */
+int client_parse_forgery_response(const char *s);
+
 /* Handle incoming ADD_HTLC from LSP (we are the payee).
    Returns 1 on success. */
 int client_handle_add_htlc(channel_t *ch, const wire_msg_t *msg);

--- a/src/client.c
+++ b/src/client.c
@@ -444,6 +444,14 @@ int client_handle_lsp_revoke_and_ack(channel_t *ch, secp256k1_context *ctx,
     return 1;
 }
 
+int client_parse_forgery_response(const char *s) {
+    if (!s) return -1;
+    if (strcmp(s, "continue") == 0) return LSP_FORGERY_CONTINUE;
+    if (strcmp(s, "halt")     == 0) return LSP_FORGERY_HALT;
+    if (strcmp(s, "close")    == 0) return LSP_FORGERY_CLOSE;
+    return -1;
+}
+
 int client_handle_add_htlc(channel_t *ch, const wire_msg_t *msg) {
     uint64_t htlc_id, amount_msat;
     unsigned char payment_hash[32];

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -72,6 +72,22 @@ void lsp_send_revocation(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (!channel_get_revocation_secret(ch, old_cn, lsp_rev_secret))
         return;
 
+    /* ADV Phase 4 (adversarial item-1): a CHEATING LSP that hands the client a
+       valid-LOOKING but WRONG revocation secret, to prove the client's
+       fail-closed verifier rejects a forged 0x50 in a LIVE routed payment and
+       refuses to arm its watchtower from it. Defense-bypass class -> regtest-
+       gated: a directly-set env var is inert on signet/testnet/mainnet (gate
+       default 0). Marker: LSP-CHEAT-BADREV. */
+    {
+        const char *badrev = getenv("SS_CHEAT_LSP_BAD_REVOCATION");
+        if (badrev && badrev[0] && badrev[0] != '0' && superscalar_cheat_allowed()) {
+            fprintf(stderr, "LSP-CHEAT-BADREV: corrupting revocation secret for "
+                    "client %zu (commitment %llu) — client MUST reject + refuse "
+                    "WT-arm\n", client_idx, (unsigned long long)old_cn);
+            lsp_rev_secret[0] ^= 0xff;   /* secret*G now != the committed PCP */
+        }
+    }
+
     /* Get LSP's next per-commitment point */
     secp256k1_pubkey next_pcp;
     if (!channel_get_per_commitment_point(ch, ch->commitment_number + 1, &next_pcp)) {

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -261,7 +261,7 @@ int test_persist_schema_v3(void)
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 36, "schema version is 36 (v36 adds htlcs.signed_resolution_tx_hex + old_commitments.signed_burn_tx_hex + #219 agg hard guard)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 37, "schema version is 37 (v37 adds the #327 at-rest field-encryption marker; v36 added htlcs.signed_resolution_tx_hex + old_commitments.signed_burn_tx_hex + #219 agg hard guard)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_dust_recovery.c
+++ b/tests/test_dust_recovery.c
@@ -37,6 +37,7 @@
 
 #include "superscalar/htlc_commit.h"
 #include "superscalar/channel.h"
+#include "superscalar/crash_inject.h"   /* #9 cheat-gate: cheats are inert unless armed */
 
 #include <string.h>
 #include <stdio.h>
@@ -148,6 +149,10 @@ int test_dust_race_defense_rejects_ptlc(void) {
 /* DR3 — SS_CHEAT_DUST_RACE=1 ACCEPTS the otherwise-rejected feerate   */
 /* ------------------------------------------------------------------ */
 int test_dust_race_cheat_bypass(void) {
+    /* #9: defense-bypass cheats require BOTH the env flag AND the regtest
+       cheat-gate. This test exercises the cheat's bypass behavior, so it must
+       arm the gate (as the regtest binary does); it is reset before return. */
+    superscalar_set_cheat_gate(1);
     setenv("SS_CHEAT_DUST_RACE", "1", 1);
 
     channel_t ch;
@@ -173,6 +178,7 @@ int test_dust_race_cheat_bypass(void) {
            "DR3: fee_rate updated to attacker-chosen ceiling");
 
     unsetenv("SS_CHEAT_DUST_RACE");
+    superscalar_set_cheat_gate(0);
     return 1;
 }
 
@@ -255,6 +261,10 @@ int test_dust_race_boundary_accept(void) {
 /* DR6 — cheat does NOT bypass floor/ceiling checks                    */
 /* ------------------------------------------------------------------ */
 int test_dust_race_cheat_does_not_bypass_floor(void) {
+    /* #9: arm the cheat-gate so the cheat is genuinely active — proving the
+       floor/ceiling bounds hold EVEN against an armed cheat (not trivially
+       because the cheat was inert). */
+    superscalar_set_cheat_gate(1);
     setenv("SS_CHEAT_DUST_RACE", "1", 1);
 
     channel_t ch;
@@ -290,6 +300,7 @@ int test_dust_race_cheat_does_not_bypass_floor(void) {
     ASSERT(ch.fee_rate_sat_per_kvb == 1000, "DR6: fee_rate unchanged");
 
     unsetenv("SS_CHEAT_DUST_RACE");
+    superscalar_set_cheat_gate(0);
     return 1;
 }
 
@@ -297,6 +308,8 @@ int test_dust_race_cheat_does_not_bypass_floor(void) {
 /* DR7 — cheat applies per-HTLC and still updates ch->fee_rate          */
 /* ------------------------------------------------------------------ */
 int test_dust_race_cheat_per_htlc(void) {
+    /* #9: arm the regtest cheat-gate so the bypass behavior is reachable. */
+    superscalar_set_cheat_gate(1);
     setenv("SS_CHEAT_DUST_RACE", "1", 1);
 
     channel_t ch;
@@ -327,5 +340,6 @@ int test_dust_race_cheat_per_htlc(void) {
            "DR7: fee_rate updated to attacker-chosen ceiling");
 
     unsetenv("SS_CHEAT_DUST_RACE");
+    superscalar_set_cheat_gate(0);
     return 1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1232,6 +1232,7 @@ extern int test_channel_revocation_durable_pcp_verify(void);  /* revocation-veri
 extern int test_channel_revocation_failclosed(void);          /* revocation-verify Phase 2 */
 extern int test_client_verifies_lsp_revocation(void);         /* revocation-verify client side */
 extern int test_cheat_gate(void);                             /* #9 cheat-gate */
+extern int test_lsp_forgery_response_parse(void);             /* item-1 escalation policy parse */
 extern int test_adversarial_keyagg_substitution(void);        /* ADV matrix */
 extern int test_adversarial_final_sig_tamper(void);
 extern int test_adversarial_wrong_message_binding(void);
@@ -3127,6 +3128,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_channel_revocation_failclosed);
     RUN_TEST(test_client_verifies_lsp_revocation);
     RUN_TEST(test_cheat_gate);
+    RUN_TEST(test_lsp_forgery_response_parse);
     RUN_TEST(test_adversarial_keyagg_substitution);
     RUN_TEST(test_adversarial_final_sig_tamper);
     RUN_TEST(test_adversarial_wrong_message_binding);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -5358,4 +5358,20 @@ int test_cheat_gate(void) {
     return 1;
 }
 
+/* Item-1 escalation policy: the --on-lsp-forgery parser maps exactly to the
+   documented enum and REJECTS unknown/typo values (so a misconfiguration can't
+   silently fall back to the least-safe response). */
+int test_lsp_forgery_response_parse(void) {
+    TEST_ASSERT(client_parse_forgery_response("continue") == LSP_FORGERY_CONTINUE, "continue");
+    TEST_ASSERT(client_parse_forgery_response("halt")     == LSP_FORGERY_HALT,     "halt");
+    TEST_ASSERT(client_parse_forgery_response("close")    == LSP_FORGERY_CLOSE,    "close");
+    TEST_ASSERT(client_parse_forgery_response("Continue") == -1, "case-sensitive reject");
+    TEST_ASSERT(client_parse_forgery_response("")         == -1, "empty reject");
+    TEST_ASSERT(client_parse_forgery_response("force")    == -1, "unknown reject");
+    TEST_ASSERT(client_parse_forgery_response(NULL)       == -1, "NULL reject");
+    /* The client's compiled-in default is HALT, NOT the legacy CONTINUE. */
+    TEST_ASSERT(LSP_FORGERY_HALT != LSP_FORGERY_CONTINUE, "default (halt) is not legacy (continue)");
+    return 1;
+}
+
 /* === End revocation verification standard tests =========================== */

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -299,16 +299,26 @@ typedef struct {
    commitment at close, and the LSP's handle_fulfill_htlc times out waiting for the
    REVOKE and returns 0 → "event loop failed").  Deterministic: the LSP sends
    exactly one revoke per commitment, so a single blocking recv is correct. */
-static void scripted_consume_lsp_revoke(int fd, channel_t *ch) {
+static int scripted_consume_lsp_revoke(int fd, channel_t *ch, secp256k1_context *ctx) {
     wire_msg_t m;
-    if (!wire_recv(fd, &m)) return;
+    if (!wire_recv(fd, &m)) return 1;   /* nothing arrived to apply */
+    int ok = 1;
     if (m.msg_type == MSG_LSP_REVOKE_AND_ACK && m.json) {
-        uint32_t cid; unsigned char rsec[32] = {0}, rpt[33];
-        if (wire_parse_revoke_and_ack(m.json, &cid, rsec, rpt))
-            channel_receive_revocation(ch, ch->commitment_number - 1, rsec);
-        secure_zero(rsec, 32);
+        /* Revocation-verification standard: the scripted --send/--recv flows must
+           VERIFY the LSP's revocation exactly like the daemon path
+           (client_recv_lsp_revocation) — not blindly store it. Route through the
+           shared, tested, fail-closed handler: it checks secret*G == the LSP's
+           committed point, stores ONLY on success, and tracks the next PCP (which
+           this path previously discarded, so subsequent revokes were unverifiable). */
+        if (!client_handle_lsp_revoke_and_ack(ch, ctx, &m)) {
+            fprintf(stderr, "Client: SECURITY: LSP revocation FAILED verification "
+                    "(commitment %llu) — refusing, NOT stored (no WT-arm)\n",
+                    (unsigned long long)(ch->commitment_number ? ch->commitment_number - 1 : 0));
+            ok = 0;
+        }
     }
     if (m.json) cJSON_Delete(m.json);
+    return ok;
 }
 
 /* Channel callback replicating multi_payment_client_cb from test harness */
@@ -347,7 +357,7 @@ static int standalone_channel_cb(int fd, channel_t *ch, uint32_t my_index,
             if (msg.msg_type == MSG_COMMITMENT_SIGNED) {
                 client_handle_commitment_signed(fd, ch, ctx, &msg);
                 cJSON_Delete(msg.json);
-                scripted_consume_lsp_revoke(fd, ch);  /* LSP bidirectional revoke */
+                scripted_consume_lsp_revoke(fd, ch, ctx);  /* LSP bidirectional revoke (verified) */
             } else {
                 fprintf(stderr, "Client %u: expected COMMIT_SIGNED, got 0x%02x\n",
                         my_index, msg.msg_type);
@@ -385,7 +395,7 @@ static int standalone_channel_cb(int fd, channel_t *ch, uint32_t my_index,
             if (msg.msg_type == MSG_COMMITMENT_SIGNED) {
                 client_handle_commitment_signed(fd, ch, ctx, &msg);
                 cJSON_Delete(msg.json);
-                scripted_consume_lsp_revoke(fd, ch);  /* LSP bidirectional revoke */
+                scripted_consume_lsp_revoke(fd, ch, ctx);  /* LSP bidirectional revoke (verified) */
             } else {
                 cJSON_Delete(msg.json);
             }
@@ -420,7 +430,7 @@ static int standalone_channel_cb(int fd, channel_t *ch, uint32_t my_index,
             if (msg.msg_type == MSG_COMMITMENT_SIGNED) {
                 client_handle_commitment_signed(fd, ch, ctx, &msg);
                 cJSON_Delete(msg.json);
-                scripted_consume_lsp_revoke(fd, ch);  /* LSP bidirectional revoke */
+                scripted_consume_lsp_revoke(fd, ch, ctx);  /* LSP bidirectional revoke (verified) */
             } else {
                 cJSON_Delete(msg.json);
             }
@@ -453,7 +463,7 @@ static int standalone_channel_cb(int fd, channel_t *ch, uint32_t my_index,
             if (msg.msg_type == MSG_COMMITMENT_SIGNED) {
                 client_handle_commitment_signed(fd, ch, ctx, &msg);
                 cJSON_Delete(msg.json);
-                scripted_consume_lsp_revoke(fd, ch);  /* LSP bidirectional revoke */
+                scripted_consume_lsp_revoke(fd, ch, ctx);  /* LSP bidirectional revoke (verified) */
             } else {
                 cJSON_Delete(msg.json);
             }

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -569,6 +569,10 @@ typedef struct {
     scripted_action_t *scripted_actions;
     size_t  n_scripted_actions;
     int     scripted_initiated;     /* 1 after sends fired + recvs registered */
+    /* Item-1 escalation: response policy + detection state (--on-lsp-forgery). */
+    int     lsp_forgery_response;   /* lsp_forgery_response_t; default HALT */
+    int     lsp_forgery_detected;   /* 1 once a forged LSP revocation is refused */
+    int     force_close_requested;  /* 1 = CLOSE policy wants a force-close after the loop */
 } daemon_cb_data_t;
 
 /* SF-PTLC-TURNOVER-AUTH #196: rotation-context state for the PTLC turnover
@@ -763,6 +767,28 @@ static void client_recv_lsp_revocation(int fd, channel_t *ch, daemon_cb_data_t *
     if (!client_handle_lsp_revoke_and_ack(ch, ctx, &rev_msg)) {
         fprintf(stderr, "Client %u: LSP revocation FAILED verification "
                 "— refusing (penalty NOT armed)\n", my_index);
+        /* Item-1 escalation: the bad secret is already refused and no watchtower
+           is armed from it. Apply the configured response so the client does not
+           keep building states it cannot protect against a proven-cheating LSP. */
+        if (cbd) {
+            cbd->lsp_forgery_detected = 1;
+            switch (cbd->lsp_forgery_response) {
+            case LSP_FORGERY_HALT:
+                fprintf(stderr, "Client %u: CRITICAL: LSP revocation forgery — HALT "
+                        "policy: refusing all further commitments. Operator should "
+                        "force-close (--force-close) on the last verified state.\n",
+                        my_index);
+                break;
+            case LSP_FORGERY_CLOSE:
+                fprintf(stderr, "Client %u: CRITICAL: LSP revocation forgery — CLOSE "
+                        "policy: force-closing on the last verified state.\n", my_index);
+                cbd->force_close_requested = 1;
+                break;
+            case LSP_FORGERY_CONTINUE:
+            default:
+                break;  /* legacy: refuse + no-arm, keep the session */
+            }
+        }
         cJSON_Delete(rev_msg.json);
         return;
     }
@@ -974,6 +1000,19 @@ static int daemon_channel_cb(int fd, channel_t *ch, uint32_t my_index,
 
     while (!g_shutdown) {
         wire_msg_t msg;
+
+        /* Item-1 escalation: if a forged LSP revocation was detected and the policy
+           is HALT or CLOSE, stop here — refuse to accept any further commitment from
+           a proven-cheating LSP. The bad secret was already refused at detection;
+           this exits the message loop before the next commitment cycle. The actual
+           force-close (CLOSE policy) runs after the loop, from the persisted state. */
+        if (cbd && cbd->lsp_forgery_detected &&
+            cbd->lsp_forgery_response != LSP_FORGERY_CONTINUE) {
+            fprintf(stderr, "Client %u: halting daemon loop (LSP revocation forgery, "
+                    "policy=%s)\n", my_index,
+                    cbd->lsp_forgery_response == LSP_FORGERY_CLOSE ? "close" : "halt");
+            break;
+        }
 
         /* Drain messages queued by recv_or_handle_ptlc before blocking.
            MSG_COMMITMENT_SIGNED is handled inline (needs immediate revocation
@@ -2209,6 +2248,10 @@ static void usage(const char *prog) {
         "  --from-mnemonic WORDS             Restore key from BIP39 mnemonic, save to --keyfile, then exit\n"
         "  --mnemonic-passphrase P           BIP39 passphrase for seed derivation (default: empty)\n"
         "  --force-close                     Broadcast factory tree from DB (recover funds without LSP)\n"
+        "  --on-lsp-forgery MODE             Response to a detected forged LSP revocation:\n"
+        "                                      continue = refuse secret only (legacy)\n"
+        "                                      halt     = refuse + stop session + alert (default)\n"
+        "                                      close    = refuse + force-close on last verified state\n"
         "  --sweep-to-local                  Sweep to_local output after CSV maturity\n"
         "  --sweep-dest HEX                  Destination xonly pubkey (64 hex) or P2TR SPK (68 hex)\n"
         "  --config PATH                     Load settings from JSON config file (CLI overrides)\n"
@@ -2216,6 +2259,68 @@ static void usage(const char *prog) {
         "  --version                         Show version and exit\n"
         "  --help                            Show this help\n",
         prog);
+}
+
+/* Item-1 CLOSE policy: force-close on the last fully-verified state, reusing the
+   #313 self-custody recovery path from the client's persisted DB. Called after the
+   daemon loop exits on a detected LSP revocation forgery. Returns 1 if a recovery
+   run was executed, 0 if it could not (no DB / no chain backend). */
+static int client_force_close_from_db(const char *db_path, const char *network,
+                                      const char *cli_path, const char *rpcuser,
+                                      const char *rpcpassword, const char *datadir,
+                                      int rpcport) {
+    if (!db_path) {
+        fprintf(stderr, "Client: CLOSE policy needs --db to force-close; cannot proceed\n");
+        return 0;
+    }
+    persist_t db;
+    if (!persist_open(&db, db_path)) {
+        fprintf(stderr, "Client: CLOSE policy: cannot open DB %s\n", db_path);
+        return 0;
+    }
+    chain_backend_t chain;
+    int have_chain = 0;
+    regtest_t rt;
+    if (strcmp(network, "regtest") == 0) {
+        if (regtest_init_full(&rt, "regtest", cli_path, rpcuser, rpcpassword, datadir, rpcport)) {
+            extern void chain_backend_regtest_init(chain_backend_t *, regtest_t *);
+            chain_backend_regtest_init(&chain, &rt);
+            have_chain = 1;
+        }
+    } else if (rpcuser && rpcpassword) {
+        if (chain_backend_rpc_init(&chain, "127.0.0.1", rpcport, rpcuser,
+                                    rpcpassword, NULL, network))
+            have_chain = 1;
+    }
+    if (!have_chain) {
+        fprintf(stderr, "Client: CLOSE policy: no chain backend (need regtest or "
+                "--rpcuser/--rpcpassword) — cannot force-close\n");
+        persist_close(&db);
+        return 0;
+    }
+    char fr_status[256] = {0};
+    int result = factory_recovery_run(&db, &chain, 0, fr_status, sizeof(fr_status));
+    fprintf(stderr, "Client: CLOSE policy force-close: %s (run=%d)\n", fr_status, result);
+    /* Broadcast the signed commitment TX (last verified state) if present. */
+    unsigned char signed_tx_data[4096];
+    size_t signed_tx_len = 0;
+    uint64_t sig_cn = 0;
+    if (persist_load_commitment_sig(&db, 0, &sig_cn, NULL, signed_tx_data,
+                                    &signed_tx_len, sizeof(signed_tx_data)) &&
+        signed_tx_len > 0) {
+        char *tx_hex = malloc(signed_tx_len * 2 + 1);
+        if (tx_hex) {
+            extern void hex_encode(const unsigned char *, size_t, char *);
+            hex_encode(signed_tx_data, signed_tx_len, tx_hex);
+            char commit_txid[65];
+            if (chain.send_raw_tx(&chain, tx_hex, commit_txid))
+                fprintf(stderr, "Client: CLOSE policy commitment TX broadcast: %s "
+                        "(cn=%llu)\n", commit_txid, (unsigned long long)sig_cn);
+            free(tx_hex);
+        }
+    }
+    persist_close(&db);
+    return 1;
 }
 
 int main(int argc, char *argv[]) {
@@ -2256,6 +2361,7 @@ int main(int argc, char *argv[]) {
     uint32_t hd_lookahead = HD_WALLET_LOOKAHEAD;
     const char *light_client_arg = NULL;
     const char *fee_estimator_arg = NULL;
+    int lsp_forgery_mode = LSP_FORGERY_HALT;  /* --on-lsp-forgery: item-1 escalation policy */
     const char *lc_fallbacks[BIP158_MAX_PEERS - 1];
     memset(lc_fallbacks, 0, sizeof(lc_fallbacks));
     int n_lc_fallbacks = 0;
@@ -2377,6 +2483,14 @@ int main(int argc, char *argv[]) {
         }
         else if (strcmp(argv[i], "--fee-estimator") == 0 && i + 1 < argc)
             fee_estimator_arg = argv[++i];
+        else if (strcmp(argv[i], "--on-lsp-forgery") == 0 && i + 1 < argc) {
+            int m = client_parse_forgery_response(argv[++i]);
+            if (m < 0) {
+                fprintf(stderr, "Error: --on-lsp-forgery must be continue|halt|close\n");
+                return 1;
+            }
+            lsp_forgery_mode = m;
+        }
         else if (strcmp(argv[i], "--light-client") == 0 && i + 1 < argc)
             light_client_arg = argv[++i];
         else if (strcmp(argv[i], "--light-client-fallback") == 0 && i + 1 < argc) {
@@ -3305,6 +3419,7 @@ int main(int argc, char *argv[]) {
         cbd.wt = &client_wt;
         cbd.fee = client_fee_ptr;
         cbd.rt = rt_ok ? &rt : NULL;
+        cbd.lsp_forgery_response = lsp_forgery_mode;
         cbd.auto_accept_jit = auto_accept_jit;
         cbd.test_lsps2     = test_lsps2;
         cbd.test_lsps2_buy = test_lsps2_buy;
@@ -3432,6 +3547,12 @@ int main(int argc, char *argv[]) {
                                             daemon_channel_cb, &cbd);
             }
             if (g_shutdown) break;
+            if (cbd.lsp_forgery_detected &&
+                cbd.lsp_forgery_response != LSP_FORGERY_CONTINUE) {
+                fprintf(stderr, "Client: LSP revocation forgery — not reconnecting "
+                        "to a proven-cheating LSP\n");
+                break;
+            }
             if (!ok) {
                 fprintf(stderr, "Client: disconnected, retrying in 1s...\n");
                 /* Run watchtower check between reconnect attempts so we can
@@ -3443,6 +3564,9 @@ int main(int argc, char *argv[]) {
                 break;  /* clean exit */
             }
         }
+        if (cbd.force_close_requested)
+            client_force_close_from_db(db_path, network, cli_path,
+                                       rpcuser, rpcpassword, datadir, rpcport);
     } else if (n_actions > 0 || expect_channels) {
         /* Funding verification (if RPC available) — shared by both sub-paths. */
         regtest_t sa_verify_rt;
@@ -3478,11 +3602,15 @@ int main(int argc, char *argv[]) {
             cbd.wt  = &client_wt;
             cbd.fee = client_fee_ptr;
             cbd.rt  = rt_ok ? &rt : NULL;
+            cbd.lsp_forgery_response = lsp_forgery_mode;
             cbd.scripted_actions   = actions;
             cbd.n_scripted_actions = n_actions;
             ok = client_run_with_channels(ctx, &kp, host, port,
                                           daemon_channel_cb, &cbd,
                                           sa_vfn, sa_vctx);
+            if (cbd.force_close_requested)
+                client_force_close_from_db(db_path, network, cli_path,
+                                           rpcuser, rpcpassword, datadir, rpcport);
         } else {
             /* Bare --channels (no scripted payment): unchanged legacy path. */
             multi_payment_data_t data = { actions, n_actions, 0 };

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -571,8 +571,11 @@ typedef struct {
     int     scripted_initiated;     /* 1 after sends fired + recvs registered */
     /* Item-1 escalation: response policy + detection state (--on-lsp-forgery). */
     int     lsp_forgery_response;   /* lsp_forgery_response_t; default HALT */
+    int     lsp_forgery_response_ps;/* per-leaf-type override for PS leaves; -1 = inherit (#21) */
+    int     lsp_leaf_is_ps;         /* 1 if this factory uses PS (CLTV-gated) leaves (#21) */
     int     lsp_forgery_detected;   /* 1 once a forged LSP revocation is refused */
     int     force_close_requested;  /* 1 = CLOSE policy wants a force-close after the loop */
+    const char *poison_db_path;     /* db path for the poisoned-LSP sentinel file (#20) */
 } daemon_cb_data_t;
 
 /* SF-PTLC-TURNOVER-AUTH #196: rotation-context state for the PTLC turnover
@@ -744,6 +747,8 @@ static void client_persist_commitment_sig(channel_t *ch, daemon_cb_data_t *cbd) 
    Call after each client_handle_commitment_signed in daemon mode.
    old_local/old_remote are the channel amounts at the OLD commitment being
    revoked (before the state-advancing add/fulfill that preceded this). */
+static void client_mark_lsp_poisoned(const char *db_path, const char *reason);  /* #20 fwd-decl */
+
 static void client_recv_lsp_revocation(int fd, channel_t *ch, daemon_cb_data_t *cbd,
                                          secp256k1_context *ctx,
                                          uint64_t old_local, uint64_t old_remote,
@@ -772,22 +777,39 @@ static void client_recv_lsp_revocation(int fd, channel_t *ch, daemon_cb_data_t *
            keep building states it cannot protect against a proven-cheating LSP. */
         if (cbd) {
             cbd->lsp_forgery_detected = 1;
-            switch (cbd->lsp_forgery_response) {
+            /* #21 per-leaf-type: a PS (CLTV-gated) leaf MAY warrant a different
+               response than a revocation-gated leaf. We default to UNIFORM (the PS
+               override is "inherit" unless the operator explicitly set
+               --on-lsp-forgery-ps) and NEVER auto-downgrade: PS leaf *chaining*
+               does not by itself prove the channel-level revocation is non-load-
+               bearing (open security-model question — see revocation doc §9). The
+               leaf type is reported so the operator/auditor sees the severity. */
+            int mode = cbd->lsp_forgery_response;
+            if (cbd->lsp_leaf_is_ps && cbd->lsp_forgery_response_ps >= 0)
+                mode = cbd->lsp_forgery_response_ps;
+            fprintf(stderr, "Client %u: forgery on a %s leaf\n", my_index,
+                    cbd->lsp_leaf_is_ps ? "PS/CLTV-gated" : "revocation-gated");
+            switch (mode) {
             case LSP_FORGERY_HALT:
                 fprintf(stderr, "Client %u: CRITICAL: LSP revocation forgery — HALT "
                         "policy: refusing all further commitments. Operator should "
                         "force-close (--force-close) on the last verified state.\n",
                         my_index);
+                client_mark_lsp_poisoned(cbd->poison_db_path, "lsp revocation forgery (halt)");
                 break;
             case LSP_FORGERY_CLOSE:
                 fprintf(stderr, "Client %u: CRITICAL: LSP revocation forgery — CLOSE "
                         "policy: force-closing on the last verified state.\n", my_index);
                 cbd->force_close_requested = 1;
+                client_mark_lsp_poisoned(cbd->poison_db_path, "lsp revocation forgery (close)");
                 break;
             case LSP_FORGERY_CONTINUE:
             default:
                 break;  /* legacy: refuse + no-arm, keep the session */
             }
+            /* Collapse to the effective decision so the daemon-loop / reconnect
+               break (which reads lsp_forgery_response) honours the PS override. */
+            cbd->lsp_forgery_response = mode;
         }
         cJSON_Delete(rev_msg.json);
         return;
@@ -842,6 +864,14 @@ static int daemon_channel_cb(int fd, channel_t *ch, uint32_t my_index,
                                size_t n_participants,
                                void *user_data) {
     daemon_cb_data_t *cbd = (daemon_cb_data_t *)user_data;
+
+    /* #21: record whether this factory uses PS (CLTV-gated) leaves, for the
+       per-leaf-type forgery response. Factory-level signal (any PS leaf present);
+       cheap + idempotent. */
+    if (cbd && factory) {
+        for (size_t ni = 0; ni < factory->n_nodes; ni++)
+            if (factory->nodes[ni].is_ps_leaf) { cbd->lsp_leaf_is_ps = 1; break; }
+    }
 
     /* Save factory + channel + basepoints on first entry (Phase 16 persistence) */
     if (cbd && cbd->db && !cbd->saved_initial) {
@@ -2252,6 +2282,8 @@ static void usage(const char *prog) {
         "                                      continue = refuse secret only (legacy)\n"
         "                                      halt     = refuse + stop session + alert (default)\n"
         "                                      close    = refuse + force-close on last verified state\n"
+        "  --on-lsp-forgery-ps MODE          Override the above for PS (CLTV-gated) leaves\n"
+        "                                      (default: inherit --on-lsp-forgery; no auto-downgrade)\n"
         "  --sweep-to-local                  Sweep to_local output after CSV maturity\n"
         "  --sweep-dest HEX                  Destination xonly pubkey (64 hex) or P2TR SPK (68 hex)\n"
         "  --config PATH                     Load settings from JSON config file (CLI overrides)\n"
@@ -2323,6 +2355,25 @@ static int client_force_close_from_db(const char *db_path, const char *network,
     return 1;
 }
 
+/* #20 poisoned-LSP marker: persist that THIS node's LSP was caught forging a
+   revocation, so a later restart does not silently reconnect to a proven-cheating
+   LSP. File sentinel next to the DB (no schema change); checked at startup. */
+static void client_mark_lsp_poisoned(const char *db_path, const char *reason) {
+    if (!db_path) return;
+    char path[1100];
+    snprintf(path, sizeof path, "%s.lsp_poisoned", db_path);
+    FILE *f = fopen(path, "w");
+    if (f) { fprintf(f, "%s\n", reason ? reason : "lsp revocation forgery"); fclose(f); }
+}
+static int client_lsp_is_poisoned(const char *db_path) {
+    if (!db_path) return 0;
+    char path[1100];
+    snprintf(path, sizeof path, "%s.lsp_poisoned", db_path);
+    FILE *f = fopen(path, "r");
+    if (f) { fclose(f); return 1; }
+    return 0;
+}
+
 int main(int argc, char *argv[]) {
     /* Line-buffered stdout so logs are visible even if process is killed */
     setvbuf(stdout, NULL, _IOLBF, 0);
@@ -2362,6 +2413,7 @@ int main(int argc, char *argv[]) {
     const char *light_client_arg = NULL;
     const char *fee_estimator_arg = NULL;
     int lsp_forgery_mode = LSP_FORGERY_HALT;  /* --on-lsp-forgery: item-1 escalation policy */
+    int lsp_forgery_mode_ps = -1;             /* --on-lsp-forgery-ps: PS-leaf override; -1=inherit (#21) */
     const char *lc_fallbacks[BIP158_MAX_PEERS - 1];
     memset(lc_fallbacks, 0, sizeof(lc_fallbacks));
     int n_lc_fallbacks = 0;
@@ -2411,6 +2463,16 @@ int main(int argc, char *argv[]) {
                     if ((v = cJSON_GetObjectItem(cfg, "rpcuser")) && cJSON_IsString(v)) rpcuser = strdup(v->valuestring);
                     if ((v = cJSON_GetObjectItem(cfg, "rpcpassword")) && cJSON_IsString(v)) rpcpassword = strdup(v->valuestring);
                     if ((v = cJSON_GetObjectItem(cfg, "rpcport")) && cJSON_IsNumber(v)) rpcport = (int)v->valuedouble;
+                    if ((v = cJSON_GetObjectItem(cfg, "on-lsp-forgery")) && cJSON_IsString(v)) {
+                        int m = client_parse_forgery_response(v->valuestring);
+                        if (m >= 0) lsp_forgery_mode = m;
+                        else fprintf(stderr, "WARNING: config on-lsp-forgery invalid: %s\n", v->valuestring);
+                    }
+                    if ((v = cJSON_GetObjectItem(cfg, "on-lsp-forgery-ps")) && cJSON_IsString(v)) {
+                        int m = client_parse_forgery_response(v->valuestring);
+                        if (m >= 0) lsp_forgery_mode_ps = m;
+                        else fprintf(stderr, "WARNING: config on-lsp-forgery-ps invalid: %s\n", v->valuestring);
+                    }
                     printf("Loaded config from %s\n", argv[i + 1]);
                     cJSON_Delete(cfg);
                 } else {
@@ -2490,6 +2552,14 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
             lsp_forgery_mode = m;
+        }
+        else if (strcmp(argv[i], "--on-lsp-forgery-ps") == 0 && i + 1 < argc) {
+            int m = client_parse_forgery_response(argv[++i]);
+            if (m < 0) {
+                fprintf(stderr, "Error: --on-lsp-forgery-ps must be continue|halt|close\n");
+                return 1;
+            }
+            lsp_forgery_mode_ps = m;
         }
         else if (strcmp(argv[i], "--light-client") == 0 && i + 1 < argc)
             light_client_arg = argv[++i];
@@ -3411,6 +3481,16 @@ int main(int argc, char *argv[]) {
                                     hd_mnemonic, hd_passphrase, hd_lookahead);
     }
 
+    /* #20 poisoned-LSP marker: if a prior session caught this LSP forging a
+       revocation, refuse to reconnect. (--force-close is handled earlier, so the
+       operator can still recover; deleting the marker re-enables connecting.) */
+    if (db_path && client_lsp_is_poisoned(db_path)) {
+        fprintf(stderr, "Client: REFUSING to connect — this LSP was previously caught "
+                "forging a revocation (marker %s.lsp_poisoned). Force-close with "
+                "--force-close, then delete the marker to re-enable.\n", db_path);
+        return 1;
+    }
+
     int ok;
     if (daemon_mode) {
         daemon_cb_data_t cbd;
@@ -3420,6 +3500,8 @@ int main(int argc, char *argv[]) {
         cbd.fee = client_fee_ptr;
         cbd.rt = rt_ok ? &rt : NULL;
         cbd.lsp_forgery_response = lsp_forgery_mode;
+        cbd.lsp_forgery_response_ps = lsp_forgery_mode_ps;
+        cbd.poison_db_path = db_path;
         cbd.auto_accept_jit = auto_accept_jit;
         cbd.test_lsps2     = test_lsps2;
         cbd.test_lsps2_buy = test_lsps2_buy;
@@ -3603,6 +3685,8 @@ int main(int argc, char *argv[]) {
             cbd.fee = client_fee_ptr;
             cbd.rt  = rt_ok ? &rt : NULL;
             cbd.lsp_forgery_response = lsp_forgery_mode;
+            cbd.lsp_forgery_response_ps = lsp_forgery_mode_ps;
+            cbd.poison_db_path = db_path;
             cbd.scripted_actions   = actions;
             cbd.n_scripted_actions = n_actions;
             ok = client_run_with_channels(ctx, &kp, host, port,

--- a/tools/test_regtest_n64_payments.sh
+++ b/tools/test_regtest_n64_payments.sh
@@ -136,6 +136,8 @@ for i in $(seq 1 "$N_CLIENTS"); do
             --lsp-pubkey "$LSP_PUBKEY" --participant-id "$i"
             --rpcuser rpcuser --rpcpassword rpcpass --rpcport 18443
             --wallet "$WALLET" --db "/tmp/ss_${TAG}_c${SK:60:4}.db")
+    # Item-1 escalation policy passthrough (continue|halt|close); unset = client default.
+    [ -n "${ON_LSP_FORGERY:-}" ] && COMMON+=(--on-lsp-forgery "$ON_LSP_FORGERY")
     case "$R" in
         send:*) DEST="${R#send:}"; DEST="${DEST%%:*}"; PRE="${R##*:}"
                 EXTRA=(--channels --send "$DEST:$PAY_AMT:$PRE") ;;


### PR DESCRIPTION
Stacks on **#380 + #381 + #382** (base branch = their merge point). Delivers the cohesive item-1 *response* feature that bridges #380's daemon payment loop and #381's revocation verifier, plus the live adversarial proof.

## What
- **Scripted `--send`/`--recv` flows now VERIFY the LSP revocation** (were storing blindly + discarding the next PCP) — routed through #381's `client_handle_lsp_revoke_and_ack`.
- **Adversarial LSP cheat hook** `SS_CHEAT_LSP_BAD_REVOCATION` (regtest-gated) — forges every `0x50` to prove the client refuses it live.
- **Selectable escalation policy** `--on-lsp-forgery continue|halt|close` (default `halt`) — detection → response: refuse + (halt | force-close on last verified state). Parser unit-tested.
- **Refinements:** config-file support, poisoned-LSP marker (no auto-reconnect to a proven-cheating LSP), per-leaf-type `--on-lsp-forgery-ps` (default inherit; no auto-downgrade — open security-model Q documented), surgical-close documented as already per-client.

## Proven live (regtest, N=4 daemon payment harness)
- happy-path (default halt, honest LSP): settles e2e, **0 false halts**
- adversarial: LSP forged **24** revocations → clients refused **24/24** fail-closed, no WT armed
- modes: `continue` settles, `halt` halts 4/4 clients, `close` force-closes 4/4 (`broadcast 3 TXs`)
- integration unit suite **1504/1504**; penalty regression (commitment-breach + kind3 + dual-factory) green

## Reconciled here too (also backported to source PRs)
- schema-v37 pin → #380; dust-race cheat-gate tests → #381

Docs: `doc/revocation-verification-standard.md` §9/§9.1, `doc/adversarial-verification-matrix.md`.