### PR TITLE
Trustless model hardening — Phase 1: WT fee-bump (#52) + foundation

### DIFF
--- a/docs/trustless-hardening-design-and-test-plan.md
+++ b/docs/trustless-hardening-design-and-test-plan.md
@@ -115,6 +115,35 @@ orphan-verification lesson).
 **regtest = primary** (rows 1-7 + INV-*; only regtest gives controllable fee/deadline). **signet =
 re-validate rows 1a + 7** (real fee market) with the 2-stage confirm budget + sat discipline.
 
+## 5b. #59 Reveal state machine (PINNED — the commit point that closes residual Scenario A)
+The advance leaf state s→s+1 is a **two-phase commit** whose commit point is the secret reveal:
+- **Phase 1 (recourse first):** exchange + per-partial-verify ALL psigs for BOTH (a) the new leaf tx s+1 AND
+  (b) poison_s over Leaf-P(H_s). UNIVERSAL ALL_PSIGS (no sole completer). Nothing observable changes yet.
+- **Phase 2 (commit = reveal):** LSP reveals secret_s; client checks `SHA256(secret_s)==H_s` (H_s baked into
+  state s's L-stock SPK), **fail-closed** (mismatch ⇒ ABORT, stay on s). Only on success does the client
+  advance its **live-state pointer** s→s+1.
+**The load-bearing invariant:** the client's live pointer advances **iff** it has durably persisted
+`(poison_s co-sig ∧ verified secret_s)`. Persist order = (1) write recourse-for-s, fsync, (2) then bump live
+pointer. Crash between ⇒ on restart live is still s, recourse-for-s present, re-drive Phase 2 idempotently.
+**Why no residual A:** during the Phase-1→reveal window the mutually-live state is STILL s, so the LSP
+broadcasting s is *honest* (not theft); broadcasting any r<s is covered by the already-held
+poison_r+secret_r. The LSP only gives away secret_s (its own punishment key) last, which can only hurt the
+LSP. So "committed-without-recourse" is unreachable: recourse (Phase 1) strictly precedes commit (Phase 2),
+and commit is exactly the moment the client gains the secret. Mirrors Poon-Dryja `revoke_and_ack` ordering
+and `channel_verify_revocation_secret` (channel.c:597). #46 makes Phase-1 ALL_PSIGS mandatory + deletes the
+"advance anyway" degradation so Phase 2 is never reachable without full recourse.
+
+## 5c. #53-A implementation map (the crypto core — purely additive until #53-B sets the hash)
+- `build_l_stock_spk` + the key-path signer both route through ONE `build_l_stock_taptree(f,node,&P,&L,root,&two)`
+  helper (no SPK/tweak drift). Tree = {Leaf P, Leaf L} iff `node->has_l_stock_hash`, else legacy {Leaf L}.
+- Leaf P = `tapscript_build_l_stock_poison_leaf` = the audited offered-HTLC-success bytes
+  (`OP_SIZE 0x20 OP_EQUALVERIFY OP_SHA256 <H_s> OP_EQUALVERIFY <agg_xonly> OP_CHECKSIG`).
+- Poison signs the **UNtweaked** agg key (`musig_sign_all_local`) over the **Leaf-P script-path** sighash
+  (`compute_tapscript_sighash`); witness = `[sig, secret, Leaf-P script, 2-leaf control block]`
+  (`finalize_script_path_tx_preimage`). nVersion=2 — bumpable via the client-owned poison outputs (no P2A
+  needed; #60 satisfied by output structure). REPLACES the key-path poison: `factory_sign_l_stock_poison_tx`
+  (key-path) refuses once `has_l_stock_hash` (so the B-vulnerable key-path sig is never produced; #53-B).
+
 ## 6. Sequencing (decided)
 1. **#53 revocation poison** (closes A+B at the root; unblocks rows 3/4 + INV-1/2/3) — wire up the bypassed infra.
 2. **#46 atomic 2-phase + delete degradation** (depends on #53's recourse-secret being the Phase-2 object).

--- a/docs/trustless-hardening-design-and-test-plan.md
+++ b/docs/trustless-hardening-design-and-test-plan.md
@@ -115,6 +115,54 @@ orphan-verification lesson).
 **regtest = primary** (rows 1-7 + INV-*; only regtest gives controllable fee/deadline). **signet =
 re-validate rows 1a + 7** (real fee market) with the 2-stage confirm budget + sat discipline.
 
+## 5d. #53-B3b-part-2 — DAEMON/WIRE INTEGRATION PLAN (researched 2026-06-21, 4 opus agents)
+The in-process poison construction+signing layer (#53-A/B1/B3a/B3b-1) is proven. Wiring it into the live
+LSP↔client daemon protocol is larger than first scoped — three research findings reshape it:
+
+**F1 (gating prerequisite). Enabling hashlock BREAKS the advance unless the client builds the matching
+2-leaf L-stock SPK.** The leaf STATE tx's last output IS the L-stock; if the LSP builds a 2-leaf {Leaf-P,Leaf-L}
+SPK and the client builds the legacy single-leaf SPK, the leaf tx bytes differ → MuSig co-sign mismatch →
+the whole advance fails (not just the poison). The client only gets H over the wire (it has no seed). The
+existing `l_stock_hashes` wire (wire.c:660 build / client.c:1894,2001 parse) is **per-EPOCH flat** — the WRONG
+shape; #53 H is **per-(leaf,state)** = SHA256(tagged(seed‖leaf_agg‖state_counter)). And `factory_set_l_stock_hashes`
+(factory.c:3366) only fills the flat array; it never sets node->l_stock_hash/has_l_stock_hash. So the client
+builds the single-leaf SPK and never enables the path.
+
+**F2. The leaf-advance ceremony (the PRIMARY 2-of-2 PS-leaf path) was NOT covered by B3a's retarget.** In
+`lsp_advance_leaf_stateless` (lsp_channels.c:1353-1933) the CLIENT aggregates the poison sig
+(`final_poison_sig`, client.c:3857) and returns it in FINAL; the LSP `finalize_signed_tx` at lsp_channels.c:1754
+builds a KEY-PATH witness. B3a only retargeted the Tier-B `complete_node_poison` path (lsp_channels.c:2511).
+So with hashlock on, the leaf-advance poison finalize must ALSO store the agg sig (script-path) + assemble
+-with-secret later, on BOTH the LSP finalize (1754) and the client aggregate (3857).
+
+**F3. Reveal carriers + timing.** DONE is broadcast to ALL clients (leaf-advance, lsp_channels.c:1880-1883) /
+epoch-only (Tier-B MSG_PATH_SIGN_DONE) — neither can carry a leaf-specific secret. Use NEW messages
+`MSG_LEAF_ADVANCE_REVEAL`(0x8C) {leaf_side, revoked_state, secret32} sent targeted to client_fds[leaf_side]
+just before DONE (1880); `MSG_STATE_ADV_REVEAL`(0x8D) {epoch, n, secrets_per_leaf flat blob} per-affected-leaf
+in/after the WT loop (2570-2630). Unifying rule: **old_counter = leaf->l_stock_state_counter − 1** at the reveal
+point (counter is always bumped by then). Encode via wire_json_add_hex (template: revoke_and_ack revocation_secret
+wire.c:844). Daemon enable goes in src/lsp.c between :437 (set_shachain_seed) and :442 (build_tree) — NOT in
+superscalar_lsp.c (factory_init_from_pubkeys lsp.c:413 wipes use_hashlock_poison); seed must be a REAL random
+seed (flat-secrets leaves shachain_seed zeroed). Client persist: new table `l_stock_poison_reveals` (schema
+v37→v38) {factory_id, leaf_node_idx, state_counter, l_stock_hash, secret(sealed), agg_sig, unsigned_tx,
+leaf_script, control_block}; verify-then-persist mirroring channel_receive_revocation_flat (channel.c:625);
+persist BEFORE adopting new state (#59). B4 degradation = ~80 "reset_poison+clear-flag+continue" sites across
+5 ceremony families × LSP+client → gated hard-abort (`return 0` + stay on old state) when use_hashlock_poison
+(LSP) / has_l_stock_hash (client).
+
+**SEQUENCED INCREMENTS (each built+tested before the next; in-process proof, then B6 flips the daemon flag):**
+- **B3b.2a (PREREQUISITE):** ship per-(leaf,state) H to the client + client maps it onto node->l_stock_hash/
+  has_l_stock_hash after factory_build_tree (creation + per-advance). Prove: client-built leaf L-stock SPK ==
+  LSP-built SPK (so the advance co-signs). Gates everything.
+- **B3b.2b:** retarget the leaf-advance poison finalize (LSP 1754 + client 3857) to script-path (store agg_sig).
+- **B3b.2c:** reveal — MSG_*_REVEAL; LSP derives secret(leaf, counter−1) + sends after poison-complete; gated.
+- **B3b.2d:** client verify (SHA256==H_old, fail-closed) + persist (v38 table) before adopting new state (#59);
+  LSP "reveal-owed" journal for restart re-send.
+- **B3b.2e:** daemon enable — `--enable-hashlock-poison` + random seed + factory_enable_hashlock_poison @ lsp.c.
+- **B4:** delete degradation (gated hard-abort) at the ~80 sites.
+- **B6:** e2e — hashlock factory, advance a leaf, LSP broadcasts the stale OLD state, client/WT assembles the
+  poison from the PERSISTED secret + broadcasts, poison confirms + redistributes, under high fee (the gold proof).
+
 ## 5b. #59 Reveal state machine (PINNED — the commit point that closes residual Scenario A)
 The advance leaf state s→s+1 is a **two-phase commit** whose commit point is the secret reveal:
 - **Phase 1 (recourse first):** exchange + per-partial-verify ALL psigs for BOTH (a) the new leaf tx s+1 AND

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -459,6 +459,13 @@ int factory_sign_l_stock_poison_tx(
     uint64_t fee_sats,
     tx_buf_t *signed_out);
 
+/* Build the L-stock output scriptPubKey (P2TR) for a leaf state node — the
+   2-leaf {poison, LSP-CSV} taptree when the node carries a per-state hash
+   (#53), else the legacy single LSP-CSV leaf.  Exposed for tests and the
+   reveal/recourse wiring; spk_out34 receives the 34-byte P2TR SPK. */
+int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
+                      unsigned char *spk_out34);
+
 /* #53: hashlock-gated L-stock poison over the Leaf-P SCRIPT-path (replaces the
    key-path poison, which is vulnerable to Scenario B).  Builds the per-client
    redistribution outputs, N-of-N MuSig-signs the UNtweaked agg key over the

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -188,6 +188,13 @@ typedef struct {
        active; the secret_s itself stays LSP-private until revealed on advance. */
     unsigned char l_stock_hash[32];
     int has_l_stock_hash;
+    /* #53-B: per-leaf monotonic L-stock state index, bumped every time this
+       leaf's L-stock SPK is (re)built (initial setup + each epoch advance / JIT
+       L-stock change).  Combined with the leaf's agg pubkey it forms the unique
+       per-(leaf, state) secret index, so independently-advancing leaves never
+       collide.  state s's revealed secret is derived at the value this had when
+       state s's L-stock output was built. */
+    uint32_t l_stock_state_counter;
 
     /* Pseudo-Spilman leaf state (is_ps_leaf == 1 only) */
     int is_ps_leaf;              /* 1 if this leaf uses PS chaining instead of DW nSequence */
@@ -312,6 +319,16 @@ typedef struct {
        L-stock taptrees without sharing the actual secrets. */
     unsigned char l_stock_hashes[FACTORY_MAX_EPOCHS][32];
     size_t n_l_stock_hashes;
+
+    /* #53-B: revocation-gated (hashlock) L-stock poison.  When enabled, each
+       leaf state's L-stock output commits H_s = SHA256(secret(leaf, state)) into
+       Leaf P of its taptree (see build_l_stock_taptree).  The secret is derived
+       PER-(leaf, state) from shachain_seed — keyed on the leaf's agg pubkey AND a
+       per-leaf monotonic counter — so revealing one leaf's revoked-state secret
+       can NEVER unlock another leaf's (or a later state's) live poison (the
+       cross-leaf leak of the old global-epoch index).  LSP-private; revealed to
+       the leaf's clients only when the state is superseded (#53-B3). */
+    int use_hashlock_poison;
 
     /* Per-leaf DW layers (for independent leaf advance) */
     dw_layer_t leaf_layers[FACTORY_MAX_LEAVES];
@@ -458,6 +475,25 @@ int factory_sign_l_stock_poison_tx(
     uint64_t l_stock_amount_sats,
     uint64_t fee_sats,
     tx_buf_t *signed_out);
+
+/* #53-B: enable revocation-gated (hashlock) L-stock poison.  Requires the
+   factory seed to be set first (factory_set_shachain_seed); thereafter every
+   leaf-state L-stock output (initial build + each advance) commits a per-(leaf,
+   state) hash and the key-path poison is refused in favour of the script-path
+   poison.  Returns 1 on success, 0 if no seed is set. */
+int factory_enable_hashlock_poison(factory_t *f);
+
+/* #53-B: derive the LSP-private per-(leaf, state) L-stock revocation secret.
+   secret = tagged_hash("SS/LStockPoison/v1", seed32 || leaf_agg_xonly32 ||
+   state_counter_le32).  Deterministic + crash-recoverable (re-derivable from the
+   persisted seed + the leaf's agg key + the state counter).  The matching hash
+   H_s = SHA256(secret) is what Leaf P commits to; the secret is revealed to the
+   leaf's clients only once state `state_counter` is superseded.  Returns 1 on
+   success, 0 if the factory has no seed. */
+int factory_derive_l_stock_secret(const factory_t *f,
+                                  const factory_node_t *leaf_node,
+                                  uint32_t state_counter,
+                                  unsigned char secret_out32[32]);
 
 /* Build the L-stock output scriptPubKey (P2TR) for a leaf state node — the
    2-leaf {poison, LSP-CSV} taptree when the node carries a per-state hash

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -179,6 +179,16 @@ typedef struct {
        can be keyed on the poison (G1 #44) without a txid-from-bytes helper. */
     unsigned char poison_txid[32];
 
+    /* #53 hashlock-gated poison: per-(leaf,state) revocation hash H_s = SHA256(secret_s)
+       committed into THIS leaf state's L-stock output (Leaf P of the taptree).  When
+       has_l_stock_hash==1 the L-stock SPK is the 2-leaf {poison, LSP-CSV} tree and the
+       poison must be spent via the Leaf-P script-path with the revealed secret_s as the
+       witness preimage — so a non-revoked (live) state's poison has no satisfying witness
+       (closes Scenario B).  Set during leaf-state construction when flat secrets are
+       active; the secret_s itself stays LSP-private until revealed on advance. */
+    unsigned char l_stock_hash[32];
+    int has_l_stock_hash;
+
     /* Pseudo-Spilman leaf state (is_ps_leaf == 1 only) */
     int is_ps_leaf;              /* 1 if this leaf uses PS chaining instead of DW nSequence */
     int ps_chain_len;            /* number of state advances (0 = initial state) */
@@ -448,6 +458,27 @@ int factory_sign_l_stock_poison_tx(
     uint64_t l_stock_amount_sats,
     uint64_t fee_sats,
     tx_buf_t *signed_out);
+
+/* #53: hashlock-gated L-stock poison over the Leaf-P SCRIPT-path (replaces the
+   key-path poison, which is vulnerable to Scenario B).  Builds the per-client
+   redistribution outputs, N-of-N MuSig-signs the UNtweaked agg key over the
+   Leaf-P script-path sighash, and finalizes a complete consensus-valid witness
+   tx using `secret32` (= the revealed revocation secret) as the hashlock preimage.
+   Requires leaf_node->has_l_stock_hash; fails fast unless SHA256(secret32) equals
+   the leaf's committed l_stock_hash.  Single-process (needs f->keypairs[] for every
+   leaf signer); the multi-process wire ceremony co-signs the same Leaf-P sighash
+   and supplies the preimage at broadcast (#53-B).  `poison_txid_out32` (optional,
+   internal byte order) receives the poison txid. */
+int factory_build_l_stock_poison_scriptpath(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    const unsigned char *secret32,
+    tx_buf_t *signed_out,
+    unsigned char *poison_txid_out32);
 
 /* Cooperative N-of-N spend of an L-stock UTXO to a caller-specified
    output distribution.  The poison TX is a special case of this where

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -196,6 +196,19 @@ typedef struct {
        state s's L-stock output was built. */
     uint32_t l_stock_state_counter;
 
+    /* #53-B3a: script-path (Leaf-P) poison ceremony state.  When the leaf carries a
+       hashlock (has_l_stock_hash), the multi-process poison ceremony signs the Leaf-P
+       script path against the UNTWEAKED agg key (not the key path = Scenario B); the
+       aggregated 64-byte sig + these witness components are combined with the revealed
+       secret at broadcast via factory_assemble_poison_with_secret. */
+    int poison_is_scriptpath;
+    int poison_has_agg_sig;
+    unsigned char poison_agg_sig[64];
+    unsigned char poison_leaf_script[128];   /* TAPSCRIPT_MAX_SCRIPT; Leaf-P = 73 bytes */
+    size_t poison_leaf_script_len;
+    unsigned char poison_control_block[65];
+    size_t poison_control_block_len;
+
     /* Pseudo-Spilman leaf state (is_ps_leaf == 1 only) */
     int is_ps_leaf;              /* 1 if this leaf uses PS chaining instead of DW nSequence */
     int ps_chain_len;            /* number of state advances (0 = initial state) */
@@ -809,6 +822,14 @@ int factory_session_set_partial_sig_poison(factory_t *f, size_t node_idx,
                                              size_t signer_slot,
                                              const secp256k1_musig_partial_sig *psig);
 int factory_session_complete_node_poison(factory_t *f, size_t node_idx);
+
+/* #53-B3a: assemble the broadcastable hashlock poison from the ceremony-aggregated
+   sig + the revealed secret (Leaf-P witness preimage).  Only valid for a script-path
+   poison node (poison_is_scriptpath + poison_has_agg_sig) whose secret matches the
+   committed hash.  `out` receives the complete witness tx.  Returns 1 on success. */
+int factory_assemble_poison_with_secret(factory_t *f, size_t node_idx,
+                                        const unsigned char *secret32,
+                                        tx_buf_t *out);
 
 /* Reset poison state on a node (free the unsigned/signed tx buffers + clear
    sighash + reset received counter).  Safe to call on a never-prepared

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -523,6 +523,28 @@ int factory_build_l_stock_poison_scriptpath(
     tx_buf_t *signed_out,
     unsigned char *poison_txid_out32);
 
+/* #53-B3a: build the unsigned hashlock poison + its Leaf-P script-path sighash and
+   witness components (Leaf-P script, 2-leaf control block), WITHOUT signing.  Used by
+   the multi-process poison ceremony (which signs the sighash via the poison MuSig
+   session) and by the single-process builder above.  The aggregated 64-byte Schnorr
+   sig + the revealed secret are combined with these components at broadcast time via
+   finalize_script_path_tx_preimage.  leaf_p_script_out (>= TAPSCRIPT_MAX_SCRIPT) and
+   control_block_out (>= 65) are optional.  Requires has_l_stock_hash. */
+int factory_build_l_stock_poison_scriptpath_unsigned(
+    const factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    tx_buf_t *unsigned_tx_out,
+    unsigned char *sighash_out32,
+    unsigned char *poison_txid_out32,
+    unsigned char *leaf_p_script_out,
+    size_t *leaf_p_script_len_out,
+    unsigned char *control_block_out,
+    size_t *control_block_len_out);
+
 /* Cooperative N-of-N spend of an L-stock UTXO to a caller-specified
    output distribution.  The poison TX is a special case of this where
    outputs are the per-client equal split; the same helper is used for

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -208,6 +208,10 @@ typedef struct {
     size_t poison_leaf_script_len;
     unsigned char poison_control_block[65];
     size_t poison_control_block_len;
+    /* The Leaf-P hash THIS poison was built to spend (the superseded state's H_old,
+       or the node's current hash when poisoning the live output).  assemble verifies
+       the revealed secret against THIS, not l_stock_hash, which may have advanced. */
+    unsigned char poison_l_stock_hash[32];
 
     /* Pseudo-Spilman leaf state (is_ps_leaf == 1 only) */
     int is_ps_leaf;              /* 1 if this leaf uses PS chaining instead of DW nSequence */
@@ -550,6 +554,8 @@ int factory_build_l_stock_poison_scriptpath_unsigned(
     uint32_t l_stock_vout,
     uint64_t l_stock_amount_sats,
     uint64_t fee_sats,
+    const unsigned char *override_hash32,  /* NULL = node's current hash; else the
+                                              superseded state's H_old (#53-B3b) */
     tx_buf_t *unsigned_tx_out,
     unsigned char *sighash_out32,
     unsigned char *poison_txid_out32,
@@ -804,7 +810,8 @@ int factory_node_uses_multi_input(const factory_t *f, size_t node_idx);
 int factory_session_prepare_poison_tx_subfactory(
     factory_t *f, size_t sub_node_idx,
     const unsigned char *old_chain_txid32, uint32_t old_sstock_vout,
-    uint64_t old_sstock_amount_sats, uint64_t fee_sats);
+    uint64_t old_sstock_amount_sats, uint64_t fee_sats,
+    const unsigned char *override_hash32);  /* #53-B3b: superseded state's H_old; NULL = node's current */
 
 /* Same as the subfactory variant but for a DW / PS LEAF node — used by
    the lsp_advance_leaf wire ceremony to bundle a poison TX over the
@@ -812,7 +819,8 @@ int factory_session_prepare_poison_tx_subfactory(
 int factory_session_prepare_poison_tx_leaf(
     factory_t *f, size_t leaf_node_idx,
     const unsigned char *old_leaf_txid32, uint32_t old_l_stock_vout,
-    uint64_t old_l_stock_amount_sats, uint64_t fee_sats);
+    uint64_t old_l_stock_amount_sats, uint64_t fee_sats,
+    const unsigned char *override_hash32);  /* #53-B3b: superseded state's H_old; NULL = node's current */
 int factory_session_init_node_poison(factory_t *f, size_t node_idx);
 int factory_session_set_nonce_poison(factory_t *f, size_t node_idx,
                                        size_t signer_slot,

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -347,6 +347,17 @@ typedef struct {
        the leaf's clients only when the state is superseded (#53-B3). */
     int use_hashlock_poison;
 
+    /* #53-B3b.2a: CLIENT MIRROR.  The client has no shachain_seed, so it cannot
+       DERIVE the per-(leaf,state) L-stock hash — it receives each leaf node's
+       committed H from the LSP over the wire and stores it here (indexed by node
+       index).  When has_node_l_stock_hashes is set, apply_l_stock_hashlock uses
+       node_l_stock_hashes[idx] (the shipped H) instead of deriving, so the client
+       builds the SAME 2-leaf L-stock SPK as the LSP (else the leaf-state tx bytes
+       diverge and the MuSig co-sign fails). */
+    unsigned char node_l_stock_hashes[FACTORY_MAX_NODES][32];
+    int node_l_stock_hash_valid[FACTORY_MAX_NODES];
+    int has_node_l_stock_hashes;
+
     /* Per-leaf DW layers (for independent leaf advance) */
     dw_layer_t leaf_layers[FACTORY_MAX_LEAVES];
     int n_leaf_nodes;              /* number of leaf state nodes */
@@ -511,6 +522,14 @@ int factory_derive_l_stock_secret(const factory_t *f,
                                   const factory_node_t *leaf_node,
                                   uint32_t state_counter,
                                   unsigned char secret_out32[32]);
+
+/* #53-B3b.2a: CLIENT-side — record the LSP-shipped per-node L-stock hash so the
+   client builds the matching 2-leaf L-stock SPK without the (LSP-private) seed.
+   Call once per leaf node BEFORE factory_build_tree (and update before each advance
+   when the new state's H arrives over the wire).  Sets the factory into mirror mode
+   (apply_l_stock_hashlock then uses these hashes instead of deriving). */
+void factory_set_node_l_stock_hash(factory_t *f, size_t node_idx,
+                                   const unsigned char *h32);
 
 /* Build the L-stock output scriptPubKey (P2TR) for a leaf state node — the
    2-leaf {poison, LSP-CSV} taptree when the node carries a per-state hash

--- a/include/superscalar/musig.h
+++ b/include/superscalar/musig.h
@@ -160,6 +160,17 @@ int musig_session_finalize_nonces(
     const secp256k1_pubkey *adaptor       /* NULL for normal, non-NULL for PTLC */
 );
 
+/* #53-B3a: finalize a session signing the RAW aggregate key — NO taproot tweak
+   (not even BIP-86).  Matches musig_sign_all_local.  Use for tapscript SCRIPT-PATH
+   spends whose OP_CHECKSIG verifies the untweaked agg/internal key (e.g. the Leaf-P
+   L-stock poison).  Do NOT use for key-path spends (use musig_session_finalize_nonces
+   with the matching merkle_root). */
+int musig_session_finalize_nonces_untweaked(
+    const secp256k1_context *ctx,
+    musig_signing_session_t *session,
+    const unsigned char *msg32
+);
+
 /* Produce a partial signature. Uses secnonce (zeroed after -- single use!).
    keypair: this signer's keypair. */
 int musig_create_partial_sig(

--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -19,7 +19,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 37
+#define PERSIST_SCHEMA_VERSION 38
 
 /* #185 / wallet-team CEREMONY_DESIGN.md §6.1:
    Ceremony state enum (column `ceremonies.state`).
@@ -147,6 +147,29 @@ int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
                                  uint64_t chan_amount_sats,
                                  const unsigned char *poison_tx,
                                  size_t poison_tx_len);
+
+/* #53-B3b.2d: persisted script-path L-stock poison reveals (table l_stock_poison_reveals,
+   schema v38).  save: at ceremony-complete (secret NULL).  update_secret: when the reveal
+   verifies.  load: on restart -> rebuild + factory_assemble_poison_with_secret + broadcast. */
+int persist_save_l_stock_poison(persist_t *p, uint32_t factory_id, uint32_t node_idx,
+                                uint32_t state_counter,
+                                const unsigned char *l_stock_hash32,
+                                const unsigned char *agg_sig64,
+                                const unsigned char *unsigned_tx, size_t unsigned_tx_len,
+                                const unsigned char *leaf_script, size_t leaf_script_len,
+                                const unsigned char *control_block,
+                                size_t control_block_len);
+int persist_update_l_stock_secret(persist_t *p, uint32_t factory_id, uint32_t node_idx,
+                                  uint32_t state_counter,
+                                  const unsigned char *secret32);
+int persist_load_l_stock_poison(persist_t *p, uint32_t factory_id, uint32_t node_idx,
+                                uint32_t state_counter,
+                                unsigned char *l_stock_hash_out32,
+                                unsigned char *agg_sig_out64,
+                                tx_buf_t *unsigned_tx_out,
+                                unsigned char *leaf_script_out, size_t *leaf_script_len_out,
+                                unsigned char *control_block_out, size_t *control_block_len_out,
+                                unsigned char *secret_out32, int *out_has_secret);
 
 /* Load all PS chain entries for a leaf in chain_pos order.
    chain_txs_out: caller-allocated tx_buf_t[max_chain] (caller must free each on success).

--- a/include/superscalar/tapscript.h
+++ b/include/superscalar/tapscript.h
@@ -128,6 +128,16 @@ int tapscript_build_htlc_received_timeout(tapscript_leaf_t *leaf,
     const secp256k1_xonly_pubkey *remote_htlcpubkey,
     const secp256k1_context *ctx);
 
+/* L-stock poison "Leaf P" (#53): hashlock(state_hash) + N-of-N agg checksig.
+   Identical bytes to the offered-HTLC success leaf; named for the L-stock context.
+   Spendable only with the revealed revocation secret (preimage) AND the N-of-N
+   poison signature, so a non-revoked (live) state's poison has no satisfying
+   witness (closes Scenario B). */
+int tapscript_build_l_stock_poison_leaf(tapscript_leaf_t *leaf,
+    const unsigned char *state_hash32,
+    const secp256k1_xonly_pubkey *agg_xonly,
+    const secp256k1_context *ctx);
+
 /* Build control block for script-path spend of a 2-leaf tree.
    out must be >= 65 bytes. Result: [leaf_version|parity] || internal_key(32) || sibling_hash(32) */
 int tapscript_build_control_block_2leaf(

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -205,6 +205,14 @@
    0x01 partial-close-only. */
 #define MSG_ROTATE 0x8B
 
+/* #53-B3b: LSP -> Client.  After an advance commits the new leaf state, the LSP
+   reveals the SUPERSEDED state's L-stock revocation secret(s) so the client (or its
+   watchtower) can spend the Leaf-P poison if the LSP later broadcasts that stale
+   state.  Carries an array of {node, revoked_state, secret} — one entry for the
+   single-leaf advance, N for a Tier-B rollover.  Verify-before-persist
+   (SHA256(secret)==committed H_old), mirroring channel revoke-and-ack. */
+#define MSG_LSTOCK_REVEAL 0x8C
+
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
 #define CEREMONY_ABORT_LSP_RESTART          0x01
@@ -938,6 +946,23 @@ int wire_parse_leaf_advance_psig(const cJSON *json,
 cJSON *wire_build_leaf_advance_done(int leaf_side);
 
 int wire_parse_leaf_advance_done(const cJSON *json, int *leaf_side);
+
+/* #53-B3b: MSG_LSTOCK_REVEAL.  LSP -> Client; reveals superseded-state L-stock
+   revocation secrets so the client can spend the Leaf-P poison on a later breach of
+   that state.  Carries n entries of {node, revoked_state, secret32} (n=1 for a
+   single-leaf advance, N for a Tier-B rollover).  Build from parallel arrays; parse
+   into caller arrays.  Build returns the cJSON (NULL on OOM); parse returns 1 on
+   success with *n_out set, 0 on malformed input. */
+cJSON *wire_build_lstock_reveal(const uint32_t *node_idx,
+                                const uint32_t *revoked_state,
+                                const unsigned char secrets[][32],
+                                size_t n);
+int wire_parse_lstock_reveal(const cJSON *json,
+                             uint32_t *node_idx_out,
+                             uint32_t *revoked_state_out,
+                             unsigned char secrets_out[][32],
+                             size_t max_entries,
+                             size_t *n_out);
 
 /* --- Tier B: state-advance ceremony (root rollover, MSG_PATH_*) ---
 

--- a/src/client.c
+++ b/src/client.c
@@ -2586,7 +2586,8 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
         if (factory_session_prepare_poison_tx_leaf(
                 factory, pre_node_idx_r,
                 pre_old_leaf_txid_r, (uint32_t)(pre_old_n_outputs_r - 1),
-                pre_old_l_amount_r, REALLOC_POISON_FEE_SATS)) {
+                pre_old_l_amount_r, REALLOC_POISON_FEE_SATS,
+                NULL /* #53-B3b: client mirrors LSP; daemon hashlock off -> key-path */)) {
             realloc_poison_prepared = 1;
         }
     }
@@ -2847,7 +2848,7 @@ static int client_handle_subfactory_advance_stateless_multi(
             memcpy(old_chain_txid, sub->txid, 32);
             if (factory_session_prepare_poison_tx_subfactory(
                     factory, sub_node_i, old_chain_txid, (uint32_t)old_n_chans,
-                    old_sstock, POISON_FEE_SATS))
+                    old_sstock, POISON_FEE_SATS, NULL))
                 poison_prepared_c = 1;
         }
     }
@@ -3239,7 +3240,7 @@ static int client_handle_subfactory_advance_stateless(int fd,
             memcpy(old_chain_txid, sub->txid, 32);
             if (factory_session_prepare_poison_tx_subfactory(
                     factory, sub_node_i, old_chain_txid, (uint32_t)old_n_chans,
-                    old_sstock, POISON_FEE_SATS)) {
+                    old_sstock, POISON_FEE_SATS, NULL)) {
                 poison_prepared_c = 1;  /* init_node_poison after state init */
             }
         }
@@ -3600,7 +3601,7 @@ static int client_handle_leaf_advance_stateless(int fd,
         if (factory_session_prepare_poison_tx_leaf(
                 factory, node_idx,
                 old_leaf_txid, (uint32_t)(old_n_outputs_c - 1),
-                old_l_amount_c, LEAF_POISON_FEE_SATS_C)) {
+                old_l_amount_c, LEAF_POISON_FEE_SATS_C, NULL)) {
             leaf_poison_prepared_c = 1;
         }
     }
@@ -4034,7 +4035,7 @@ static int client_handle_state_advance_stateless(int fd,
             memcpy(old_txid, an->txid, 32);
             if (factory_session_prepare_poison_tx_leaf(
                     factory, affected[k], old_txid, (uint32_t)(old_no - 1),
-                    old_l, TIERB_POISON_FEE_SATS)) {
+                    old_l, TIERB_POISON_FEE_SATS, NULL)) {
                 poison_prepared_c[k] = 1;  /* init_node_poison after state init */
             }
         }

