### PR TITLE
Refuse all dev/test/cheat hooks on mainnet (two-layer cheat gate)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ find_package(OpenSSL REQUIRED)
 add_library(superscalar
     src/dw_state.c
     src/tx_builder.c
+    src/cheat_guard.c
     src/musig.c
     src/regtest.c
     src/chain_backend_regtest.c
@@ -283,6 +284,7 @@ add_executable(test_superscalar
     tests/test_regtest.c
     tests/test_factory.c
     tests/test_factory_multi_input_keyagg.c
+    tests/test_cheat_guard.c
     tests/test_tapscript.c
     tests/test_shachain.c
     tests/test_channel.c

--- a/include/superscalar/cheat_guard.h
+++ b/include/superscalar/cheat_guard.h
@@ -3,24 +3,25 @@
 
 /* #9: mainnet cheat/test-hook startup refusal (Layer 1).
  *
- * The repo carries dev/test/cheat options (--cheat-*, --test-*, --breach*,
- * --kill-after-*, --demo, and SS_CHEAT*/SS_KILL* env vars) that deliberately
- * bypass or weaken the security model.  None may EVER be reachable on mainnet.
+ * The repo carries dev/test/cheat options (the '--cheat', '--test-', '--breach',
+ * '--kill-after', '--demo' arg families, and the SS_CHEAT and SS_KILL env-var
+ * families) that deliberately bypass or weaken the security model.  None may ever
+ * be reachable on mainnet.
  *
  * Two complementary layers enforce this:
- *   Layer 1 (this) — startup refusal: ss_find_mainnet_cheat() scans argv + the
- *     environment; on mainnet ANY such option => the daemon refuses to run.
- *     Prefix-based, so a future --cheat-X / SS_CHEAT_X is caught automatically
- *     (cannot be silently missed the way a scattered #ifdef can).
- *   Layer 2 (pre-existing) — superscalar_cheat_allowed() (crash_inject.h): the
- *     individual defense-bypass cheat read sites are inert unless on regtest,
- *     even if the env is set directly.  Defense in depth.
+ *   Layer 1 (this) - startup refusal: ss_find_mainnet_cheat() scans argv and the
+ *     environment; on mainnet ANY such option means the daemon refuses to run.
+ *     Prefix-based, so a future cheat flag/env is caught automatically (cannot be
+ *     silently missed the way a scattered ifdef can).
+ *   Layer 2 (pre-existing) - superscalar_cheat_allowed() (crash_inject.h): the
+ *     individual defense-bypass cheat read sites are inert unless on regtest, even
+ *     if the env is set directly.  Defense in depth.
  *
  * Returns the offending argv token or "NAME=value" env string (for the error
- * message) when network is mainnet/bitcoin AND a dev/test/cheat option is
- * present; NULL otherwise (clean, or a non-mainnet network where these are
- * intentionally permitted).  A NULL/unknown network is treated as mainnet
- * (fail-safe).  The caller refuses to start on a non-NULL return.
+ * message) when network is mainnet/bitcoin AND a dev/test/cheat option is present;
+ * NULL otherwise (clean, or a non-mainnet network where these are intentionally
+ * permitted).  A NULL/unknown network is treated as mainnet (fail-safe).  The
+ * caller refuses to start on a non-NULL return.
  */
 const char *ss_find_mainnet_cheat(int argc, char **argv, const char *network);
 

--- a/include/superscalar/cheat_guard.h
+++ b/include/superscalar/cheat_guard.h
@@ -1,0 +1,27 @@
+#ifndef SUPERSCALAR_CHEAT_GUARD_H
+#define SUPERSCALAR_CHEAT_GUARD_H
+
+/* #9: mainnet cheat/test-hook startup refusal (Layer 1).
+ *
+ * The repo carries dev/test/cheat options (--cheat-*, --test-*, --breach*,
+ * --kill-after-*, --demo, and SS_CHEAT*/SS_KILL* env vars) that deliberately
+ * bypass or weaken the security model.  None may EVER be reachable on mainnet.
+ *
+ * Two complementary layers enforce this:
+ *   Layer 1 (this) — startup refusal: ss_find_mainnet_cheat() scans argv + the
+ *     environment; on mainnet ANY such option => the daemon refuses to run.
+ *     Prefix-based, so a future --cheat-X / SS_CHEAT_X is caught automatically
+ *     (cannot be silently missed the way a scattered #ifdef can).
+ *   Layer 2 (pre-existing) — superscalar_cheat_allowed() (crash_inject.h): the
+ *     individual defense-bypass cheat read sites are inert unless on regtest,
+ *     even if the env is set directly.  Defense in depth.
+ *
+ * Returns the offending argv token or "NAME=value" env string (for the error
+ * message) when network is mainnet/bitcoin AND a dev/test/cheat option is
+ * present; NULL otherwise (clean, or a non-mainnet network where these are
+ * intentionally permitted).  A NULL/unknown network is treated as mainnet
+ * (fail-safe).  The caller refuses to start on a non-NULL return.
+ */
+const char *ss_find_mainnet_cheat(int argc, char **argv, const char *network);
+
+#endif /* SUPERSCALAR_CHEAT_GUARD_H */

--- a/src/cheat_guard.c
+++ b/src/cheat_guard.c
@@ -16,13 +16,21 @@ static const char *const ENV_PREFIXES[] = {
     "SS_CHEAT", "SS_KILL", NULL
 };
 
+/* Cheats are permitted ONLY on a known dev/test network (allowlist).  Anything
+   else - mainnet, bitcoin, an unknown string, or NULL - is treated as production
+   and enforced (fail-safe: a new/unrecognized network never silently permits a
+   cheat; it must be added here explicitly). */
+static int is_dev_network(const char *network) {
+    return network != NULL && (
+        strcmp(network, "regtest")  == 0 ||
+        strcmp(network, "testnet")  == 0 ||
+        strcmp(network, "testnet4") == 0 ||
+        strcmp(network, "signet")   == 0);
+}
+
 const char *ss_find_mainnet_cheat(int argc, char **argv, const char *network) {
-    /* Only enforced on mainnet/bitcoin; NULL/unknown network treated as mainnet
-       (fail-safe).  Dev/test networks (regtest/testnet/signet) permit cheats. */
-    if (network &&
-        strcmp(network, "mainnet") != 0 &&
-        strcmp(network, "bitcoin") != 0)
-        return NULL;
+    if (is_dev_network(network)) return NULL;  /* dev/test network: cheats permitted */
+    /* production (mainnet/bitcoin) or unknown/NULL: enforce the refusal. */
 
     for (int i = 1; i < argc; i++) {
         if (!argv[i]) continue;

--- a/src/cheat_guard.c
+++ b/src/cheat_guard.c
@@ -1,0 +1,37 @@
+/* #9: mainnet cheat/test-hook startup refusal (Layer 1).
+   See include/superscalar/cheat_guard.h.  Layer 2 (per-site inert reads) is the
+   pre-existing superscalar_cheat_allowed() in crash_inject.c. */
+#include "superscalar/cheat_guard.h"
+#include <string.h>
+
+extern char **environ;
+
+/* Argv tokens that are unambiguously dev/test/cheat (never valid on mainnet).
+   Prefix match => future --cheat-X / --test-X are caught without code changes. */
+static const char *const ARG_PREFIXES[] = {
+    "--cheat", "--test-", "--breach", "--kill-after", "--demo", NULL
+};
+/* Environment-variable test/cheat toggles. */
+static const char *const ENV_PREFIXES[] = {
+    "SS_CHEAT", "SS_KILL", NULL
+};
+
+const char *ss_find_mainnet_cheat(int argc, char **argv, const char *network) {
+    /* Only enforced on mainnet/bitcoin; NULL/unknown network treated as mainnet
+       (fail-safe).  Dev/test networks (regtest/testnet/signet) permit cheats. */
+    if (network &&
+        strcmp(network, "mainnet") != 0 &&
+        strcmp(network, "bitcoin") != 0)
+        return NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (!argv[i]) continue;
+        for (const char *const *p = ARG_PREFIXES; *p; p++)
+            if (strncmp(argv[i], *p, strlen(*p)) == 0) return argv[i];
+    }
+    for (char **e = environ; e && *e; e++) {
+        for (const char *const *p = ENV_PREFIXES; *p; p++)
+            if (strncmp(*e, *p, strlen(*p)) == 0) return *e;
+    }
+    return NULL;
+}

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1457,7 +1457,8 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        prep so it co-signs the new state but NOT the Leaf-P poison — exercising
        the client's fail-closed "no revoke without recourse" abort.  Env-gated
        test path only (same pattern as SS_CHEAT_DAEMON_MODE). */
-    if (mgr->watchtower && poison_required && !getenv("SS_CHEAT_OMIT_POISON")) {
+    if (mgr->watchtower && poison_required &&
+        !(getenv("SS_CHEAT_OMIT_POISON") && superscalar_cheat_allowed())) {
         if (factory_session_prepare_poison_tx_leaf(
                 f, pre_node_idx,
                 old_leaf_txid, (uint32_t)(old_n_outputs - 1),

--- a/tests/test_cheat_guard.c
+++ b/tests/test_cheat_guard.c
@@ -49,7 +49,7 @@ int test_cheat_guard_mainnet_refusal(void) {
       TEST_ASSERT(ss_find_mainnet_cheat(2, a, "signet")  == NULL, "signet permits cheats");
       TEST_ASSERT(ss_find_mainnet_cheat(2, a, "testnet") == NULL, "testnet permits cheats"); }
 
-    /* --- env-var cheats (SS_CHEAT*/SS_KILL*) are caught on mainnet --- */
+    /* --- env-var cheats (SS_CHEAT and SS_KILL families) are caught on mainnet --- */
     setenv("SS_CHEAT_OMIT_POISON", "1", 1);
     { char *a[] = { prog, (char *)"--port", (char *)"9735" };
       TEST_ASSERT(ss_find_mainnet_cheat(3, a, "mainnet") != NULL, "mainnet refuses SS_CHEAT_* env");

--- a/tests/test_cheat_guard.c
+++ b/tests/test_cheat_guard.c
@@ -1,0 +1,68 @@
+/* #9: unit tests for the mainnet cheat/test-hook startup refusal (Layer 1). */
+#include "superscalar/cheat_guard.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef TEST_ASSERT
+#define TEST_ASSERT(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "  FAIL: %s\n", msg); return 0; } \
+} while (0)
+#endif
+
+int test_cheat_guard_mainnet_refusal(void) {
+    char *prog = (char *)"superscalar_lsp";
+
+    /* --- mainnet: every dev/test/cheat surface is refused --- */
+    { char *a[] = { prog, (char *)"--cheat-leaf", (char *)"0" };
+      TEST_ASSERT(ss_find_mainnet_cheat(3, a, "mainnet") != NULL, "mainnet refuses --cheat-leaf"); }
+    { char *a[] = { prog, (char *)"--cheat-daemon-leaf" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "mainnet") != NULL, "mainnet refuses --cheat-daemon-leaf"); }
+    { char *a[] = { prog, (char *)"--test-burn" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "mainnet") != NULL, "mainnet refuses --test-burn"); }
+    { char *a[] = { prog, (char *)"--breach-test" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "mainnet") != NULL, "mainnet refuses --breach-test"); }
+    { char *a[] = { prog, (char *)"--kill-after-state-advance" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "mainnet") != NULL, "mainnet refuses --kill-after-*"); }
+    { char *a[] = { prog, (char *)"--demo" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "mainnet") != NULL, "mainnet refuses --demo"); }
+    /* "bitcoin" is the mainnet alias */
+    { char *a[] = { prog, (char *)"--cheat-leaf" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "bitcoin") != NULL, "bitcoin alias refuses cheats"); }
+    /* NULL/unknown network => fail-safe (treat as mainnet) */
+    { char *a[] = { prog, (char *)"--cheat-leaf" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, NULL) != NULL, "NULL network refuses cheat (fail-safe)"); }
+    { char *a[] = { prog, (char *)"--cheat-leaf" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "wibble") != NULL, "unknown network refuses cheat (fail-safe)"); }
+
+    /* --- mainnet: legitimate production flags are NOT refused --- */
+    { char *a[] = { prog, (char *)"--port", (char *)"9735", (char *)"--db", (char *)"l.db",
+                    (char *)"--enable-hashlock-poison", (char *)"--wallet", (char *)"w" };
+      TEST_ASSERT(ss_find_mainnet_cheat(8, a, "mainnet") == NULL, "mainnet allows clean prod args"); }
+    /* --enable-hashlock-poison is a production SECURITY feature, never a cheat */
+    { char *a[] = { prog, (char *)"--enable-hashlock-poison" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "mainnet") == NULL, "mainnet allows --enable-hashlock-poison"); }
+
+    /* --- non-mainnet networks intentionally permit cheats (for testing) --- */
+    { char *a[] = { prog, (char *)"--cheat-leaf" };
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "regtest") == NULL, "regtest permits cheats");
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "signet")  == NULL, "signet permits cheats");
+      TEST_ASSERT(ss_find_mainnet_cheat(2, a, "testnet") == NULL, "testnet permits cheats"); }
+
+    /* --- env-var cheats (SS_CHEAT*/SS_KILL*) are caught on mainnet --- */
+    setenv("SS_CHEAT_OMIT_POISON", "1", 1);
+    { char *a[] = { prog, (char *)"--port", (char *)"9735" };
+      TEST_ASSERT(ss_find_mainnet_cheat(3, a, "mainnet") != NULL, "mainnet refuses SS_CHEAT_* env");
+      TEST_ASSERT(ss_find_mainnet_cheat(3, a, "regtest") == NULL, "regtest permits SS_CHEAT_* env"); }
+    unsetenv("SS_CHEAT_OMIT_POISON");
+    { char *a[] = { prog, (char *)"--port", (char *)"9735" };
+      TEST_ASSERT(ss_find_mainnet_cheat(3, a, "mainnet") == NULL, "mainnet clean once env cleared"); }
+    setenv("SS_KILL_AFTER_STATE_ADVANCE", "1", 1);
+    { char *a[] = { prog };
+      TEST_ASSERT(ss_find_mainnet_cheat(1, a, "mainnet") != NULL, "mainnet refuses SS_KILL_* env"); }
+    unsetenv("SS_KILL_AFTER_STATE_ADVANCE");
+
+    printf("  cheat_guard: mainnet refuses --cheat/--test/--breach/--kill/--demo + SS_CHEAT/SS_KILL env; "
+           "prod flags allowed; non-mainnet permits\n");
+    return 1;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1764,6 +1764,7 @@ extern int test_factory_ps_subfactory_chain_tx_validity(void);
 extern int test_factory_ps_subfactory_poison_tx_k2_n4(void);
 extern int test_factory_lstock_client_mirror(void);
 extern int test_factory_lstock_seed_derivation(void);
