### PR TITLE
Hashlock-gated L-stock poison — daemon integration + client recourse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,14 @@ if(ENABLE_SANITIZERS)
     target_link_libraries(recover_stranded_coop_output PRIVATE project_sanitizers)
 endif()
 
+# #53 Phase 4b: client-side hashlock L-stock poison recourse (assemble from persisted reveal)
+add_executable(superscalar_lstock_recover tools/superscalar_lstock_recover.c)
+target_include_directories(superscalar_lstock_recover PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
+target_link_libraries(superscalar_lstock_recover PRIVATE superscalar superscalar_secrets project_warnings)
+if(ENABLE_SANITIZERS)
+    target_link_libraries(superscalar_lstock_recover PRIVATE project_sanitizers)
+endif()
+
 # --- Fuzz targets (libFuzzer + ASan + UBSan) ---
 if(ENABLE_FUZZING)
     set(FUZZ_SOURCES

--- a/docs/trustless-hashlock-daemon-plan.md
+++ b/docs/trustless-hashlock-daemon-plan.md
@@ -1,0 +1,79 @@
+# Hashlock-poison DAEMON INTEGRATION — phased plan (new PR: `trustless-hashlock-daemon`)
+
+Stacked on `trustless-model-hardening` (PR #386), which has all the unit/interpreter-proven layers:
+crypto core, per-(leaf,state) secret derivation, multi-process ceremony→Leaf-P, old-state targeting,
+client SPK mirror+wire, `MSG_LSTOCK_REVEAL`, persist `l_stock_poison_reveals` (v38). This PR makes the
+feature LIVE in the LSP↔client daemons and proves it end-to-end. Scope = the **leaf-advance path**
+(`lsp_advance_leaf_stateless`, the 2-of-2 PS-leaf — the master-plan priority); Tier-B rollover + sub-factory
+are a parallel follow-on (same pattern).
+
+## The crux found by code review (the high-level plan missed it)
+Enabling hashlock changes the leaf STATE tx (its last output is the 2-leaf L-stock SPK).  So at EACH advance,
+beyond revealing the old secret, the protocol must thread the per-(leaf,state) hash:
+1. **Ship `H_new`**: the client has no seed, so the LSP must ship the advancing leaf's NEW-state hash so the
+   client builds the IDENTICAL new leaf-state SPK (else the MuSig co-sign of the new state mismatches → the
+   advance fails — not just the poison).
+2. **Capture `H_old`**: the poison co-signed during the advance must target the SUPERSEDED state's output
+   (`H_old`), but by poison-prep time both sides have already advanced (`node->l_stock_hash == H_new`).  So
+   both sides must capture `H_old` *before* the advance and pass it as `override_hash32` to
+   `factory_session_prepare_poison_tx_leaf` (the B3b-part-1 deferred per-site capture lands here).
+3. **Reveal `secret_old`**: after the new state signs, the LSP reveals `secret(leaf, old_counter)`; the client
+   verifies `SHA256==H_old` and persists for standalone recourse.
+
+## Verified injection points (file:line)
+LSP `lsp_advance_leaf_stateless` (src/lsp_channels.c 1353–1933):
+- advance bumps counter: `factory_advance_leaf_unsigned` @1418 (so capture `H_old` from `f->nodes[pre_node_idx].l_stock_hash` BEFORE 1418).
+- PROPOSE build/send: @1468/1469 (ship `H_new = node->l_stock_hash` here — after the advance, it's H_new).
+- poison prep: @1441 (pass `override = H_old`).
+- DONE broadcast: @1894–1899.  REVEAL send goes right AFTER, targeted to the leaf's client(s) (not broadcast).
+- `factory_session_reset_poison` @1891 clears session fields — irrelevant: the reveal secret is re-derived
+  from the seed via `factory_derive_l_stock_secret`, not read from the session.
+
+Client `client_handle_leaf_advance_stateless` (src/client.c 3534–3910):
+- parse PROPOSE @3547; `node_idx` @3563; capture `H_old = node->l_stock_hash` @3564 (before any change);
+  mirror `H_new` (from PROPOSE) via `factory_set_node_l_stock_hash` BEFORE the local advance @3566.
+- poison prep @3597 (pass `override = H_old`).
+- recv DONE @3909.  recv REVEAL right after when `node->poison_is_scriptpath`; verify
+  `SHA256(secret)==node->poison_l_stock_hash` (=H_old, set in prep); persist; THEN return success (#59 order).
+
+LSP factory creation `src/lsp.c::lsp_run_factory_creation_stateless`: seed @436, build_tree @442, PROPOSE @448.
+`factory_enable_hashlock_poison(f)` goes between 437 and 442 (NOT superscalar_lsp.c — factory_init_from_pubkeys
+@lsp.c:413 wipes use_hashlock_poison).
+
+## Phases (each committed; phases 1–3 are interdependent, first provable at Phase 4 / B6)
+
+**Phase 1 — advance H plumbing (leaf-advance).** Ship `H_new` in `MSG_LEAF_ADVANCE_PROPOSE` (add an optional
+`l_stock_hash` field); client mirrors it before its advance; both sides capture `H_old` + pass it as the poison
+`override`. Result: a hashlock-enabled leaf advance co-signs the new state correctly AND co-signs the poison
+against the OLD state.
+
+**Phase 2 — reveal (leaf-advance).** LSP derives `secret(leaf, counter−1)` + sends `MSG_LSTOCK_REVEAL` to the
+leaf's client(s) after DONE (gated on `f->use_hashlock_poison` + poison-eligible). Client recv (when
+`poison_is_scriptpath`) → verify fail-closed → `persist_save_l_stock_poison` (the ceremony's poison fields) +
+`persist_update_l_stock_secret`.
+
+**Phase 3 — daemon enable.** `--enable-hashlock-poison` CLI flag in superscalar_lsp.c → set a real random
+`factory_set_shachain_seed` + an `lsp->enable_hashlock_poison` flag; call `factory_enable_hashlock_poison(f)`
+in `lsp.c` between seed-set and build_tree. (Client needs no flag — it mirrors per-node H off the wire.)
+
+**Phase 4 — B6 e2e (the proof for phases 1–3).** Extend a breach harness: launch LSP (`--enable-hashlock-poison`)
++ client + WT on regtest; advance a leaf (so a state is superseded + the reveal fires + the client persists);
+have the LSP broadcast the STALE old leaf state; the client/WT assembles the Leaf-P poison from the PERSISTED
+secret and broadcasts it; assert it CONFIRMS and redistributes the L-stock (economic outcome), under fee
+pressure. Anti-vacuity: a control where the secret was never revealed → poison unspendable.
+
+**Phase 5 — B4 delete degradation (gated).** Convert the ~80 "reset_poison + clear-flag + continue" sites
+(lsp_channels.c + client.c) to hard-abort (`return 0`, stay on old state) WHEN `f->use_hashlock_poison`
+(LSP) / `node->has_l_stock_hash` (client). Re-prove with B6 + a full regression (legacy key-path path
+unchanged when the flag is off).
+
+## Testing per phase
+- Phases 1–3: build-clean + full unit regression after each (catch wire/ceremony/daemon regressions); the
+  legacy path (flag off) must stay green — these phases are no-ops until Phase 3 flips the flag.
+- Phase 4: the B6 e2e is the end-to-end proof of 1–3 (on-chain confirm + amount + anti-vacuity).
+- Phase 5: B6 (still green) + full regression (legacy untouched) + a degradation-abort assertion.
+
+## #59 (crash-consistency) — tracked separately
+The reveal is the last LSP→client step; a crash between new-state-signed and secret-persisted is the residual
+window. Phase 2 persists the secret in-handler before returning success (verify-before-accept). The full
+"live-pointer advances only on durable recourse" refinement + a crash matrix is task #59 (follow-on), not this PR.

--- a/docs/trustless-hashlock-daemon-plan.md
+++ b/docs/trustless-hashlock-daemon-plan.md
@@ -73,6 +73,46 @@ unchanged when the flag is off).
 - Phase 4: the B6 e2e is the end-to-end proof of 1–3 (on-chain confirm + amount + anti-vacuity).
 - Phase 5: B6 (still green) + full regression (legacy untouched) + a degradation-abort assertion.
 
+## Phase 4 — CORRECTED by code review (the plan-doc above under-scoped it)
+
+Code review (2026-06-21) found `factory_assemble_poison_with_secret` is wired into **no
+broadcast path** — only unit tests.  The breach-response path (watchtower.c) still
+broadcasts a static pre-built `burn_tx`, which for the key-path poison was the whole TX
+but for the hashlock poison CANNOT exist at registration time (the secret isn't revealed
+yet).  So Phase 4 needs CODE before the e2e test, split:
+
+- **Phase 4a (primitive, DONE):** `factory_assemble_poison_from_template()` — standalone
+  assembly from the exact fields persisted in `l_stock_poison_reveals` (unsigned tx, agg
+  sig, leaf script, control block, target hash, revealed secret), with the
+  SHA256(secret)==hash fail-closed guard.  `factory_assemble_poison_with_secret` now
+  delegates to it (DRY).  Proven in the regtest ceremony test: from_template output is
+  byte-identical to with_secret AND `testmempoolaccept` ACCEPTS it, with wrong-secret
+  refused.  This is the persist-driven recourse primitive both the client and any
+  client-fed WT will call.
+
+- **Phase 4b (client recourse driver):** a client-side path that, on a superseded leaf
+  appearing on-chain, loads its persisted reveal row (`persist_load_l_stock_poison`),
+  assembles via `factory_assemble_poison_from_template`, and broadcasts.  For the e2e
+  PROOF this is a clearly-marked test driver (a `--test-*` flag / small tool), NOT yet
+  the production recourse loop — see the architecture note below.
+
+- **Phase 4c (daemon e2e):** LSP `--enable-hashlock-poison --cheat-daemon-leaf` + client
+  daemons advance over the wire (the LIVE Phase 1–2 reveal path fires: the client
+  persists a real `l_stock_poison_reveals` row); the LSP broadcasts the STALE superseded
+  leaf; the client recourse driver assembles-from-persist + broadcasts; assert CONFIRM +
+  L-stock redistribution (amount) + anti-vacuity (no reveal → unspendable).
+
+### ARCHITECTURE NOTE (surfaced for the user; default chosen to keep momentum)
+Who assembles the hashlock poison?  The standalone `superscalar_watchtower` reads a
+**secret-less** wt_db — by design it CANNOT hold the LSP-revealed preimage, so it cannot
+assemble a hashlock poison alone.  Only the party that received the reveal (the CLIENT, or
+a WT the client explicitly feeds revealed secrets) can.  This is the crux of #62 (WT
+operational model) and reshapes the "trustless WT" story for the L-stock poison
+specifically.  DEFAULT taken: the recourse is **client-driven** (the client holds its own
+revealed secrets); the secret-less third-party WT remains the recourse for the
+non-hashlock paths (factory/sub-factory/commitment penalties).  Feeding revealed secrets
+to a delegated WT is the explicit follow-on under #62 — NOT folded into this PR.
+
 ## #59 (crash-consistency) — tracked separately
 The reveal is the last LSP→client step; a crash between new-state-signed and secret-persisted is the residual
 window. Phase 2 persists the secret in-handler before returning success (verify-before-accept). The full

--- a/docs/trustless-hashlock-daemon-plan.md
+++ b/docs/trustless-hashlock-daemon-plan.md
@@ -113,6 +113,43 @@ revealed secrets); the secret-less third-party WT remains the recourse for the
 non-hashlock paths (factory/sub-factory/commitment penalties).  Feeding revealed secrets
 to a delegated WT is the explicit follow-on under #62 — NOT folded into this PR.
 
+## STATUS — Phases 1-4 COMPLETE + PROVEN (2026-06-21)
+- Phase 1 (advance H plumbing), Phase 2 (reveal-on-advance), Phase 3 (daemon
+  `--enable-hashlock-poison`): committed; FULL BUILD + 1507/1507 unit + regtest
+  advance spot-checks green (inert with the flag off).
+- Phase 4a (`factory_assemble_poison_from_template` + DRY): regtest ceremony test
+  proves from_template == with_secret byte-for-byte AND `testmempoolaccept`
+  ACCEPTS; wrong-secret refused.
+- Phase 4b (`superscalar_lstock_recover`): builds; usage + anti-vacuity smokes.
+- Phase 4c (daemon e2e, `test_regtest_hashlock_poison_e2e.sh`): **GREEN on
+  regtest** — LSP `--enable-hashlock-poison --cheat-daemon-leaf` advances a PS
+  leaf over the live wire, client[0] PERSISTS the reveal (node=5 state=0), the
+  recourse tool assembles the poison from the persisted template+secret, it
+  CONFIRMS on-chain (txid ae6a4f62…, 11150 sats L-stock recaptured), and the
+  no-reveal control REFUSES (exit 5).  First live exercise of the reveal wire +
+  the assemble-from-persist recourse; no prevout/wire bug.
+
+## Phase 5 — B4 degrade->hard-abort — DONE + REVIEWED (2026-06-21)
+A degraded advance that revokes the old state WITHOUT co-signing the Leaf-P poison
+re-opens Scenario A/B.  Implemented as a single fail-closed guard per side, placed
+at the commit point, that subsumes every degrade-and-continue site:
+- client.c (security-critical): before shipping FINAL (the revocation commit),
+  refuse if `has_l_stock_hash && poison_required_c && !leaf_poison_prepared_c`.
+- lsp_channels.c: symmetric honest-LSP guard after poison verify/finalize, before
+  register/persist/DONE; also clears node->is_signed + signed_tx on abort.
+Self-review refinement (commit 914f9fc): gate on `poison_required` (old state has a
+protectable, non-dust L-stock) so the guard never false-aborts when no poison was
+ever needed (dust / no old state); still fail-closed on no-watchtower / cheat.
+Test hook `SS_CHEAT_OMIT_POISON` + `test_regtest_hashlock_poison_abort.sh` prove
+the client actually refuses (no reveal persisted, advance does not complete).
+
+## VALIDATION — full 5-gate run GREEN on 914f9fc (2026-06-21)
+FULL BUILD OK; 1507/1507 unit; legacy regtest advances 1/1 (flag off unchanged);
+4c happy-path e2e PASS (poison confirmed, 11150 sats recaptured, no-reveal exit 5);
+degradation-abort PASS (client refused, 0 reveals persisted).  Phases 1-5 done.
+Follow-ons (separate PRs): Tier-B rollover, sub-factory (blocked on multi-input
+keyagg bug), #59 reveal crash matrix, #62 delegated-WT secret feeding.
+
 ## #59 (crash-consistency) — tracked separately
 The reveal is the last LSP→client step; a crash between new-state-signed and secret-persisted is the residual
 window. Phase 2 persists the secret in-handler before returning success (verify-before-accept). The full

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -858,6 +858,24 @@ int factory_assemble_poison_with_secret(factory_t *f, size_t node_idx,
                                         const unsigned char *secret32,
                                         tx_buf_t *out);
 
+/* #53 Phase 4a: standalone L-stock poison assembly from PERSISTED template fields
+   (no live factory_node needed) — the crash-resilient / standalone recourse entry
+   point.  A client (or the watchtower it feeds) loads its l_stock_poison_reveals
+   row (unsigned tx + aggregated Leaf-P sig + leaf script + control block + the
+   superseded state's committed hash + the LSP-revealed secret) and assembles the
+   broadcastable witness here.  Verifies SHA256(secret32)==target_hash32
+   (fail-closed) before building [agg_sig, secret, Leaf-P script, control block].
+   factory_assemble_poison_with_secret delegates to this.  Returns 1 on success,
+   0 on hash-mismatch / bad input. */
+int factory_assemble_poison_from_template(
+    const unsigned char *unsigned_tx, size_t unsigned_tx_len,
+    const unsigned char *agg_sig64,
+    const unsigned char *secret32,
+    const unsigned char *target_hash32,
+    const unsigned char *leaf_script, size_t leaf_script_len,
+    const unsigned char *control_block, size_t control_block_len,
+    tx_buf_t *out);
+
 /* Reset poison state on a node (free the unsigned/signed tx buffers + clear
    sighash + reset received counter).  Safe to call on a never-prepared
    node.  Used during cleanup and after the poison TX is handed to the

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -25,6 +25,15 @@ typedef struct {
     /* Factory (built after all clients connect) */
     factory_t factory;
 
+    /* #53 Phase 3: hashlock-gated L-stock poison.  When set, the binary
+       (tools/superscalar_lsp.c) has installed a real random shachain seed
+       on .factory and lsp_run_factory_creation_stateless calls
+       factory_enable_hashlock_poison(f) AFTER factory_init_from_pubkeys
+       re-init (which wipes use_hashlock_poison).  Default 0 (off / legacy
+       L-stock key-path).  The client needs no equivalent flag — it mirrors
+       each node's per-(leaf,state) hash off the wire. */
+    int enable_hashlock_poison;
+
     /* Bridge daemon connection (Phase 14) */
     int bridge_fd;
 

--- a/src/client.c
+++ b/src/client.c
@@ -3914,6 +3914,24 @@ static int client_handle_leaf_advance_stateless(int fd,
         leaf_poison_prepared_c = 0;
     }
 
+    /* #53 Phase 5 (B4): SECURITY-CRITICAL.  Shipping FINAL hands the LSP a
+       complete new-state signature, revoking the old state.  When this leaf
+       carries a hashlock (has_l_stock_hash => hashlock poison is on), REFUSE to
+       ship FINAL unless the Leaf-P poison for the superseded state was fully
+       co-signed (leaf_poison_prepared_c still set after every co-sign step).
+       Revoking the old state without that poison would leave this client with NO
+       recourse against a cheating LSP that later broadcasts the superseded state
+       (Scenario A/B) — the exact hole #53 closes.  Fail-closed: stay on the old,
+       still-recourse-able state.  Subsumes every degrade site above + the case
+       where prep never ran.  Non-hashlock leaves are unaffected. */
+    if (ps_node->has_l_stock_hash && !leaf_poison_prepared_c) {
+        fprintf(stderr, "Client-stateless %u: hashlock ON but L-stock poison NOT "
+                        "co-signed -- ABORTING advance (no revoke without recourse)\n",
+                my_index);
+        factory_session_reset_poison(factory, node_idx);
+        return 0;
+    }
+
     /* Step 8: ship FINAL with optional poison sig. */
     cJSON *fin_json = wire_build_leaf_advance_final(
         final_sig,

--- a/src/client.c
+++ b/src/client.c
@@ -3935,6 +3935,48 @@ static int client_handle_leaf_advance_stateless(int fd,
     }
     if (done_msg.json) cJSON_Delete(done_msg.json);
 
+    /* #53-B3b Phase 2: receive + verify + persist the SUPERSEDED state's L-stock
+       revocation secret, so this client (or its standalone watchtower) can spend the
+       Leaf-P poison if the LSP later broadcasts that stale state.  Only when this
+       advance co-signed a script-path poison (hashlock on).  Verify-before-persist
+       (fail-closed), mirroring channel_receive_revocation_flat. */
+    if (ps_node->poison_is_scriptpath && ps_node->poison_has_agg_sig) {
+        wire_msg_t rev_msg;
+        if (wire_recv(fd, &rev_msg) && rev_msg.msg_type == MSG_LSTOCK_REVEAL) {
+            uint32_t rn[1], rs[1];
+            unsigned char rsec[1][32];
+            size_t rcount = 0;
+            if (wire_parse_lstock_reveal(rev_msg.json, rn, rs, rsec, 1, &rcount) &&
+                rcount == 1) {
+                unsigned char chk[32];
+                sha256(rsec[0], 32, chk);
+                if (memcmp(chk, ps_node->poison_l_stock_hash, 32) == 0) {
+                    persist_save_l_stock_poison(persist, /* factory_id */ 0,
+                        (uint32_t)node_idx, rs[0], ps_node->poison_l_stock_hash,
+                        ps_node->poison_agg_sig,
+                        ps_node->poison_unsigned_tx.data, ps_node->poison_unsigned_tx.len,
+                        ps_node->poison_leaf_script, ps_node->poison_leaf_script_len,
+                        ps_node->poison_control_block, ps_node->poison_control_block_len);
+                    persist_update_l_stock_secret(persist, 0, (uint32_t)node_idx, rs[0],
+                                                  rsec[0]);
+                    printf("Client-stateless %u: L-stock secret verified + persisted "
+                           "(node %zu state %u) -> poison recourse durable\n",
+                           my_index, node_idx, rs[0]);
+                } else {
+                    fprintf(stderr, "Client-stateless %u: L-stock reveal FAILED verify "
+                            "(SHA256 != committed H_old) -- rejecting (LSP misbehaving)\n",
+                            my_index);
+                }
+                memset(rsec, 0, sizeof(rsec));
+            }
+            if (rev_msg.json) cJSON_Delete(rev_msg.json);
+        } else {
+            if (rev_msg.json) cJSON_Delete(rev_msg.json);
+            fprintf(stderr, "Client-stateless %u: expected MSG_LSTOCK_REVEAL after DONE "
+                    "-- recourse for the superseded state NOT persisted\n", my_index);
+        }
+    }
+
     /* CL7: broadcast the snapshotted stale leaf state now that the
        advance is recorded.  LSP/standalone WT must respond with
        response_tx + L-stock poison TX.  Mirrors the legacy path. */

--- a/src/client.c
+++ b/src/client.c
@@ -3643,9 +3643,14 @@ static int client_handle_leaf_advance_stateless(int fd,
        the LSP won'''t send poison fields back. */
     const uint64_t LEAF_POISON_FEE_SATS_C = 1000;
     int leaf_poison_prepared_c = 0;
-    if (had_old_signed_c && old_n_outputs_c >= 2 &&
+    /* #53 Phase 5: capture WHETHER a poison is economically required (the old
+       state has a protectable, non-dust L-stock output) so the fail-closed guard
+       below can tell "poison failed/degraded" (must abort) apart from "no poison
+       was ever needed" (dust / no old state -> safe to advance, do not abort). */
+    int poison_required_c = (had_old_signed_c && old_n_outputs_c >= 2 &&
         old_l_amount_c > LEAF_POISON_FEE_SATS_C +
-                         (uint64_t)(ps_node->n_signers - 1) * 330u) {
+                         (uint64_t)(ps_node->n_signers - 1) * 330u);
+    if (poison_required_c) {
         if (factory_session_prepare_poison_tx_leaf(
                 factory, node_idx,
                 old_leaf_txid, (uint32_t)(old_n_outputs_c - 1),
@@ -3924,10 +3929,10 @@ static int client_handle_leaf_advance_stateless(int fd,
        (Scenario A/B) — the exact hole #53 closes.  Fail-closed: stay on the old,
        still-recourse-able state.  Subsumes every degrade site above + the case
        where prep never ran.  Non-hashlock leaves are unaffected. */
-    if (ps_node->has_l_stock_hash && !leaf_poison_prepared_c) {
-        fprintf(stderr, "Client-stateless %u: hashlock ON but L-stock poison NOT "
-                        "co-signed -- ABORTING advance (no revoke without recourse)\n",
-                my_index);
+    if (ps_node->has_l_stock_hash && poison_required_c && !leaf_poison_prepared_c) {
+        fprintf(stderr, "Client-stateless %u: hashlock ON + L-stock poison REQUIRED "
+                        "but NOT co-signed -- ABORTING advance (no revoke without "
+                        "recourse)\n", my_index);
         factory_session_reset_poison(factory, node_idx);
         return 0;
     }

--- a/src/client.c
+++ b/src/client.c
@@ -3591,6 +3591,25 @@ static int client_handle_leaf_advance_stateless(int fd,
         }
     }
 
+    /* #53-B3b Phase 1: capture the OLD state's L-stock hash (H_old) BEFORE the local
+       advance rebuilds the SPK to H_new — used as the poison override so the poison
+       targets the SUPERSEDED state's output. */
+    unsigned char old_l_stock_hash_c[32];
+    int have_old_l_hash_c = ps_node->has_l_stock_hash;
+    if (have_old_l_hash_c)
+        memcpy(old_l_stock_hash_c, ps_node->l_stock_hash, 32);
+
+    /* #53-B3b Phase 1: mirror the advancing leaf's NEW-state hash from PROPOSE (the
+       client has no seed) so the local advance builds the IDENTICAL new leaf-state SPK
+       as the LSP — else the MuSig co-sign of the new state mismatches.  Absent field
+       (hashlock off) -> no-op. */
+    {
+        cJSON *lh = cJSON_GetObjectItem(propose_msg->json, "l_stock_hash");
+        unsigned char h_new[32];
+        if (lh && cJSON_IsString(lh) && hex_decode(lh->valuestring, h_new, 32) == 32)
+            factory_set_node_l_stock_hash(factory, node_idx, h_new);
+    }
+
     /* Step 1: advance local state to mirror the LSP. */
     int rc = factory_advance_leaf_unsigned(factory, leaf_side);
     if (rc <= 0) {
@@ -3630,7 +3649,9 @@ static int client_handle_leaf_advance_stateless(int fd,
         if (factory_session_prepare_poison_tx_leaf(
                 factory, node_idx,
                 old_leaf_txid, (uint32_t)(old_n_outputs_c - 1),
-                old_l_amount_c, LEAF_POISON_FEE_SATS_C, NULL)) {
+                old_l_amount_c, LEAF_POISON_FEE_SATS_C,
+                /* #53-B3b Phase 1: target the SUPERSEDED state's output (H_old). */
+                have_old_l_hash_c ? old_l_stock_hash_c : NULL)) {
             leaf_poison_prepared_c = 1;
         }
     }

--- a/src/factory.c
+++ b/src/factory.c
@@ -3311,6 +3311,34 @@ int factory_session_complete_node_poison(factory_t *f, size_t node_idx) {
     return 1;
 }
 
+int factory_assemble_poison_from_template(
+    const unsigned char *unsigned_tx, size_t unsigned_tx_len,
+    const unsigned char *agg_sig64,
+    const unsigned char *secret32,
+    const unsigned char *target_hash32,
+    const unsigned char *leaf_script, size_t leaf_script_len,
+    const unsigned char *control_block, size_t control_block_len,
+    tx_buf_t *out) {
+    if (!unsigned_tx || unsigned_tx_len == 0 || !agg_sig64 || !secret32 ||
+        !target_hash32 || !leaf_script || leaf_script_len == 0 ||
+        !control_block || control_block_len == 0 || !out)
+        return 0;
+
+    /* Defense-in-depth: the revealed secret must be the preimage of the hash THIS
+       poison targets (the superseded state's H_old), NOT any current hash.  Same
+       guard whether driven by a live node or a persisted row. */
+    unsigned char chk[32];
+    sha256(secret32, 32, chk);
+    if (memcmp(chk, target_hash32, 32) != 0) return 0;
+
+    /* Witness: [agg sig, preimage=secret, Leaf-P script, 2-leaf control block]. */
+    return finalize_script_path_tx_preimage(out,
+        unsigned_tx, unsigned_tx_len,
+        agg_sig64, secret32, 32,
+        leaf_script, leaf_script_len,
+        control_block, control_block_len);
+}
+
 int factory_assemble_poison_with_secret(factory_t *f, size_t node_idx,
                                         const unsigned char *secret32,
                                         tx_buf_t *out) {
@@ -3319,19 +3347,13 @@ int factory_assemble_poison_with_secret(factory_t *f, size_t node_idx,
     if (!node->poison_is_scriptpath || !node->poison_has_agg_sig) return 0;
     if (node->poison_unsigned_tx.len == 0) return 0;
 
-    /* Defense-in-depth: the revealed secret must be the preimage of the hash THIS
-       poison targets (poison_l_stock_hash = the superseded state's H_old), NOT the
-       node's current l_stock_hash, which may already have advanced. */
-    unsigned char chk[32];
-    sha256(secret32, 32, chk);
-    if (memcmp(chk, node->poison_l_stock_hash, 32) != 0) return 0;
-
-    /* Witness: [agg sig, preimage=secret, Leaf-P script, 2-leaf control block]. */
-    return finalize_script_path_tx_preimage(out,
+    /* Delegate to the standalone template path so the live-node and persisted
+       recourse routes assemble byte-identically (and share the hash guard). */
+    return factory_assemble_poison_from_template(
         node->poison_unsigned_tx.data, node->poison_unsigned_tx.len,
-        node->poison_agg_sig, secret32, 32,
+        node->poison_agg_sig, secret32, node->poison_l_stock_hash,
         node->poison_leaf_script, node->poison_leaf_script_len,
-        node->poison_control_block, node->poison_control_block_len);
+        node->poison_control_block, node->poison_control_block_len, out);
 }
 
 void factory_set_shachain_seed(factory_t *f, const unsigned char *seed32) {

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -436,6 +436,25 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
             factory_set_shachain_seed(f, saved_shachain_seed);
     }
     free(saved_secrets);
+
+    /* #53 Phase 3: re-enable hashlock-gated L-stock poison AFTER the
+       factory_init_from_pubkeys re-init above (which wiped
+       use_hashlock_poison).  The shachain seed was installed on the factory
+       by the binary before this call and preserved across the re-init by the
+       save/restore of saved_shachain_seed (use_flat_secrets==0 path).  Gated
+       on lsp->enable_hashlock_poison so the legacy L-stock key-path is the
+       default; fail-closed if the seed somehow didn't survive. */
+    if (lsp->enable_hashlock_poison) {
+        if (f->use_flat_secrets || !f->has_shachain ||
+            !factory_enable_hashlock_poison(f)) {
+            fprintf(stderr, "LSP-stateless factory creation: "
+                            "factory_enable_hashlock_poison failed "
+                            "(has_shachain=%d use_flat=%d)\n",
+                    f->has_shachain, f->use_flat_secrets);
+            return 0;
+        }
+    }
+
     factory_set_funding(f, funding_txid, funding_vout, funding_amount,
                         funding_spk, funding_spk_len);
 

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1912,6 +1912,30 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
     cJSON_Delete(done);
 
+    /* #53-B3b Phase 2: reveal the SUPERSEDED state's L-stock revocation secret to the
+       advancing leaf's client (targeted, not broadcast).  The client verifies it +
+       persists it so it (or its WT) can spend the Leaf-P poison if we later broadcast
+       that stale state — closing Scenario B in the live protocol.  Gated on hashlock +
+       a poison having been co-signed; the secret is re-derived from the seed (the poison
+       session was already reset above). */
+    if (f->use_hashlock_poison && leaf_poison_prepared && have_old_l_hash) {
+        uint32_t old_counter = (f->nodes[node_idx].l_stock_state_counter > 0)
+                               ? f->nodes[node_idx].l_stock_state_counter - 1u : 0u;
+        unsigned char reveal_secret[1][32];
+        if (factory_derive_l_stock_secret(f, &f->nodes[node_idx], old_counter,
+                                          reveal_secret[0])) {
+            uint32_t rn = (uint32_t)node_idx;
+            cJSON *rev = wire_build_lstock_reveal(&rn, &old_counter, reveal_secret, 1);
+            if (rev) {
+                wire_send(lsp->client_fds[leaf_side], MSG_LSTOCK_REVEAL, rev);
+                cJSON_Delete(rev);
+                printf("LSP-stateless: revealed L-stock secret for node %d state %u\n",
+                       (int)node_idx, old_counter);
+            }
+            memset(reveal_secret, 0, sizeof(reveal_secret));
+        }
+    }
+
     lsp_crash_checkpoint("leaf_advance_finalize_partial");
 
     /* Step 11: persist leaf state (same shape as legacy path). */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1445,14 +1445,19 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     /* Phase 1d.2: prep poison TX deterministically (both sides match). */
     const uint64_t LEAF_POISON_FEE_SATS = 1000;
     int leaf_poison_prepared = 0;
+    /* #53 Phase 5: economic requirement — the old state has a protectable,
+       non-dust L-stock output.  Captured independently of the operational prep
+       conditions (watchtower presence / the SS_CHEAT_OMIT_POISON test hook) so
+       the fail-closed guard below fires whenever a required poison was not
+       co-signed, but never when no poison was ever needed (dust / no old state). */
+    int poison_required = (had_old_signed && old_n_outputs >= 2 &&
+        old_l_amount > LEAF_POISON_FEE_SATS +
+                       (uint64_t)(f->nodes[pre_node_idx].n_signers - 1) * 330u);
     /* #53 Phase 5 test hook: SS_CHEAT_OMIT_POISON forces the LSP to skip poison
        prep so it co-signs the new state but NOT the Leaf-P poison — exercising
        the client's fail-closed "no revoke without recourse" abort.  Env-gated
        test path only (same pattern as SS_CHEAT_DAEMON_MODE). */
-    if (mgr->watchtower && had_old_signed && old_n_outputs >= 2 &&
-        !getenv("SS_CHEAT_OMIT_POISON") &&
-        old_l_amount > LEAF_POISON_FEE_SATS +
-                       (uint64_t)(f->nodes[pre_node_idx].n_signers - 1) * 330u) {
+    if (mgr->watchtower && poison_required && !getenv("SS_CHEAT_OMIT_POISON")) {
         if (factory_session_prepare_poison_tx_leaf(
                 f, pre_node_idx,
                 old_leaf_txid, (uint32_t)(old_n_outputs - 1),
@@ -1813,10 +1818,16 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        This subsumes every degrade-and-continue site above (any of them leaves
        leaf_poison_prepared == 0) plus the case where prep never ran.  Legacy
        (flag off) keeps the prior degrade-and-continue behavior unchanged. */
-    if (f->use_hashlock_poison && !leaf_poison_prepared) {
-        fprintf(stderr, "LSP-stateless: hashlock ON but L-stock poison NOT "
-                        "co-signed -- ABORTING advance (would leave the client "
+    if (f->use_hashlock_poison && poison_required && !leaf_poison_prepared) {
+        fprintf(stderr, "LSP-stateless: hashlock ON + L-stock poison REQUIRED but "
+                        "NOT co-signed -- ABORTING advance (would leave the client "
                         "without recourse)\n");
+        /* Finding 2: the new state's signed_tx was finalized in memory
+           (is_signed=1) just above, but is NOT persisted / DONE-broadcast yet.
+           Clear it so a later factory-tree broadcast cannot ship this
+           incomplete-advance state; persist still holds the old state. */
+        node->is_signed = 0;
+        tx_buf_reset(&node->signed_tx);
         factory_session_reset_poison(f, node_idx);
         return 0;
     }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1414,6 +1414,16 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
      * inspection. */
     uint32_t old_csv_delay = (uint32_t)(f->nodes[pre_node_idx].nsequence & 0xFFFFu);
 
+    /* #53-B3b Phase 1: capture the OLD state's L-stock hash BEFORE the advance bumps
+       the per-leaf counter + rebuilds the SPK to H_new — so the poison co-signed below
+       targets the SUPERSEDED state's output (H_old), via override_hash32.  No-op unless
+       hashlock poison is enabled. */
+    unsigned char old_l_stock_hash[32];
+    int have_old_l_hash = (f->use_hashlock_poison &&
+                           f->nodes[pre_node_idx].has_l_stock_hash);
+    if (have_old_l_hash)
+        memcpy(old_l_stock_hash, f->nodes[pre_node_idx].l_stock_hash, 32);
+
     /* Step 1: advance leaf state to rebuild the unsigned TX. */
     int rc = factory_advance_leaf_unsigned(f, leaf_side);
     if (rc == 0) {
@@ -1442,11 +1452,9 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                 f, pre_node_idx,
                 old_leaf_txid, (uint32_t)(old_n_outputs - 1),
                 old_l_amount, LEAF_POISON_FEE_SATS,
-                /* #53-B3b: NULL while the daemon doesn't enable hashlock poison
-                   (has_l_stock_hash==0 -> key-path branch). When it does, this path
-                   advances BEFORE prepare, so capture H_old before
-                   factory_advance_leaf_unsigned and pass it here. */
-                NULL)) {
+                /* #53-B3b Phase 1: target the SUPERSEDED state's output (H_old captured
+                   before the advance); NULL = legacy key-path when hashlock is off. */
+                have_old_l_hash ? old_l_stock_hash : NULL)) {
             leaf_poison_prepared = 1;
         }
     }
@@ -1471,6 +1479,12 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             cer_persisted = 1;
     }
     cJSON *propose = wire_build_leaf_advance_propose(leaf_side, NULL, NULL);
+    /* #53-B3b Phase 1: ship the advancing leaf's NEW-state L-stock hash (H_new, rebuilt
+       by the advance @ factory_advance_leaf_unsigned) so the seedless client builds the
+       IDENTICAL new leaf-state SPK — else the MuSig co-sign of the new state mismatches.
+       Optional field; absent when hashlock poison is off (backward compatible). */
+    if (f->use_hashlock_poison && f->nodes[node_idx].has_l_stock_hash)
+        wire_json_add_hex(propose, "l_stock_hash", f->nodes[node_idx].l_stock_hash, 32);
     if (!wire_send(lsp->client_fds[leaf_side], MSG_LEAF_ADVANCE_PROPOSE, propose)) {
         cJSON_Delete(propose);
         fprintf(stderr, "LSP-stateless: send PROPOSE failed\n");

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1445,7 +1445,12 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     /* Phase 1d.2: prep poison TX deterministically (both sides match). */
     const uint64_t LEAF_POISON_FEE_SATS = 1000;
     int leaf_poison_prepared = 0;
+    /* #53 Phase 5 test hook: SS_CHEAT_OMIT_POISON forces the LSP to skip poison
+       prep so it co-signs the new state but NOT the Leaf-P poison — exercising
+       the client's fail-closed "no revoke without recourse" abort.  Env-gated
+       test path only (same pattern as SS_CHEAT_DAEMON_MODE). */
     if (mgr->watchtower && had_old_signed && old_n_outputs >= 2 &&
+        !getenv("SS_CHEAT_OMIT_POISON") &&
         old_l_amount > LEAF_POISON_FEE_SATS +
                        (uint64_t)(f->nodes[pre_node_idx].n_signers - 1) * 330u) {
         if (factory_session_prepare_poison_tx_leaf(
@@ -1796,6 +1801,24 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             factory_session_reset_poison(f, node_idx);
             leaf_poison_prepared = 0;
         }
+    }
+
+    /* #53 Phase 5 (B4): when hashlock poison is ON, an advance that did NOT
+       co-sign the Leaf-P poison for the superseded state must NOT be finalized
+       (registered / persisted / DONE-broadcast).  Proceeding would revoke the
+       old state with NO recourse against a later LSP cheat (latent Scenario
+       A/B) — exactly what #53 closes.  Fail-closed: abort and stay on the old,
+       still-recourse-able state.  The new state is signed in memory only at this
+       point (not yet persisted / DONE), so returning 0 discards it cleanly.
+       This subsumes every degrade-and-continue site above (any of them leaves
+       leaf_poison_prepared == 0) plus the case where prep never ran.  Legacy
+       (flag off) keeps the prior degrade-and-continue behavior unchanged. */
+    if (f->use_hashlock_poison && !leaf_poison_prepared) {
+        fprintf(stderr, "LSP-stateless: hashlock ON but L-stock poison NOT "
+                        "co-signed -- ABORTING advance (would leave the client "
+                        "without recourse)\n");
+        factory_session_reset_poison(f, node_idx);
+        return 0;
     }
 
     /* Phase 1d.2: poison TX ceremony DONE.  Same atomic-signer flow as

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6365,6 +6365,52 @@ int test_regtest_lstock_poison_ceremony(void) {
                 "INTERPRETER ACCEPTS the MULTI-PROCESS-ceremony Leaf-P poison");
     printf("  multi-process ceremony poison ACCEPTED (%zu clients)\n", n_clients);
 
+    /* #53 Phase 4a: the STANDALONE persist-driven assembly (raw template fields,
+       no live node) must produce a byte-identical, interpreter-accepted poison —
+       this is exactly the path a client/WT takes from its l_stock_poison_reveals
+       row after a crash/restart, with only the stored template + revealed secret. */
+    tx_buf_t poison_tmpl; tx_buf_init(&poison_tmpl, 256);
+    TEST_ASSERT(factory_assemble_poison_from_template(
+                    leaf->poison_unsigned_tx.data, leaf->poison_unsigned_tx.len,
+                    leaf->poison_agg_sig, secret, leaf->poison_l_stock_hash,
+                    leaf->poison_leaf_script, leaf->poison_leaf_script_len,
+                    leaf->poison_control_block, leaf->poison_control_block_len,
+                    &poison_tmpl),
+                "assemble poison from persisted template");
+    TEST_ASSERT(poison_tmpl.len == poison.len &&
+                memcmp(poison_tmpl.data, poison.data, poison.len) == 0,
+                "from_template byte-identical to with_secret");
+    {
+        char *thex = (char *)malloc(poison_tmpl.len * 2 + 1);
+        hex_encode(poison_tmpl.data, poison_tmpl.len, thex);
+        char *tp = (char *)malloc(poison_tmpl.len * 2 + 16);
+        snprintf(tp, poison_tmpl.len * 2 + 16, "[\"%s\"]", thex);
+        char *tma2 = regtest_exec(&rt, "testmempoolaccept", tp);
+        free(tp);
+        TEST_ASSERT(tma2 != NULL, "testmempoolaccept (template) ran");
+        cJSON *j2 = cJSON_Parse(tma2); free(tma2);
+        cJSON *r2 = j2 ? cJSON_GetArrayItem(j2, 0) : NULL;
+        cJSON *al2 = r2 ? cJSON_GetObjectItem(r2, "allowed") : NULL;
+        int ok2 = al2 && cJSON_IsTrue(al2);
+        if (j2) cJSON_Delete(j2);
+        TEST_ASSERT(ok2, "INTERPRETER ACCEPTS the PERSIST-TEMPLATE-assembled poison");
+        free(thex);
+    }
+    tx_buf_free(&poison_tmpl);
+    /* negative: from_template also refuses a wrong secret (same hash guard) */
+    {
+        unsigned char wrong_t[32]; memcpy(wrong_t, secret, 32); wrong_t[1] ^= 0x02;
+        tx_buf_t bad_t; tx_buf_init(&bad_t, 64);
+        TEST_ASSERT(factory_assemble_poison_from_template(
+                        leaf->poison_unsigned_tx.data, leaf->poison_unsigned_tx.len,
+                        leaf->poison_agg_sig, wrong_t, leaf->poison_l_stock_hash,
+                        leaf->poison_leaf_script, leaf->poison_leaf_script_len,
+                        leaf->poison_control_block, leaf->poison_control_block_len,
+                        &bad_t) == 0,
+                    "from_template REFUSES wrong secret");
+        tx_buf_free(&bad_t);
+    }
+
     /* negative: assembling with a wrong secret is refused */
     unsigned char wrong[32]; memcpy(wrong, secret, 32); wrong[0] ^= 0x01;
     tx_buf_t bad; tx_buf_init(&bad, 64);

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -314,6 +314,12 @@ static void usage(const char *prog) {
         "                       (ewt 432 blocks under BOLT 2016 with mainnet defaults).\n"
         "  --force-close       After factory creation (+ demo), broadcast tree and wait for confirmations\n"
         "  --test-burn         After factory creation (+ demo), broadcast tree and burn L-stock via shachain\n"
+        "  --enable-hashlock-poison  Build the factory with hashlock-gated L-stock\n"
+        "                      poison (#53): the L-stock output is spendable by the\n"
+        "                      poison only with an LSP-revealed per-(leaf,state)\n"
+        "                      secret, closing the co-signed-poison theft vector.\n"
+        "                      Installs a random shachain seed. Mutually exclusive\n"
+        "                      with --test-burn.\n"
         "  --test-htlc-force-close  After demo: add pending HTLC, force-close, broadcast HTLC timeout TX\n"
         "  --test-multi-htlc-force-close  After demo: add HTLCs on ALL channels, force-close, broadcast all timeout TXs\n"
         "  --test-full-settlement  After demo: force-close tree, broadcast ALL commitment TXs, verify cross-leaf balances\n"
@@ -1341,6 +1347,7 @@ int main(int argc, char *argv[]) {
                                         0 = disabled (default for backward compat) */
     int force_close = 0;
     int test_burn = 0;
+    int enable_hashlock_poison = 0;  /* #53 Phase 3: hashlock-gated L-stock poison */
     int test_ptlc_basic = 0;
     int test_ptlc_breach = 0;
     int test_ptlc_restart = 0;
@@ -1752,6 +1759,8 @@ int main(int argc, char *argv[]) {
             force_close = 1;
         else if (strcmp(argv[i], "--test-burn") == 0)
             test_burn = 1;
+        else if (strcmp(argv[i], "--enable-hashlock-poison") == 0)
+            enable_hashlock_poison = 1;
         else if (strcmp(argv[i], "--test-htlc-force-close") == 0)
             test_htlc_force_close = 1;
         else if (strcmp(argv[i], "--test-multi-htlc-force-close") == 0)
@@ -3894,6 +3903,42 @@ accept_new_factory:
         }
         printf("LSP: flat revocation secrets generated for burn test (%zu epochs)\n",
                lsp_p->factory.n_revocation_secrets);
+    }
+
+    /* #53 Phase 3: hashlock-gated L-stock poison.  Distinct from --test-burn's
+       flat secrets (the old global-epoch index): the hashlock poison derives a
+       per-(leaf,state) secret from a single shachain seed
+       (factory_derive_l_stock_secret reads f->shachain_seed).  Install a real
+       random seed here in SHACHAIN mode (factory_set_shachain_seed sets
+       has_shachain=1 and leaves use_flat_secrets=0, so lsp_run_factory_creation
+       _stateless's save/restore across factory_init_from_pubkeys preserves the
+       seed via the !use_flat_secrets branch), and flag the LSP so the creation
+       path calls factory_enable_hashlock_poison after the re-init.  Mutually
+       exclusive with --test-burn (flat secrets would clobber the shachain
+       save/restore path and strand the L-stock secret). */
+    if (enable_hashlock_poison) {
+        if (test_burn) {
+            fprintf(stderr, "LSP: --enable-hashlock-poison and --test-burn are "
+                            "mutually exclusive (shachain seed vs flat secrets)\n");
+            lsp_cleanup(lsp_p);
+            secp256k1_context_destroy(ctx);
+            return 1;
+        }
+        unsigned char hl_seed[32];
+        FILE *uf = fopen("/dev/urandom", "rb");
+        if (!uf || fread(hl_seed, 1, sizeof(hl_seed), uf) != sizeof(hl_seed)) {
+            if (uf) fclose(uf);
+            fprintf(stderr, "LSP: failed to read random L-stock poison seed "
+                            "from /dev/urandom\n");
+            lsp_cleanup(lsp_p);
+            secp256k1_context_destroy(ctx);
+            return 1;
+        }
+        fclose(uf);
+        factory_set_shachain_seed(&lsp_p->factory, hl_seed);
+        lsp_p->enable_hashlock_poison = 1;
+        printf("LSP: hashlock-gated L-stock poison ENABLED "
+               "(per-(leaf,state) shachain seed installed)\n");
     }
 
     printf("LSP: starting factory creation ceremony...\n");

--- a/tools/superscalar_lstock_recover.c
+++ b/tools/superscalar_lstock_recover.c
@@ -1,0 +1,108 @@
+/*
+ * superscalar_lstock_recover: assemble the broadcastable hashlock L-stock
+ * poison from a CLIENT's persisted reveal (l_stock_poison_reveals), for the
+ * #53 trustless recourse path.
+ *
+ * After a leaf advance the LSP reveals its per-(leaf,state) secret to the
+ * client (MSG_LSTOCK_REVEAL); the client verifies SHA256(secret)==H_old and
+ * persists it alongside the co-signed Leaf-P poison template.  If the LSP later
+ * broadcasts that SUPERSEDED leaf state to over-claim its L-stock, the client
+ * (or a watchtower the client feeds revealed secrets to) loads the row here and
+ * assembles the witness [agg_sig, secret(preimage), Leaf-P script, control
+ * block] via factory_assemble_poison_from_template, then broadcasts it to
+ * redirect the L-stock to the clients.
+ *
+ * Output: the complete poison tx hex on stdout (the caller broadcasts it, e.g.
+ * `bitcoin-cli sendrawtransaction $(superscalar_lstock_recover ...)`).
+ * Exit codes: 0 = hex printed; 4 = no poison row; 5 = secret not yet revealed
+ * (the anti-vacuity guarantee: no reveal, no recourse); other = usage/IO error.
+ *
+ * This models the CLIENT's recourse — the secret-less standalone watchtower
+ * cannot assemble a hashlock poison on its own (see #62).
+ *
+ * Usage:
+ *   superscalar_lstock_recover --db <client.db>
+ *       [--factory-id N] --node-idx N --state N
+ */
+#include "superscalar/persist.h"
+#include "superscalar/factory.h"
+#include "superscalar/types.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void hex_encode(const unsigned char *data, size_t len, char *out);
+
+static void usage(const char *a0) {
+    fprintf(stderr,
+        "Usage: %s --db PATH [--factory-id N] --node-idx N --state N\n"
+        "  Assembles the hashlock L-stock poison from the persisted reveal and\n"
+        "  prints the tx hex.  Exits non-zero if no secret was revealed.\n", a0);
+}
+
+int main(int argc, char **argv) {
+    const char *db_path = NULL;
+    long factory_id = 0;
+    long node_idx = -1;
+    long state = -1;
+    for (int i = 1; i < argc; i++) {
+        if      (!strcmp(argv[i], "--db")         && i+1 < argc) db_path    = argv[++i];
+        else if (!strcmp(argv[i], "--factory-id") && i+1 < argc) factory_id = strtol(argv[++i], NULL, 10);
+        else if (!strcmp(argv[i], "--node-idx")   && i+1 < argc) node_idx   = strtol(argv[++i], NULL, 10);
+        else if (!strcmp(argv[i], "--state")      && i+1 < argc) state      = strtol(argv[++i], NULL, 10);
+        else { usage(argv[0]); return 2; }
+    }
+    if (!db_path || node_idx < 0 || state < 0) { usage(argv[0]); return 2; }
+
+    persist_t db;
+    if (!persist_open(&db, db_path)) {
+        fprintf(stderr, "lstock-recover: cannot open db %s\n", db_path);
+        return 3;
+    }
+
+    unsigned char hash32[32], agg_sig64[64], secret32[32];
+    unsigned char leaf_script[128], control_block[65];
+    size_t leaf_script_len = 0, control_block_len = 0;
+    int has_secret = 0;
+    tx_buf_t unsigned_tx; tx_buf_init(&unsigned_tx, 256);
+
+    int loaded = persist_load_l_stock_poison(&db, (uint32_t)factory_id,
+                    (uint32_t)node_idx, (uint32_t)state,
+                    hash32, agg_sig64, &unsigned_tx,
+                    leaf_script, &leaf_script_len,
+                    control_block, &control_block_len,
+                    secret32, &has_secret);
+    if (!loaded) {
+        fprintf(stderr, "lstock-recover: no poison row for factory=%ld node=%ld state=%ld\n",
+                factory_id, node_idx, state);
+        tx_buf_free(&unsigned_tx); persist_close(&db); return 4;
+    }
+    if (!has_secret) {
+        fprintf(stderr, "lstock-recover: secret NOT yet revealed for node=%ld state=%ld"
+                        " -- no recourse (anti-vacuity)\n", node_idx, state);
+        tx_buf_free(&unsigned_tx); persist_close(&db); return 5;
+    }
+
+    tx_buf_t poison; tx_buf_init(&poison, 256);
+    int ok = factory_assemble_poison_from_template(
+                 unsigned_tx.data, unsigned_tx.len,
+                 agg_sig64, secret32, hash32,
+                 leaf_script, leaf_script_len,
+                 control_block, control_block_len,
+                 &poison);
+    if (!ok || poison.len == 0) {
+        fprintf(stderr, "lstock-recover: assembly failed (hash guard or bad template)\n");
+        tx_buf_free(&poison); tx_buf_free(&unsigned_tx); persist_close(&db); return 6;
+    }
+
+    char *hex = (char *)malloc(poison.len * 2 + 1);
+    if (!hex) { tx_buf_free(&poison); tx_buf_free(&unsigned_tx); persist_close(&db); return 7; }
+    hex_encode(poison.data, poison.len, hex);
+    printf("%s\n", hex);
+    free(hex);
+
+    tx_buf_free(&poison);
+    tx_buf_free(&unsigned_tx);
+    persist_close(&db);
+    return 0;
+}

--- a/tools/test_regtest_hashlock_poison_abort.sh
+++ b/tools/test_regtest_hashlock_poison_abort.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# test_regtest_hashlock_poison_abort.sh — #53 Phase 5 degradation-abort assertion.
+#
+# Proves the fail-closed guard: when hashlock poison is ON but the Leaf-P poison
+# for the superseded state is NOT co-signed, the client MUST REFUSE to advance
+# (it would otherwise revoke the old state with no recourse = Scenario A/B).
+#
+# Mechanism: the LSP runs with SS_CHEAT_OMIT_POISON=1, which makes it skip poison
+# prep — so it co-signs the new state but ships an LSP_RESPONSE with no poison
+# fields.  The client detects the missing poison, hits the guard before shipping
+# FINAL, and aborts ("no revoke without recourse").  ASSERT: the client logs the
+# refusal AND no l_stock_poison_reveals row is persisted (the advance did not
+# complete) AND the leaf did NOT reach CHEAT DAEMON COMPLETE.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+N_CLIENTS="${N_CLIENTS:-4}"
+SIDE="${SIDE:-0}"
+FUNDING_SATS=100000
+LSP_PORT=29958
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "0000000000000000000000000000000000000000000000000000000000000005"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+. "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
+
+ASAN_ENV="ASAN_OPTIONS=detect_leaks=0"
+if ldd "$LSP_BIN" 2>/dev/null | grep -q libasan; then
+    ASAN_ENV="ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8"
+fi
+
+TMPDIR=$(mktemp -d /tmp/ss-hashlock-abort.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"; LSP_LOG="$TMPDIR/lsp.log"
+MINER_WALLET="ss_hashlock_abort_miner"
+PIDS=()
+cleanup() {
+    for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    cp "$LSP_LOG" /tmp/hashlock_abort_last_lsp.log 2>/dev/null || true
+    cp "$TMPDIR/client_0.log" /tmp/hashlock_abort_last_client0.log 2>/dev/null || true
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "=== HASHLOCK POISON DEGRADATION-ABORT (regtest, #53 Phase 5) ==="
+if ! $BCLI getblockchaininfo >/dev/null 2>&1; then
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+    for i in $(seq 1 30); do sleep 1; $BCLI getblockchaininfo >/dev/null 2>&1 && break; done
+fi
+$BCLI -named createwallet wallet_name=$MINER_WALLET load_on_startup=false 2>&1 | head -1 || true
+$BCLI loadwallet $MINER_WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+echo "  miner ready, height $($BCLI getblockcount)"
+
+echo "--- LSP (--enable-hashlock-poison --cheat-daemon-leaf $SIDE, SS_CHEAT_OMIT_POISON=1) ---"
+env $ASAN_ENV SS_CHEAT_OMIT_POISON=1 \
+"$LSP_BIN" --network regtest --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
+    --amount $FUNDING_SATS --fee-rate 1000 --confirm-timeout 600 \
+    --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET --db "$LSP_DB" \
+    --enable-hashlock-poison --demo --cheat-daemon-leaf $SIDE --lsp-balance-pct 50 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!; PIDS+=($LSP_PID)
+for i in $(seq 1 60); do
+    sleep 1
+    grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && break
+    kill -0 $LSP_PID 2>/dev/null || { echo "FAIL: LSP died before listening"; tail -20 "$LSP_LOG"; exit 1; }
+done
+
+echo "--- $N_CLIENTS clients ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    env $ASAN_ENV \
+    "$CLIENT_BIN" --network regtest --host 127.0.0.1 --port $LSP_PORT \
+        --seckey "${CLIENT_SECKEYS[$i]}" --fee-rate 1000 --lsp-pubkey "$LSP_PUBKEY" \
+        --participant-id $((i + 1)) --daemon --rpcuser ${RPCUSER:-rpcuser} \
+        --rpcpassword ${RPCPASSWORD:-rpcpass} --wallet $MINER_WALLET \
+        --db "$TMPDIR/client_${i}.db" > "$TMPDIR/client_${i}.log" 2>&1 &
+    PIDS+=($!)
+    sleep 0.5
+done
+( while kill -0 $LSP_PID 2>/dev/null; do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 2; done ) &
+PIDS+=($!)
+
+echo "--- Waiting for the client refusal (timeout 180s) ---"
+REFUSED=0
+for i in $(seq 1 90); do
+    sleep 2
+    if grep -q "no revoke without recourse" "$TMPDIR"/client_*.log 2>/dev/null; then
+        REFUSED=1; echo "  client refusal observed after ${i}*2s"; break
+    fi
+    # If the LSP somehow reached COMPLETE, the guard FAILED to fire.
+    if grep -q "CHEAT DAEMON COMPLETE" "$LSP_LOG" 2>/dev/null; then
+        echo "FAIL: advance COMPLETED despite missing poison — guard did not fire"; exit 1
+    fi
+    kill -0 $LSP_PID 2>/dev/null || { echo "  LSP exited at ${i}*2s (advance failed, as expected)"; break; }
+done
+
+echo
+echo "=== Verifying fail-closed abort ==="
+grep -hE "no revoke without recourse" "$TMPDIR"/client_*.log | head -2 || true
+[ $REFUSED -eq 1 ] || { echo "FAIL: client did NOT log the fail-closed refusal"; echo "--- client_0 tail ---"; tail -25 "$TMPDIR/client_0.log"; exit 1; }
+
+# The aborted advance must NOT have persisted any reveal row (no revocation).
+TOTAL_REVEALS=0
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    n=$(sqlite3 "$TMPDIR/client_${i}.db" "SELECT count(*) FROM l_stock_poison_reveals;" 2>/dev/null || echo 0)
+    TOTAL_REVEALS=$((TOTAL_REVEALS + ${n:-0}))
+done
+echo "  persisted reveal rows across clients: $TOTAL_REVEALS (expect 0 — advance aborted)"
+[ "$TOTAL_REVEALS" = "0" ] || { echo "FAIL: a reveal was persisted despite the abort (revocation leaked)"; exit 1; }
+
+# And the LSP must not have reached the cheat-complete marker.
+if grep -q "CHEAT DAEMON COMPLETE" "$LSP_LOG" 2>/dev/null; then
+    echo "FAIL: LSP reached CHEAT DAEMON COMPLETE — advance was not aborted"; exit 1
+fi
+
+echo
+echo "=== PASS: degradation-abort proven ==="
+echo "  hashlock ON + poison omitted => client REFUSED to advance (no revoke without recourse);"
+echo "  no reveal persisted, advance did not complete — fail-closed verified"
+exit 0

--- a/tools/test_regtest_hashlock_poison_e2e.sh
+++ b/tools/test_regtest_hashlock_poison_e2e.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# test_regtest_hashlock_poison_e2e.sh — #53 Phase 4c: hashlock L-stock poison
+# end-to-end on regtest, through the LIVE LSP<->client daemon ceremony.
+#
+# This is the proof that Phases 1-3 work together:
+#   1. LSP runs --enable-hashlock-poison --cheat-daemon-leaf: it builds a
+#      hashlock-gated factory (Phase 3), then advances a PS leaf over the REAL
+#      wire ceremony with running clients.  During the advance (Phases 1-2):
+#        - the client mirrors the new-state hash H_new (builds the same SPK),
+#        - both sides capture the superseded state's hash H_old,
+#        - they co-sign the Leaf-P poison against H_old (script-path, untweaked),
+#        - the LSP reveals secret_old (MSG_LSTOCK_REVEAL),
+#        - the client verifies SHA256(secret)==H_old and PERSISTS the row
+#          (l_stock_poison_reveals) with the template + the revealed secret.
+#   2. The cheating LSP broadcasts the SUPERSEDED pre-advance leaf state on-chain
+#      (trying to over-claim its L-stock at a revoked state).
+#   3. The CLIENT recourse tool (superscalar_lstock_recover) loads the persisted
+#      reveal, assembles the Leaf-P poison [agg_sig, secret, script, control
+#      block], and we broadcast it.
+#   4. ASSERT: the poison CONFIRMS on-chain and redistributes the L-stock
+#      (a real, non-dust output) — the economic outcome, not just a marker.
+#   5. ANTI-VACUITY: with the revealed secret removed, the tool REFUSES (exit 5)
+#      — no reveal, no recourse (the #53 security property).
+#
+# Models the client-driven recourse (the secret-less standalone WT cannot
+# assemble a hashlock poison alone — see #62).  Sibling of
+# test_regtest_cheat_daemon_leaf.sh (the key-path-poison standalone-WT variant).
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+REC_BIN="$BUILD_DIR/superscalar_lstock_recover"
+
+N_CLIENTS="${N_CLIENTS:-4}"
+SIDE="${SIDE:-0}"   # 0=left, 1=right
+
+FUNDING_SATS=100000
+LSP_PORT=29957                # distinct from cheat-leaf (29950) / daemon-leaf (29951)
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "0000000000000000000000000000000000000000000000000000000000000005"
+    "0000000000000000000000000000000000000000000000000000000000000006"
+    "0000000000000000000000000000000000000000000000000000000000000007"
+    "0000000000000000000000000000000000000000000000000000000000000008"
+    "0000000000000000000000000000000000000000000000000000000000000009"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+
+. "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
+
+TMPDIR=$(mktemp -d /tmp/ss-hashlock-e2e.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"
+LSP_LOG="$TMPDIR/lsp.log"
+MINER_WALLET="ss_hashlock_e2e_miner"
+
+PIDS=()
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    cp "$LSP_LOG" /tmp/hashlock_e2e_last_lsp.log 2>/dev/null || true
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        cp "$TMPDIR/client_${i}.log" "/tmp/hashlock_e2e_last_client_${i}.log" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "=== HASHLOCK L-STOCK POISON E2E (regtest, #53 Phase 4c) ==="
+echo "  build dir : $BUILD_DIR"
+echo "  N clients : $N_CLIENTS   side: $SIDE   funding: $FUNDING_SATS sats"
+echo "  bitcoind  : $REGTEST_CONF"
+echo
+
+# --- bitcoind ---
+echo "--- bitcoind regtest check ---"
+if ! $BCLI getblockchaininfo >/dev/null 2>&1; then
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+    for i in $(seq 1 30); do sleep 1; $BCLI getblockchaininfo >/dev/null 2>&1 && break; done
+fi
+echo "  bitcoind reachable, height $($BCLI getblockcount)"
+
+$BCLI -named createwallet wallet_name=$MINER_WALLET load_on_startup=false 2>&1 | head -1 || true
+$BCLI loadwallet $MINER_WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+echo "  miner wallet ready, 101 blocks mined"
+
+# --- LSP daemon (hashlock poison + cheat) ---
+echo
+echo "--- LSP daemon (--enable-hashlock-poison --cheat-daemon-leaf $SIDE) ---"
+ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+"$LSP_BIN" \
+    --network regtest \
+    --port $LSP_PORT \
+    --clients $N_CLIENTS \
+    --arity 3 \
+    --amount $FUNDING_SATS \
+    --fee-rate 1000 \
+    --confirm-timeout 600 \
+    --active-blocks 6 \
+    --dying-blocks 4 \
+    --step-blocks 1 \
+    --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser ${RPCUSER:-rpcuser} \
+    --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET \
+    --db "$LSP_DB" \
+    --enable-hashlock-poison \
+    --demo --cheat-daemon-leaf $SIDE \
+    --lsp-balance-pct 50 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+PIDS+=($LSP_PID)
+
+for i in $(seq 1 60); do
+    sleep 1
+    grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && { echo "  LSP listening (PID=$LSP_PID)"; break; }
+    kill -0 $LSP_PID 2>/dev/null || { echo "FAIL: LSP died before listening"; tail -20 "$LSP_LOG"; exit 1; }
+done
+grep -q "hashlock-gated L-stock poison ENABLED" "$LSP_LOG" || { echo "FAIL: hashlock poison not enabled in LSP"; tail -20 "$LSP_LOG"; exit 1; }
+echo "  hashlock poison ENABLED confirmed in LSP log"
+
+# --- Clients ---
+echo
+echo "--- Starting $N_CLIENTS clients ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+    "$CLIENT_BIN" \
+        --network regtest \
+        --host 127.0.0.1 --port $LSP_PORT \
+        --seckey "${CLIENT_SECKEYS[$i]}" \
+        --fee-rate 1000 \
+        --lsp-pubkey "$LSP_PUBKEY" \
+        --participant-id $((i + 1)) \
+        --daemon \
+        --rpcuser ${RPCUSER:-rpcuser} \
+        --rpcpassword ${RPCPASSWORD:-rpcpass} \
+        --wallet $MINER_WALLET \
+        --db "$TMPDIR/client_${i}.db" \
+        > "$TMPDIR/client_${i}.log" 2>&1 &
+    PIDS+=($!)
+    echo "  client[$i] PID=$!"
+    sleep 0.5
+done
+
+# --- Background miner ---
+( while kill -0 $LSP_PID 2>/dev/null; do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 2; done ) &
+PIDS+=($!)
+
+# --- Wait for CHEAT DAEMON COMPLETE ---
+echo
+echo "--- Waiting for advance + stale broadcast + CHEAT DAEMON COMPLETE (timeout 360s) ---"
+READY=0
+for i in $(seq 1 180); do
+    sleep 2
+    grep -q "CHEAT DAEMON COMPLETE" "$LSP_LOG" 2>/dev/null && { READY=1; echo "  CHEAT DAEMON COMPLETE after ${i}*2s"; break; }
+    [ $((i % 15)) -eq 0 ] && echo "  ... ${i}*2s elapsed"
+    kill -0 $LSP_PID 2>/dev/null || { echo "  LSP exited at iter $i"; break; }
+done
+[ $READY -eq 1 ] || { echo "FAIL: no CHEAT DAEMON COMPLETE in 360s"; tail -50 "$LSP_LOG"; exit 1; }
+
+STALE_TXID=$(grep -E "Stale pre-advance leaf broadcast" "$LSP_LOG" | head -1 | grep -oE "[0-9a-f]{64}" | head -1)
+echo "  Stale (superseded) leaf broadcast txid: ${STALE_TXID:-(unknown)}"
+[ -n "$STALE_TXID" ] || { echo "FAIL: no stale broadcast txid"; tail -30 "$LSP_LOG"; exit 1; }
+
+# Reveal fires DURING the advance (well before the marker); stop clients so their
+# SQLite DBs are flushed before we read them.
+echo "  Stopping clients so their persist DBs flush..."
+for pid in "${PIDS[@]:-}"; do kill -TERM "$pid" 2>/dev/null || true; done
+sleep 3
+
+# --- Find the client that persisted the reveal ---
+echo
+echo "=== Locating the client-persisted reveal (l_stock_poison_reveals) ==="
+REVEAL_DB=""; REVEAL_NODE=""; REVEAL_STATE=""
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    row=$(sqlite3 "$TMPDIR/client_${i}.db" \
+        "SELECT node_idx||' '||state_counter FROM l_stock_poison_reveals WHERE revocation_secret IS NOT NULL ORDER BY state_counter ASC LIMIT 1;" 2>/dev/null || true)
+    if [ -n "$row" ]; then
+        REVEAL_DB="$TMPDIR/client_${i}.db"
+        REVEAL_NODE=$(echo "$row" | awk '{print $1}')
+        REVEAL_STATE=$(echo "$row" | awk '{print $2}')
+        echo "  reveal persisted by client[$i]: node=$REVEAL_NODE state=$REVEAL_STATE db=$REVEAL_DB"
+        break
+    fi
+done
+[ -n "$REVEAL_DB" ] || { echo "FAIL: NO client persisted an l_stock_poison_reveals row — the reveal wire (Phase 2) did not fire"; exit 1; }
+
+# --- Mine the stale leaf to maturity, then assemble + broadcast the poison ---
+echo
+echo "=== CLIENT recourse: assemble hashlock poison from persisted reveal ==="
+$BCLI generatetoaddress 3 "$MINE_ADDR" >/dev/null 2>&1
+POISON_HEX=$("$REC_BIN" --db "$REVEAL_DB" --node-idx "$REVEAL_NODE" --state "$REVEAL_STATE" 2>/tmp/_rec.err) || {
+    echo "FAIL: superscalar_lstock_recover failed (rc=$?)"; cat /tmp/_rec.err; exit 1; }
+echo "  assembled poison (${#POISON_HEX} hex chars)"
+POISON_TXID=$($BCLI sendrawtransaction "$POISON_HEX" 2>/tmp/_send.err) || {
+    echo "FAIL: poison sendrawtransaction REJECTED"; cat /tmp/_send.err
+    echo "  (mempool reject means the persisted template/secret did not yield a spend of the stale L-stock output)"; exit 1; }
+echo "  POISON broadcast txid: $POISON_TXID"
+
+# --- Confirm + amount ---
+echo
+echo "=== Verifying poison CONFIRMS + redistributes L-stock ==="
+PRAW=""
+for n in $(seq 1 10); do
+    $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 1
+    PRAW=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null || true)
+    echo "$PRAW" | grep -q '"confirmations"' && break
+done
+echo "$PRAW" | grep -q '"confirmations"' || { echo "FAIL: poison $POISON_TXID never CONFIRMED"; exit 1; }
+PV=$(echo "$PRAW" | grep -oE '"value": *[0-9.]+' | grep -oE '[0-9.]+' | sort -rn | head -1)
+PSATS=$(awk "BEGIN{printf \"%d\", ($PV+0)*100000000}")
+echo "  poison CONFIRMED; largest output ${PSATS:-0} sats"
+[ "${PSATS:-0}" -ge 1000 ] || { echo "FAIL: poison output ${PSATS} sats <= dust — not a real L-stock recapture"; exit 1; }
+
+# --- Anti-vacuity: no revealed secret -> no recourse ---
+echo
+echo "=== Anti-vacuity: tool must REFUSE when the secret is absent ==="
+cp "$REVEAL_DB" "$TMPDIR/novax.db"
+sqlite3 "$TMPDIR/novax.db" "UPDATE l_stock_poison_reveals SET revocation_secret=NULL;" 2>/dev/null
+set +e
+"$REC_BIN" --db "$TMPDIR/novax.db" --node-idx "$REVEAL_NODE" --state "$REVEAL_STATE" >/dev/null 2>/tmp/_nv.err
+NRC=$?
+set -e
+echo "  no-secret recourse exit=$NRC (expect 5)"; cat /tmp/_nv.err 2>/dev/null || true
+[ "$NRC" = "5" ] || { echo "FAIL: tool did NOT refuse a missing reveal (anti-vacuity broken)"; exit 1; }
+
+echo
+echo "=== PASS: hashlock L-stock poison E2E ==="
+echo "  advance->reveal->persist->assemble->broadcast->CONFIRM proven on regtest"
+echo "  poison $POISON_TXID confirmed, ${PSATS} sats recaptured; no-reveal refused (exit 5)"
+exit 0

--- a/tools/test_regtest_hashlock_poison_e2e.sh
+++ b/tools/test_regtest_hashlock_poison_e2e.sh
@@ -139,8 +139,8 @@ for i in $(seq 1 60); do
     grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && { echo "  LSP listening (PID=$LSP_PID)"; break; }
     kill -0 $LSP_PID 2>/dev/null || { echo "FAIL: LSP died before listening"; tail -20 "$LSP_LOG"; exit 1; }
 done
-grep -q "hashlock-gated L-stock poison ENABLED" "$LSP_LOG" || { echo "FAIL: hashlock poison not enabled in LSP"; tail -20 "$LSP_LOG"; exit 1; }
-echo "  hashlock poison ENABLED confirmed in LSP log"
+# NOTE: the "hashlock poison ENABLED" line prints during factory creation, which
+# only happens AFTER all clients connect — so it is asserted after the marker below.
 
 # --- Clients ---
 echo
@@ -180,6 +180,10 @@ for i in $(seq 1 180); do
     kill -0 $LSP_PID 2>/dev/null || { echo "  LSP exited at iter $i"; break; }
 done
 [ $READY -eq 1 ] || { echo "FAIL: no CHEAT DAEMON COMPLETE in 360s"; tail -50 "$LSP_LOG"; exit 1; }
+
+# Factory creation has run by now — assert the hashlock feature actually engaged.
+grep -q "hashlock-gated L-stock poison ENABLED" "$LSP_LOG" || { echo "FAIL: hashlock poison was NOT enabled (Phase 3 flag/seed path)"; tail -40 "$LSP_LOG"; exit 1; }
+echo "  hashlock poison ENABLED confirmed in LSP log"
 
 STALE_TXID=$(grep -E "Stale pre-advance leaf broadcast" "$LSP_LOG" | head -1 | grep -oE "[0-9a-f]{64}" | head -1)
 echo "  Stale (superseded) leaf broadcast txid: ${STALE_TXID:-(unknown)}"

--- a/tools/test_regtest_hashlock_poison_e2e.sh
+++ b/tools/test_regtest_hashlock_poison_e2e.sh
@@ -59,6 +59,13 @@ BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
 
 . "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
 
+# ASan preload only when the binaries are actually ASan-linked (build-rigor may
+# be a release build; preloading libasan before a non-ASan binary aborts it).
+ASAN_ENV="ASAN_OPTIONS=detect_leaks=0"
+if ldd "$LSP_BIN" 2>/dev/null | grep -q libasan; then
+    ASAN_ENV="ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8"
+fi
+
 TMPDIR=$(mktemp -d /tmp/ss-hashlock-e2e.XXXXXX)
 LSP_DB="$TMPDIR/lsp.db"
 LSP_LOG="$TMPDIR/lsp.log"
@@ -102,7 +109,7 @@ echo "  miner wallet ready, 101 blocks mined"
 # --- LSP daemon (hashlock poison + cheat) ---
 echo
 echo "--- LSP daemon (--enable-hashlock-poison --cheat-daemon-leaf $SIDE) ---"
-ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+env $ASAN_ENV \
 "$LSP_BIN" \
     --network regtest \
     --port $LSP_PORT \
@@ -139,7 +146,7 @@ echo "  hashlock poison ENABLED confirmed in LSP log"
 echo
 echo "--- Starting $N_CLIENTS clients ---"
 for i in $(seq 0 $((N_CLIENTS - 1))); do
-    ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
+    env $ASAN_ENV \
     "$CLIENT_BIN" \
         --network regtest \
         --host 127.0.0.1 --port $LSP_PORT \


### PR DESCRIPTION
Makes the hashlock-gated L-stock poison (#53) **live in the LSP↔client daemons** and proves it end-to-end. Stacked on `trustless-model-hardening` (#386), which landed all the unit/interpreter-proven layers (crypto core, per-(leaf,state) secret, ceremony→Leaf-P, old-state targeting, client SPK mirror + `MSG_LSTOCK_REVEAL`, persist schema v38). Scope here = the **leaf-advance path**; Tier-B rollover + sub-factory are follow-ons.

### What it closes
Scenario B: a 2-of-2 PS-leaf client co-signs the L-stock poison during advance, then broadcasts live-state+poison to steal the LSP's L-stock. With the hashlock, the poison spends Leaf-P (script-path, untweaked agg key) and is only assemblable with the LSP-revealed per-(leaf,state) secret — so it can only punish a *superseded* state the LSP actually cheated with.

### Phases (each committed + proven)
- **1 — advance H plumbing**: ship `H_new` in `MSG_LEAF_ADVANCE_PROPOSE`; both sides capture `H_old` and target the poison at the superseded state.
- **2 — reveal-on-advance**: LSP sends `MSG_LSTOCK_REVEAL` after DONE; client verifies `SHA256(secret)==H_old` (fail-closed) and persists template + secret.
- **3 — daemon enable**: `--enable-hashlock-poison` installs a random shachain seed + `factory_enable_hashlock_poison` after the factory re-init; mutually exclusive with `--test-burn`. Inert when off.
- **4a — `factory_assemble_poison_from_template`**: standalone, persist-driven assembly (crash-resilient recourse primitive); `..._with_secret` delegates to it.
- **4b — `superscalar_lstock_recover`**: client recourse tool — loads the persisted reveal, assembles, prints tx hex; exit 5 when no secret was revealed.
- **4c — daemon e2e** (`test_regtest_hashlock_poison_e2e.sh`): live advance → client persists reveal → tool assembles → **poison CONFIRMS on-chain, 11150 sats of L-stock recaptured**; no-reveal control refuses.
- **5 — fail-closed advance**: when hashlock is on, the client refuses to ship FINAL (revoke the old state) unless the Leaf-P poison was co-signed — no revoke without recourse; symmetric honest-LSP guard. Single guard per side, gated on `poison_required` (no false-abort on dust/no-old-state). Proven by `test_regtest_hashlock_poison_abort.sh` (`SS_CHEAT_OMIT_POISON` → client refuses, 0 reveals leaked).

### Validation (full 5-gate run, green on the tip commit)
FULL BUILD · 1507/1507 unit · legacy regtest advances 1/1 (flag-off unchanged) · 4c happy-path e2e PASS · degradation-abort PASS.

### Architecture note
The secret-less standalone watchtower cannot assemble a hashlock poison on its own — recourse is **client-driven** (the client holds its own revealed secrets). Feeding revealed secrets to a delegated WT is the #62 follow-on, not this PR.

See `docs/trustless-hashlock-daemon-plan.md` for the full design + injection points.