--- a/src/client.c
+++ b/src/client.c
@@ -1902,6 +1902,28 @@ int client_run_with_channels(secp256k1_context *ctx,
         }
     }
 
+    /* #53-B3b: per-NODE L-stock hashes (present when the LSP runs hashlock poison).
+       Parsed here into temp arrays (survive cJSON_Delete); applied to the factory
+       after factory_init + before build_tree so the client builds the matching
+       2-leaf L-stock SPK without the (LSP-private) seed. */
+    uint32_t *parsed_node_h_idx = (uint32_t *)calloc(FACTORY_MAX_NODES, sizeof(uint32_t));
+    unsigned char (*parsed_node_h)[32] = (unsigned char (*)[32])calloc(FACTORY_MAX_NODES, 32);
+    size_t n_node_h = 0;
+    cJSON *nlsh_arr = cJSON_GetObjectItem(msg.json, "node_l_stock_hashes");
+    if (parsed_node_h_idx && parsed_node_h && nlsh_arr && cJSON_IsArray(nlsh_arr)) {
+        int nn = cJSON_GetArraySize(nlsh_arr);
+        for (int i = 0; i < nn && n_node_h < FACTORY_MAX_NODES; i++) {
+            cJSON *o = cJSON_GetArrayItem(nlsh_arr, i);
+            cJSON *no = o ? cJSON_GetObjectItem(o, "node") : NULL;
+            cJSON *hh = o ? cJSON_GetObjectItem(o, "h") : NULL;
+            if (no && cJSON_IsNumber(no) && hh && cJSON_IsString(hh) &&
+                hex_decode(hh->valuestring, parsed_node_h[n_node_h], 32) == 32) {
+                parsed_node_h_idx[n_node_h] = (uint32_t)no->valuedouble;
+                n_node_h++;
+            }
+        }
+    }
+
     cJSON_Delete(msg.json);
 
     /* Verify funding TX on-chain before signing anything.  If the caller
@@ -2000,6 +2022,13 @@ int client_run_with_channels(secp256k1_context *ctx,
     if (n_parsed_hashes > 0)
         factory_set_l_stock_hashes(factory, parsed_l_stock_hashes, n_parsed_hashes);
     free(parsed_l_stock_hashes);
+    /* #53-B3b: mirror the LSP's per-node L-stock hashes onto our nodes BEFORE
+       build_tree, so the client builds the SAME 2-leaf L-stock SPK (it has no seed
+       to derive them).  Inert when the LSP didn't ship any (hashlock off). */
+    for (size_t nh = 0; nh < n_node_h; nh++)
+        factory_set_node_l_stock_hash(factory, parsed_node_h_idx[nh], parsed_node_h[nh]);
+    free(parsed_node_h_idx);
+    free(parsed_node_h);
     factory_set_funding(factory, funding_txid, funding_vout, funding_amount,
                         funding_spk, spk_len);
 

--- a/src/factory.c
+++ b/src/factory.c
@@ -280,8 +280,8 @@ static int build_l_stock_taptree(const factory_t *f,
     return 1;
 }
 
-static int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
-                              unsigned char *spk_out34) {
+int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
+                       unsigned char *spk_out34) {
     if (!f || !leaf_node || !spk_out34) return 0;
 
     /* Internal key = leaf's N-of-N MuSig agg pubkey (LSP + all leaf clients). */

--- a/src/factory.c
+++ b/src/factory.c
@@ -301,6 +301,61 @@ int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
     return 1;
 }
 
+int factory_enable_hashlock_poison(factory_t *f) {
+    if (!f || !f->has_shachain) return 0;  /* need a seed to derive secrets from */
+    f->use_hashlock_poison = 1;
+    return 1;
+}
+
+int factory_derive_l_stock_secret(const factory_t *f,
+                                  const factory_node_t *leaf_node,
+                                  uint32_t state_counter,
+                                  unsigned char secret_out32[32]) {
+    if (!f || !leaf_node || !secret_out32 || !f->has_shachain) return 0;
+    unsigned char agg32[32];
+    if (!secp256k1_xonly_pubkey_serialize(f->ctx, agg32,
+                                          &leaf_node->keyagg.agg_pubkey))
+        return 0;
+    /* secret = tagged_hash(seed || leaf_agg_xonly || state_counter_le) — keyed on
+       BOTH the leaf identity and the per-leaf state index, so no cross-leaf or
+       cross-state secret reuse (fixes the old global-epoch index). */
+    unsigned char buf[32 + 32 + 4];
+    memcpy(buf, f->shachain_seed, 32);
+    memcpy(buf + 32, agg32, 32);
+    buf[64] = (unsigned char)(state_counter & 0xff);
+    buf[65] = (unsigned char)((state_counter >> 8) & 0xff);
+    buf[66] = (unsigned char)((state_counter >> 16) & 0xff);
+    buf[67] = (unsigned char)((state_counter >> 24) & 0xff);
+    sha256_tagged("SS/LStockPoison/v1", buf, sizeof(buf), secret_out32);
+    return 1;
+}
+
+/* #53-B: derive + commit the per-(leaf, state) revocation hash onto a leaf node
+   so its next-built L-stock SPK carries Leaf P (the hashlock-gated poison path).
+   No-op unless hashlock poison is enabled.  Must be called AFTER node->keyagg is
+   set and BEFORE build_l_stock_spk. */
+static int apply_l_stock_hashlock(factory_t *f, factory_node_t *node) {
+    if (!f->use_hashlock_poison) return 1;
+    unsigned char secret[32];
+    if (!factory_derive_l_stock_secret(f, node, node->l_stock_state_counter, secret))
+        return 0;
+    sha256(secret, 32, node->l_stock_hash);
+    node->has_l_stock_hash = 1;
+    memset(secret, 0, sizeof(secret));  /* LSP re-derives on demand; don't retain */
+    return 1;
+}
+
+/* Build a leaf's L-stock OUTPUT scriptPubKey, first committing the per-(leaf,state)
+   hashlock (#53-B) when enabled.  ALL leaf-output construction paths route through
+   this so no leaf type is left with an un-gated (Scenario-B-vulnerable) L-stock when
+   the factory has hashlock poison on.  The poison signers instead call the const
+   build_l_stock_spk directly — they READ the already-committed hash. */
+static int set_leaf_l_stock_output(factory_t *f, factory_node_t *node,
+                                   unsigned char *spk_out34) {
+    if (!apply_l_stock_hashlock(f, node)) return 0;
+    return build_l_stock_spk(f, node, spk_out34);
+}
+
 /* Update L-stock outputs on leaf state nodes after epoch change.
    Called by factory_advance() after counter advance.
    L-stock is always the last output of a leaf node. */
@@ -317,8 +372,12 @@ static int update_l_stock_outputs(factory_t *f) {
         if (node->n_outputs < 2)
             continue;
 
-        /* L-stock is always the last output */
-        if (!build_l_stock_spk(f, node, node->outputs[node->n_outputs - 1].script_pubkey))
+        /* #53-B: this leaf's L-stock state is advancing — bump its per-leaf
+           counter and re-commit the NEW state's hash before rebuilding the SPK.
+           The just-superseded state's secret (counter-1) is what the LSP reveals
+           to this leaf's clients for recourse against the old state. */
+        node->l_stock_state_counter++;
+        if (!set_leaf_l_stock_output(f, node, node->outputs[node->n_outputs - 1].script_pubkey))
             return 0;
     }
     return 1;
@@ -391,7 +450,7 @@ static int setup_leaf_outputs(
     }
 
     /* L-stock SPK: or(N-of-N keyagg, L&CSV) per ZmnSCPxj's t/1242 */
-    if (!build_l_stock_spk(f, node, node->outputs[2].script_pubkey))
+    if (!set_leaf_l_stock_output(f, node, node->outputs[2].script_pubkey))
         return 0;
     node->outputs[2].script_pubkey_len = 34;
     node->outputs[2].amount_sats = per_output + remainder;
@@ -984,7 +1043,7 @@ static int setup_single_leaf_outputs(
     }
 
     /* L-stock SPK: or(N-of-N keyagg, L&CSV) per ZmnSCPxj's t/1242 */
-    if (!build_l_stock_spk(f, node, node->outputs[1].script_pubkey))
+    if (!set_leaf_l_stock_output(f, node, node->outputs[1].script_pubkey))
         return 0;
     node->outputs[1].script_pubkey_len = 34;
     node->outputs[1].amount_sats = per_output + remainder;
