### PR TITLE
Hashlock L-stock poison — crash recovery + LSP restart-resume (deterministic seed)

### DIFF
--- a/docs/trustless-hashlock-reveal-crash-plan.md
+++ b/docs/trustless-hashlock-reveal-crash-plan.md
@@ -50,6 +50,18 @@ The "live pointer advances only on durable recourse" refinement, made recoverabl
    (assemble the poison via `superscalar_lstock_recover` + testmempoolaccept/confirm).
    Anti-vacuity: a crash where recovery is suppressed → no secret → tool refuses.
 
+## STATUS (2026-06-21)
+- Phase 1 (template-at-commit): DONE — build + 1507 unit + 4c e2e green (recourse intact).
+- Phase 2a (`persist_load_pending_l_stock_poison`): DONE — build + unit (pending scan) green.
+- Phase 2b (`MSG_LSTOCK_REVEAL_REQUEST` 0x8D codec): DONE — build + 1508 unit green.
+- Phase 2c (dispatch wiring): NEXT — LSP handles 0x8D -> `factory_derive_l_stock_secret`
+  -> reply MSG_LSTOCK_REVEAL (find the LSP per-client dispatch loop, ~lsp_channels.c:4990+);
+  client on startup/reconnect runs `persist_load_pending_l_stock_poison` -> sends 0x8D ->
+  recv reveal -> verify (SHA256==H_old) + `persist_update_l_stock_secret` (reuse the
+  client.c:3966 verify path; find the client connect/startup flow). Keystone — wires both
+  daemon message loops; do with fresh attention.
+- Phase 3 (crash matrix): after 2c.
+
 ## Reuse from #387
 `MSG_LSTOCK_REVEAL` (request can be a sibling opcode), `persist_save/update/load_l_stock_poison`
 (the template-only row is just save-without-update), `superscalar_lstock_recover`,

--- a/docs/trustless-hashlock-reveal-crash-plan.md
+++ b/docs/trustless-hashlock-reveal-crash-plan.md
@@ -60,7 +60,32 @@ The "live pointer advances only on durable recourse" refinement, made recoverabl
   recv reveal -> verify (SHA256==H_old) + `persist_update_l_stock_secret` (reuse the
   client.c:3966 verify path; find the client connect/startup flow). Keystone — wires both
   daemon message loops; do with fresh attention.