+extern int test_cheat_guard_mainnet_refusal(void);
 extern int test_factory_ps_leaf_build_n64(void);
 extern int test_factory_ps_build_n128(void);
 extern int test_factory_ps_leaf_advance(void);
@@ -3646,6 +3647,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_ps_subfactory_poison_tx_k2_n4);
     RUN_TEST(test_factory_lstock_client_mirror);
     RUN_TEST(test_factory_lstock_seed_derivation);
+    RUN_TEST(test_cheat_guard_mainnet_refusal);
     RUN_TEST(test_factory_ps_leaf_build_n64);
     RUN_TEST(test_factory_ps_build_n128);
     RUN_TEST(test_factory_ps_leaf_advance);

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -5,6 +5,7 @@
 #include "superscalar/factory.h"
 #include "superscalar/report.h"
 #include "superscalar/crash_inject.h"   /* #9 superscalar_set_cheat_gate() */
+#include "superscalar/cheat_guard.h"    /* #9 ss_find_mainnet_cheat() */
 #include "superscalar/persist.h"
 #include "superscalar/keyfile.h"
 #include "superscalar/adaptor.h"
@@ -2696,14 +2697,16 @@ int main(int argc, char *argv[]) {
     /* #9 cheat-gate: defense-bypass cheats inert unless regtest; refuse all
        test/cheat scaffolding flags on mainnet (footgun guard). */
     superscalar_set_cheat_gate(strcmp(network, "regtest") == 0);
-    if (strcmp(network, "mainnet") == 0) {
-        for (int ci = 1; ci < argc; ci++) {
-            if (strncmp(argv[ci], "--cheat-", 8) == 0 ||
-                strncmp(argv[ci], "--test-", 7) == 0) {
-                fprintf(stderr, "Error: %s is test/cheat scaffolding and is "
-                        "refused on mainnet.\n", argv[ci]);
-                return 1;
-            }
+    /* #9 cheat-gate Layer 1: comprehensive mainnet refusal — covers every
+       dev/test/cheat arg prefix (--cheat-*/--test-*/--breach*/--kill-after*/--demo)
+       AND the SS_CHEAT*/SS_KILL* env vars (the prior inline check missed --breach,
+       --kill-after, --demo, and all env toggles). */
+    {
+        const char *cheat_opt = ss_find_mainnet_cheat(argc, argv, network);
+        if (cheat_opt) {
+            fprintf(stderr, "Error: '%s' is test/cheat scaffolding that bypasses the "
+                    "security model and is refused on mainnet.\n", cheat_opt);
+            return 1;
         }
     }
 

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -2697,10 +2697,10 @@ int main(int argc, char *argv[]) {
     /* #9 cheat-gate: defense-bypass cheats inert unless regtest; refuse all
        test/cheat scaffolding flags on mainnet (footgun guard). */
     superscalar_set_cheat_gate(strcmp(network, "regtest") == 0);
-    /* #9 cheat-gate Layer 1: comprehensive mainnet refusal — covers every
-       dev/test/cheat arg prefix (--cheat-*/--test-*/--breach*/--kill-after*/--demo)
-       AND the SS_CHEAT*/SS_KILL* env vars (the prior inline check missed --breach,
-       --kill-after, --demo, and all env toggles). */
+    /* #9 cheat-gate Layer 1: comprehensive mainnet refusal covering every
+       dev/test/cheat arg family (--cheat, --test-, --breach, --kill-after, --demo)
+       AND the SS_CHEAT / SS_KILL env families (the prior inline check missed
+       --breach, --kill-after, --demo, and all env toggles). */
     {
         const char *cheat_opt = ss_find_mainnet_cheat(argc, argv, network);
         if (cheat_opt) {

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -15,6 +15,7 @@
 #include "superscalar/tapscript.h"
 #include "superscalar/log.h"
 #include "superscalar/crash_inject.h"   /* #9 superscalar_set_cheat_gate() */
+#include "superscalar/cheat_guard.h"    /* #9 ss_find_mainnet_cheat() */
 #ifdef __linux__
 #include <syslog.h>
 #endif
@@ -2130,9 +2131,23 @@ int main(int argc, char *argv[]) {
     if (!network)
         network = "regtest";  /* default to regtest */
     int is_regtest = (strcmp(network, "regtest") == 0);
-    /* #9 cheat-gate: defense-bypass cheats (e.g. SS_CHEAT_DUST_RACE) are inert
-       unless this is regtest, even if the env var is set directly. */
+    /* #9 cheat-gate Layer 2: defense-bypass cheats (e.g. SS_CHEAT_DUST_RACE) are
+       inert unless this is regtest, even if the env var is set directly. */
     superscalar_set_cheat_gate(is_regtest);
+    /* #9 cheat-gate Layer 1: refuse to start on mainnet with ANY dev/test/cheat
+       option (--cheat-*/--test-*/--breach*/--kill-after*/--demo or SS_CHEAT*/SS_KILL*
+       env).  Comprehensive + prefix-based — catches every cheat surface, incl.
+       future ones, so none is reachable on mainnet. */
+    {
+        const char *cheat_opt = ss_find_mainnet_cheat(argc, argv, network);
+        if (cheat_opt) {
+            fprintf(stderr, "FATAL: refusing to start on %s with dev/test/cheat "
+                            "option '%s' present -- it bypasses the security model "
+                            "and must never be reachable on mainnet.\n",
+                    network, cheat_opt);
+            return 1;
+        }
+    }
 
     /* Redirect logs if requested */
     if (log_file_path) {

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2135,9 +2135,9 @@ int main(int argc, char *argv[]) {
        inert unless this is regtest, even if the env var is set directly. */
     superscalar_set_cheat_gate(is_regtest);
     /* #9 cheat-gate Layer 1: refuse to start on mainnet with ANY dev/test/cheat
-       option (--cheat-*/--test-*/--breach*/--kill-after*/--demo or SS_CHEAT*/SS_KILL*
-       env).  Comprehensive + prefix-based — catches every cheat surface, incl.
-       future ones, so none is reachable on mainnet. */
+       option (the --cheat, --test-, --breach, --kill-after, --demo arg families or
+       the SS_CHEAT / SS_KILL env families).  Comprehensive, prefix-based: catches
+       every cheat surface incl. future ones, so none is reachable on mainnet. */
     {
         const char *cheat_opt = ss_find_mainnet_cheat(argc, argv, network);
         if (cheat_opt) {


### PR DESCRIPTION
Makes every dev/test/cheat hook provably unreachable on mainnet (#9). Stacked on the crash/restart-durability branch (its Layer-2 gate references the SS_CHEAT_OMIT_POISON hook added there).

### Two complementary layers
**Layer 1 (new) — startup refusal** (`src/cheat_guard.c`, `ss_find_mainnet_cheat`): at startup the LSP + client scan argv + the environment; on mainnet ANY dev/test/cheat option means the daemon **refuses to run**. Prefix-based — the `--cheat`, `--test-`, `--breach`, `--kill-after`, `--demo` arg families and the `SS_CHEAT`/`SS_KILL` env families — so it catches the **whole surface and future hooks by naming convention**. This is strictly more complete than hand-wrapping each scattered site in `#ifdef`, where missing one leaves it reachable.

- **Fail-safe allowlist**: cheats are permitted ONLY on a known dev network (regtest/testnet/testnet4/signet). mainnet, bitcoin, an unknown string, or NULL all enforce the refusal — a new/unrecognized network never silently permits a cheat.
- Wired into both `superscalar_lsp.c` and `superscalar_client.c` (the watchtower has no cheat surface). **Replaced the client's prior partial inline check** (only `--cheat-`/`--test-`; it missed `--breach`/`--kill-after`/`--demo` and every env toggle).

**Layer 2 (defense in depth)** — the pre-existing `superscalar_cheat_allowed()` (crash_inject.c, regtest-only per-site inert reads) already guards the defense-bypass cheat sites; extended it to the `SS_CHEAT_OMIT_POISON` read so that path is inert off-regtest even if Layer 1 were ever removed.

### Proof
- Unit (`test_cheat_guard.c`, 1510/1510): mainnet refuses every `--cheat`/`--test`/`--breach`/`--kill`/`--demo` arg + `SS_CHEAT`/`SS_KILL` env (incl. NULL-network + unknown-network fail-safe + `bitcoin` alias); production flags (`--enable-hashlock-poison`, `--port`, `--db`) allowed; regtest/testnet/signet permit cheats.
- Daemon smoke: `superscalar_lsp --network mainnet --cheat-leaf` => refuses (exit 1); `SS_CHEAT_OMIT_POISON=1 ... --network mainnet` => refuses; `--network regtest --cheat-leaf` => does not refuse.

Removes a mainnet-shipping blocker from the §10 gate.