@@ -1027,7 +1086,7 @@ static int setup_ps_leaf_outputs(
     node->outputs[0].amount_sats = per_output;
 
     /* vout 1: L-stock SPK = or(N-of-N keyagg, L&CSV) per t/1242 */
-    if (!build_l_stock_spk(f, node, node->outputs[1].script_pubkey))
+    if (!set_leaf_l_stock_output(f, node, node->outputs[1].script_pubkey))
         return 0;
     node->outputs[1].script_pubkey_len = 34;
     node->outputs[1].amount_sats = per_output + remainder;
@@ -1172,7 +1231,7 @@ static int setup_ps_leaf_with_subfactories(
     }
 
     /* Leaf-level L-stock at the LAST output. */
-    if (!build_l_stock_spk(f, leaf, leaf->outputs[k].script_pubkey))
+    if (!set_leaf_l_stock_output(f, leaf, leaf->outputs[k].script_pubkey))
         return 0;
     leaf->outputs[k].script_pubkey_len = 34;
     leaf->outputs[k].amount_sats = per_output + remainder;
@@ -1293,7 +1352,7 @@ static int setup_nway_leaf_outputs(
     }
 
     /* L-stock at LAST output: or(N-of-N keyagg, L&CSV) per t/1242 */
-    if (!build_l_stock_spk(f, node, node->outputs[n_client].script_pubkey))
+    if (!set_leaf_l_stock_output(f, node, node->outputs[n_client].script_pubkey))
         return 0;
     node->outputs[n_client].script_pubkey_len = 34;
     node->outputs[n_client].amount_sats = per_output + remainder;
@@ -2291,7 +2350,10 @@ static int update_l_stock_for_leaf(factory_t *f, size_t node_idx) {
     if (node->n_outputs < 2)
         return 1;
 
-    return build_l_stock_spk(f, node, node->outputs[node->n_outputs - 1].script_pubkey);
+    /* #53-B: per-leaf advance — bump this leaf's L-stock state index so the new
+       state commits a fresh hash (the old state's secret becomes revealable). */
+    node->l_stock_state_counter++;
+    return set_leaf_l_stock_output(f, node, node->outputs[node->n_outputs - 1].script_pubkey);
 }
 
 int factory_advance_leaf(factory_t *f, int leaf_side) {

--- a/src/factory.c
+++ b/src/factory.c
@@ -3080,6 +3080,12 @@ void factory_session_reset_poison(factory_t *f, size_t node_idx) {
     /* secp256k1_musig structures are POD-style; zeroing is safe. */
     memset(&node->poison_signing_session, 0, sizeof(node->poison_signing_session));
     memset(node->poison_partial_sigs, 0, sizeof(node->poison_partial_sigs));
+    /* #53-B3a script-path ceremony state */
+    node->poison_is_scriptpath = 0;
+    node->poison_has_agg_sig = 0;
+    memset(node->poison_agg_sig, 0, sizeof(node->poison_agg_sig));
+    node->poison_leaf_script_len = 0;
+    node->poison_control_block_len = 0;
 }
 
 int factory_session_prepare_poison_tx_subfactory(
@@ -3096,7 +3102,19 @@ int factory_session_prepare_poison_tx_subfactory(
        what the wire ceremony rounds do. */
     factory_session_reset_poison(f, sub_node_idx);
     tx_buf_init(&sub->poison_unsigned_tx, 256);
-    if (!factory_build_l_stock_poison_tx_unsigned(
+    if (sub->has_l_stock_hash) {
+        /* #53-B3a: hashlock poison — sign the Leaf-P script path (untweaked). */
+        sub->poison_is_scriptpath = 1;
+        if (!factory_build_l_stock_poison_scriptpath_unsigned(
+                f, sub, old_chain_txid32, old_sstock_vout,
+                old_sstock_amount_sats, fee_sats,
+                &sub->poison_unsigned_tx, sub->poison_sighash, sub->poison_txid,
+                sub->poison_leaf_script, &sub->poison_leaf_script_len,
+                sub->poison_control_block, &sub->poison_control_block_len)) {
+            factory_session_reset_poison(f, sub_node_idx);
+            return 0;
+        }
+    } else if (!factory_build_l_stock_poison_tx_unsigned(
             f, sub, old_chain_txid32, old_sstock_vout,
             old_sstock_amount_sats, fee_sats,
             &sub->poison_unsigned_tx, sub->poison_sighash, sub->poison_txid)) {
@@ -3116,7 +3134,19 @@ int factory_session_prepare_poison_tx_leaf(
 
     factory_session_reset_poison(f, leaf_node_idx);
     tx_buf_init(&leaf->poison_unsigned_tx, 256);
-    if (!factory_build_l_stock_poison_tx_unsigned(
+    if (leaf->has_l_stock_hash) {
+        /* #53-B3a: hashlock poison — sign the Leaf-P script path (untweaked). */
+        leaf->poison_is_scriptpath = 1;
+        if (!factory_build_l_stock_poison_scriptpath_unsigned(
+                f, leaf, old_leaf_txid32, old_l_stock_vout,
+                old_l_stock_amount_sats, fee_sats,
+                &leaf->poison_unsigned_tx, leaf->poison_sighash, leaf->poison_txid,
+                leaf->poison_leaf_script, &leaf->poison_leaf_script_len,
+                leaf->poison_control_block, &leaf->poison_control_block_len)) {
+            factory_session_reset_poison(f, leaf_node_idx);
+            return 0;
+        }
+    } else if (!factory_build_l_stock_poison_tx_unsigned(
             f, leaf, old_leaf_txid32, old_l_stock_vout,
             old_l_stock_amount_sats, fee_sats,
             &leaf->poison_unsigned_tx, leaf->poison_sighash, leaf->poison_txid)) {
@@ -3151,7 +3181,23 @@ int factory_session_finalize_node_poison(factory_t *f, size_t node_idx) {
     if (!f || node_idx >= f->n_nodes) return 0;
     factory_node_t *node = &f->nodes[node_idx];
 
-    /* The poison TX spends the OLD state's L-stock / sales-stock UTXO
+    /* #53-B3a: hashlock poison spends via the Leaf-P SCRIPT path, whose OP_CHECKSIG
+       verifies the UNTWEAKED agg key.  Finalize with no taptweak (mirrors
+       musig_sign_all_local) so LSP + clients sign the same raw-key message. */
+    if (node->poison_is_scriptpath) {
+        int ok = musig_session_finalize_nonces_untweaked(
+            f->ctx, &node->poison_signing_session, node->poison_sighash);
+        if (!ok)
+            fprintf(stderr,
+                    "finalize_node_poison %zu (script-path): "
+                    "musig_session_finalize_nonces_untweaked failed "
+                    "(n_signers=%zu, nonces_collected=%d)\n",
+                    node_idx, node->n_signers,
+                    node->poison_signing_session.nonces_collected);
+        return ok;
+    }
+
+    /* Legacy key-path poison: spends the OLD state's L-stock / sales-stock UTXO
        whose SPK is `or(N-of-N keyagg, L&CSV)` — the keypath spend uses
        the leaf-level taptree merkle root (single CSV leaf).  Match what
        sign_l_stock_spend_with_outputs does internally so the sighash
@@ -3210,6 +3256,17 @@ int factory_session_complete_node_poison(factory_t *f, size_t node_idx) {
                                         node->n_signers))
         return 0;
 
+    if (node->poison_is_scriptpath) {
+        /* #53-B3a: the broadcastable poison needs the revealed secret as the Leaf-P
+           witness preimage, which isn't available at ceremony time.  Store the
+           aggregated 64-byte Schnorr sig; factory_assemble_poison_with_secret builds
+           the full witness tx once the secret is revealed (#53-B3b). */
+        memcpy(node->poison_agg_sig, sig, 64);
+        node->poison_has_agg_sig = 1;
+        node->poison_is_signed = 1;
+        return 1;
+    }
+
     if (!finalize_signed_tx(&node->poison_signed_tx,
                               node->poison_unsigned_tx.data,
                               node->poison_unsigned_tx.len, sig))
@@ -3217,6 +3274,28 @@ int factory_session_complete_node_poison(factory_t *f, size_t node_idx) {
 
     node->poison_is_signed = 1;
     return 1;
+}
+
+int factory_assemble_poison_with_secret(factory_t *f, size_t node_idx,
+                                        const unsigned char *secret32,
+                                        tx_buf_t *out) {
+    if (!f || node_idx >= f->n_nodes || !secret32 || !out) return 0;
+    factory_node_t *node = &f->nodes[node_idx];
+    if (!node->poison_is_scriptpath || !node->poison_has_agg_sig) return 0;
+    if (node->poison_unsigned_tx.len == 0) return 0;
+
+    /* Defense-in-depth: the revealed secret must be the committed hash's preimage,
+       else the assembled witness can't satisfy Leaf P (avoid emitting a dead tx). */
+    unsigned char chk[32];
+    sha256(secret32, 32, chk);
+    if (memcmp(chk, node->l_stock_hash, 32) != 0) return 0;
+
+    /* Witness: [agg sig, preimage=secret, Leaf-P script, 2-leaf control block]. */
+    return finalize_script_path_tx_preimage(out,
+        node->poison_unsigned_tx.data, node->poison_unsigned_tx.len,
+        node->poison_agg_sig, secret32, 32,
+        node->poison_leaf_script, node->poison_leaf_script_len,
+        node->poison_control_block, node->poison_control_block_len);
 }
 
 void factory_set_shachain_seed(factory_t *f, const unsigned char *seed32) {

--- a/src/factory.c
+++ b/src/factory.c
@@ -342,6 +342,17 @@ int factory_derive_l_stock_secret(const factory_t *f,
    No-op unless hashlock poison is enabled.  Must be called AFTER node->keyagg is
    set and BEFORE build_l_stock_spk. */
 static int apply_l_stock_hashlock(factory_t *f, factory_node_t *node) {
+    /* #53-B3b.2a: CLIENT MIRROR — no seed locally, so use the LSP-shipped per-node
+       hash for this node index instead of deriving.  Lets the client build the SAME
+       2-leaf L-stock SPK as the LSP (else the leaf-state tx diverges + co-sign fails). */
+    if (f->has_node_l_stock_hashes) {
+        size_t idx = (size_t)(node - f->nodes);
+        if (idx < FACTORY_MAX_NODES && f->node_l_stock_hash_valid[idx]) {
+            memcpy(node->l_stock_hash, f->node_l_stock_hashes[idx], 32);
+            node->has_l_stock_hash = 1;
+        }
+        return 1;
+    }
     if (!f->use_hashlock_poison) return 1;
     unsigned char secret[32];
     if (!factory_derive_l_stock_secret(f, node, node->l_stock_state_counter, secret))
@@ -350,6 +361,14 @@ static int apply_l_stock_hashlock(factory_t *f, factory_node_t *node) {
     node->has_l_stock_hash = 1;
     memset(secret, 0, sizeof(secret));  /* LSP re-derives on demand; don't retain */
     return 1;
+}
+
+void factory_set_node_l_stock_hash(factory_t *f, size_t node_idx,
+                                   const unsigned char *h32) {
+    if (!f || node_idx >= FACTORY_MAX_NODES || !h32) return;
+    memcpy(f->node_l_stock_hashes[node_idx], h32, 32);
+    f->node_l_stock_hash_valid[node_idx] = 1;
+    f->has_node_l_stock_hashes = 1;
 }
 
 /* Build a leaf's L-stock OUTPUT scriptPubKey, first committing the per-(leaf,state)

--- a/src/factory.c
+++ b/src/factory.c
@@ -235,14 +235,24 @@ static int add_node(
    Caller passes the leaf state node — `leaf_node->keyagg.agg_pubkey` is
    the N-of-N internal key, `leaf_node->signer_indices[]` enumerates the
    clients that will receive equal shares in the poison TX. */
-static int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
-                              unsigned char *spk_out34) {
-    if (!f || !leaf_node || !spk_out34) return 0;
+/* #53: Build the L-stock taptree leaves + merkle root, used by BOTH the SPK
+   builder and every L-stock spender so the SPK and the taptweak can never drift.
+   - Leaf L (always) = <csv> CSV DROP <LSP_xonly> CHECKSIG — LSP unilateral fallback.
+   - Leaf P (iff leaf_node->has_l_stock_hash) = hashlock(H_s) + N-of-N agg checksig —
+     the revocation-gated poison path.
+   When the node carries no per-state hash the tree is the legacy single leaf {Leaf L}
+   (byte-identical to the pre-#53 SPK), so this change is a no-op until a state's hash
+   is wired (#53-B).  `leaf_P_out` may be NULL only when the caller knows the node has
+   no hash; `*is_2leaf_out` (optional) reports which tree was built. */
+static int build_l_stock_taptree(const factory_t *f,
+                                  const factory_node_t *leaf_node,
+                                  tapscript_leaf_t *leaf_P_out,
+                                  tapscript_leaf_t *leaf_L_out,
+                                  unsigned char *merkle_root_out32,
+                                  int *is_2leaf_out) {
+    if (!f || !leaf_node || !leaf_L_out || !merkle_root_out32) return 0;
 
-    /* Internal key = leaf's N-of-N MuSig agg pubkey (LSP + all leaf clients). */
-    secp256k1_xonly_pubkey internal_key = leaf_node->keyagg.agg_pubkey;
-
-    /* Script-leaf: <csv_blocks> CSV DROP <LSP_xonly> CHECKSIG. */
+    /* Leaf L: <csv_blocks> CSV DROP <LSP_xonly> CHECKSIG. */
     secp256k1_xonly_pubkey lsp_xonly;
     if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL,
                                               &f->pubkeys[0]))
@@ -250,12 +260,36 @@ static int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node
     uint32_t csv = f->l_stock_csv_blocks > 0
                    ? f->l_stock_csv_blocks
                    : L_STOCK_CSV_DEFAULT_BLOCKS;
-    tapscript_leaf_t csv_leaf;
-    if (!tapscript_build_csv_delay(&csv_leaf, csv, &lsp_xonly, f->ctx))
+    if (!tapscript_build_csv_delay(leaf_L_out, csv, &lsp_xonly, f->ctx))
         return 0;
 
+    int two = leaf_node->has_l_stock_hash ? 1 : 0;
+    if (two) {
+        if (!leaf_P_out) return 0;
+        if (!tapscript_build_l_stock_poison_leaf(leaf_P_out, leaf_node->l_stock_hash,
+                                                  &leaf_node->keyagg.agg_pubkey, f->ctx))
+            return 0;
+        tapscript_leaf_t leaves[2] = { *leaf_P_out, *leaf_L_out };
+        if (!tapscript_merkle_root(merkle_root_out32, leaves, 2))
+            return 0;
+    } else {
+        if (!tapscript_merkle_root(merkle_root_out32, leaf_L_out, 1))
+            return 0;
+    }
+    if (is_2leaf_out) *is_2leaf_out = two;
+    return 1;
+}
+
+static int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
+                              unsigned char *spk_out34) {
+    if (!f || !leaf_node || !spk_out34) return 0;
+
+    /* Internal key = leaf's N-of-N MuSig agg pubkey (LSP + all leaf clients). */
+    secp256k1_xonly_pubkey internal_key = leaf_node->keyagg.agg_pubkey;
+
+    tapscript_leaf_t leaf_P, leaf_L;
     unsigned char merkle_root[32];
-    if (!tapscript_merkle_root(merkle_root, &csv_leaf, 1))
+    if (!build_l_stock_taptree(f, leaf_node, &leaf_P, &leaf_L, merkle_root, NULL))
         return 0;
 
     secp256k1_xonly_pubkey tweaked;
@@ -3403,23 +3437,13 @@ static int sign_l_stock_spend_with_outputs(
         kps[i] = f->keypairs[idx];
     }
 
-    /* 4. Compute the L-stock SPK's script-tree merkle root (single leaf:
-       <csv> CSV DROP <LSP> CHECKSIG).  musig_sign_taproot needs this to
-       apply the BIP-341 taptweak that matches the SPK. */
-    secp256k1_xonly_pubkey lsp_xonly;
-    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL,
-                                              &f->pubkeys[0])) {
-        free(kps); tx_buf_free(&unsigned_tx); return 0;
-    }
-    uint32_t csv = f->l_stock_csv_blocks > 0
-                   ? f->l_stock_csv_blocks
-                   : L_STOCK_CSV_DEFAULT_BLOCKS;
-    tapscript_leaf_t csv_leaf;
-    if (!tapscript_build_csv_delay(&csv_leaf, csv, &lsp_xonly, f->ctx)) {
-        free(kps); tx_buf_free(&unsigned_tx); return 0;
-    }
+    /* 4. Compute the L-stock SPK's taptree merkle root (2-leaf {poison, LSP-CSV}
+       when the state carries a hashlock, else legacy single {LSP-CSV} leaf) via the
+       shared builder so the key-path taptweak always matches the SPK (#53). */
+    tapscript_leaf_t coop_leaf_P, coop_leaf_L;
     unsigned char merkle_root[32];
-    if (!tapscript_merkle_root(merkle_root, &csv_leaf, 1)) {
+    if (!build_l_stock_taptree(f, leaf_node, &coop_leaf_P, &coop_leaf_L,
+                               merkle_root, NULL)) {
         free(kps); tx_buf_free(&unsigned_tx); return 0;
     }
 
@@ -3484,6 +3508,134 @@ int factory_sign_l_stock_poison_tx(
                                                l_stock_vout, l_stock_amount_sats,
                                                outs, n_clients, signed_out);
     free(outs);
+    return ok;
+}
+
+int factory_build_l_stock_poison_scriptpath(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    const unsigned char *secret32,
+    tx_buf_t *signed_out,
+    unsigned char *poison_txid_out32)
+{
+    if (!f || !leaf_node || !l_stock_txid32 || !secret32 || !signed_out) return 0;
+    /* No hashlock poison without the per-state hash committed in the SPK. */
+    if (!leaf_node->has_l_stock_hash) return 0;
+    if (leaf_node->n_signers < 2) return 0;
+
+    /* Fail fast unless the supplied secret is the actual preimage of the leaf's
+       committed hash — otherwise we'd emit a tx whose Leaf-P witness can never
+       satisfy OP_SHA256 <H_s> OP_EQUALVERIFY. */
+    unsigned char chk[32];
+    sha256(secret32, 32, chk);
+    if (memcmp(chk, leaf_node->l_stock_hash, 32) != 0) return 0;
+
+    size_t n_clients = leaf_node->n_signers - 1;
+    uint64_t per_client = 0, last_extra = 0;
+    if (!compute_l_stock_poison_per_client(l_stock_amount_sats, fee_sats,
+                                            n_clients, &per_client, &last_extra))
+        return 0;
+
+    /* Per-client key-path P2TR(client) outputs — same redistribution as the
+       key-path poison; each client sweeps (and can CPFP-bump) its own output. */
+    tx_output_t *outputs = (tx_output_t *)calloc(n_clients, sizeof(tx_output_t));
+    if (!outputs) return 0;
+    for (size_t i = 0; i < n_clients; i++) {
+        uint32_t signer_idx = leaf_node->signer_indices[1 + i];  /* skip LSP[0] */
+        if (signer_idx >= f->n_participants) { free(outputs); return 0; }
+        secp256k1_xonly_pubkey client_xonly, tw;
+        if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &client_xonly, NULL,
+                                                  &f->pubkeys[signer_idx]) ||
+            !taproot_tweak_pubkey(f->ctx, &tw, NULL, &client_xonly, NULL)) {
+            free(outputs); return 0;
+        }
+        build_p2tr_script_pubkey(outputs[i].script_pubkey, &tw);
+        outputs[i].script_pubkey_len = 34;
+        outputs[i].amount_sats = per_client;
+    }
+    outputs[n_clients - 1].amount_sats += last_extra;
+
+    /* Unsigned TX: single input from the L-stock outpoint, nSequence 0xFFFFFFFE
+       (the CSV gate lives on Leaf L, not this spend). */
+    tx_buf_t unsigned_tx;
+    tx_buf_init(&unsigned_tx, 256);
+    unsigned char disp_txid[32];
+    if (!build_unsigned_tx(&unsigned_tx, poison_txid_out32 ? disp_txid : NULL,
+                            l_stock_txid32, l_stock_vout, 0xFFFFFFFEu,
+                            outputs, n_clients)) {
+        tx_buf_free(&unsigned_tx); free(outputs); return 0;
+    }
+    free(outputs);
+    if (poison_txid_out32) {
+        memcpy(poison_txid_out32, disp_txid, 32);
+        reverse_bytes(poison_txid_out32, 32);
+    }
+
+    /* Rebuild the 2-leaf taptree (must be 2-leaf since has_l_stock_hash). */
+    secp256k1_xonly_pubkey internal_key = leaf_node->keyagg.agg_pubkey;
+    tapscript_leaf_t leaf_P, leaf_L;
+    unsigned char merkle_root[32];
+    int two = 0;
+    if (!build_l_stock_taptree(f, leaf_node, &leaf_P, &leaf_L, merkle_root, &two)
+        || !two) {
+        tx_buf_free(&unsigned_tx); return 0;
+    }
+
+    /* Prevout SPK the sighash commits to. */
+    unsigned char l_stock_spk[34];
+    if (!build_l_stock_spk(f, leaf_node, l_stock_spk)) {
+        tx_buf_free(&unsigned_tx); return 0;
+    }
+
+    /* BIP-341 script-path sighash over Leaf P. */
+    unsigned char sighash[32];
+    if (!compute_tapscript_sighash(sighash, unsigned_tx.data, unsigned_tx.len, 0,
+                                    l_stock_spk, 34, l_stock_amount_sats,
+                                    0xFFFFFFFEu, &leaf_P)) {
+        tx_buf_free(&unsigned_tx); return 0;
+    }
+
+    /* N-of-N MuSig over the UNtweaked agg key (Leaf-P checksig verifies the raw
+       agg key, not the taproot output key) — musig_sign_all_local applies no tweak. */
+    secp256k1_keypair *kps = (secp256k1_keypair *)calloc(leaf_node->n_signers,
+                                                          sizeof(secp256k1_keypair));
+    if (!kps) { tx_buf_free(&unsigned_tx); return 0; }
+    for (size_t i = 0; i < leaf_node->n_signers; i++) {
+        uint32_t idx = leaf_node->signer_indices[i];
+        if (idx >= f->n_participants) { free(kps); tx_buf_free(&unsigned_tx); return 0; }
+        kps[i] = f->keypairs[idx];
+    }
+    unsigned char sig64[64];
+    if (!musig_sign_all_local(f->ctx, sig64, sighash, kps,
+                               leaf_node->n_signers, &leaf_node->keyagg)) {
+        free(kps); tx_buf_free(&unsigned_tx); return 0;
+    }
+    free(kps);
+
+    /* Control block for the Leaf-P script path (sibling = Leaf L, parity from tweak). */
+    int parity = 0;
+    secp256k1_xonly_pubkey tweaked;
+    if (!tapscript_tweak_pubkey(f->ctx, &tweaked, &parity, &internal_key, merkle_root)) {
+        tx_buf_free(&unsigned_tx); return 0;
+    }
+    unsigned char control_block[65];
+    size_t cb_len = 0;
+    if (!tapscript_build_control_block_2leaf(control_block, &cb_len, parity,
+                                              &internal_key, &leaf_L, f->ctx)) {
+        tx_buf_free(&unsigned_tx); return 0;
+    }
+
+    /* Witness: [sig, preimage=secret, Leaf-P script, control block]. */
+    int ok = finalize_script_path_tx_preimage(signed_out,
+                                              unsigned_tx.data, unsigned_tx.len,
+                                              sig64, secret32, 32,
+                                              leaf_P.script, leaf_P.script_len,
+                                              control_block, cb_len);
+    tx_buf_free(&unsigned_tx);
     return ok;
 }
 

--- a/src/factory.c
+++ b/src/factory.c
@@ -243,9 +243,14 @@ static int add_node(
    When the node carries no per-state hash the tree is the legacy single leaf {Leaf L}
    (byte-identical to the pre-#53 SPK), so this change is a no-op until a state's hash
    is wired (#53-B).  `leaf_P_out` may be NULL only when the caller knows the node has
-   no hash; `*is_2leaf_out` (optional) reports which tree was built. */
+   no hash; `*is_2leaf_out` (optional) reports which tree was built.
+   `override_hash32` (optional): build Leaf P with this hash instead of the node's
+   current l_stock_hash — used by the poison builder to target a SUPERSEDED state's
+   output (whose SPK committed H_old) after the leaf has already advanced to H_new
+   (#53-B3b).  NULL = use the node's current hash. */
 static int build_l_stock_taptree(const factory_t *f,
                                   const factory_node_t *leaf_node,
+                                  const unsigned char *override_hash32,
                                   tapscript_leaf_t *leaf_P_out,
                                   tapscript_leaf_t *leaf_L_out,
                                   unsigned char *merkle_root_out32,
@@ -263,10 +268,12 @@ static int build_l_stock_taptree(const factory_t *f,
     if (!tapscript_build_csv_delay(leaf_L_out, csv, &lsp_xonly, f->ctx))
         return 0;
 
-    int two = leaf_node->has_l_stock_hash ? 1 : 0;
+    const unsigned char *h = override_hash32 ? override_hash32
+                                             : leaf_node->l_stock_hash;
+    int two = (override_hash32 != NULL) || leaf_node->has_l_stock_hash;
     if (two) {
         if (!leaf_P_out) return 0;
-        if (!tapscript_build_l_stock_poison_leaf(leaf_P_out, leaf_node->l_stock_hash,
+        if (!tapscript_build_l_stock_poison_leaf(leaf_P_out, h,
                                                   &leaf_node->keyagg.agg_pubkey, f->ctx))
             return 0;
         tapscript_leaf_t leaves[2] = { *leaf_P_out, *leaf_L_out };
@@ -289,7 +296,7 @@ int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
 
     tapscript_leaf_t leaf_P, leaf_L;
     unsigned char merkle_root[32];
-    if (!build_l_stock_taptree(f, leaf_node, &leaf_P, &leaf_L, merkle_root, NULL))
+    if (!build_l_stock_taptree(f, leaf_node, NULL, &leaf_P, &leaf_L, merkle_root, NULL))
         return 0;
 
     secp256k1_xonly_pubkey tweaked;
@@ -3086,12 +3093,14 @@ void factory_session_reset_poison(factory_t *f, size_t node_idx) {
     memset(node->poison_agg_sig, 0, sizeof(node->poison_agg_sig));
     node->poison_leaf_script_len = 0;
     node->poison_control_block_len = 0;
+    memset(node->poison_l_stock_hash, 0, sizeof(node->poison_l_stock_hash));
 }
 
 int factory_session_prepare_poison_tx_subfactory(
     factory_t *f, size_t sub_node_idx,
     const unsigned char *old_chain_txid32, uint32_t old_sstock_vout,
-    uint64_t old_sstock_amount_sats, uint64_t fee_sats)
+    uint64_t old_sstock_amount_sats, uint64_t fee_sats,
+    const unsigned char *override_hash32)
 {
     if (!f || sub_node_idx >= f->n_nodes || !old_chain_txid32) return 0;
     factory_node_t *sub = &f->nodes[sub_node_idx];
@@ -3102,12 +3111,15 @@ int factory_session_prepare_poison_tx_subfactory(
        what the wire ceremony rounds do. */
     factory_session_reset_poison(f, sub_node_idx);
     tx_buf_init(&sub->poison_unsigned_tx, 256);
-    if (sub->has_l_stock_hash) {
-        /* #53-B3a: hashlock poison — sign the Leaf-P script path (untweaked). */
+    if (override_hash32 || sub->has_l_stock_hash) {
+        /* #53-B3a/b: hashlock poison — Leaf-P script path (untweaked), targeting the
+           superseded state's H_old (override) or the node's current hash. */
         sub->poison_is_scriptpath = 1;
+        memcpy(sub->poison_l_stock_hash,
+               override_hash32 ? override_hash32 : sub->l_stock_hash, 32);
         if (!factory_build_l_stock_poison_scriptpath_unsigned(
                 f, sub, old_chain_txid32, old_sstock_vout,
-                old_sstock_amount_sats, fee_sats,
+                old_sstock_amount_sats, fee_sats, override_hash32,
                 &sub->poison_unsigned_tx, sub->poison_sighash, sub->poison_txid,
                 sub->poison_leaf_script, &sub->poison_leaf_script_len,
                 sub->poison_control_block, &sub->poison_control_block_len)) {
@@ -3127,19 +3139,23 @@ int factory_session_prepare_poison_tx_subfactory(
 int factory_session_prepare_poison_tx_leaf(
     factory_t *f, size_t leaf_node_idx,
     const unsigned char *old_leaf_txid32, uint32_t old_l_stock_vout,
-    uint64_t old_l_stock_amount_sats, uint64_t fee_sats)
+    uint64_t old_l_stock_amount_sats, uint64_t fee_sats,
+    const unsigned char *override_hash32)
 {
     if (!f || leaf_node_idx >= f->n_nodes || !old_leaf_txid32) return 0;
     factory_node_t *leaf = &f->nodes[leaf_node_idx];
 
     factory_session_reset_poison(f, leaf_node_idx);
     tx_buf_init(&leaf->poison_unsigned_tx, 256);
-    if (leaf->has_l_stock_hash) {
-        /* #53-B3a: hashlock poison — sign the Leaf-P script path (untweaked). */
+    if (override_hash32 || leaf->has_l_stock_hash) {
+        /* #53-B3a/b: hashlock poison — Leaf-P script path (untweaked), targeting the
+           superseded state's H_old (override) or the node's current hash. */
         leaf->poison_is_scriptpath = 1;
+        memcpy(leaf->poison_l_stock_hash,
+               override_hash32 ? override_hash32 : leaf->l_stock_hash, 32);
         if (!factory_build_l_stock_poison_scriptpath_unsigned(
                 f, leaf, old_leaf_txid32, old_l_stock_vout,
-                old_l_stock_amount_sats, fee_sats,
+                old_l_stock_amount_sats, fee_sats, override_hash32,
                 &leaf->poison_unsigned_tx, leaf->poison_sighash, leaf->poison_txid,
                 leaf->poison_leaf_script, &leaf->poison_leaf_script_len,
                 leaf->poison_control_block, &leaf->poison_control_block_len)) {
@@ -3284,11 +3300,12 @@ int factory_assemble_poison_with_secret(factory_t *f, size_t node_idx,
     if (!node->poison_is_scriptpath || !node->poison_has_agg_sig) return 0;
     if (node->poison_unsigned_tx.len == 0) return 0;
 
-    /* Defense-in-depth: the revealed secret must be the committed hash's preimage,
-       else the assembled witness can't satisfy Leaf P (avoid emitting a dead tx). */
+    /* Defense-in-depth: the revealed secret must be the preimage of the hash THIS
+       poison targets (poison_l_stock_hash = the superseded state's H_old), NOT the
+       node's current l_stock_hash, which may already have advanced. */
     unsigned char chk[32];
     sha256(secret32, 32, chk);
-    if (memcmp(chk, node->l_stock_hash, 32) != 0) return 0;
+    if (memcmp(chk, node->poison_l_stock_hash, 32) != 0) return 0;
 
     /* Witness: [agg sig, preimage=secret, Leaf-P script, 2-leaf control block]. */
     return finalize_script_path_tx_preimage(out,
@@ -3583,7 +3600,7 @@ static int sign_l_stock_spend_with_outputs(
        shared builder so the key-path taptweak always matches the SPK (#53). */
     tapscript_leaf_t coop_leaf_P, coop_leaf_L;
     unsigned char merkle_root[32];
-    if (!build_l_stock_taptree(f, leaf_node, &coop_leaf_P, &coop_leaf_L,
+    if (!build_l_stock_taptree(f, leaf_node, NULL, &coop_leaf_P, &coop_leaf_L,
                                merkle_root, NULL)) {
         free(kps); tx_buf_free(&unsigned_tx); return 0;
     }
@@ -3659,6 +3676,7 @@ int factory_build_l_stock_poison_scriptpath_unsigned(
     uint32_t l_stock_vout,
     uint64_t l_stock_amount_sats,
     uint64_t fee_sats,
+    const unsigned char *override_hash32,
     tx_buf_t *unsigned_tx_out,
     unsigned char *sighash_out32,
     unsigned char *poison_txid_out32,
@@ -3669,8 +3687,9 @@ int factory_build_l_stock_poison_scriptpath_unsigned(
 {
     if (!f || !leaf_node || !l_stock_txid32 || !unsigned_tx_out || !sighash_out32)
         return 0;
-    /* No hashlock poison without the per-state hash committed in the SPK. */
-    if (!leaf_node->has_l_stock_hash) return 0;
+    /* No hashlock poison without a committed per-state hash (the node's current
+       hash, or an explicit override for a superseded state's output). */
+    if (!override_hash32 && !leaf_node->has_l_stock_hash) return 0;
     if (leaf_node->n_signers < 2) return 0;
 
     size_t n_clients = leaf_node->n_signers - 1;
@@ -3713,17 +3732,26 @@ int factory_build_l_stock_poison_scriptpath_unsigned(
         reverse_bytes(poison_txid_out32, 32);
     }
 
-    /* Rebuild the 2-leaf taptree (must be 2-leaf since has_l_stock_hash). */
+    /* Build the 2-leaf taptree for the TARGET output's hash (override_hash32 when
+       spending a superseded state's output, else the node's current hash). */
     secp256k1_xonly_pubkey internal_key = leaf_node->keyagg.agg_pubkey;
     tapscript_leaf_t leaf_P, leaf_L;
     unsigned char merkle_root[32];
     int two = 0;
-    if (!build_l_stock_taptree(f, leaf_node, &leaf_P, &leaf_L, merkle_root, &two) || !two)
+    if (!build_l_stock_taptree(f, leaf_node, override_hash32, &leaf_P, &leaf_L,
+                               merkle_root, &two) || !two)
         return 0;
 
-    /* Prevout SPK the sighash commits to. */
+    /* Tweak once from THIS taptree's root: the prevout SPK the sighash commits to
+       AND the control block the witness reconstructs must both come from the target
+       output's hash — NOT build_l_stock_spk, which uses the node's (possibly already
+       advanced) current hash. */
+    int parity = 0;
+    secp256k1_xonly_pubkey tweaked;
+    if (!tapscript_tweak_pubkey(f->ctx, &tweaked, &parity, &internal_key, merkle_root))
+        return 0;
     unsigned char l_stock_spk[34];
-    if (!build_l_stock_spk(f, leaf_node, l_stock_spk)) return 0;
+    build_p2tr_script_pubkey(l_stock_spk, &tweaked);
 
     /* BIP-341 script-path sighash over Leaf P. */
     if (!compute_tapscript_sighash(sighash_out32, unsigned_tx_out->data,
@@ -3731,17 +3759,13 @@ int factory_build_l_stock_poison_scriptpath_unsigned(
                                     l_stock_amount_sats, 0xFFFFFFFEu, &leaf_P))
         return 0;
 
-    /* Leaf-P script + 2-leaf control block (sibling = Leaf L, parity from tweak) —
-       the witness components a holder later combines with [agg sig, revealed secret]. */
+    /* Leaf-P script + 2-leaf control block (sibling = Leaf L) — the witness
+       components a holder later combines with [agg sig, revealed secret]. */
     if (leaf_p_script_out && leaf_p_script_len_out) {
         memcpy(leaf_p_script_out, leaf_P.script, leaf_P.script_len);
         *leaf_p_script_len_out = leaf_P.script_len;
     }
     if (control_block_out && control_block_len_out) {
-        int parity = 0;
-        secp256k1_xonly_pubkey tweaked;
-        if (!tapscript_tweak_pubkey(f->ctx, &tweaked, &parity, &internal_key, merkle_root))
-            return 0;
         size_t cb_len = 0;
         if (!tapscript_build_control_block_2leaf(control_block_out, &cb_len, parity,
                                                   &internal_key, &leaf_L, f->ctx))
@@ -3779,7 +3803,7 @@ int factory_build_l_stock_poison_scriptpath(
     unsigned char cb[65]; size_t cb_len = 0;
     if (!factory_build_l_stock_poison_scriptpath_unsigned(
             f, leaf_node, l_stock_txid32, l_stock_vout, l_stock_amount_sats,
-            fee_sats, &utx, sighash, poison_txid_out32,
+            fee_sats, NULL, &utx, sighash, poison_txid_out32,
             lp_script, &lp_len, cb, &cb_len)) {
         tx_buf_free(&utx); return 0;
     }

--- a/src/factory.c
+++ b/src/factory.c
@@ -3573,28 +3573,26 @@ int factory_sign_l_stock_poison_tx(
     return ok;
 }
 
-int factory_build_l_stock_poison_scriptpath(
-    factory_t *f,
+int factory_build_l_stock_poison_scriptpath_unsigned(
+    const factory_t *f,
     const factory_node_t *leaf_node,
     const unsigned char *l_stock_txid32,
     uint32_t l_stock_vout,
     uint64_t l_stock_amount_sats,
     uint64_t fee_sats,
-    const unsigned char *secret32,
-    tx_buf_t *signed_out,
-    unsigned char *poison_txid_out32)
+    tx_buf_t *unsigned_tx_out,
+    unsigned char *sighash_out32,
+    unsigned char *poison_txid_out32,
+    unsigned char *leaf_p_script_out,
+    size_t *leaf_p_script_len_out,
+    unsigned char *control_block_out,
+    size_t *control_block_len_out)
 {
-    if (!f || !leaf_node || !l_stock_txid32 || !secret32 || !signed_out) return 0;
+    if (!f || !leaf_node || !l_stock_txid32 || !unsigned_tx_out || !sighash_out32)
+        return 0;
     /* No hashlock poison without the per-state hash committed in the SPK. */
     if (!leaf_node->has_l_stock_hash) return 0;
     if (leaf_node->n_signers < 2) return 0;
-
-    /* Fail fast unless the supplied secret is the actual preimage of the leaf's
-       committed hash — otherwise we'd emit a tx whose Leaf-P witness can never
-       satisfy OP_SHA256 <H_s> OP_EQUALVERIFY. */
-    unsigned char chk[32];
-    sha256(secret32, 32, chk);
-    if (memcmp(chk, leaf_node->l_stock_hash, 32) != 0) return 0;
 
     size_t n_clients = leaf_node->n_signers - 1;
     uint64_t per_client = 0, last_extra = 0;
@@ -3602,8 +3600,8 @@ int factory_build_l_stock_poison_scriptpath(
                                             n_clients, &per_client, &last_extra))
         return 0;
 
-    /* Per-client key-path P2TR(client) outputs — same redistribution as the
-       key-path poison; each client sweeps (and can CPFP-bump) its own output. */
+    /* Per-client key-path P2TR(client) outputs — each client sweeps (and can
+       CPFP-bump) its own output. */
     tx_output_t *outputs = (tx_output_t *)calloc(n_clients, sizeof(tx_output_t));
     if (!outputs) return 0;
     for (size_t i = 0; i < n_clients; i++) {
@@ -3623,13 +3621,12 @@ int factory_build_l_stock_poison_scriptpath(
 
     /* Unsigned TX: single input from the L-stock outpoint, nSequence 0xFFFFFFFE
        (the CSV gate lives on Leaf L, not this spend). */
-    tx_buf_t unsigned_tx;
-    tx_buf_init(&unsigned_tx, 256);
+    tx_buf_reset(unsigned_tx_out);
     unsigned char disp_txid[32];
-    if (!build_unsigned_tx(&unsigned_tx, poison_txid_out32 ? disp_txid : NULL,
+    if (!build_unsigned_tx(unsigned_tx_out, poison_txid_out32 ? disp_txid : NULL,
                             l_stock_txid32, l_stock_vout, 0xFFFFFFFEu,
                             outputs, n_clients)) {
-        tx_buf_free(&unsigned_tx); free(outputs); return 0;
+        free(outputs); return 0;
     }
     free(outputs);
     if (poison_txid_out32) {
@@ -3642,62 +3639,94 @@ int factory_build_l_stock_poison_scriptpath(
     tapscript_leaf_t leaf_P, leaf_L;
     unsigned char merkle_root[32];
     int two = 0;
-    if (!build_l_stock_taptree(f, leaf_node, &leaf_P, &leaf_L, merkle_root, &two)
-        || !two) {
-        tx_buf_free(&unsigned_tx); return 0;
-    }
+    if (!build_l_stock_taptree(f, leaf_node, &leaf_P, &leaf_L, merkle_root, &two) || !two)
+        return 0;
 
     /* Prevout SPK the sighash commits to. */
     unsigned char l_stock_spk[34];
-    if (!build_l_stock_spk(f, leaf_node, l_stock_spk)) {
-        tx_buf_free(&unsigned_tx); return 0;
-    }
+    if (!build_l_stock_spk(f, leaf_node, l_stock_spk)) return 0;
 
     /* BIP-341 script-path sighash over Leaf P. */
+    if (!compute_tapscript_sighash(sighash_out32, unsigned_tx_out->data,
+                                    unsigned_tx_out->len, 0, l_stock_spk, 34,
+                                    l_stock_amount_sats, 0xFFFFFFFEu, &leaf_P))
+        return 0;
+
+    /* Leaf-P script + 2-leaf control block (sibling = Leaf L, parity from tweak) —
+       the witness components a holder later combines with [agg sig, revealed secret]. */
+    if (leaf_p_script_out && leaf_p_script_len_out) {
+        memcpy(leaf_p_script_out, leaf_P.script, leaf_P.script_len);
+        *leaf_p_script_len_out = leaf_P.script_len;
+    }
+    if (control_block_out && control_block_len_out) {
+        int parity = 0;
+        secp256k1_xonly_pubkey tweaked;
+        if (!tapscript_tweak_pubkey(f->ctx, &tweaked, &parity, &internal_key, merkle_root))
+            return 0;
+        size_t cb_len = 0;
+        if (!tapscript_build_control_block_2leaf(control_block_out, &cb_len, parity,
+                                                  &internal_key, &leaf_L, f->ctx))
+            return 0;
+        *control_block_len_out = cb_len;
+    }
+    return 1;
+}
+
+int factory_build_l_stock_poison_scriptpath(
+    factory_t *f,
+    const factory_node_t *leaf_node,
+    const unsigned char *l_stock_txid32,
+    uint32_t l_stock_vout,
+    uint64_t l_stock_amount_sats,
+    uint64_t fee_sats,
+    const unsigned char *secret32,
+    tx_buf_t *signed_out,
+    unsigned char *poison_txid_out32)
+{
+    if (!f || !leaf_node || !secret32 || !signed_out) return 0;
+    if (!leaf_node->has_l_stock_hash) return 0;
+
+    /* Fail fast unless the supplied secret is the actual preimage of the leaf's
+       committed hash — otherwise we'd emit a tx whose Leaf-P witness can never
+       satisfy OP_SHA256 <H_s> OP_EQUALVERIFY. */
+    unsigned char chk[32];
+    sha256(secret32, 32, chk);
+    if (memcmp(chk, leaf_node->l_stock_hash, 32) != 0) return 0;
+
+    tx_buf_t utx;
+    tx_buf_init(&utx, 256);
     unsigned char sighash[32];
-    if (!compute_tapscript_sighash(sighash, unsigned_tx.data, unsigned_tx.len, 0,
-                                    l_stock_spk, 34, l_stock_amount_sats,
-                                    0xFFFFFFFEu, &leaf_P)) {
-        tx_buf_free(&unsigned_tx); return 0;
+    unsigned char lp_script[TAPSCRIPT_MAX_SCRIPT]; size_t lp_len = 0;
+    unsigned char cb[65]; size_t cb_len = 0;
+    if (!factory_build_l_stock_poison_scriptpath_unsigned(
+            f, leaf_node, l_stock_txid32, l_stock_vout, l_stock_amount_sats,
+            fee_sats, &utx, sighash, poison_txid_out32,
+            lp_script, &lp_len, cb, &cb_len)) {
+        tx_buf_free(&utx); return 0;
     }
 
     /* N-of-N MuSig over the UNtweaked agg key (Leaf-P checksig verifies the raw
        agg key, not the taproot output key) — musig_sign_all_local applies no tweak. */
     secp256k1_keypair *kps = (secp256k1_keypair *)calloc(leaf_node->n_signers,
                                                           sizeof(secp256k1_keypair));
-    if (!kps) { tx_buf_free(&unsigned_tx); return 0; }
+    if (!kps) { tx_buf_free(&utx); return 0; }
     for (size_t i = 0; i < leaf_node->n_signers; i++) {
         uint32_t idx = leaf_node->signer_indices[i];
-        if (idx >= f->n_participants) { free(kps); tx_buf_free(&unsigned_tx); return 0; }
+        if (idx >= f->n_participants) { free(kps); tx_buf_free(&utx); return 0; }
         kps[i] = f->keypairs[idx];
     }
     unsigned char sig64[64];
     if (!musig_sign_all_local(f->ctx, sig64, sighash, kps,
                                leaf_node->n_signers, &leaf_node->keyagg)) {
-        free(kps); tx_buf_free(&unsigned_tx); return 0;
+        free(kps); tx_buf_free(&utx); return 0;
     }
     free(kps);
 
-    /* Control block for the Leaf-P script path (sibling = Leaf L, parity from tweak). */
-    int parity = 0;
-    secp256k1_xonly_pubkey tweaked;
-    if (!tapscript_tweak_pubkey(f->ctx, &tweaked, &parity, &internal_key, merkle_root)) {
-        tx_buf_free(&unsigned_tx); return 0;
-    }
-    unsigned char control_block[65];
-    size_t cb_len = 0;
-    if (!tapscript_build_control_block_2leaf(control_block, &cb_len, parity,
-                                              &internal_key, &leaf_L, f->ctx)) {
-        tx_buf_free(&unsigned_tx); return 0;
-    }
-
     /* Witness: [sig, preimage=secret, Leaf-P script, control block]. */
-    int ok = finalize_script_path_tx_preimage(signed_out,
-                                              unsigned_tx.data, unsigned_tx.len,
+    int ok = finalize_script_path_tx_preimage(signed_out, utx.data, utx.len,
                                               sig64, secret32, 32,
-                                              leaf_P.script, leaf_P.script_len,
-                                              control_block, cb_len);
-    tx_buf_free(&unsigned_tx);
+                                              lp_script, lp_len, cb, cb_len);
+    tx_buf_free(&utx);
     return ok;
 }
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1747,13 +1747,28 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (leaf_poison_prepared) {
         secp256k1_pubkey poison_output_pk;
         secp256k1_xonly_pubkey poison_output_xpub;
-        if (secp256k1_musig_pubkey_get(lsp->ctx, &poison_output_pk,
+        /* The verify works for BOTH paths: the session cache is the tweaked output
+           key for key-path poison, or the RAW agg key after the untweaked finalize
+           for script-path (#53-B3a), so musig_pubkey_get returns the correct key. */
+        int poison_verified =
+            secp256k1_musig_pubkey_get(lsp->ctx, &poison_output_pk,
                                          &node->poison_signing_session.cache) &&
             secp256k1_xonly_pubkey_from_pubkey(lsp->ctx, &poison_output_xpub, NULL,
                                                  &poison_output_pk) &&
             secp256k1_schnorrsig_verify(lsp->ctx, final_poison_sig,
                                           node->poison_signing_session.msg32, 32,
-                                          &poison_output_xpub) &&
+                                          &poison_output_xpub);
+        if (poison_verified && node->poison_is_scriptpath) {
+            /* #53-B3b.2b: script-path (Leaf-P) poison — the broadcastable witness
+               needs the revealed secret as the preimage, unavailable at ceremony
+               time.  Store the aggregated Leaf-P sig; factory_assemble_poison_with_secret
+               builds the full witness once the secret is revealed (#53-B3b). */
+            memcpy(node->poison_agg_sig, final_poison_sig, 64);
+            node->poison_has_agg_sig = 1;
+            node->poison_is_signed = 1;
+            printf("LSP-stateless: script-path poison agg sig stored (L-stock %llu sats)\n",
+                   (unsigned long long)old_l_amount);
+        } else if (poison_verified &&
             finalize_signed_tx(&node->poison_signed_tx,
                                 node->poison_unsigned_tx.data,
                                 node->poison_unsigned_tx.len,

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1441,7 +1441,12 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         if (factory_session_prepare_poison_tx_leaf(
                 f, pre_node_idx,
                 old_leaf_txid, (uint32_t)(old_n_outputs - 1),
-                old_l_amount, LEAF_POISON_FEE_SATS)) {
+                old_l_amount, LEAF_POISON_FEE_SATS,
+                /* #53-B3b: NULL while the daemon doesn't enable hashlock poison
+                   (has_l_stock_hash==0 -> key-path branch). When it does, this path
+                   advances BEFORE prepare, so capture H_old before
+                   factory_advance_leaf_unsigned and pass it here. */
+                NULL)) {
             leaf_poison_prepared = 1;
         }
     }
@@ -2101,7 +2106,8 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                 (uint64_t)(an->n_signers - 1) * 330u) {
             if (factory_session_prepare_poison_tx_leaf(
                     f, affected[k], poison_old_txid[k], (uint32_t)(old_no - 1),
-                    poison_old_l_amount[k], TIERB_POISON_FEE_SATS)) {
+                    poison_old_l_amount[k], TIERB_POISON_FEE_SATS,
+                    NULL /* #53-B3b: capture per-node H_old when daemon hashlock on */)) {
                 poison_prepared[k] = 1;  /* init_node_poison after state init */
             }
         }
@@ -2883,7 +2889,10 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         if (factory_session_prepare_poison_tx_leaf(
                 f, node_idx,
                 realloc_old_leaf_txid, (uint32_t)(realloc_old_n_outputs - 1),
-                realloc_old_l_amount, REALLOC_POISON_FEE_SATS)) {
+                realloc_old_l_amount, REALLOC_POISON_FEE_SATS,
+                /* #53-B3b: this path prepares BEFORE the advance, so the node's
+                   current hash IS H_old — NULL is already correct here. */
+                NULL)) {
             realloc_poison_prepared = 1;
         }
     }
@@ -3437,7 +3446,8 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
         if (factory_session_prepare_poison_tx_subfactory(
                 f, sub_node_i, wt_old_chain_txid, (uint32_t)wt_old_n_chans,
-                wt_old_sstock_amount, POISON_FEE_SATS)) {
+                wt_old_sstock_amount, POISON_FEE_SATS,
+                NULL /* #53-B3b: capture sub H_old when daemon hashlock on */)) {
             poison_prepared = 1;
         } else {
             fprintf(stderr, "LSP-stateless subfactory MULTI: poison TX prep "
@@ -4101,7 +4111,8 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
         wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
         if (factory_session_prepare_poison_tx_subfactory(
                 f, sub_node_i, wt_old_chain_txid, (uint32_t)wt_old_n_chans,
-                wt_old_sstock_amount, POISON_FEE_SATS)) {
+                wt_old_sstock_amount, POISON_FEE_SATS,
+                NULL /* #53-B3b: capture sub H_old when daemon hashlock on */)) {
             poison_prepared = 1;  /* init_node_poison after state init */
         } else {
             fprintf(stderr,

--- a/src/musig.c
+++ b/src/musig.c
@@ -341,6 +341,35 @@ int musig_session_finalize_nonces(
     return 1;
 }
 
+int musig_session_finalize_nonces_untweaked(
+    const secp256k1_context *ctx,
+    musig_signing_session_t *session,
+    const unsigned char *msg32
+) {
+    if ((size_t)session->nonces_collected != session->n_signers)
+        return 0;
+
+    const secp256k1_musig_pubnonce *ptrs[MUSIG_SESSION_MAX_SIGNERS];
+    for (size_t i = 0; i < session->n_signers; i++)
+        ptrs[i] = &session->pubnonces[i];
+
+    if (!secp256k1_musig_nonce_agg(ctx, &session->aggnonce, ptrs, session->n_signers))
+        return 0;
+
+    memcpy(session->msg32, msg32, 32);
+
+    /* #53-B3a: NO taproot tweak — sign the RAW aggregate key (cache as initialized
+       by musig_session_init).  Matches musig_sign_all_local, required for tapscript
+       script-path spends whose OP_CHECKSIG verifies the untweaked agg key (Leaf-P
+       L-stock poison).  session->cache is the raw cache here (never tweaked). */
+    if (!secp256k1_musig_nonce_process(ctx, &session->session, &session->aggnonce,
+                                        msg32, &session->cache, NULL))
+        return 0;
+
+    session->session_ready = 1;
+    return 1;
+}
+
 int musig_create_partial_sig(
     const secp256k1_context *ctx,
     secp256k1_musig_partial_sig *partial_sig_out,

--- a/src/persist.c
+++ b/src/persist.c
@@ -1352,6 +1352,26 @@ int persist_open(persist_t *p, const char *path) {
         ");",
         NULL, NULL, NULL);
 
+    /* v38 (#53-B3b): client-side persisted L-stock revocation-secret reveals — lets a
+       restarted client (or its standalone watchtower) rebuild + broadcast the Leaf-P
+       poison for a superseded leaf state.  Created unconditionally (idempotent).  The
+       revocation_secret column is sealed by persist_apply_encryption when at-rest
+       encryption is on (#327). */
+    sqlite3_exec(p->db,
+        "CREATE TABLE IF NOT EXISTS l_stock_poison_reveals ("
+        "  factory_id           INTEGER NOT NULL,"
+        "  node_idx             INTEGER NOT NULL,"
+        "  state_counter        INTEGER NOT NULL,"
+        "  l_stock_hash         BLOB NOT NULL,"
+        "  revocation_secret    BLOB,"
+        "  poison_agg_sig       BLOB NOT NULL,"
+        "  poison_unsigned_tx   BLOB NOT NULL,"
+        "  poison_leaf_script   BLOB NOT NULL,"
+        "  poison_control_block BLOB NOT NULL,"
+        "  PRIMARY KEY (factory_id, node_idx, state_counter)"
+        ");",
+        NULL, NULL, NULL);
+
     /* Record the current version if not already present */
     if (db_version < PERSIST_SCHEMA_VERSION) {
         char vsql[128];
@@ -1674,6 +1694,129 @@ int persist_save_ps_chain_entry(persist_t *p, uint32_t factory_id,
     free(tx_hex);
     free(poison_hex);
     return ok;
+}
+
+/* #53-B3b.2d: persist a leaf's script-path L-stock poison so a restarted client (or
+   its standalone watchtower) can rebuild + broadcast it for a superseded state.  Save
+   at ceremony-complete (secret not yet revealed -> NULL); persist_update_l_stock_secret
+   fills the secret when the reveal lands + verifies.  Blobs stored as hex TEXT (the
+   codebase convention).  Returns 1 on success. */
+int persist_save_l_stock_poison(persist_t *p, uint32_t factory_id, uint32_t node_idx,
+                                uint32_t state_counter,
+                                const unsigned char *l_stock_hash32,
+                                const unsigned char *agg_sig64,
+                                const unsigned char *unsigned_tx, size_t unsigned_tx_len,
+                                const unsigned char *leaf_script, size_t leaf_script_len,
+                                const unsigned char *control_block,
+                                size_t control_block_len) {
+    if (!p || !p->db || !l_stock_hash32 || !agg_sig64 || !unsigned_tx ||
+        !leaf_script || !control_block) return 0;
+
+    char h_hex[65];   hex_encode(l_stock_hash32, 32, h_hex);
+    char sig_hex[129]; hex_encode(agg_sig64, 64, sig_hex);
+    char *utx_hex = malloc(unsigned_tx_len * 2 + 1);
+    char *ls_hex  = malloc(leaf_script_len * 2 + 1);
+    char *cb_hex  = malloc(control_block_len * 2 + 1);
+    if (!utx_hex || !ls_hex || !cb_hex) { free(utx_hex); free(ls_hex); free(cb_hex); return 0; }
+    hex_encode(unsigned_tx, unsigned_tx_len, utx_hex);
+    hex_encode(leaf_script, leaf_script_len, ls_hex);
+    hex_encode(control_block, control_block_len, cb_hex);
+
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "INSERT OR REPLACE INTO l_stock_poison_reveals "
+        "(factory_id, node_idx, state_counter, l_stock_hash, revocation_secret, "
+        " poison_agg_sig, poison_unsigned_tx, poison_leaf_script, poison_control_block) "
+        "VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?);";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        free(utx_hex); free(ls_hex); free(cb_hex); return 0;
+    }
+    sqlite3_bind_int (stmt, 1, (int)factory_id);
+    sqlite3_bind_int (stmt, 2, (int)node_idx);
+    sqlite3_bind_int (stmt, 3, (int)state_counter);
+    sqlite3_bind_text(stmt, 4, h_hex,   -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 5, sig_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 6, utx_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 7, ls_hex,  -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 8, cb_hex,  -1, SQLITE_TRANSIENT);
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    free(utx_hex); free(ls_hex); free(cb_hex);
+    return ok;
+}
+
+/* #53-B3b.2d: record the revealed revocation secret for a persisted poison (call
+   AFTER verifying SHA256(secret)==l_stock_hash).  Returns 1 if a row was updated. */
+int persist_update_l_stock_secret(persist_t *p, uint32_t factory_id, uint32_t node_idx,
+                                  uint32_t state_counter,
+                                  const unsigned char *secret32) {
+    if (!p || !p->db || !secret32) return 0;
+    char s_hex[65]; hex_encode(secret32, 32, s_hex);
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "UPDATE l_stock_poison_reveals SET revocation_secret = ? "
+        "WHERE factory_id = ? AND node_idx = ? AND state_counter = ?;";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_text(stmt, 1, s_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int (stmt, 2, (int)factory_id);
+    sqlite3_bind_int (stmt, 3, (int)node_idx);
+    sqlite3_bind_int (stmt, 4, (int)state_counter);
+    int ok = (sqlite3_step(stmt) == SQLITE_DONE) && (sqlite3_changes(p->db) > 0);
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
+/* #53-B3b.2d: load a persisted poison for (factory, node, state) into caller buffers.
+   *out_has_secret = 1 if the secret has been revealed.  All out-pointers optional
+   except those needed to reconstruct the witness.  Returns 1 if the row exists. */
+int persist_load_l_stock_poison(persist_t *p, uint32_t factory_id, uint32_t node_idx,
+                                uint32_t state_counter,
+                                unsigned char *l_stock_hash_out32,
+                                unsigned char *agg_sig_out64,
+                                tx_buf_t *unsigned_tx_out,
+                                unsigned char *leaf_script_out, size_t *leaf_script_len_out,
+                                unsigned char *control_block_out, size_t *control_block_len_out,
+                                unsigned char *secret_out32, int *out_has_secret) {
+    if (!p || !p->db) return 0;
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "SELECT l_stock_hash, poison_agg_sig, poison_unsigned_tx, poison_leaf_script, "
+        " poison_control_block, revocation_secret FROM l_stock_poison_reveals "
+        "WHERE factory_id = ? AND node_idx = ? AND state_counter = ?;";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    sqlite3_bind_int(stmt, 2, (int)node_idx);
+    sqlite3_bind_int(stmt, 3, (int)state_counter);
+    int found = 0;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        found = 1;
+        const char *h   = (const char *)sqlite3_column_text(stmt, 0);
+        const char *sig = (const char *)sqlite3_column_text(stmt, 1);
+        const char *utx = (const char *)sqlite3_column_text(stmt, 2);
+        const char *ls  = (const char *)sqlite3_column_text(stmt, 3);
+        const char *cb  = (const char *)sqlite3_column_text(stmt, 4);
+        const char *sec = (const char *)sqlite3_column_text(stmt, 5);
+        if (l_stock_hash_out32 && h) hex_decode(h, l_stock_hash_out32, 32);
+        if (agg_sig_out64 && sig)    hex_decode(sig, agg_sig_out64, 64);
+        if (unsigned_tx_out && utx) {
+            size_t n = strlen(utx) / 2;
+            tx_buf_reset(unsigned_tx_out);
+            unsigned char *buf = malloc(n);
+            if (buf) { hex_decode(utx, buf, n); tx_buf_write_bytes(unsigned_tx_out, buf, n); free(buf); }
+        }
+        if (leaf_script_out && leaf_script_len_out && ls) {
+            size_t n = strlen(ls) / 2;
+            hex_decode(ls, leaf_script_out, n); *leaf_script_len_out = n;
+        }
+        if (control_block_out && control_block_len_out && cb) {
+            size_t n = strlen(cb) / 2;
+            hex_decode(cb, control_block_out, n); *control_block_len_out = n;
+        }
+        if (out_has_secret) *out_has_secret = (sec != NULL);
+        if (sec && secret_out32) hex_decode(sec, secret_out32, 32);
+    }
+    sqlite3_finalize(stmt);
+    return found;
 }
 
 /* Load PS leaf chain for a given leaf node.

--- a/src/tapscript.c
+++ b/src/tapscript.c
@@ -447,6 +447,18 @@ int tapscript_build_htlc_offered_success(tapscript_leaf_t *leaf,
     return 1;
 }
 
+/* #53: L-stock poison "Leaf P" — hashlock(state_hash) + N-of-N agg checksig.
+   Byte-identical to the offered-HTLC success leaf; a thin named wrapper keeps the
+   L-stock poison construction self-documenting and routed through one audited
+   script builder. */
+int tapscript_build_l_stock_poison_leaf(tapscript_leaf_t *leaf,
+    const unsigned char *state_hash32,
+    const secp256k1_xonly_pubkey *agg_xonly,
+    const secp256k1_context *ctx)
+{
+    return tapscript_build_htlc_offered_success(leaf, state_hash32, agg_xonly, ctx);
+}
+
 int tapscript_build_htlc_offered_timeout(tapscript_leaf_t *leaf,
     uint32_t cltv_expiry, uint32_t to_self_delay,
     const secp256k1_xonly_pubkey *local_htlcpubkey,

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -1968,8 +1968,8 @@ static int wt_hydrate_row_cb(uint32_t factory_id,
                               uint64_t fee_bump_budget_sat,
                               uint32_t fee_bump_deadline_height,
                               void *user) {
-    (void)parent_vout; (void)parent_value_sat;
-    (void)parent_spk;  (void)parent_spk_len; (void)csv_delay;
+    (void)parent_vout;
+    (void)parent_spk;  (void)parent_spk_len;
     (void)response_txid32;
     (void)fee_bump_budget_sat; (void)fee_bump_deadline_height;
     wt_hydrate_ctx_t *ctx = (wt_hydrate_ctx_t *)user;
@@ -2005,6 +2005,14 @@ static int wt_hydrate_row_cb(uint32_t factory_id,
     memcpy(parent_txid, parent_txid32, 32);
     if (watchtower_watch_factory_node(ctx->wt, factory_id, parent_txid,
                                         resp, resp_len, NULL, 0)) {
+        /* #52: carry the wt_db row's budget basis (parent value) + deadline (csv) onto
+           the just-created entry so the CPFP fee-bump escalator can RAMP. Without this a
+           hydrated entry has to_local_amount=0 -> budget_sat=0 -> max_feerate floors to
+           start_feerate -> the ramp is flat at 1 sat/vB and bumps can't overcome fee
+           pressure (proven: every CPFP child at feerate 1000). */
+        watchtower_entry_t *he = &ctx->wt->entries[ctx->wt->n_entries - 1];
+        he->to_local_amount = parent_value_sat;
+        he->csv_delay = csv_delay;
         ctx->n_loaded++;
     } else {
         fprintf(stderr,

--- a/src/wire.c
+++ b/src/wire.c
@@ -2475,6 +2475,54 @@ int wire_parse_leaf_advance_done(const cJSON *json, int *leaf_side) {
     return 1;
 }
 
+/* #53-B3b: MSG_LSTOCK_REVEAL — reveal superseded-state L-stock revocation secrets. */
+cJSON *wire_build_lstock_reveal(const uint32_t *node_idx,
+                                const uint32_t *revoked_state,
+                                const unsigned char secrets[][32],
+                                size_t n) {
+    if ((n > 0) && (!node_idx || !revoked_state || !secrets)) return NULL;
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    cJSON *arr = cJSON_CreateArray();
+    if (!arr) { cJSON_Delete(j); return NULL; }
+    for (size_t i = 0; i < n; i++) {
+        cJSON *e = cJSON_CreateObject();
+        if (!e) { cJSON_Delete(arr); cJSON_Delete(j); return NULL; }
+        cJSON_AddNumberToObject(e, "node", (double)node_idx[i]);
+        cJSON_AddNumberToObject(e, "state", (double)revoked_state[i]);
+        wire_json_add_hex(e, "secret", secrets[i], 32);
+        cJSON_AddItemToArray(arr, e);
+    }
+    cJSON_AddItemToObject(j, "reveals", arr);
+    return j;
+}
+
+int wire_parse_lstock_reveal(const cJSON *json,
+                             uint32_t *node_idx_out,
+                             uint32_t *revoked_state_out,
+                             unsigned char secrets_out[][32],
+                             size_t max_entries,
+                             size_t *n_out) {
+    if (!json || !node_idx_out || !revoked_state_out || !secrets_out || !n_out)
+        return 0;
+    cJSON *arr = cJSON_GetObjectItem(json, "reveals");
+    if (!arr || !cJSON_IsArray(arr)) return 0;
+    int an = cJSON_GetArraySize(arr);
+    size_t n = 0;
+    for (int i = 0; i < an && n < max_entries; i++) {
+        cJSON *e = cJSON_GetArrayItem(arr, i);
+        cJSON *no = e ? cJSON_GetObjectItem(e, "node") : NULL;
+        cJSON *st = e ? cJSON_GetObjectItem(e, "state") : NULL;
+        if (!no || !cJSON_IsNumber(no) || !st || !cJSON_IsNumber(st)) return 0;
+        if (wire_json_get_hex(e, "secret", secrets_out[n], 32) != 32) return 0;
+        node_idx_out[n] = (uint32_t)no->valuedouble;
+        revoked_state_out[n] = (uint32_t)st->valuedouble;
+        n++;
+    }
+    *n_out = n;
+    return 1;
+}
+
 /* --- Leaf-Level Fund Reallocation (Upgrade 3) --- */
 
 cJSON *wire_build_leaf_realloc_propose(int leaf_side,

--- a/src/wire.c
+++ b/src/wire.c
@@ -667,6 +667,28 @@ cJSON *wire_build_factory_propose(const factory_t *f) {
         cJSON_AddItemToObject(j, "l_stock_hashes", hashes);
     }
 
+    /* #53-B3b: per-(leaf,state) L-stock hashes keyed by NODE INDEX.  When the LSP
+       runs the revocation-gated poison (use_hashlock_poison), each leaf node's
+       L-stock output commits a distinct H = SHA256(secret(leaf,state)).  The client
+       has no seed and cannot derive these, so it receives them here and mirrors them
+       onto its nodes (factory_set_node_l_stock_hash) to build the SAME 2-leaf SPK —
+       otherwise the leaf-state tx bytes diverge and the MuSig co-sign fails.  Built
+       after factory_build_tree, so node->l_stock_hash is populated. */
+    {
+        cJSON *node_hashes = NULL;
+        for (size_t i = 0; i < f->n_nodes; i++) {
+            if (!f->nodes[i].has_l_stock_hash) continue;
+            if (!node_hashes) node_hashes = cJSON_CreateArray();
+            cJSON *o = cJSON_CreateObject();
+            cJSON_AddNumberToObject(o, "node", (double)i);
+            char hex[65];
+            hex_encode(f->nodes[i].l_stock_hash, 32, hex);
+            cJSON_AddStringToObject(o, "h", hex);
+            cJSON_AddItemToArray(node_hashes, o);
+        }
+        if (node_hashes) cJSON_AddItemToObject(j, "node_l_stock_hashes", node_hashes);
+    }
+
     return j;
 }
 

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -261,7 +261,7 @@ int test_persist_schema_v3(void)
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 37, "schema version is 37 (v37 adds the #327 at-rest field-encryption marker; v36 added htlcs.signed_resolution_tx_hex + old_commitments.signed_burn_tx_hex + #219 agg hard guard)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 38, "schema version is 38 (v38 adds #53-B3b l_stock_poison_reveals; v37 adds the #327 at-rest field-encryption marker; v36 added htlcs.signed_resolution_tx_hex + old_commitments.signed_burn_tx_hex + #219 agg hard guard)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -4,6 +4,7 @@
 #include "superscalar/channel.h"
 #include "superscalar/regtest.h"
 #include "superscalar/persist.h"
+#include "superscalar/wire.h"
 #include "cJSON.h"
 #include <stdio.h>
 #include <string.h>
@@ -5957,11 +5958,26 @@ int test_factory_lstock_client_mirror(void) {
     TEST_ASSERT(cli, "alloc cli");
     TEST_ASSERT(setup_variable_arity_factory(cli, ctx, kc, 3, arities, 1, 5000000),
                 "setup cli");
-    for (size_t li = 0; li < (size_t)lsp->n_leaf_nodes; li++) {
-        size_t idx = lsp->leaf_node_indices[li];
-        TEST_ASSERT(lsp->nodes[idx].has_l_stock_hash, "lsp leaf has derived hash");
-        factory_set_node_l_stock_hash(cli, idx, lsp->nodes[idx].l_stock_hash);
+    /* Ship the per-node H over the REAL wire (FACTORY_PROPOSE) and mirror it —
+       exercises the serialize -> parse -> factory_set_node_l_stock_hash round-trip,
+       not a direct in-memory copy. */
+    cJSON *propose = wire_build_factory_propose(lsp);
+    TEST_ASSERT(propose, "build FACTORY_PROPOSE");
+    cJSON *nlsh = cJSON_GetObjectItem(propose, "node_l_stock_hashes");
+    TEST_ASSERT(nlsh && cJSON_IsArray(nlsh), "PROPOSE carries node_l_stock_hashes");
+    TEST_ASSERT(cJSON_GetArraySize(nlsh) == lsp->n_leaf_nodes,
+                "one per-node hash per leaf");
+    for (int i = 0; i < cJSON_GetArraySize(nlsh); i++) {
+        cJSON *o = cJSON_GetArrayItem(nlsh, i);
+        cJSON *no = cJSON_GetObjectItem(o, "node");
+        cJSON *hh = cJSON_GetObjectItem(o, "h");
+        TEST_ASSERT(no && cJSON_IsNumber(no) && hh && cJSON_IsString(hh),
+                    "node/h fields present");
+        unsigned char h[32];
+        TEST_ASSERT(hex_decode(hh->valuestring, h, 32) == 32, "decode wire h");
+        factory_set_node_l_stock_hash(cli, (size_t)no->valuedouble, h);
     }
+    cJSON_Delete(propose);
     TEST_ASSERT(cli->has_node_l_stock_hashes, "client is in mirror mode");
     TEST_ASSERT(factory_build_tree(cli), "build cli tree");
     TEST_ASSERT(cli->n_leaf_nodes == lsp->n_leaf_nodes, "same topology");

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5928,6 +5928,217 @@ int test_factory_ps_subfactory_poison_tx_k2_n4(void) {
     return 1;
 }
 
+/* Derive the bech32m address for a 32-byte taproot output key via a rawtr()
+   descriptor (mirrors the funding path in test_tapscript.c). */
+static int derive_p2tr_addr_from_outputkey(regtest_t *rt,
+                                           const unsigned char *outkey32,
+                                           char *addr_out, size_t addr_len) {
+    char keyhex[65];
+    hex_encode(outkey32, 32, keyhex);
+    char params[160];
+    snprintf(params, sizeof(params), "\"rawtr(%s)\"", keyhex);
+    char *di = regtest_exec(rt, "getdescriptorinfo", params);
+    if (!di) return 0;
+    cJSON *dij = cJSON_Parse(di); free(di);
+    if (!dij) return 0;
+    cJSON *desc = cJSON_GetObjectItem(dij, "descriptor");
+    if (!desc || !cJSON_IsString(desc)) { cJSON_Delete(dij); return 0; }
+    char dparams[220];
+    snprintf(dparams, sizeof(dparams), "\"%s\"", desc->valuestring);
+    cJSON_Delete(dij);
+    char *da = regtest_exec(rt, "deriveaddresses", dparams);
+    if (!da) return 0;
+    cJSON *daj = cJSON_Parse(da); free(da);
+    if (!daj || !cJSON_IsArray(daj)) { if (daj) cJSON_Delete(daj); return 0; }
+    cJSON *a0 = cJSON_GetArrayItem(daj, 0);
+    if (!a0 || !cJSON_IsString(a0)) { cJSON_Delete(daj); return 0; }
+    strncpy(addr_out, a0->valuestring, addr_len - 1);
+    addr_out[addr_len - 1] = '\0';
+    cJSON_Delete(daj);
+    return 1;
+}
+
+/* #53-A CONSENSUS PROOF: the hashlock-gated L-stock poison (Leaf-P script-path)
+   is accepted by the real Bitcoin Core interpreter ONLY with the revealed secret.
+   - positive: poison built with the correct secret is ACCEPTED + CONFIRMED, and
+     actually redistributes the L-stock to the clients (economic outcome asserted);
+   - anti-vacuity: the same poison with a mangled witness preimage is REJECTED by
+     the interpreter (the hashlock genuinely gates -> a LIVE state whose secret is
+     unrevealed cannot be poisoned -> Scenario B closed on-chain, not just at the API);
+   - API: the builder refuses a secret that doesn't match the committed hash. */
+int test_regtest_lstock_hashlock_poison(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[3];
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+
+    uint8_t arities[1] = {2};
+    TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 3, arities, 1, 5000000),
+                "setup n3 {2}");
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+    TEST_ASSERT(factory_sign_all(f), "sign all");
+    TEST_ASSERT_EQ(f->n_leaf_nodes, 1, "1 leaf");
+
+    factory_node_t *leaf = &f->nodes[f->leaf_node_indices[0]];
+    size_t n_clients = leaf->n_signers - 1;
+    TEST_ASSERT(n_clients == 2, "leaf has 2 clients (LSP + 2)");
+
+    /* Commit a per-state revocation hash H_s = SHA256(secret) into Leaf P. */
+    unsigned char secret[32];
+    for (int i = 0; i < 32; i++) secret[i] = (unsigned char)(0x53 ^ i);
+    sha256(secret, 32, leaf->l_stock_hash);
+    leaf->has_l_stock_hash = 1;
+
+    /* The hashlock taptree must change the SPK vs the legacy single-leaf SPK. */
+    unsigned char spk_hash[34], spk_plain[34];
+    TEST_ASSERT(build_l_stock_spk(f, leaf, spk_hash), "build 2-leaf L-stock SPK");
+    leaf->has_l_stock_hash = 0;
+    TEST_ASSERT(build_l_stock_spk(f, leaf, spk_plain), "build legacy L-stock SPK");
+    leaf->has_l_stock_hash = 1;
+    TEST_ASSERT(memcmp(spk_hash, spk_plain, 34) != 0,
+                "hashlock changes the L-stock SPK (taptree wired)");
+    TEST_ASSERT(spk_hash[0] == 0x51 && spk_hash[1] == 0x20, "P2TR SPK shape");
+
+    /* --- regtest: fund the real 2-leaf L-stock SPK, then spend via Leaf P --- */
+    regtest_t rt;
+    if (!regtest_init(&rt)) {
+        printf("  SKIP: no regtest node available\n");
+        factory_free(f); secp256k1_context_destroy(ctx); free(f); return 1;
+    }
+    regtest_create_wallet(&rt, "ss_lstock_poison");
+    char mine_addr[128];
+    TEST_ASSERT(regtest_get_new_address(&rt, mine_addr, sizeof(mine_addr)), "mine addr");
+    regtest_mine_blocks(&rt, 101, mine_addr);
+
+    char lstock_addr[128];
+    TEST_ASSERT(derive_p2tr_addr_from_outputkey(&rt, spk_hash + 2,
+                    lstock_addr, sizeof(lstock_addr)),
+                "derive L-stock address");
+
+    char fund_txid_hex[65];
+    TEST_ASSERT(regtest_fund_address(&rt, lstock_addr, 0.001, fund_txid_hex),
+                "fund L-stock SPK");
+    regtest_mine_blocks(&rt, 1, mine_addr);
+
+    unsigned char fund_txid_bytes[32];
+    hex_decode(fund_txid_hex, fund_txid_bytes, 32);
+    reverse_bytes(fund_txid_bytes, 32);
+    int vout = -1; uint64_t amount = 0;
+    TEST_ASSERT(find_funding_vout(&rt, fund_txid_hex, spk_hash, 34, &vout, &amount),
+                "find L-stock vout");
+    TEST_ASSERT(amount > 10000, "L-stock funded");
+
+    const uint64_t fee = 1000;
+    uint64_t per_client = (amount - fee) / (uint64_t)n_clients;
+
+    /* Build the poison with the CORRECT secret. */
+    tx_buf_t poison; tx_buf_init(&poison, 256);
+    unsigned char ptxid[32];
+    TEST_ASSERT(factory_build_l_stock_poison_scriptpath(f, leaf, fund_txid_bytes,
+                    (uint32_t)vout, amount, fee, secret, &poison, ptxid),
+                "build script-path poison (correct secret)");
+
+    char *poison_hex = (char *)malloc(poison.len * 2 + 1);
+    TEST_ASSERT(poison_hex, "alloc poison hex");
+    hex_encode(poison.data, poison.len, poison_hex);
+
+    /* POSITIVE consensus: the interpreter accepts it. */
+    {
+        char *p = (char *)malloc(poison.len * 2 + 16);
+        snprintf(p, poison.len * 2 + 16, "[\"%s\"]", poison_hex);
+        char *tma = regtest_exec(&rt, "testmempoolaccept", p);
+        free(p);
+        TEST_ASSERT(tma != NULL, "testmempoolaccept ran (positive)");
+        cJSON *j = cJSON_Parse(tma); free(tma);
+        TEST_ASSERT(j && cJSON_IsArray(j), "parse testmempoolaccept (positive)");
+        cJSON *r0 = cJSON_GetArrayItem(j, 0);
+        cJSON *allowed = r0 ? cJSON_GetObjectItem(r0, "allowed") : NULL;
+        int ok_allowed = allowed && cJSON_IsTrue(allowed);
+        if (!ok_allowed) {
+            cJSON *rr = r0 ? cJSON_GetObjectItem(r0, "reject-reason") : NULL;
+            printf("  unexpected reject: %s\n",
+                   rr && rr->valuestring ? rr->valuestring : "?");
+        }
+        cJSON_Delete(j);
+        TEST_ASSERT(ok_allowed,
+                    "INTERPRETER ACCEPTS hashlock poison with the revealed secret");
+    }
+
+    /* ANTI-VACUITY negative: mangle the witness preimage -> interpreter REJECTS.
+       Proves the hashlock actually gates spendability on-chain (Scenario B). */
+    {
+        int off = -1;
+        for (size_t i = 0; i + 32 <= poison.len; i++)
+            if (memcmp(poison.data + i, secret, 32) == 0) { off = (int)i; break; }
+        TEST_ASSERT(off >= 0, "preimage present in poison witness");
+        unsigned char *mangled = (unsigned char *)malloc(poison.len);
+        memcpy(mangled, poison.data, poison.len);
+        mangled[off] ^= 0xFF;  /* break SHA256(preimage)==H_s, keep 32-byte length */
+        char *mhex = (char *)malloc(poison.len * 2 + 1);
+        hex_encode(mangled, poison.len, mhex);
+        char *p = (char *)malloc(poison.len * 2 + 16);
+        snprintf(p, poison.len * 2 + 16, "[\"%s\"]", mhex);
+        char *tma = regtest_exec(&rt, "testmempoolaccept", p);
+        free(p); free(mhex); free(mangled);
+        TEST_ASSERT(tma != NULL, "testmempoolaccept ran (negative)");
+        cJSON *j = cJSON_Parse(tma); free(tma);
+        TEST_ASSERT(j && cJSON_IsArray(j), "parse testmempoolaccept (negative)");
+        cJSON *r0 = cJSON_GetArrayItem(j, 0);
+        cJSON *allowed = r0 ? cJSON_GetObjectItem(r0, "allowed") : NULL;
+        int still_allowed = allowed && cJSON_IsTrue(allowed);
+        cJSON_Delete(j);
+        TEST_ASSERT(!still_allowed,
+                    "INTERPRETER REJECTS poison with a wrong preimage (hashlock gates)");
+    }
+
+    /* API negative: a secret that doesn't match H_s is refused at build time. */
+    {
+        unsigned char wrong[32]; memcpy(wrong, secret, 32); wrong[0] ^= 0x01;
+        tx_buf_t bad; tx_buf_init(&bad, 64);
+        TEST_ASSERT(factory_build_l_stock_poison_scriptpath(f, leaf, fund_txid_bytes,
+                        (uint32_t)vout, amount, fee, wrong, &bad, NULL) == 0,
+                    "builder REFUSES a secret that doesn't match the committed hash");
+        tx_buf_free(&bad);
+    }
+
+    /* ECONOMIC OUTCOME: broadcast + confirm + the L-stock is redistributed. */
+    {
+        char *p = (char *)malloc(poison.len * 2 + 16);
+        snprintf(p, poison.len * 2 + 16, "\"%s\"", poison_hex);
+        char *srt = regtest_exec(&rt, "sendrawtransaction", p);
+        free(p);
+        TEST_ASSERT(srt != NULL, "sendrawtransaction poison");
+        free(srt);
+        regtest_mine_blocks(&rt, 1, mine_addr);
+
+        unsigned char disp[32]; memcpy(disp, ptxid, 32); reverse_bytes(disp, 32);
+        char ptxid_hex[65]; hex_encode(disp, 32, ptxid_hex);
+        char go[96]; snprintf(go, sizeof(go), "\"%s\" 0", ptxid_hex);
+        char *gor = regtest_exec(&rt, "gettxout", go);
+        TEST_ASSERT(gor != NULL, "gettxout poison vout 0");
+        cJSON *gj = cJSON_Parse(gor); free(gor);
+        TEST_ASSERT(gj, "parse gettxout");
+        cJSON *conf = cJSON_GetObjectItem(gj, "confirmations");
+        cJSON *val = cJSON_GetObjectItem(gj, "value");
+        int confirmed = conf && conf->valueint >= 1;
+        /* value is BTC; per_client is sats. */
+        uint64_t got_sats = val ? (uint64_t)(val->valuedouble * 1e8 + 0.5) : 0;
+        cJSON_Delete(gj);
+        TEST_ASSERT(confirmed, "poison output 0 confirmed on-chain");
+        TEST_ASSERT(got_sats == per_client,
+                    "poison output 0 pays the client its redistributed share");
+        printf("  poison CONFIRMED: %s — %llu sats to each of %zu clients\n",
+               ptxid_hex, (unsigned long long)per_client, n_clients);
+    }
+
+    free(poison_hex);
+    tx_buf_free(&poison);
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* Build, sign, verify, and advance a PS factory at N=64 (1 LSP + 63 clients).
  * This is the scale test — the existing PS tests use N=3 (2 clients), which
  * doesn't exercise the interior-tree layers or the 64-way MuSig ceremony.

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6156,6 +6156,138 @@ int test_regtest_lstock_hashlock_poison(void) {
     return 1;
 }
 
+/* #53-B3a CONSENSUS PROOF: the MULTI-PROCESS poison ceremony (the production signing
+   path: prepare -> init -> per-signer nonce -> untweaked finalize -> per-signer
+   partial-sign -> complete -> assemble-with-secret) produces a Leaf-P poison that the
+   real Bitcoin Core interpreter accepts.  This is what the LSP + clients run over the
+   wire; here we drive both sides in-process with all keypairs. */
+int test_regtest_lstock_poison_ceremony(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[3];
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+
+    uint8_t arities[1] = {2};
+    TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 3, arities, 1, 5000000),
+                "setup n3 {2}");
+    unsigned char seed[32];
+    for (int i = 0; i < 32; i++) seed[i] = (unsigned char)(0x5C ^ i);
+    factory_set_shachain_seed(f, seed);
+    TEST_ASSERT(factory_enable_hashlock_poison(f), "enable hashlock poison");
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+    TEST_ASSERT(factory_sign_all(f), "sign all");
+
+    size_t leaf_idx = f->leaf_node_indices[0];
+    factory_node_t *leaf = &f->nodes[leaf_idx];
+    size_t n_clients = leaf->n_signers - 1;
+    TEST_ASSERT(leaf->has_l_stock_hash, "leaf carries hashlock");
+
+    unsigned char secret[32];
+    TEST_ASSERT(factory_derive_l_stock_secret(f, leaf, leaf->l_stock_state_counter, secret),
+                "derive secret");
+
+    unsigned char spk[34];
+    TEST_ASSERT(build_l_stock_spk(f, leaf, spk), "build L-stock SPK");
+
+    regtest_t rt;
+    if (!regtest_init(&rt)) {
+        printf("  SKIP: no regtest node\n");
+        factory_free(f); secp256k1_context_destroy(ctx); free(f); return 1;
+    }
+    regtest_create_wallet(&rt, "ss_lstock_cer");
+    char mine_addr[128];
+    TEST_ASSERT(regtest_get_new_address(&rt, mine_addr, sizeof(mine_addr)), "mine addr");
+    if (!regtest_fund_from_faucet(&rt, 0.05))
+        regtest_mine_blocks(&rt, 101, mine_addr);
+
+    char addr[128];
+    TEST_ASSERT(derive_p2tr_addr_from_outputkey(&rt, spk + 2, addr, sizeof(addr)),
+                "derive L-stock address");
+    char fund_txid_hex[65];
+    TEST_ASSERT(regtest_fund_address(&rt, addr, 0.001, fund_txid_hex), "fund L-stock");
+    regtest_mine_blocks(&rt, 1, mine_addr);
+    unsigned char fund_txid[32];
+    hex_decode(fund_txid_hex, fund_txid, 32);
+    reverse_bytes(fund_txid, 32);
+    int vout = -1; uint64_t amount = 0;
+    TEST_ASSERT(find_funding_vout(&rt, fund_txid_hex, spk, 34, &vout, &amount), "find vout");
+
+    /* --- drive the multi-process poison ceremony in-process --- */
+    const uint64_t fee = 1000;
+    TEST_ASSERT(factory_session_prepare_poison_tx_leaf(f, leaf_idx, fund_txid,
+                    (uint32_t)vout, amount, fee), "prepare poison (script-path)");
+    TEST_ASSERT(leaf->poison_is_scriptpath, "prepare set script-path mode");
+    TEST_ASSERT(factory_session_init_node_poison(f, leaf_idx), "init poison session");
+
+    secp256k1_musig_secnonce secnonces[FACTORY_MAX_SIGNERS];
+    for (size_t j = 0; j < leaf->n_signers; j++) {
+        uint32_t participant = leaf->signer_indices[j];
+        unsigned char sk[32]; secp256k1_pubkey pk;
+        TEST_ASSERT(secp256k1_keypair_sec(ctx, sk, &kps[participant]), "sk");
+        TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[participant]), "pk");
+        secp256k1_musig_pubnonce pubnonce;
+        TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[j], &pubnonce, sk, &pk,
+                                           &leaf->keyagg.cache), "poison nonce gen");
+        memset(sk, 0, 32);
+        TEST_ASSERT(factory_session_set_nonce_poison(f, leaf_idx, j, &pubnonce),
+                    "set poison nonce");
+    }
+    TEST_ASSERT(factory_session_finalize_node_poison(f, leaf_idx),
+                "finalize poison nonces (untweaked)");
+    for (size_t j = 0; j < leaf->n_signers; j++) {
+        uint32_t participant = leaf->signer_indices[j];
+        secp256k1_musig_partial_sig psig;
+        TEST_ASSERT(musig_create_partial_sig(ctx, &psig, &secnonces[j],
+                                               &kps[participant],
+                                               &leaf->poison_signing_session),
+                    "poison partial sig");
+        TEST_ASSERT(factory_session_set_partial_sig_poison(f, leaf_idx, j, &psig),
+                    "set poison partial sig");
+    }
+    TEST_ASSERT(factory_session_complete_node_poison(f, leaf_idx),
+                "complete poison ceremony");
+    TEST_ASSERT(leaf->poison_has_agg_sig, "ceremony produced an aggregated sig");
+
+    /* assemble with the revealed secret + prove the interpreter accepts it */
+    tx_buf_t poison; tx_buf_init(&poison, 256);
+    TEST_ASSERT(factory_assemble_poison_with_secret(f, leaf_idx, secret, &poison),
+                "assemble poison with secret");
+    char *phex = (char *)malloc(poison.len * 2 + 1);
+    hex_encode(poison.data, poison.len, phex);
+    char *p = (char *)malloc(poison.len * 2 + 16);
+    snprintf(p, poison.len * 2 + 16, "[\"%s\"]", phex);
+    char *tma = regtest_exec(&rt, "testmempoolaccept", p);
+    free(p);
+    TEST_ASSERT(tma != NULL, "testmempoolaccept ran");
+    cJSON *j = cJSON_Parse(tma); free(tma);
+    cJSON *r0 = j ? cJSON_GetArrayItem(j, 0) : NULL;
+    cJSON *allowed = r0 ? cJSON_GetObjectItem(r0, "allowed") : NULL;
+    int ok_allowed = allowed && cJSON_IsTrue(allowed);
+    if (!ok_allowed && r0) {
+        cJSON *rr = cJSON_GetObjectItem(r0, "reject-reason");
+        printf("  ceremony poison rejected: %s\n",
+               rr && rr->valuestring ? rr->valuestring : "?");
+    }
+    if (j) cJSON_Delete(j);
+    TEST_ASSERT(ok_allowed,
+                "INTERPRETER ACCEPTS the MULTI-PROCESS-ceremony Leaf-P poison");
+    printf("  multi-process ceremony poison ACCEPTED (%zu clients)\n", n_clients);
+
+    /* negative: assembling with a wrong secret is refused */
+    unsigned char wrong[32]; memcpy(wrong, secret, 32); wrong[0] ^= 0x01;
+    tx_buf_t bad; tx_buf_init(&bad, 64);
+    TEST_ASSERT(factory_assemble_poison_with_secret(f, leaf_idx, wrong, &bad) == 0,
+                "assemble REFUSES wrong secret");
+    tx_buf_free(&bad);
+
+    free(phex);
+    tx_buf_free(&poison);
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* Build, sign, verify, and advance a PS factory at N=64 (1 LSP + 63 clients).
  * This is the scale test — the existing PS tests use N=3 (2 clients), which
  * doesn't exercise the interior-tree layers or the 64-way MuSig ceremony.

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6215,7 +6215,7 @@ int test_regtest_lstock_poison_ceremony(void) {
     /* --- drive the multi-process poison ceremony in-process --- */
     const uint64_t fee = 1000;
     TEST_ASSERT(factory_session_prepare_poison_tx_leaf(f, leaf_idx, fund_txid,
-                    (uint32_t)vout, amount, fee), "prepare poison (script-path)");
+                    (uint32_t)vout, amount, fee, NULL), "prepare poison (script-path)");
     TEST_ASSERT(leaf->poison_is_scriptpath, "prepare set script-path mode");
     TEST_ASSERT(factory_session_init_node_poison(f, leaf_idx), "init poison session");
 
@@ -6279,6 +6279,146 @@ int test_regtest_lstock_poison_ceremony(void) {
     TEST_ASSERT(factory_assemble_poison_with_secret(f, leaf_idx, wrong, &bad) == 0,
                 "assemble REFUSES wrong secret");
     tx_buf_free(&bad);
+
+    free(phex);
+    tx_buf_free(&poison);
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
+/* #53-B3b CONSENSUS PROOF (old-hash targeting): after a leaf advances to H_new, a
+   poison built for the SUPERSEDED state (override_hash32 = H_old) must spend the OLD
+   state's output validly — even though the node's current hash is now H_new.  This is
+   exactly the trustless recourse: the LSP broadcasts a stale state, the client poisons
+   THAT (old) output.  Proves the override threading + assemble-against-poison_l_stock_hash. */
+int test_regtest_lstock_poison_old_state(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[3];
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+
+    uint8_t arities[1] = {2};
+    TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 3, arities, 1, 5000000),
+                "setup n3 {2}");
+    unsigned char seed[32];
+    for (int i = 0; i < 32; i++) seed[i] = (unsigned char)(0x7E ^ i);
+    factory_set_shachain_seed(f, seed);
+    TEST_ASSERT(factory_enable_hashlock_poison(f), "enable hashlock poison");
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+    TEST_ASSERT(factory_sign_all(f), "sign all");
+
+    size_t leaf_idx = f->leaf_node_indices[0];
+    factory_node_t *leaf = &f->nodes[leaf_idx];
+    size_t n_clients = leaf->n_signers - 1;
+    TEST_ASSERT(leaf->has_l_stock_hash && leaf->l_stock_state_counter == 0,
+                "state 0 hashlock committed");
+
+    /* Capture the OLD (state 0) secret + hash, and the OLD output's SPK to fund. */
+    unsigned char secret0[32], h0[32], spk_old[34];
+    TEST_ASSERT(factory_derive_l_stock_secret(f, leaf, 0, secret0), "derive secret0");
+    memcpy(h0, leaf->l_stock_hash, 32);
+    TEST_ASSERT(build_l_stock_spk(f, leaf, spk_old), "build old-state SPK");
+
+    /* Simulate the leaf advancing to state 1: counter++ and re-commit H_1. */
+    unsigned char secret1[32];
+    TEST_ASSERT(factory_derive_l_stock_secret(f, leaf, 1, secret1), "derive secret1");
+    leaf->l_stock_state_counter = 1;
+    sha256(secret1, 32, leaf->l_stock_hash);  /* node now at H_1 */
+    TEST_ASSERT(memcmp(h0, leaf->l_stock_hash, 32) != 0, "advance changed the hash");
+
+    regtest_t rt;
+    if (!regtest_init(&rt)) {
+        printf("  SKIP: no regtest node\n");
+        factory_free(f); secp256k1_context_destroy(ctx); free(f); return 1;
+    }
+    regtest_create_wallet(&rt, "ss_lstock_old");
+    char mine_addr[128];
+    TEST_ASSERT(regtest_get_new_address(&rt, mine_addr, sizeof(mine_addr)), "mine addr");
+    if (!regtest_fund_from_faucet(&rt, 0.05))
+        regtest_mine_blocks(&rt, 101, mine_addr);
+
+    char addr[128];
+    TEST_ASSERT(derive_p2tr_addr_from_outputkey(&rt, spk_old + 2, addr, sizeof(addr)),
+                "derive OLD L-stock address");
+    char fund_txid_hex[65];
+    TEST_ASSERT(regtest_fund_address(&rt, addr, 0.001, fund_txid_hex), "fund OLD output");
+    regtest_mine_blocks(&rt, 1, mine_addr);
+    unsigned char fund_txid[32];
+    hex_decode(fund_txid_hex, fund_txid, 32);
+    reverse_bytes(fund_txid, 32);
+    int vout = -1; uint64_t amount = 0;
+    TEST_ASSERT(find_funding_vout(&rt, fund_txid_hex, spk_old, 34, &vout, &amount),
+                "find OLD vout");
+
+    /* Prepare the poison for the SUPERSEDED state via the override (H_old). */
+    const uint64_t fee = 1000;
+    TEST_ASSERT(factory_session_prepare_poison_tx_leaf(f, leaf_idx, fund_txid,
+                    (uint32_t)vout, amount, fee, h0 /* override = H_old */),
+                "prepare poison targeting OLD state");
+    TEST_ASSERT(leaf->poison_is_scriptpath, "script-path mode");
+    TEST_ASSERT(memcmp(leaf->poison_l_stock_hash, h0, 32) == 0,
+                "poison records the OLD target hash");
+    TEST_ASSERT(factory_session_init_node_poison(f, leaf_idx), "init poison session");
+
+    secp256k1_musig_secnonce secnonces[FACTORY_MAX_SIGNERS];
+    for (size_t j = 0; j < leaf->n_signers; j++) {
+        uint32_t participant = leaf->signer_indices[j];
+        unsigned char sk[32]; secp256k1_pubkey pk;
+        TEST_ASSERT(secp256k1_keypair_sec(ctx, sk, &kps[participant]), "sk");
+        TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[participant]), "pk");
+        secp256k1_musig_pubnonce pubnonce;
+        TEST_ASSERT(musig_generate_nonce(ctx, &secnonces[j], &pubnonce, sk, &pk,
+                                           &leaf->keyagg.cache), "nonce gen");
+        memset(sk, 0, 32);
+        TEST_ASSERT(factory_session_set_nonce_poison(f, leaf_idx, j, &pubnonce),
+                    "set nonce");
+    }
+    TEST_ASSERT(factory_session_finalize_node_poison(f, leaf_idx), "finalize (untweaked)");
+    for (size_t j = 0; j < leaf->n_signers; j++) {
+        uint32_t participant = leaf->signer_indices[j];
+        secp256k1_musig_partial_sig psig;
+        TEST_ASSERT(musig_create_partial_sig(ctx, &psig, &secnonces[j],
+                                               &kps[participant],
+                                               &leaf->poison_signing_session),
+                    "partial sig");
+        TEST_ASSERT(factory_session_set_partial_sig_poison(f, leaf_idx, j, &psig),
+                    "set partial sig");
+    }
+    TEST_ASSERT(factory_session_complete_node_poison(f, leaf_idx), "complete");
+
+    /* Assemble with the OLD secret (verified against poison_l_stock_hash = H_old). */
+    tx_buf_t poison; tx_buf_init(&poison, 256);
+    TEST_ASSERT(factory_assemble_poison_with_secret(f, leaf_idx, secret0, &poison),
+                "assemble with OLD secret");
+    /* the CURRENT-state secret must NOT assemble an old-state poison. */
+    tx_buf_t bad; tx_buf_init(&bad, 64);
+    TEST_ASSERT(factory_assemble_poison_with_secret(f, leaf_idx, secret1, &bad) == 0,
+                "current-state secret REFUSED for an old-state poison");
+    tx_buf_free(&bad);
+
+    char *phex = (char *)malloc(poison.len * 2 + 1);
+    hex_encode(poison.data, poison.len, phex);
+    char *p = (char *)malloc(poison.len * 2 + 16);
+    snprintf(p, poison.len * 2 + 16, "[\"%s\"]", phex);
+    char *tma = regtest_exec(&rt, "testmempoolaccept", p);
+    free(p);
+    TEST_ASSERT(tma != NULL, "testmempoolaccept ran");
+    cJSON *jj = cJSON_Parse(tma); free(tma);
+    cJSON *r0 = jj ? cJSON_GetArrayItem(jj, 0) : NULL;
+    cJSON *allowed = r0 ? cJSON_GetObjectItem(r0, "allowed") : NULL;
+    int ok_allowed = allowed && cJSON_IsTrue(allowed);
+    if (!ok_allowed && r0) {
+        cJSON *rr = cJSON_GetObjectItem(r0, "reject-reason");
+        printf("  old-state poison rejected: %s\n",
+               rr && rr->valuestring ? rr->valuestring : "?");
+    }
+    if (jj) cJSON_Delete(jj);
+    TEST_ASSERT(ok_allowed,
+                "INTERPRETER ACCEPTS the OLD-state poison after the leaf advanced");
+    printf("  old-state poison ACCEPTED (override H_old; node at H_1; %zu clients)\n",
+           n_clients);
 
     free(phex);
     tx_buf_free(&poison);

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5957,7 +5957,7 @@ int test_factory_lstock_client_mirror(void) {
     TEST_ASSERT(cli, "alloc cli");
     TEST_ASSERT(setup_variable_arity_factory(cli, ctx, kc, 3, arities, 1, 5000000),
                 "setup cli");
-    for (size_t li = 0; li < lsp->n_leaf_nodes; li++) {
+    for (size_t li = 0; li < (size_t)lsp->n_leaf_nodes; li++) {
         size_t idx = lsp->leaf_node_indices[li];
         TEST_ASSERT(lsp->nodes[idx].has_l_stock_hash, "lsp leaf has derived hash");
         factory_set_node_l_stock_hash(cli, idx, lsp->nodes[idx].l_stock_hash);
@@ -5967,7 +5967,7 @@ int test_factory_lstock_client_mirror(void) {
     TEST_ASSERT(cli->n_leaf_nodes == lsp->n_leaf_nodes, "same topology");
 
     /* Each leaf: client reproduced the hash AND the 2-leaf L-stock SPK. */
-    for (size_t li = 0; li < lsp->n_leaf_nodes; li++) {
+    for (size_t li = 0; li < (size_t)lsp->n_leaf_nodes; li++) {
         factory_node_t *ln = &lsp->nodes[lsp->leaf_node_indices[li]];
         factory_node_t *cn = &cli->nodes[cli->leaf_node_indices[li]];
         TEST_ASSERT(cn->has_l_stock_hash, "client leaf carries the hashlock");

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6008,7 +6008,10 @@ int test_regtest_lstock_hashlock_poison(void) {
     regtest_create_wallet(&rt, "ss_lstock_poison");
     char mine_addr[128];
     TEST_ASSERT(regtest_get_new_address(&rt, mine_addr, sizeof(mine_addr)), "mine addr");
-    regtest_mine_blocks(&rt, 101, mine_addr);
+    /* Fund the test wallet from the shared faucet (robust on a tall chain where
+       fresh coinbases are 0-sat); fall back to mining on a fresh node. */
+    if (!regtest_fund_from_faucet(&rt, 0.05))
+        regtest_mine_blocks(&rt, 101, mine_addr);
 
     char lstock_addr[128];
     TEST_ASSERT(derive_p2tr_addr_from_outputkey(&rt, spk_hash + 2,

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5975,6 +5975,13 @@ int test_regtest_lstock_hashlock_poison(void) {
     uint8_t arities[1] = {2};
     TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 3, arities, 1, 5000000),
                 "setup n3 {2}");
+    /* #53-B: enable revocation-gated poison so build_tree commits the per-(leaf,
+       state) hash into each leaf's L-stock SPK via the production path (not a
+       manual set). */
+    unsigned char seed[32];
+    for (int i = 0; i < 32; i++) seed[i] = (unsigned char)(0xA5 ^ i);
+    factory_set_shachain_seed(f, seed);
+    TEST_ASSERT(factory_enable_hashlock_poison(f), "enable hashlock poison");
     TEST_ASSERT(factory_build_tree(f), "build tree");
     TEST_ASSERT(factory_sign_all(f), "sign all");
     TEST_ASSERT_EQ(f->n_leaf_nodes, 1, "1 leaf");
@@ -5983,11 +5990,18 @@ int test_regtest_lstock_hashlock_poison(void) {
     size_t n_clients = leaf->n_signers - 1;
     TEST_ASSERT(n_clients == 2, "leaf has 2 clients (LSP + 2)");
 
-    /* Commit a per-state revocation hash H_s = SHA256(secret) into Leaf P. */
+    /* build_tree committed the state-0 hash via setup_leaf_outputs. */
+    TEST_ASSERT(leaf->has_l_stock_hash, "leaf carries the hashlock after build_tree");
+    TEST_ASSERT_EQ(leaf->l_stock_state_counter, 0, "initial L-stock state = 0");
+
+    /* The LSP-derived per-(leaf,state) secret must reproduce the committed hash. */
     unsigned char secret[32];
-    for (int i = 0; i < 32; i++) secret[i] = (unsigned char)(0x53 ^ i);
-    sha256(secret, 32, leaf->l_stock_hash);
-    leaf->has_l_stock_hash = 1;
+    TEST_ASSERT(factory_derive_l_stock_secret(f, leaf, leaf->l_stock_state_counter, secret),
+                "derive L-stock secret");
+    unsigned char h_check[32];
+    sha256(secret, 32, h_check);
+    TEST_ASSERT(memcmp(h_check, leaf->l_stock_hash, 32) == 0,
+                "derived secret reproduces the committed Leaf-P hash");
 
     /* The hashlock taptree must change the SPK vs the legacy single-leaf SPK. */
     unsigned char spk_hash[34], spk_plain[34];

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5928,6 +5928,82 @@ int test_factory_ps_subfactory_poison_tx_k2_n4(void) {
     return 1;
 }
 
+/* #53-B3b.2a (in-process, no regtest): the CLIENT MIRROR — given the LSP's per-node
+   L-stock hashes over the (here simulated) wire, a seedless client builds the SAME
+   2-leaf L-stock SPK as the hashlock-enabled LSP, so the leaf-state advance co-signs.
+   Without the mirror the client builds a different (single-leaf) SPK (control case).
+   setup_variable_arity_factory uses deterministic seckeys, so all three factories
+   share pubkeys — isolating the hash mirror. */
+int test_factory_lstock_client_mirror(void) {
+    secp256k1_context *ctx = test_ctx();
+    uint8_t arities[1] = {2};
+
+    /* LSP: hashlock ON — derives per-node H from its seed. */
+    secp256k1_keypair kl[3];
+    factory_t *lsp = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(lsp, "alloc lsp");
+    TEST_ASSERT(setup_variable_arity_factory(lsp, ctx, kl, 3, arities, 1, 5000000),
+                "setup lsp");
+    unsigned char seed[32];
+    for (int i = 0; i < 32; i++) seed[i] = (unsigned char)(0x90 ^ i);
+    factory_set_shachain_seed(lsp, seed);
+    TEST_ASSERT(factory_enable_hashlock_poison(lsp), "enable hashlock (lsp)");
+    TEST_ASSERT(factory_build_tree(lsp), "build lsp tree");
+    TEST_ASSERT(lsp->n_leaf_nodes >= 1, "lsp has leaves");
+
+    /* CLIENT: NO seed; mirror the LSP's per-node H (simulated FACTORY_PROPOSE). */
+    secp256k1_keypair kc[3];
+    factory_t *cli = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(cli, "alloc cli");
+    TEST_ASSERT(setup_variable_arity_factory(cli, ctx, kc, 3, arities, 1, 5000000),
+                "setup cli");
+    for (size_t li = 0; li < lsp->n_leaf_nodes; li++) {
+        size_t idx = lsp->leaf_node_indices[li];
+        TEST_ASSERT(lsp->nodes[idx].has_l_stock_hash, "lsp leaf has derived hash");
+        factory_set_node_l_stock_hash(cli, idx, lsp->nodes[idx].l_stock_hash);
+    }
+    TEST_ASSERT(cli->has_node_l_stock_hashes, "client is in mirror mode");
+    TEST_ASSERT(factory_build_tree(cli), "build cli tree");
+    TEST_ASSERT(cli->n_leaf_nodes == lsp->n_leaf_nodes, "same topology");
+
+    /* Each leaf: client reproduced the hash AND the 2-leaf L-stock SPK. */
+    for (size_t li = 0; li < lsp->n_leaf_nodes; li++) {
+        factory_node_t *ln = &lsp->nodes[lsp->leaf_node_indices[li]];
+        factory_node_t *cn = &cli->nodes[cli->leaf_node_indices[li]];
+        TEST_ASSERT(cn->has_l_stock_hash, "client leaf carries the hashlock");
+        TEST_ASSERT(memcmp(cn->l_stock_hash, ln->l_stock_hash, 32) == 0,
+                    "client H == LSP H");
+        unsigned char lspk[34], cspk[34];
+        TEST_ASSERT(build_l_stock_spk(lsp, ln, lspk), "lsp spk");
+        TEST_ASSERT(build_l_stock_spk(cli, cn, cspk), "cli spk");
+        TEST_ASSERT(memcmp(lspk, cspk, 34) == 0,
+                    "client L-stock SPK == LSP SPK (advance will co-sign)");
+        TEST_ASSERT(memcmp(cn->outputs[cn->n_outputs - 1].script_pubkey,
+                           ln->outputs[ln->n_outputs - 1].script_pubkey, 34) == 0,
+                    "leaf-tx L-stock output SPK matches");
+    }
+
+    /* CONTROL: a client WITHOUT the mirror builds a DIFFERENT (single-leaf) SPK. */
+    secp256k1_keypair kb[3];
+    factory_t *bare = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(bare, "alloc bare");
+    TEST_ASSERT(setup_variable_arity_factory(bare, ctx, kb, 3, arities, 1, 5000000),
+                "setup bare");
+    TEST_ASSERT(factory_build_tree(bare), "build bare tree");
+    {
+        unsigned char lspk[34], bspk[34];
+        build_l_stock_spk(lsp, &lsp->nodes[lsp->leaf_node_indices[0]], lspk);
+        build_l_stock_spk(bare, &bare->nodes[bare->leaf_node_indices[0]], bspk);
+        TEST_ASSERT(memcmp(lspk, bspk, 34) != 0,
+                    "WITHOUT the mirror the client SPK differs (mirror is required)");
+    }
+
+    factory_free(lsp); factory_free(cli); factory_free(bare);
+    free(lsp); free(cli); free(bare);
+    secp256k1_context_destroy(ctx);
+    return 1;
+}
+
 /* Derive the bech32m address for a 32-byte taproot output key via a rawtr()
    descriptor (mirrors the funding path in test_tapscript.c). */
 static int derive_p2tr_addr_from_outputkey(regtest_t *rt,

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1759,6 +1759,7 @@ extern int test_factory_ps_subfactory_k2_n4(void);
 extern int test_factory_ps_subfactory_chain_extension(void);
 extern int test_factory_ps_subfactory_chain_tx_validity(void);
 extern int test_factory_ps_subfactory_poison_tx_k2_n4(void);
+extern int test_factory_lstock_client_mirror(void);
 extern int test_factory_ps_leaf_build_n64(void);
 extern int test_factory_ps_build_n128(void);
 extern int test_factory_ps_leaf_advance(void);
@@ -3636,6 +3637,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_ps_subfactory_chain_extension);
     RUN_TEST(test_factory_ps_subfactory_chain_tx_validity);
     RUN_TEST(test_factory_ps_subfactory_poison_tx_k2_n4);
+    RUN_TEST(test_factory_lstock_client_mirror);
     RUN_TEST(test_factory_ps_leaf_build_n64);
     RUN_TEST(test_factory_ps_build_n128);
     RUN_TEST(test_factory_ps_leaf_advance);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1120,6 +1120,7 @@ extern int test_regtest_ladder_distribution_fallback(void);
 /* Phase 9: Wire protocol */
 extern int test_wire_pubkey_only_factory(void);
 extern int test_wire_framing(void);
+extern int test_wire_lstock_reveal_round_trip(void);
 extern int test_wire_crypto_serialization(void);
 extern int test_wire_nonce_bundle(void);
 extern int test_wire_psig_bundle(void);
@@ -3071,6 +3072,7 @@ static void run_unit_tests(void) {
     printf("\n=== Wire Protocol (Phase 9) ===\n");
     RUN_TEST(test_wire_pubkey_only_factory);
     RUN_TEST(test_wire_framing);
+    RUN_TEST(test_wire_lstock_reveal_round_trip);
     RUN_TEST(test_wire_crypto_serialization);
     RUN_TEST(test_wire_nonce_bundle);
     RUN_TEST(test_wire_psig_bundle);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1037,6 +1037,7 @@ extern int test_factory_l_stock_with_burn_path(void);
 extern int test_factory_burn_tx_construction(void);
 extern int test_factory_advance_with_shachain(void);
 extern int test_regtest_burn_tx(void);
+extern int test_regtest_lstock_hashlock_poison(void);
 
 extern int test_channel_key_derivation(void);
 extern int test_channel_commitment_tx(void);
@@ -3902,6 +3903,7 @@ static void run_regtest_tests(void) {
     RUN_TEST(test_regtest_factory_tree);
     RUN_TEST(test_regtest_timeout_spend);
     RUN_TEST(test_regtest_burn_tx);
+    RUN_TEST(test_regtest_lstock_hashlock_poison);
     RUN_TEST(test_regtest_channel_unilateral);
     RUN_TEST(test_regtest_channel_penalty);
     RUN_TEST(test_regtest_htlc_success);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1198,6 +1198,7 @@ extern int test_regtest_lsp_restart_recovery(void);
 extern int test_persist_open_close(void);
 extern int test_persist_migration_ladder(void);
 extern int test_persist_ps_subfactory_chain_round_trip(void);
+extern int test_persist_l_stock_poison_round_trip(void);
 extern int test_persist_ps_subfactory_chain_v21_round_trip(void);
 extern int test_persist_ps_leaf_chain_v22_poison_round_trip(void);
 extern int test_ceremony_helpers_save_load(void);
@@ -3095,6 +3096,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_encryption_wrong_key_refused);
     RUN_TEST(test_persist_encryption_disabled_is_plaintext);
     RUN_TEST(test_persist_ps_subfactory_chain_round_trip);
+    RUN_TEST(test_persist_l_stock_poison_round_trip);
     RUN_TEST(test_persist_ps_subfactory_chain_v21_round_trip);
     RUN_TEST(test_persist_ps_leaf_chain_v22_poison_round_trip);
     /* SF-CEREMONY-HELPERS #199 (wallet team v34 API). */

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1039,6 +1039,7 @@ extern int test_factory_advance_with_shachain(void);
 extern int test_regtest_burn_tx(void);
 extern int test_regtest_lstock_hashlock_poison(void);
 extern int test_regtest_lstock_poison_ceremony(void);
+extern int test_regtest_lstock_poison_old_state(void);
 
 extern int test_channel_key_derivation(void);
 extern int test_channel_commitment_tx(void);
@@ -3906,6 +3907,7 @@ static void run_regtest_tests(void) {
     RUN_TEST(test_regtest_burn_tx);
     RUN_TEST(test_regtest_lstock_hashlock_poison);
     RUN_TEST(test_regtest_lstock_poison_ceremony);
+    RUN_TEST(test_regtest_lstock_poison_old_state);
     RUN_TEST(test_regtest_channel_unilateral);
     RUN_TEST(test_regtest_channel_penalty);
     RUN_TEST(test_regtest_htlc_success);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1038,6 +1038,7 @@ extern int test_factory_burn_tx_construction(void);
 extern int test_factory_advance_with_shachain(void);
 extern int test_regtest_burn_tx(void);
 extern int test_regtest_lstock_hashlock_poison(void);
+extern int test_regtest_lstock_poison_ceremony(void);
 
 extern int test_channel_key_derivation(void);
 extern int test_channel_commitment_tx(void);
@@ -3904,6 +3905,7 @@ static void run_regtest_tests(void) {
     RUN_TEST(test_regtest_timeout_spend);
     RUN_TEST(test_regtest_burn_tx);
     RUN_TEST(test_regtest_lstock_hashlock_poison);
+    RUN_TEST(test_regtest_lstock_poison_ceremony);
     RUN_TEST(test_regtest_channel_unilateral);
     RUN_TEST(test_regtest_channel_penalty);
     RUN_TEST(test_regtest_htlc_success);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -153,6 +153,59 @@ int test_persist_ps_subfactory_chain_round_trip(void) {
     return ok;
 }
 
+/* #53-B3b.2d: l_stock_poison_reveals save -> load -> update-secret -> reload round-trip.
+   Proves a restarted client/WT can recover the script-path poison witness components +
+   the revealed secret (so it can rebuild + broadcast the Leaf-P poison). */
+int test_persist_l_stock_poison_round_trip(void) {
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, NULL), "open in-memory");
+
+    const uint32_t fid = 0, nidx = 7, state = 3;
+    unsigned char h[32], sig[64], lscript[73], cb[65], utx[80], secret[32];
+    for (int i = 0; i < 32; i++) h[i]      = (unsigned char)(0xA0 ^ i);
+    for (int i = 0; i < 64; i++) sig[i]    = (unsigned char)(0x10 + i);
+    for (size_t i = 0; i < sizeof(lscript); i++) lscript[i] = (unsigned char)(0x20 + i);
+    for (int i = 0; i < 65; i++) cb[i]     = (unsigned char)(0x30 + i);
+    for (size_t i = 0; i < sizeof(utx); i++) utx[i] = (unsigned char)(i & 0xff);
+    for (int i = 0; i < 32; i++) secret[i] = (unsigned char)(0x53 ^ i);
+
+    TEST_ASSERT(persist_save_l_stock_poison(&db, fid, nidx, state, h, sig,
+                    utx, sizeof(utx), lscript, sizeof(lscript), cb, sizeof(cb)),
+                "save l_stock poison");
+
+    unsigned char lh[32], lsig[64], lls[128], lcb[65], lsec[32];
+    size_t lls_len = 0, lcb_len = 0; int has_secret = -1;
+    tx_buf_t lutx; tx_buf_init(&lutx, 128);
+    TEST_ASSERT(persist_load_l_stock_poison(&db, fid, nidx, state, lh, lsig, &lutx,
+                    lls, &lls_len, lcb, &lcb_len, lsec, &has_secret), "load");
+    TEST_ASSERT(memcmp(lh, h, 32) == 0, "hash round-trips");
+    TEST_ASSERT(memcmp(lsig, sig, 64) == 0, "agg sig round-trips");
+    TEST_ASSERT(lutx.len == sizeof(utx) && memcmp(lutx.data, utx, sizeof(utx)) == 0,
+                "unsigned tx round-trips");
+    TEST_ASSERT(lls_len == sizeof(lscript) && memcmp(lls, lscript, sizeof(lscript)) == 0,
+                "leaf script round-trips");
+    TEST_ASSERT(lcb_len == sizeof(cb) && memcmp(lcb, cb, sizeof(cb)) == 0,
+                "control block round-trips");
+    TEST_ASSERT(has_secret == 0, "no secret before reveal");
+
+    TEST_ASSERT(persist_update_l_stock_secret(&db, fid, nidx, state, secret),
+                "update secret");
+    has_secret = -1;
+    TEST_ASSERT(persist_load_l_stock_poison(&db, fid, nidx, state, NULL, NULL, NULL,
+                    NULL, NULL, NULL, NULL, lsec, &has_secret), "reload");
+    TEST_ASSERT(has_secret == 1, "secret present after reveal");
+    TEST_ASSERT(memcmp(lsec, secret, 32) == 0, "secret round-trips");
+
+    TEST_ASSERT(persist_load_l_stock_poison(&db, fid, nidx, 999, lh, lsig, &lutx,
+                    lls, &lls_len, lcb, &lcb_len, lsec, &has_secret) == 0,
+                "missing (factory,node,state) row not found");
+
+    tx_buf_free(&lutx);
+    persist_close(&db);
+    printf("  l_stock_poison_reveals save/load/update-secret round-trips\n");
+    return 1;
+}
+
 /* ---- §10 mainnet-gate: schema migration ladder is idempotent + data-preserving ----
    Populate a file-backed DB at the current schema, force user_version back to 1
    (simulating an old DB), then re-open to re-run migrations 2..PERSIST_SCHEMA_VERSION

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -491,6 +491,57 @@ int test_wire_path_bundle_no_poison_back_compat(void) {
     return 1;
 }
 
+/* #53-B3b: MSG_LSTOCK_REVEAL build->parse round-trip (single + multi entry). */
+int test_wire_lstock_reveal_round_trip(void) {
+    uint32_t nodes[3]  = { 1, 5, 42 };
+    uint32_t states[3] = { 0, 7, 1000000 };
+    unsigned char secrets[3][32];
+    for (int e = 0; e < 3; e++)
+        for (int i = 0; i < 32; i++) secrets[e][i] = (unsigned char)(e * 0x40 + i);
+
+    uint32_t pn[8], ps[8];
+    unsigned char psec[8][32];
+    size_t n = 0;
+
+    /* Multi-entry (Tier-B shape). */
+    cJSON *j = wire_build_lstock_reveal(nodes, states, secrets, 3);
+    TEST_ASSERT(j != NULL, "build reveal (3)");
+    TEST_ASSERT(wire_parse_lstock_reveal(j, pn, ps, psec, 8, &n), "parse reveal (3)");
+    TEST_ASSERT(n == 3, "3 entries parsed");
+    for (size_t e = 0; e < 3; e++) {
+        TEST_ASSERT(pn[e] == nodes[e], "node matches");
+        TEST_ASSERT(ps[e] == states[e], "state matches");
+        TEST_ASSERT(memcmp(psec[e], secrets[e], 32) == 0, "secret matches");
+    }
+    cJSON_Delete(j);
+
+    /* Single-entry (leaf-advance shape). */
+    cJSON *j1 = wire_build_lstock_reveal(nodes, states, secrets, 1);
+    TEST_ASSERT(j1 != NULL, "build reveal (1)");
+    n = 0;
+    TEST_ASSERT(wire_parse_lstock_reveal(j1, pn, ps, psec, 8, &n), "parse reveal (1)");
+    TEST_ASSERT(n == 1 && pn[0] == nodes[0] && ps[0] == states[0] &&
+                memcmp(psec[0], secrets[0], 32) == 0, "single entry round-trips");
+    cJSON_Delete(j1);
+
+    /* Malformed: missing 'reveals' -> parse fails. */
+    cJSON *bad = cJSON_CreateObject();
+    cJSON_AddNumberToObject(bad, "x", 1);
+    TEST_ASSERT(wire_parse_lstock_reveal(bad, pn, ps, psec, 8, &n) == 0,
+                "parse rejects missing reveals array");
+    cJSON_Delete(bad);
+
+    /* max_entries cap respected. */
+    cJSON *j3 = wire_build_lstock_reveal(nodes, states, secrets, 3);
+    n = 99;
+    TEST_ASSERT(wire_parse_lstock_reveal(j3, pn, ps, psec, 2, &n), "parse with cap");
+    TEST_ASSERT(n == 2, "capped at max_entries");
+    cJSON_Delete(j3);
+
+    printf("  MSG_LSTOCK_REVEAL round-trips (single + multi + malformed + cap)\n");
+    return 1;
+}
+
 /* ---- Test 6: cooperative close unsigned ---- */
 
 int test_wire_close_unsigned(void) {

--- a/tools/superscalar_watchtower.c
+++ b/tools/superscalar_watchtower.c
@@ -42,6 +42,7 @@ static void usage(const char *prog) {
         "  --rpcport PORT      Bitcoin RPC port\n"
         "  --bump-budget-pct N CPFP fee budget as %% of penalty value (1-100, default 50)\n"
         "  --max-bump-fee SAT  Absolute fee ceiling per CPFP bump (default 50000)\n"
+        "  --bump-wallet NAME  Funded wallet the CPFP fee-bumper draws UTXOs from (#52)\n"
         "  --version           Show version and exit\n"
         "  --help              Show this help\n"
         "\n"
@@ -66,6 +67,7 @@ int main(int argc, char *argv[]) {
     const char *rpcpassword = NULL;
     const char *datadir = NULL;
     int rpcport = 0;
+    const char *bump_wallet = NULL;  /* #52: wallet the CPFP fee-bumper draws UTXOs from */
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--db") == 0) {
@@ -102,6 +104,8 @@ int main(int argc, char *argv[]) {
             datadir = argv[++i];
         else if (strcmp(argv[i], "--rpcport") == 0 && i + 1 < argc)
             rpcport = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--bump-wallet") == 0 && i + 1 < argc)
+            bump_wallet = argv[++i];
         else if (strcmp(argv[i], "--max-bump-fee") == 0 && i + 1 < argc)
             max_bump_fee = (uint64_t)strtoull(argv[++i], NULL, 10);
         else if (strcmp(argv[i], "--bump-budget-pct") == 0 && i + 1 < argc) {
@@ -139,6 +143,19 @@ int main(int argc, char *argv[]) {
     if (!rt_ok) {
         fprintf(stderr, "Error: cannot connect to bitcoind\n");
         return 1;
+    }
+
+    /* #52: point the CPFP fee-bumper at a FUNDED wallet. Without this, regtest_exec
+       runs listunspent on the node's default wallet (empty for a standalone WT) ->
+       "no suitable wallet UTXO for bump" -> the penalty can't be fee-bumped and loses
+       the race under fee pressure. This is the operator/client-funded bumper wallet
+       (the design's "client-funded bumper" realized as the WT's own RPC wallet). The
+       WT still holds NO signing keys; it only spends this wallet's UTXOs to CPFP the
+       anyone-can-spend P2A anchor on a pre-signed penalty. */
+    if (bump_wallet) {
+        strncpy(rt.wallet, bump_wallet, sizeof(rt.wallet) - 1);
+        rt.wallet[sizeof(rt.wallet) - 1] = '\0';
+        printf("WT-TRUSTLESS: CPFP fee-bump wallet = %s\n", bump_wallet);
     }
 
     /* Initialize fee estimator */

--- a/tools/test_regtest_trustless_commitment_breach.sh
+++ b/tools/test_regtest_trustless_commitment_breach.sh
@@ -69,7 +69,7 @@ mine 1; sleep 1   # ensure the revoked commitment is confirmed on-chain
 
 echo "--- launch STANDALONE trustless WT (--wt-db only, NO secrets) ---"
 "$WT_BIN" --network regtest --wt-db "$WT_DB" --poll-interval 3 --cli-path bitcoin-cli \
-    --rpcuser "$RU" --rpcpassword "$RP" --rpcport "$RPORT" > "$WT_LOG" 2>&1 &
+    --rpcuser "$RU" --rpcpassword "$RP" --rpcport "$RPORT" ${SS_HIFEE_BUMP:+--bump-wallet "$WALLET"} > "$WT_LOG" 2>&1 &
 WT_PID=$!; PIDS+=($WT_PID)
 FIRED=0
 for i in $(seq 1 60); do
@@ -109,6 +109,31 @@ if [ "${SS_HIFEE_GAP:-0}" = 1 ]; then
         echo "HIFEE_GAP_DEMO_DONE"; exit 0
     else
         echo "  #52 gap NOT reproduced (penalty confirmed despite stall) — harness/scenario issue"; exit 1
+    fi
+fi
+# === #52 BUMP PROOF (SS_HIFEE_BUMP=1): the FUNDED WT (--bump-wallet) must CPFP a stalled penalty
+# to confirmation. Deprioritise the penalty by a MODERATE amount the CPFP child CAN overcome (unlike
+# the GAP mode's -10e9). The bare penalty can't get mined; the ONLY way it confirms is a CPFP child,
+# so confirmation == the funding fix works. Pre-funding (#52 gap) it stayed stuck. ===
+if [ "${SS_HIFEE_BUMP:-0}" = 1 ]; then
+    . "$(dirname "$(realpath "$0")")"/regtest_hifee_helpers.sh
+    echo "=== #52 BUMP PROOF: funded WT must CPFP stalled penalty $PEN_TXID to confirmation ==="
+    $BCLI prioritisetransaction "$PEN_TXID" 0 -3000 >/dev/null 2>&1
+    echo "  penalty deprioritised by 3000 sats — bare penalty unmineable; only a CPFP child can confirm it"
+    BUMPED=0
+    for i in $(seq 1 80); do
+        mine 1; sleep 2
+        c=$(tx_confs "$BCLI" "$PEN_TXID")
+        { [ -n "$c" ] && [ "$c" -ge 1 ]; } && { BUMPED=1; echo "  penalty CONFIRMED after ${i} blocks"; break; }
+    done
+    CPFP_SEEN=$(grep -ciE "CPFP child broadcast|cpfp.*broadcast|fee.?bump.*broadcast|bumped" "$WT_LOG" 2>/dev/null | head -1)
+    if [ "$BUMPED" = 1 ]; then
+        echo "  #52 BUMP PROOF PASS: funded WT CPFP-confirmed the stalled penalty (cpfp-child-log-lines=${CPFP_SEEN:-?})"
+        grep -aiE "CPFP|bump" "$WT_LOG" 2>/dev/null | tail -4
+        echo "HIFEE_BUMP_PROOF_DONE"; exit 0
+    else
+        echo "  #52 BUMP PROOF FAIL: penalty never confirmed despite --bump-wallet"
+        grep -aiE "CPFP|bump|wallet|UTXO|suitable" "$WT_LOG" 2>/dev/null | tail -10; exit 1
     fi
 fi
 echo "  penalty txid: $PEN_TXID — mining to confirm + verify payout"

--- a/tools/test_regtest_trustless_commitment_breach.sh
+++ b/tools/test_regtest_trustless_commitment_breach.sh
@@ -121,10 +121,10 @@ if [ "${SS_HIFEE_BUMP:-0}" = 1 ]; then
     $BCLI prioritisetransaction "$PEN_TXID" 0 -3000 >/dev/null 2>&1
     echo "  penalty deprioritised by 3000 sats — bare penalty unmineable; only a CPFP child can confirm it"
     BUMPED=0
-    for i in $(seq 1 80); do
+    for i in $(seq 1 130); do
         mine 1; sleep 2
         c=$(tx_confs "$BCLI" "$PEN_TXID")
-        { [ -n "$c" ] && [ "$c" -ge 1 ]; } && { BUMPED=1; echo "  penalty CONFIRMED after ${i} blocks"; break; }
+        { [ -n "$c" ] && [ "$c" -ge 1 ]; } && { BUMPED=1; echo "  penalty CONFIRMED after ${i} blocks (CPFP ramp overcame the deficit)"; break; }
     done
     CPFP_SEEN=$(grep -ciE "CPFP child broadcast|cpfp.*broadcast|fee.?bump.*broadcast|bumped" "$WT_LOG" 2>/dev/null | head -1)
     if [ "$BUMPED" = 1 ]; then


### PR DESCRIPTION
Forward trustless-model hardening, stacked on the rigor foundation in #385 (harness, G1/G2, #52 enqueue, design docs).

**Plan:** `docs/trustless-hardening-MASTER-PLAN.md` (frozen sequencing + dep graph + the 'perfect' gate). Problem inventory + canonical comparison in `trustless-model-research-findings.md`; fix designs + test strategy in `trustless-hardening-design-and-test-plan.md`.

**Phase 1 (this PR, in progress) — WT fee-bump (#52):**
- [x] gap proven on-chain (SS_HIFEE_GAP): standalone WT can't confirm a penalty under fee pressure
- [x] CPFP enqueue for WATCH_FACTORY_NODE handler (6fe04d8) — was never monitored
- [x] `--bump-wallet` so the bumper draws from a funded wallet (this commit)
- [ ] fee-flood proof: funded WT + small-block node + sustained floor -> CPFP child confirms penalty before the csv deadline

**Next phases (stacked PRs):** #53 hashlock poison + #46 atomic advance + #59 reveal state machine; #45/#55 wt_db coverage; #54 offline-tolerant rollover; #48-51 liveness; #62-64 UX/ops.

**Gate ("perfect"):** every test-matrix row + INV-1..5 green on regtest under the high-fee harness with anti-vacuity controls, A/B exploits rejected, then signet re-prove.

Multi-session; built prove-gap -> fix -> prove-fix, each step committed.