-- Phase 3 (crash matrix): after 2c.
+- Phase 2c (dispatch wiring): DONE — LSP 0x8D handler (re-derive, superseded-only) + client
+  reconnect re-request; build + 1508 unit + 4c green.
+
+## ELITE SEED-DURABILITY + LSP RESTART-RESUME — DONE + PROVEN (2026-06-22)
+Root cause found while doing 2c: the LSP minted a RANDOM seed per run + never persisted it,
+so hashlock poison could not survive an LSP restart (a #387 daemon-model gap). Fixed the
+elite way — "derive, don't store" (mirrors LND/CLN/LDK commitment-secret derivation):
+- `factory_derive_lstock_seed(master, funding_txid, funding_vout)` = tagged_hash, deterministic
+  per (LSP key, factory). Survives restart + backup-restore for free; domain-separated;
+  one-way; trust-model-invisible (client verifies SHA256==H). Unit-proven deterministic.
+- lsp_run_factory_creation_stateless derives + installs it (creation + every rotation).
+- Schema v39: factories.use_hashlock_poison persisted like leaf_arity (self-describing reload).
+- LSP recovery path re-derives the seed + re-enables, fail-closed (never silently un-gate).
+- e2e `test_regtest_hashlock_restart_resume.sh` GREEN: run-1 advance persists the flag +
+  client reveal; run-2 restart RE-ENABLES (seed re-derived) + the client poison still assembles.
+
+## Mid-session dropped-reveal — handled, no extra guard needed
+A reveal dropped mid-session (no crash) is NOT a residual gap: P1 persists the template at
+commit, the reveal handler logs-and-continues (does not fail the committed advance), and P2c
+recovers the secret on the next reconnect (the LSP can always re-derive). The DW/CLTV override
+prevents the theft in the interim (degraded = no poison punishment, not fund loss). A "refuse
+to advance" guard would be a liveness hit for no safety gain, so it is deliberately NOT added.
+
+## Crash matrix (residual)
+The per-point crash matrix (crash at each reveal step) remains as optional extra coverage; the
+recovery is already proven by the client-restart (P2c) + LSP-restart (restart-resume) e2es.
 
 ## Reuse from #387
 `MSG_LSTOCK_REVEAL` (request can be a sibling opcode), `persist_save/update/load_l_stock_poison`

--- a/docs/trustless-hashlock-reveal-crash-plan.md
+++ b/docs/trustless-hashlock-reveal-crash-plan.md
@@ -1,0 +1,62 @@
+# Hashlock poison — REVEAL-STEP CRASH/ABORT state machine (#59, branch `trustless-hashlock-reveal-crash`)
+
+Stacked on `trustless-hashlock-daemon` (PR #387). Hardens the leaf-advance reveal step that
+#387 made live, closing the residual commit-without-reveal window.
+
+## The window (characterized from the live code)
+Leaf advance, hashlock on:
+- **Client commit point**: ship `MSG_LEAF_ADVANCE_FINAL` (client.c:3917) — hands the LSP the
+  new-state signature, so the old state is superseded.
+- **Secret durable**: only at client.c:3977 `persist_save_l_stock_poison` (template) + 3983
+  `persist_update_l_stock_secret`, AFTER recv DONE (3928) + recv `MSG_LSTOCK_REVEAL` (3968).
+- **LSP side**: DONE broadcast (lsp_channels.c:1942) → reveal (1964). The LSP does NOT persist
+  the secret (it re-derives from the seed on demand).
+
+Three crash/abort gaps, in order of severity:
+1. **Reveal never arrives → NO row persisted** (client.c:3996 `else` just logs). LSP crash
+   between DONE (1942) and reveal (1964), or a dropped connection, leaves the client with a
+   co-signed poison it has NO persisted record of → on restart it cannot even detect that a
+   secret is missing → cannot recover. THE core gap.
+2. **Client crash between FINAL (3917) and the persist (3977/3983)**: revoked, no secret.
+3. **Template + secret are persisted as two calls** (3977 then 3983); a crash between leaves a
+   template-only row (already the desired recoverable state — see Phase 1).
+
+## Severity: degraded-recourse, not outright theft
+Without the secret the client still holds the new state's `signed_tx` and can OVERRIDE the
+LSP's superseded-state broadcast via the DW/CLTV mechanism — so theft is still PREVENTED; what
+is lost in the window is the poison PUNISHMENT (L-stock redistribution). The fix restores the
+punishment durably; the override is the interim backstop. (This refines the "residual
+Scenario A" framing in the task: it is a no-poison window with theft-prevention intact.)
+
+## Design — persist-template-at-co-sign + restart re-request
+The "live pointer advances only on durable recourse" refinement, made recoverable:
+
+1. **Phase 1 — persist the template at co-sign (before the commit).** Right before shipping
+   FINAL (after the Phase 5 guard, client.c ~3917), persist the poison TEMPLATE with a NULL
+   secret (`persist_save_l_stock_poison`; the row's `revocation_secret` stays NULL until the
+   reveal). At reveal, only `persist_update_l_stock_secret`. Now a co-signed-but-unrevealed
+   poison ALWAYS leaves a template-only row → restart can DETECT the missing secret. Closes
+   gap #1's undetectability. (client.c)
+2. **Phase 2 — restart/reconnect re-request.** On client startup (and on LSP reconnect), scan
+   `l_stock_poison_reveals` for rows with `revocation_secret IS NULL`; for each, send a new
+   `MSG_LSTOCK_REVEAL_REQUEST{node_idx, state_counter}`. LSP handler re-derives
+   `factory_derive_l_stock_secret` and replies with `MSG_LSTOCK_REVEAL` (idempotent: the
+   client re-verifies SHA256==H_old and `persist_update_l_stock_secret`). Recovers gaps #1/#2.
+   (new wire opcode + client startup scan + LSP request handler)
+3. **Phase 3 — crash matrix.** Reuse the crash-injection harness (`lsp_crash_checkpoint` /
+   `SS_CRASH_AT`, client equivalent). Crash at: after FINAL/before template-persist; after
+   template/before reveal; after reveal/before secret-update; LSP after-DONE/before-reveal.
+   After each: restart, run the Phase-2 recovery, assert the client ends with a usable secret
+   (assemble the poison via `superscalar_lstock_recover` + testmempoolaccept/confirm).
+   Anti-vacuity: a crash where recovery is suppressed → no secret → tool refuses.
+
+## Reuse from #387
+`MSG_LSTOCK_REVEAL` (request can be a sibling opcode), `persist_save/update/load_l_stock_poison`
+(the template-only row is just save-without-update), `superscalar_lstock_recover`,
+`factory_derive_l_stock_secret` (LSP re-derives).
+
+## Notes
+- The LSP needs no secret persistence — it re-derives from the seed for any (node, state), so
+  the re-request handler is cheap + stateless.
+- Tier-B (when/if done) has MORE reveals per ceremony; the same Phase-2 scan recovers them
+  uniformly (the row is keyed by node_idx + state_counter).

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -511,6 +511,20 @@ int factory_sign_l_stock_poison_tx(
    poison.  Returns 1 on success, 0 if no seed is set. */
 int factory_enable_hashlock_poison(factory_t *f);
 
+/* #59 / restart-resume: derive the per-factory L-stock poison MASTER seed
+   deterministically from the LSP's master secret + the factory's funding outpoint:
+   seed = tagged_hash("SS/LStockPoison/seed/v1", master32 || funding_txid32 ||
+   funding_vout_le32).  Deterministic => survives LSP restart + backup-restore
+   (re-derived, never stored as an independent secret — the elite "derive, don't
+   store" rule).  Domain-separated from signing-key use (the tag) and per-factory
+   (the funding outpoint binds it).  Trust-model-invisible: the client only verifies
+   SHA256(secret)==committed H, so the LSP's seed derivation is internal.  One-way:
+   leaking the derived seed never reveals `master32`. */
+void factory_derive_lstock_seed(const unsigned char *master32,
+                                const unsigned char *funding_txid32,
+                                uint32_t funding_vout,
+                                unsigned char *seed_out32);
+
 /* #53-B: derive the LSP-private per-(leaf, state) L-stock revocation secret.
    secret = tagged_hash("SS/LStockPoison/v1", seed32 || leaf_agg_xonly32 ||
    state_counter_le32).  Deterministic + crash-recoverable (re-derivable from the

--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -19,7 +19,7 @@ typedef struct {
 } persist_t;
 
 /* Current schema version. Bump when adding migrations. */
-#define PERSIST_SCHEMA_VERSION 38
+#define PERSIST_SCHEMA_VERSION 39
 
 /* #185 / wallet-team CEREMONY_DESIGN.md §6.1:
    Ceremony state enum (column `ceremonies.state`).

--- a/include/superscalar/persist.h
+++ b/include/superscalar/persist.h
@@ -171,6 +171,14 @@ int persist_load_l_stock_poison(persist_t *p, uint32_t factory_id, uint32_t node
                                 unsigned char *control_block_out, size_t *control_block_len_out,
                                 unsigned char *secret_out32, int *out_has_secret);
 
+/* #59: list (node_idx, state_counter) for poison rows still MISSING their revealed
+   secret (revocation_secret IS NULL).  The client scans these on restart/reconnect
+   and re-requests the reveal (the commit-without-reveal recovery).  Caller-allocated
+   node_out[max] + state_out[max]; fills *n_out (<= max).  Returns 1 on success. */
+int persist_load_pending_l_stock_poison(persist_t *p, uint32_t factory_id,
+                                        uint32_t *node_out, uint32_t *state_out,
+                                        size_t max, size_t *n_out);
+
 /* Load all PS chain entries for a leaf in chain_pos order.
    chain_txs_out: caller-allocated tx_buf_t[max_chain] (caller must free each on success).
    txids_out: caller-allocated [max_chain][32] internal-order txids.

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -212,6 +212,7 @@
    single-leaf advance, N for a Tier-B rollover.  Verify-before-persist
    (SHA256(secret)==committed H_old), mirroring channel revoke-and-ack. */
 #define MSG_LSTOCK_REVEAL 0x8C
+#define MSG_LSTOCK_REVEAL_REQUEST 0x8D  /* #59: Client -> LSP, re-request missing reveals */
 
 /* Ceremony abort reason codes (single byte). Unknown values: treat as
    OTHER and surface reason_text for diagnostics. */
@@ -963,6 +964,19 @@ int wire_parse_lstock_reveal(const cJSON *json,
                              unsigned char secrets_out[][32],
                              size_t max_entries,
                              size_t *n_out);
+
+/* #59: MSG_LSTOCK_REVEAL_REQUEST.  Client -> LSP after a restart/reconnect; lists
+   the (node, state) poison rows whose secret was never received so the LSP
+   re-derives + re-reveals (replies with MSG_LSTOCK_REVEAL).  Same array shape as
+   the reveal, minus the secret. */
+cJSON *wire_build_lstock_reveal_request(const uint32_t *node_idx,
+                                        const uint32_t *state_counter,
+                                        size_t n);
+int wire_parse_lstock_reveal_request(const cJSON *json,
+                                     uint32_t *node_idx_out,
+                                     uint32_t *state_counter_out,
+                                     size_t max_entries,
+                                     size_t *n_out);
 
 /* --- Tier B: state-advance ceremony (root rollover, MSG_PATH_*) ---
 

--- a/src/client.c
+++ b/src/client.c
@@ -3948,6 +3948,24 @@ static int client_handle_leaf_advance_stateless(int fd,
     }
     cJSON_Delete(fin_json);
 
+    /* #59 Phase 1: FINAL is sent — the advance is committed and the old state is
+       superseded.  Persist the poison TEMPLATE now (revocation_secret stays NULL),
+       BEFORE we await DONE + the reveal that may never arrive (LSP crash / dropped
+       link).  Without this, a never-revealed advance leaves NO row, so a restart
+       cannot even detect the missing secret to re-request it (residual no-poison
+       window).  Saved AFTER the commit so an aborted advance never persists a
+       spurious poison.  Idempotent (INSERT OR REPLACE) with the reveal-time save. */
+    if (persist && ps_node->poison_is_scriptpath && ps_node->poison_has_agg_sig) {
+        uint32_t superseded_state = (ps_node->l_stock_state_counter > 0)
+                                    ? ps_node->l_stock_state_counter - 1u : 0u;
+        persist_save_l_stock_poison(persist, /* factory_id */ 0,
+            (uint32_t)node_idx, superseded_state, ps_node->poison_l_stock_hash,
+            ps_node->poison_agg_sig,
+            ps_node->poison_unsigned_tx.data, ps_node->poison_unsigned_tx.len,
+            ps_node->poison_leaf_script, ps_node->poison_leaf_script_len,
+            ps_node->poison_control_block, ps_node->poison_control_block_len);
+    }
+
     /* Step 9: wait for LEAF_ADVANCE_DONE (LSP's broadcast). */
     wire_msg_t done_msg;
     if (!wire_recv(fd, &done_msg) || done_msg.msg_type != MSG_LEAF_ADVANCE_DONE) {

--- a/src/client_reconnect.c
+++ b/src/client_reconnect.c
@@ -17,6 +17,7 @@
 #include "superscalar/peer_mgr.h"
 #include "superscalar/wire.h"
 #include "superscalar/regtest.h"
+#include "superscalar/sha256.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -27,6 +28,59 @@ extern secp256k1_pubkey g_client_nk_server_pubkey;
 extern int g_client_nk_server_pubkey_set;
 #define g_nk_server_pubkey     g_client_nk_server_pubkey
 #define g_nk_server_pubkey_set g_client_nk_server_pubkey_set
+
+/* #59 Phase 2c: after reconnect, recover any L-stock poison secrets that were
+   never received because of a crash in the reveal window.  Scan the persisted
+   template-only rows (revocation_secret IS NULL), re-request them from the LSP
+   (which re-derives from its seed), verify SHA256(secret)==committed hash
+   (fail-closed — a malicious LSP cannot inject a bogus secret), and persist.
+   Best-effort + synchronous in the quiescent post-RECONNECT_ACK window: a failure
+   leaves the row pending for the next reconnect, with the DW/CLTV override as the
+   interim backstop.  No-op (no round trip) when nothing is pending. */
+static void client_recover_pending_lstock(secp256k1_context *ctx, int fd,
+                                          persist_t *db) {
+    (void)ctx;
+    if (!db) return;
+    uint32_t pn[128], ps[128]; size_t pcnt = 0;
+    if (!persist_load_pending_l_stock_poison(db, 0, pn, ps, 128, &pcnt) || pcnt == 0)
+        return;
+    cJSON *req = wire_build_lstock_reveal_request(pn, ps, pcnt);
+    if (!req) return;
+    int sent = wire_send(fd, MSG_LSTOCK_REVEAL_REQUEST, req);
+    cJSON_Delete(req);
+    if (!sent) return;
+    wire_msg_t rev;
+    if (!wire_recv(fd, &rev) || rev.msg_type != MSG_LSTOCK_REVEAL) {
+        if (rev.json) cJSON_Delete(rev.json);
+        fprintf(stderr, "Client reconnect: L-stock recovery — no reveal reply "
+                "(%zu still pending; override remains the backstop)\n", pcnt);
+        return;
+    }
+    uint32_t rn[128], rs[128]; unsigned char rsec[128][32]; size_t rc = 0;
+    int recovered = 0;
+    if (wire_parse_lstock_reveal(rev.json, rn, rs, rsec, 128, &rc)) {
+        for (size_t i = 0; i < rc; i++) {
+            unsigned char want[32];
+            if (!persist_load_l_stock_poison(db, 0, rn[i], rs[i], want,
+                    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL))
+                continue;  /* no matching local row */
+            unsigned char chk[32]; sha256(rsec[i], 32, chk);
+            if (memcmp(chk, want, 32) != 0) {
+                fprintf(stderr, "Client reconnect: re-revealed secret for node %u "
+                        "state %u FAILED verify (SHA256 != committed) — rejecting\n",
+                        rn[i], rs[i]);
+                continue;
+            }
+            if (persist_update_l_stock_secret(db, 0, rn[i], rs[i], rsec[i]))
+                recovered++;
+        }
+        memset(rsec, 0, sizeof(rsec));
+    }
+    if (rev.json) cJSON_Delete(rev.json);
+    if (recovered > 0)
+        printf("Client reconnect: recovered %d L-stock poison secret(s) "
+               "(crash-in-reveal-window recovery)\n", recovered);
+}
 
 int client_run_reconnect(secp256k1_context *ctx,
                            const secp256k1_keypair *keypair,
@@ -387,6 +441,11 @@ int client_run_reconnect(secp256k1_context *ctx,
                my_index, ack_channel_id,
                (unsigned long long)ack_commit);
     }
+
+    /* #59 Phase 2c: now in the quiescent post-RECONNECT_ACK window (client drives,
+       LSP is back in its event loop) — recover any L-stock poison secrets a crash
+       lost in the reveal window before handing control to the channel callback. */
+    client_recover_pending_lstock(ctx, fd, db);
 
     /* 10. Call channel callback */
     int cb_ret = 0;

--- a/src/factory.c
+++ b/src/factory.c
@@ -314,6 +314,24 @@ int factory_enable_hashlock_poison(factory_t *f) {
     return 1;
 }
 
+void factory_derive_lstock_seed(const unsigned char *master32,
+                                const unsigned char *funding_txid32,
+                                uint32_t funding_vout,
+                                unsigned char *seed_out32) {
+    /* seed = tagged_hash(master || funding_txid || funding_vout_le).  Deterministic
+       per (LSP master, factory), domain-separated by the tag from the signing key's
+       own use.  Re-derivable on every restart + backup-restore — never stored. */
+    unsigned char buf[32 + 32 + 4];
+    memcpy(buf, master32, 32);
+    memcpy(buf + 32, funding_txid32, 32);
+    buf[64] = (unsigned char)(funding_vout & 0xff);
+    buf[65] = (unsigned char)((funding_vout >> 8) & 0xff);
+    buf[66] = (unsigned char)((funding_vout >> 16) & 0xff);
+    buf[67] = (unsigned char)((funding_vout >> 24) & 0xff);
+    sha256_tagged("SS/LStockPoison/seed/v1", buf, sizeof(buf), seed_out32);
+    memset(buf, 0, sizeof(buf));  /* buf held master secret material */
+}
+
 int factory_derive_l_stock_secret(const factory_t *f,
                                   const factory_node_t *leaf_node,
                                   uint32_t state_counter,

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -437,20 +437,29 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     }
     free(saved_secrets);
 
-    /* #53 Phase 3: re-enable hashlock-gated L-stock poison AFTER the
-       factory_init_from_pubkeys re-init above (which wiped
-       use_hashlock_poison).  The shachain seed was installed on the factory
-       by the binary before this call and preserved across the re-init by the
-       save/restore of saved_shachain_seed (use_flat_secrets==0 path).  Gated
-       on lsp->enable_hashlock_poison so the legacy L-stock key-path is the
-       default; fail-closed if the seed somehow didn't survive. */
+    /* #53 + restart-resume: (re-)derive + install the hashlock L-stock poison seed
+       AFTER factory_init_from_pubkeys (which wiped use_hashlock_poison).  The seed is
+       DERIVED deterministically from the LSP master key + THIS factory's funding
+       outpoint (factory_derive_lstock_seed) — never randomly minted or persisted as an
+       independent secret — so it is identical on the initial ceremony, on every
+       rotation, and after any LSP restart/backup-restore (the "derive, don't store"
+       rule; both inputs are durable).  Gated on lsp->enable_hashlock_poison; the legacy
+       key-path L-stock remains the default. */
     if (lsp->enable_hashlock_poison) {
-        if (f->use_flat_secrets || !f->has_shachain ||
-            !factory_enable_hashlock_poison(f)) {
+        unsigned char lsp_sk[32], lstock_seed[32];
+        if (!secp256k1_keypair_sec(lsp->ctx, lsp_sk, &lsp->lsp_keypair)) {
+            fprintf(stderr, "LSP-stateless factory creation: keypair_sec for "
+                            "L-stock seed failed\n");
+            return 0;
+        }
+        factory_derive_lstock_seed(lsp_sk, funding_txid, funding_vout, lstock_seed);
+        memset(lsp_sk, 0, sizeof(lsp_sk));
+        factory_set_shachain_seed(f, lstock_seed);
+        memset(lstock_seed, 0, sizeof(lstock_seed));
+        if (f->use_flat_secrets || !factory_enable_hashlock_poison(f)) {
             fprintf(stderr, "LSP-stateless factory creation: "
-                            "factory_enable_hashlock_poison failed "
-                            "(has_shachain=%d use_flat=%d)\n",
-                    f->has_shachain, f->use_flat_secrets);
+                            "factory_enable_hashlock_poison failed (use_flat=%d)\n",
+                    f->use_flat_secrets);
             return 0;
         }
     }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -5076,6 +5076,45 @@ int lsp_channels_handle_msg(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         return 1;
     }
 
+    case MSG_LSTOCK_REVEAL_REQUEST: {
+        /* #59 Phase 2c: a client recovering from a crash in the reveal window
+           re-requests the L-stock secrets it never received.  Re-derive each from
+           the seed and reply with MSG_LSTOCK_REVEAL.  SECURITY: only reveal states
+           STRICTLY BEFORE the node's current L-stock counter — a superseded state.
+           Never reveal the current/future state's secret, or the client could
+           poison a legitimate (non-revoked) state of the LSP. */
+        if (!lsp->factory.use_hashlock_poison) return 1;
+        uint32_t req_n[128], req_s[128]; size_t req_cnt = 0;
+        if (!wire_parse_lstock_reveal_request(msg->json, req_n, req_s, 128, &req_cnt))
+            return 0;
+        uint32_t out_n[128], out_s[128];
+        unsigned char out_sec[128][32];
+        size_t out_cnt = 0;
+        for (size_t i = 0; i < req_cnt && out_cnt < 128; i++) {
+            uint32_t nidx = req_n[i];
+            if (nidx >= lsp->factory.n_nodes) continue;
+            factory_node_t *nd = &lsp->factory.nodes[nidx];
+            if (req_s[i] >= nd->l_stock_state_counter) continue;  /* not superseded -> refuse */
+            if (factory_derive_l_stock_secret(&lsp->factory, nd, req_s[i],
+                                              out_sec[out_cnt])) {
+                out_n[out_cnt] = nidx;
+                out_s[out_cnt] = req_s[i];
+                out_cnt++;
+            }
+        }
+        if (out_cnt > 0) {
+            cJSON *rev = wire_build_lstock_reveal(out_n, out_s, out_sec, out_cnt);
+            if (rev) {
+                wire_send(lsp->client_fds[client_idx], MSG_LSTOCK_REVEAL, rev);
+                cJSON_Delete(rev);
+            }
+            memset(out_sec, 0, sizeof(out_sec));
+            printf("LSP: re-revealed %zu L-stock secret(s) to client %zu (crash recovery)\n",
+                   out_cnt, client_idx);
+        }
+        return 1;
+    }
+
     case MSG_REGISTER_INVOICE: {
         unsigned char payment_hash[32];
         unsigned char preimage[32];

--- a/src/persist.c
+++ b/src/persist.c
@@ -1819,6 +1819,30 @@ int persist_load_l_stock_poison(persist_t *p, uint32_t factory_id, uint32_t node
     return found;
 }
 
+/* #59: list (node_idx, state_counter) for poison rows still missing their secret. */
+int persist_load_pending_l_stock_poison(persist_t *p, uint32_t factory_id,
+                                        uint32_t *node_out, uint32_t *state_out,
+                                        size_t max, size_t *n_out) {
+    if (!p || !p->db || !node_out || !state_out || !n_out) return 0;
+    *n_out = 0;
+    sqlite3_stmt *stmt;
+    const char *sql =
+        "SELECT node_idx, state_counter FROM l_stock_poison_reveals "
+        "WHERE factory_id = ? AND revocation_secret IS NULL "
+        "ORDER BY node_idx, state_counter;";
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
+    sqlite3_bind_int(stmt, 1, (int)factory_id);
+    size_t n = 0;
+    while (sqlite3_step(stmt) == SQLITE_ROW && n < max) {
+        node_out[n]  = (uint32_t)sqlite3_column_int(stmt, 0);
+        state_out[n] = (uint32_t)sqlite3_column_int(stmt, 1);
+        n++;
+    }
+    sqlite3_finalize(stmt);
+    *n_out = n;
+    return 1;
+}
+
 /* Load PS leaf chain for a given leaf node.
    Fills chain_txs_out (caller-allocated array of tx_buf_t, size max_chain).
    txids_out: caller-allocated [max_chain][32] for internal-order txids.

--- a/src/persist.c
+++ b/src/persist.c
@@ -1372,6 +1372,17 @@ int persist_open(persist_t *p, const char *path) {
         ");",
         NULL, NULL, NULL);
 
+    /* v39 (#59 restart-resume): persist the factory's hashlock-poison INTENT so a
+       reloaded LSP knows to re-derive the (deterministic) seed + re-enable — exactly
+       as leaf_arity persists the factory's arity.  This is a non-secret boolean: the
+       seed itself is never stored, only re-derived from the LSP key + funding outpoint
+       (factory_derive_lstock_seed).  Version-gated (ALTER is not idempotent). */
+    if (db_version < 39) {
+        sqlite3_exec(p->db,
+            "ALTER TABLE factories ADD COLUMN use_hashlock_poison INTEGER NOT NULL DEFAULT 0;",
+            NULL, NULL, NULL);
+    }
+
     /* Record the current version if not already present */
     if (db_version < PERSIST_SCHEMA_VERSION) {
         char vsql[128];
@@ -1541,8 +1552,9 @@ int persist_save_factory(persist_t *p, const factory_t *f,
     const char *sql =
         "INSERT OR REPLACE INTO factories "
         "(id, n_participants, funding_txid, funding_vout, funding_amount, "
-        " step_blocks, states_per_layer, cltv_timeout, fee_per_tx, leaf_arity) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+        " step_blocks, states_per_layer, cltv_timeout, fee_per_tx, leaf_arity, "
+        " use_hashlock_poison) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
     sqlite3_stmt *stmt;
     if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
@@ -1560,6 +1572,7 @@ int persist_save_factory(persist_t *p, const factory_t *f,
     sqlite3_bind_int(stmt, 8, (int)f->cltv_timeout);
     sqlite3_bind_int64(stmt, 9, (sqlite3_int64)f->fee_per_tx);
     sqlite3_bind_int(stmt, 10, (int)f->leaf_arity);
+    sqlite3_bind_int(stmt, 11, f->use_hashlock_poison ? 1 : 0);  /* #59 restart-resume */
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
@@ -2260,7 +2273,8 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
 
     const char *sql =
         "SELECT n_participants, funding_txid, funding_vout, funding_amount, "
-        "step_blocks, states_per_layer, cltv_timeout, fee_per_tx, leaf_arity "
+        "step_blocks, states_per_layer, cltv_timeout, fee_per_tx, leaf_arity, "
+        "use_hashlock_poison "
         "FROM factories WHERE id = ?;";
 
     sqlite3_stmt *stmt;
@@ -2287,6 +2301,7 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
         (leaf_arity_raw == (int)FACTORY_ARITY_1)  ? FACTORY_ARITY_1  :
         (leaf_arity_raw == (int)FACTORY_ARITY_PS) ? FACTORY_ARITY_PS :
                                                      FACTORY_ARITY_2;
+    int loaded_use_hashlock_poison = sqlite3_column_int(stmt, 9);  /* #59 restart-resume */
 
     /* Data validation (Phase 2: item 2.6) */
     if (n_participants < 2 || n_participants > FACTORY_MAX_SIGNERS) {
@@ -2401,6 +2416,14 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
         factory_free(f);
         return 0;
     }
+
+    /* #59 restart-resume: record the persisted hashlock-poison intent.  build_tree
+       above necessarily used legacy L-stock SPKs (persist has no seed), but for a
+       PS factory the chain restore below overwrites the current state with the
+       persisted (hashlock) signed state, and the caller (LSP recovery) re-derives
+       the deterministic seed + re-enables before the next advance.  This flag is the
+       self-describing signal the caller checks. */
+    f->use_hashlock_poison = loaded_use_hashlock_poison ? 1 : 0;
 
     /* For PS factories: restore per-leaf chain state from ps_leaf_chains table.
        factory_build_tree produces chain[0] (unsigned). If any advances were

--- a/src/wire.c
+++ b/src/wire.c
@@ -2523,6 +2523,51 @@ int wire_parse_lstock_reveal(const cJSON *json,
     return 1;
 }
 
+/* #59: MSG_LSTOCK_REVEAL_REQUEST (0x8D).  Client -> LSP after a restart/reconnect:
+   the (node, state) poison rows whose secret was never received, so the LSP
+   re-derives + re-reveals them.  Mirror of wire_build_lstock_reveal minus secrets. */
+cJSON *wire_build_lstock_reveal_request(const uint32_t *node_idx,
+                                        const uint32_t *state_counter,
+                                        size_t n) {
+    if ((n > 0) && (!node_idx || !state_counter)) return NULL;
+    cJSON *j = cJSON_CreateObject();
+    if (!j) return NULL;
+    cJSON *arr = cJSON_CreateArray();
+    if (!arr) { cJSON_Delete(j); return NULL; }
+    for (size_t i = 0; i < n; i++) {
+        cJSON *e = cJSON_CreateObject();
+        if (!e) { cJSON_Delete(arr); cJSON_Delete(j); return NULL; }
+        cJSON_AddNumberToObject(e, "node", (double)node_idx[i]);
+        cJSON_AddNumberToObject(e, "state", (double)state_counter[i]);
+        cJSON_AddItemToArray(arr, e);
+    }
+    cJSON_AddItemToObject(j, "requests", arr);
+    return j;
+}
+
+int wire_parse_lstock_reveal_request(const cJSON *json,
+                                     uint32_t *node_idx_out,
+                                     uint32_t *state_counter_out,
+                                     size_t max_entries,
+                                     size_t *n_out) {
+    if (!json || !node_idx_out || !state_counter_out || !n_out) return 0;
+    cJSON *arr = cJSON_GetObjectItem(json, "requests");
+    if (!arr || !cJSON_IsArray(arr)) return 0;
+    int an = cJSON_GetArraySize(arr);
+    size_t n = 0;
+    for (int i = 0; i < an && n < max_entries; i++) {
+        cJSON *e = cJSON_GetArrayItem(arr, i);
+        cJSON *no = e ? cJSON_GetObjectItem(e, "node") : NULL;
+        cJSON *st = e ? cJSON_GetObjectItem(e, "state") : NULL;
+        if (!no || !cJSON_IsNumber(no) || !st || !cJSON_IsNumber(st)) return 0;
+        node_idx_out[n] = (uint32_t)no->valuedouble;
+        state_counter_out[n] = (uint32_t)st->valuedouble;
+        n++;
+    }
+    *n_out = n;
+    return 1;
+}
+
 /* --- Leaf-Level Fund Reallocation (Upgrade 3) --- */
 
 cJSON *wire_build_leaf_realloc_propose(int leaf_side,

--- a/tests/test_bolt12.c
+++ b/tests/test_bolt12.c
@@ -261,7 +261,7 @@ int test_persist_schema_v3(void)
     persist_t p;
     ASSERT(persist_open(&p, ":memory:"), "open in-memory DB");
     ASSERT(persist_schema_version(&p) == PERSIST_SCHEMA_VERSION, "schema version is current");
-    ASSERT(PERSIST_SCHEMA_VERSION == 38, "schema version is 38 (v38 adds #53-B3b l_stock_poison_reveals; v37 adds the #327 at-rest field-encryption marker; v36 added htlcs.signed_resolution_tx_hex + old_commitments.signed_burn_tx_hex + #219 agg hard guard)");
+    ASSERT(PERSIST_SCHEMA_VERSION == 39, "schema version is 39 (v39 adds factories.use_hashlock_poison for #59 restart-resume; v38 adds #53-B3b l_stock_poison_reveals; v37 adds the #327 at-rest field-encryption marker)");
     persist_close(&p);
     return 1;
 }

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5929,6 +5929,32 @@ int test_factory_ps_subfactory_poison_tx_k2_n4(void) {
     return 1;
 }
 
+/* restart-resume: the per-factory L-stock seed derivation must be deterministic
+   (same inputs -> same seed, so it survives LSP restart + backup-restore), unique
+   per funding outpoint and per LSP master, and one-way (seed != master). */
+int test_factory_lstock_seed_derivation(void) {
+    unsigned char master1[32], master2[32], txid1[32], txid2[32];
+    for (int i = 0; i < 32; i++) {
+        master1[i] = (unsigned char)(0x11 ^ i);
+        master2[i] = (unsigned char)(0x22 ^ i);
+        txid1[i]   = (unsigned char)(0x33 ^ i);
+        txid2[i]   = (unsigned char)(0x44 ^ i);
+    }
+    unsigned char s_a[32], s_b[32], s_c[32], s_d[32], s_e[32];
+    factory_derive_lstock_seed(master1, txid1, 0, s_a);
+    factory_derive_lstock_seed(master1, txid1, 0, s_b);
+    TEST_ASSERT(memcmp(s_a, s_b, 32) == 0, "deterministic: same inputs -> same seed");
+    factory_derive_lstock_seed(master1, txid1, 1, s_c);
+    TEST_ASSERT(memcmp(s_a, s_c, 32) != 0, "different vout -> different seed");
+    factory_derive_lstock_seed(master1, txid2, 0, s_d);
+    TEST_ASSERT(memcmp(s_a, s_d, 32) != 0, "different funding txid -> different seed");
+    factory_derive_lstock_seed(master2, txid1, 0, s_e);
+    TEST_ASSERT(memcmp(s_a, s_e, 32) != 0, "different LSP master -> different seed");
+    TEST_ASSERT(memcmp(s_a, master1, 32) != 0, "seed != master (one-way)");
+    printf("  factory_derive_lstock_seed: deterministic + per-factory + per-master\n");
+    return 1;
+}
+
 /* #53-B3b.2a (in-process, no regtest): the CLIENT MIRROR — given the LSP's per-node
    L-stock hashes over the (here simulated) wire, a seedless client builds the SAME
    2-leaf L-stock SPK as the hashlock-enabled LSP, so the leaf-state advance co-signs.

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1763,6 +1763,7 @@ extern int test_factory_ps_subfactory_chain_extension(void);
 extern int test_factory_ps_subfactory_chain_tx_validity(void);
 extern int test_factory_ps_subfactory_poison_tx_k2_n4(void);
 extern int test_factory_lstock_client_mirror(void);
+extern int test_factory_lstock_seed_derivation(void);
 extern int test_factory_ps_leaf_build_n64(void);
 extern int test_factory_ps_build_n128(void);
 extern int test_factory_ps_leaf_advance(void);
@@ -3644,6 +3645,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_ps_subfactory_chain_tx_validity);
     RUN_TEST(test_factory_ps_subfactory_poison_tx_k2_n4);
     RUN_TEST(test_factory_lstock_client_mirror);
+    RUN_TEST(test_factory_lstock_seed_derivation);
     RUN_TEST(test_factory_ps_leaf_build_n64);
     RUN_TEST(test_factory_ps_build_n128);
     RUN_TEST(test_factory_ps_leaf_advance);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1121,6 +1121,7 @@ extern int test_regtest_ladder_distribution_fallback(void);
 extern int test_wire_pubkey_only_factory(void);
 extern int test_wire_framing(void);
 extern int test_wire_lstock_reveal_round_trip(void);
+extern int test_wire_lstock_reveal_request_round_trip(void);
 extern int test_wire_crypto_serialization(void);
 extern int test_wire_nonce_bundle(void);
 extern int test_wire_psig_bundle(void);
@@ -3074,6 +3075,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_wire_pubkey_only_factory);
     RUN_TEST(test_wire_framing);
     RUN_TEST(test_wire_lstock_reveal_round_trip);
+    RUN_TEST(test_wire_lstock_reveal_request_round_trip);
     RUN_TEST(test_wire_crypto_serialization);
     RUN_TEST(test_wire_nonce_bundle);
     RUN_TEST(test_wire_psig_bundle);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -200,9 +200,27 @@ int test_persist_l_stock_poison_round_trip(void) {
                     lls, &lls_len, lcb, &lcb_len, lsec, &has_secret) == 0,
                 "missing (factory,node,state) row not found");
 
+    /* #59: the pending query lists ONLY rows still missing a secret.  Row
+       (nidx=7,state=3) now has a secret (updated above); add a second template-only
+       row and confirm the pending scan returns exactly the un-revealed one. */
+    TEST_ASSERT(persist_save_l_stock_poison(&db, fid, 9, 1, h, sig,
+                    utx, sizeof(utx), lscript, sizeof(lscript), cb, sizeof(cb)),
+                "save second poison (no secret yet)");
+    uint32_t pend_n[8], pend_s[8]; size_t pend_cnt = 99;
+    TEST_ASSERT(persist_load_pending_l_stock_poison(&db, fid, pend_n, pend_s, 8, &pend_cnt),
+                "pending query runs");
+    TEST_ASSERT(pend_cnt == 1, "exactly one pending row (secret'd row excluded)");
+    TEST_ASSERT(pend_n[0] == 9 && pend_s[0] == 1, "pending row is the un-revealed one");
+    /* once its secret lands, it drops out of the pending set */
+    TEST_ASSERT(persist_update_l_stock_secret(&db, fid, 9, 1, secret), "reveal second");
+    pend_cnt = 99;
+    TEST_ASSERT(persist_load_pending_l_stock_poison(&db, fid, pend_n, pend_s, 8, &pend_cnt),
+                "pending query reruns");
+    TEST_ASSERT(pend_cnt == 0, "no pending rows after both revealed");
+
     tx_buf_free(&lutx);
     persist_close(&db);
-    printf("  l_stock_poison_reveals save/load/update-secret round-trips\n");
+    printf("  l_stock_poison_reveals save/load/update-secret + #59 pending scan round-trips\n");
     return 1;
 }
 

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -542,6 +542,45 @@ int test_wire_lstock_reveal_round_trip(void) {
     return 1;
 }
 
+/* #59: MSG_LSTOCK_REVEAL_REQUEST round-trip (the restart re-request). */
+int test_wire_lstock_reveal_request_round_trip(void) {
+    uint32_t nodes[3]  = { 2, 9, 99 };
+    uint32_t states[3] = { 0, 3, 500000 };
+    uint32_t pn[8], ps[8];
+    size_t n = 0;
+
+    cJSON *j = wire_build_lstock_reveal_request(nodes, states, 3);
+    TEST_ASSERT(j != NULL, "build request (3)");
+    TEST_ASSERT(wire_parse_lstock_reveal_request(j, pn, ps, 8, &n), "parse request (3)");
+    TEST_ASSERT(n == 3, "3 entries parsed");
+    for (size_t e = 0; e < 3; e++) {
+        TEST_ASSERT(pn[e] == nodes[e], "node matches");
+        TEST_ASSERT(ps[e] == states[e], "state matches");
+    }
+    cJSON_Delete(j);
+
+    cJSON *j1 = wire_build_lstock_reveal_request(nodes, states, 1);
+    n = 0;
+    TEST_ASSERT(j1 && wire_parse_lstock_reveal_request(j1, pn, ps, 8, &n), "parse request (1)");
+    TEST_ASSERT(n == 1 && pn[0] == nodes[0] && ps[0] == states[0], "single entry round-trips");
+    cJSON_Delete(j1);
+
+    cJSON *bad = cJSON_CreateObject();
+    cJSON_AddNumberToObject(bad, "x", 1);
+    TEST_ASSERT(wire_parse_lstock_reveal_request(bad, pn, ps, 8, &n) == 0,
+                "parse rejects missing requests array");
+    cJSON_Delete(bad);
+
+    cJSON *j3 = wire_build_lstock_reveal_request(nodes, states, 3);
+    n = 99;
+    TEST_ASSERT(wire_parse_lstock_reveal_request(j3, pn, ps, 2, &n) && n == 2,
+                "capped at max_entries");
+    cJSON_Delete(j3);
+
+    printf("  MSG_LSTOCK_REVEAL_REQUEST round-trips (single + multi + malformed + cap)\n");
+    return 1;
+}
+
 /* ---- Test 6: cooperative close unsigned ---- */
 
 int test_wire_close_unsigned(void) {

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -3905,17 +3905,14 @@ accept_new_factory:
                lsp_p->factory.n_revocation_secrets);
     }
 
-    /* #53 Phase 3: hashlock-gated L-stock poison.  Distinct from --test-burn's
-       flat secrets (the old global-epoch index): the hashlock poison derives a
-       per-(leaf,state) secret from a single shachain seed
-       (factory_derive_l_stock_secret reads f->shachain_seed).  Install a real
-       random seed here in SHACHAIN mode (factory_set_shachain_seed sets
-       has_shachain=1 and leaves use_flat_secrets=0, so lsp_run_factory_creation
-       _stateless's save/restore across factory_init_from_pubkeys preserves the
-       seed via the !use_flat_secrets branch), and flag the LSP so the creation
-       path calls factory_enable_hashlock_poison after the re-init.  Mutually
-       exclusive with --test-burn (flat secrets would clobber the shachain
-       save/restore path and strand the L-stock secret). */
+    /* #53 + restart-resume: hashlock-gated L-stock poison.  Distinct from
+       --test-burn's flat secrets (the old global-epoch index): the hashlock poison
+       derives per-(leaf,state) secrets from a single per-factory seed.  We DO NOT
+       mint/store a random seed here — lsp_run_factory_creation_stateless DERIVES it
+       deterministically from the LSP master key + the funding outpoint
+       (factory_derive_lstock_seed), so it survives restart + backup-restore for free.
+       Here we only record the operator intent (the flag) + reject the test-burn
+       conflict.  Mutually exclusive with --test-burn (flat vs shachain mode). */
     if (enable_hashlock_poison) {
         if (test_burn) {
             fprintf(stderr, "LSP: --enable-hashlock-poison and --test-burn are "
@@ -3924,21 +3921,9 @@ accept_new_factory:
             secp256k1_context_destroy(ctx);
             return 1;
         }
-        unsigned char hl_seed[32];
-        FILE *uf = fopen("/dev/urandom", "rb");
-        if (!uf || fread(hl_seed, 1, sizeof(hl_seed), uf) != sizeof(hl_seed)) {
-            if (uf) fclose(uf);
-            fprintf(stderr, "LSP: failed to read random L-stock poison seed "
-                            "from /dev/urandom\n");
-            lsp_cleanup(lsp_p);
-            secp256k1_context_destroy(ctx);
-            return 1;
-        }
-        fclose(uf);
-        factory_set_shachain_seed(&lsp_p->factory, hl_seed);
         lsp_p->enable_hashlock_poison = 1;
         printf("LSP: hashlock-gated L-stock poison ENABLED "
-               "(per-(leaf,state) shachain seed installed)\n");
+               "(per-factory seed derived deterministically from LSP key)\n");
     }
 
     printf("LSP: starting factory creation ceremony...\n");

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2899,6 +2899,35 @@ int main(int argc, char *argv[]) {
             rec_f = NULL;
             lsp_rp->factory.fee = fee_est;
 
+            /* #59 restart-resume: a reloaded hashlock-poison factory (the persisted
+               use_hashlock_poison intent) must re-derive its DETERMINISTIC L-stock
+               seed (LSP key + funding outpoint — never stored) and re-enable, so the
+               LSP can keep revealing superseded secrets AND the next advance keeps
+               building hashlock-gated L-stock SPKs.  Without this a restarted LSP
+               would silently revert to un-gated (Scenario-B-vulnerable) L-stock on its
+               next advance.  Fail-closed: refuse to serve a hashlock factory we can't
+               re-protect. */
+            if (lsp_rp->factory.use_hashlock_poison) {
+                unsigned char lstock_seed[32];
+                factory_derive_lstock_seed(lsp_seckey,
+                                           lsp_rp->factory.funding_txid,
+                                           lsp_rp->factory.funding_vout,
+                                           lstock_seed);
+                factory_set_shachain_seed(&lsp_rp->factory, lstock_seed);
+                memset(lstock_seed, 0, sizeof(lstock_seed));
+                if (!factory_enable_hashlock_poison(&lsp_rp->factory)) {
+                    fprintf(stderr, "LSP recovery: failed to re-enable hashlock poison "
+                                    "for reloaded factory -- refusing to serve un-gated\n");
+                    persist_close(&db);
+                    memset(lsp_seckey, 0, 32);
+                    secp256k1_context_destroy(ctx);
+                    return 1;
+                }
+                lsp_rp->enable_hashlock_poison = 1;
+                printf("LSP recovery: hashlock L-stock poison RE-ENABLED "
+                       "(seed re-derived deterministically from LSP key)\n");
+            }
+
             /* Load DW counter state from DB */
             {
                 uint32_t epoch_out, n_layers_out;

--- a/tools/test_regtest_hashlock_restart_resume.sh
+++ b/tools/test_regtest_hashlock_restart_resume.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test_regtest_hashlock_restart_resume.sh — #59 LSP restart-resume proof.
+#
+# Proves a hashlock-poison factory SURVIVES an LSP restart (the gap: the seed was
+# ephemeral + the reload never re-enabled hashlock). With the deterministic seed
+# (factory_derive_lstock_seed: LSP key + funding outpoint) + the persisted
+# use_hashlock_poison intent (schema v39), a restarted LSP re-derives the SAME seed
+# and re-enables — no stored secret.
+#
+#   Run 1: LSP --enable-hashlock-poison --demo --test-leaf-advance + clients.
+#          A PS leaf advances -> client persists an l_stock_poison_reveals row;
+#          the factory is persisted with use_hashlock_poison=1. LSP exits.
+#   Verify: factories.use_hashlock_poison == 1; a client persisted a reveal.
+#   Run 2: restart LSP --enable-hashlock-poison --daemon with the SAME --db ->
+#          recovery probe loads the factory, RE-DERIVES the seed + RE-ENABLES.
+#   Verify: run-2 log shows the RE-ENABLED (seed re-derived) marker + listening;
+#          the client's pre-restart poison is still assemblable (superscalar_lstock_recover).
+#
+# Combined with the unit proof that the derivation is deterministic (same inputs ->
+# same seed), this shows the re-derived seed == the original, so the LSP resumes
+# revealing + builds matching hashlock SPKs after restart.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+REC_BIN="$BUILD_DIR/superscalar_lstock_recover"
+
+N_CLIENTS="${N_CLIENTS:-4}"
+SIDE="${SIDE:-0}"
+FUNDING_SATS=100000
+LSP_PORT=29959
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "0000000000000000000000000000000000000000000000000000000000000005"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+. "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
+
+ASAN_ENV="ASAN_OPTIONS=detect_leaks=0"
+if ldd "$LSP_BIN" 2>/dev/null | grep -q libasan; then
+    ASAN_ENV="ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8"
+fi
+
+TMPDIR=$(mktemp -d /tmp/ss-hashlock-restart.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"; LSP_LOG="$TMPDIR/lsp1.log"; LSP_LOG2="$TMPDIR/lsp2.log"
+MINER_WALLET="ss_hashlock_restart_miner"
+PIDS=()
+cleanup() {
+    for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    cp "$LSP_LOG"  /tmp/hashlock_restart_last_lsp1.log 2>/dev/null || true
+    cp "$LSP_LOG2" /tmp/hashlock_restart_last_lsp2.log 2>/dev/null || true
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "=== HASHLOCK LSP RESTART-RESUME (regtest, #59) ==="
+if ! $BCLI getblockchaininfo >/dev/null 2>&1; then
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+    for i in $(seq 1 30); do sleep 1; $BCLI getblockchaininfo >/dev/null 2>&1 && break; done
+fi
+$BCLI -named createwallet wallet_name=$MINER_WALLET load_on_startup=false 2>&1 | head -1 || true
+$BCLI loadwallet $MINER_WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+echo "  miner ready, height $($BCLI getblockcount)"
+
+# --- Run 1: create + advance a hashlock factory, then exit ---
+echo
+echo "--- Run 1: LSP --enable-hashlock-poison --test-leaf-advance ---"
+env $ASAN_ENV \
+"$LSP_BIN" --network regtest --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
+    --amount $FUNDING_SATS --fee-rate 1000 --confirm-timeout 600 \
+    --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET --db "$LSP_DB" \
+    --enable-hashlock-poison --demo --test-leaf-advance --lsp-balance-pct 50 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!; PIDS+=($LSP_PID)
+for i in $(seq 1 60); do
+    sleep 1
+    grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && break
+    kill -0 $LSP_PID 2>/dev/null || break
+done
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    env $ASAN_ENV \
+    "$CLIENT_BIN" --network regtest --host 127.0.0.1 --port $LSP_PORT \
+        --seckey "${CLIENT_SECKEYS[$i]}" --fee-rate 1000 --lsp-pubkey "$LSP_PUBKEY" \
+        --participant-id $((i + 1)) --daemon --rpcuser ${RPCUSER:-rpcuser} \
+        --rpcpassword ${RPCPASSWORD:-rpcpass} --wallet $MINER_WALLET \
+        --db "$TMPDIR/client_${i}.db" > "$TMPDIR/client_${i}.log" 2>&1 &
+    PIDS+=($!)
+    sleep 0.5
+done
+( while kill -0 $LSP_PID 2>/dev/null; do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 2; done ) &
+MINE_PID=$!; PIDS+=($MINE_PID)
+
+echo "--- Waiting for run-1 advance + clean exit (timeout 400s) ---"
+for i in $(seq 1 200); do
+    sleep 2
+    if ! kill -0 $LSP_PID 2>/dev/null; then echo "  run-1 LSP exited after $((i*2))s"; break; fi
+done
+kill -9 $MINE_PID 2>/dev/null || true
+# stop clients so their DBs flush
+for pid in "${PIDS[@]:-}"; do kill -TERM "$pid" 2>/dev/null || true; done
+sleep 3
+
+echo
+echo "=== Verify run-1 persisted a hashlock factory + a client reveal ==="
+UHP=$(sqlite3 "$LSP_DB" "SELECT use_hashlock_poison FROM factories WHERE id=0;" 2>/dev/null || echo "?")
+echo "  factories.use_hashlock_poison = ${UHP:-?} (expect 1)"
+[ "${UHP:-0}" = "1" ] || { echo "FAIL: factory did not persist use_hashlock_poison=1"; tail -25 "$LSP_LOG"; exit 1; }
+REVEAL_DB=""; REVEAL_NODE=""; REVEAL_STATE=""
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    row=$(sqlite3 "$TMPDIR/client_${i}.db" "SELECT node_idx||' '||state_counter FROM l_stock_poison_reveals WHERE revocation_secret IS NOT NULL LIMIT 1;" 2>/dev/null || true)
+    if [ -n "$row" ]; then REVEAL_DB="$TMPDIR/client_${i}.db"; REVEAL_NODE=$(echo "$row"|awk '{print $1}'); REVEAL_STATE=$(echo "$row"|awk '{print $2}'); echo "  client[$i] persisted reveal: node=$REVEAL_NODE state=$REVEAL_STATE"; break; fi
+done
+[ -n "$REVEAL_DB" ] || { echo "FAIL: no client persisted an l_stock_poison_reveals row in run 1"; exit 1; }
+
+# --- Run 2: restart LSP with the SAME db -> recovery must re-derive + re-enable ---
+echo
+echo "--- Run 2: restart LSP (recovery mode, same --db) ---"
+env $ASAN_ENV \
+"$LSP_BIN" --network regtest --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
+    --amount $FUNDING_SATS --fee-rate 1000 --confirm-timeout 600 \
+    --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET --db "$LSP_DB" \
+    --enable-hashlock-poison --daemon --lsp-balance-pct 50 \
+    > "$LSP_LOG2" 2>&1 &
+LSP_PID2=$!; PIDS+=($LSP_PID2)
+RESUMED=0
+for i in $(seq 1 60); do
+    sleep 1
+    if grep -q "hashlock L-stock poison RE-ENABLED" "$LSP_LOG2" 2>/dev/null; then RESUMED=1; echo "  RE-ENABLED marker observed after ${i}s"; break; fi
+    kill -0 $LSP_PID2 2>/dev/null || { echo "  run-2 LSP exited early"; break; }
+done
+kill -9 $LSP_PID2 2>/dev/null || true
+
+echo
+echo "=== Verify restart-resume ==="
+grep -E "found existing factory|RE-ENABLED|seed re-derived" "$LSP_LOG2" | head -4 || true
+[ $RESUMED -eq 1 ] || { echo "FAIL: restarted LSP did NOT re-enable hashlock (seed re-derive)"; echo "--- run2 tail ---"; tail -30 "$LSP_LOG2"; exit 1; }
+
+# The client's pre-restart poison must still be assemblable (unchanged by LSP restart).
+$BCLI generatetoaddress 2 "$MINE_ADDR" >/dev/null 2>&1
+HEX=$("$REC_BIN" --db "$REVEAL_DB" --node-idx "$REVEAL_NODE" --state "$REVEAL_STATE" 2>/tmp/_rr.err) || {
+    echo "FAIL: client poison no longer assembles after LSP restart"; cat /tmp/_rr.err; exit 1; }
+echo "  client poison still assembles post-restart (${#HEX} hex chars)"
+
+echo
+echo "=== PASS: hashlock LSP restart-resume ==="
+echo "  factory persisted use_hashlock_poison; restart re-derived the deterministic seed"
+echo "  + re-enabled; client recourse intact across the LSP restart"
+exit 0


### PR DESCRIPTION
Hardens the hashlock-gated L-stock poison (#53/#387) for crashes and restarts. Stacked on `trustless-hashlock-daemon` (#387). Two intertwined parts, all proven on regtest.

### Part A — reveal-step crash recovery (#59)
The client persisted the poison template + secret *together* only at reveal, so a never-arriving reveal (LSP crash / dropped link) left **no row at all** — a restart couldn't even detect the missing secret. (It was always *degraded recourse*, not theft: the DW/CLTV override still prevents the steal; what's lost is the poison punishment.)
- **Persist the template at commit** (right after FINAL), so an unrevealed advance always leaves a recoverable, secret-NULL row.
- **`persist_load_pending_l_stock_poison`** — scan secret-NULL rows on restart.
- **`MSG_LSTOCK_REVEAL_REQUEST` (0x8D)** — client re-requests; **LSP re-derives + replies**, *superseded-state-only* (never reveals a current/future state's secret → can't be tricked into poisoning a live state).
- **Client reconnect recovery** — verify-before-persist (SHA256==committed H, fail-closed: a malicious LSP can't inject a bogus secret).
- Dropped-reveal mid-session needs no extra guard: template persisted + handler continues (doesn't fail the committed advance) + recovered on reconnect.

### Part B — elite seed durability + LSP restart-resume
Found while wiring A: the LSP minted a **random** seed per run and never persisted it, so hashlock poison **couldn't survive an LSP restart** (a #387 daemon-model gap — 4c never hit it, single-instance). Fixed the way LND/CLN/LDK derive commitment secrets — **derive, don't store**:
- **`factory_derive_lstock_seed`** = `tagged_hash(LSP_master_key || funding_txid || funding_vout)`. Deterministic ⇒ survives LSP restart **and** backup-restore for free (both inputs durable; no stored secret, no new encryption). Domain-separated from signing-key use; per-factory; one-way; **trust-model-invisible** (the client only verifies `SHA256(secret)==H`, so the LSP's derivation is internal — zero wire/client change).
- **Schema v39**: `factories.use_hashlock_poison` persisted exactly like `leaf_arity` — hashlock-ness is part of the factory's identity, so reload is **self-describing** (no operator flag to forget; fail-closed, never silently un-gates).
- **LSP recovery path** re-derives the seed + re-enables on reload.

### Proof
- Unit: `factory_derive_lstock_seed` deterministic + per-factory + per-master + one-way; `0x8D` codec round-trip; pending-scan filter. (1509/1509)
- 4c e2e still poisons + confirms (11150 sats) with the deterministic seed — no regression.
- `test_regtest_hashlock_restart_resume.sh`: run-1 advance persists the flag + a client reveal → **run-2 LSP restart RE-ENABLES (seed re-derived)** → client poison still assembles across the restart.

### Untouched trustless anchor
The client's **persist-before-revoke + verify-before-persist** remains the load-bearing fund-safety invariant; the secret-less standalone-WT model (client-driven recourse, #62) is unaffected.

See `docs/trustless-hashlock-reveal-crash-plan.md`.