### PR TITLE
Hashlock L-stock poison — sub-factory multi-input ceremony

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,15 @@ if(ENABLE_SANITIZERS)
     target_link_libraries(superscalar_lstock_recover PRIVATE project_sanitizers)
 endif()
 
+# Offline factory-residual recovery: rebuild the tree in-process + MuSig key-path
+# co-sign the MuSig/CLTV/L-stock residual outputs (we hold all seckeys for test factories).
+add_executable(superscalar_factory_residual_sweep tools/superscalar_factory_residual_sweep.c)
+target_include_directories(superscalar_factory_residual_sweep PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
+target_link_libraries(superscalar_factory_residual_sweep PRIVATE superscalar superscalar_secrets project_warnings)
+if(ENABLE_SANITIZERS)
+    target_link_libraries(superscalar_factory_residual_sweep PRIVATE project_sanitizers)
+endif()
+
 # --- Fuzz targets (libFuzzer + ASan + UBSan) ---
 if(ENABLE_FUZZING)
     set(FUZZ_SOURCES

--- a/docs/trustless-subfactory-hashlock-plan.md
+++ b/docs/trustless-subfactory-hashlock-plan.md
@@ -102,5 +102,11 @@ because the existing infra was already generic):
   poison from the persisted reveal, broadcast vs the cheat's stale chain[N-1], assert CONFIRM +
   non-dust sales-stock recapture + anti-vacuity.
 
-Validation: build OK + full unit suite 1510/1510 (incl. the new Phase-0 test). Regtest
-no-regression (non-hashlock multi sub advance) + the hashlock e2e run on the VPS. Signet to follow.
+Validation: build OK + full unit suite 1510/1510 (incl. the new Phase-0 test). Regtest GREEN:
+- T1 no-regression (non-hashlock multi sub advance, k=2): PASS.
+- T2 hashlock e2e: PASS — live multi-input advance -> per-state H -> reveal -> client
+  verify-persist -> assemble -> broadcast vs the cheat's stale chain[N-1] -> CONFIRM,
+  21,667 sats sales-stock recaptured; anti-vacuity (no secret -> exit 5) enforced.
+The first e2e run caught a real N-party gap (only the LSP aggregates the sub poison; the
+client never had poison_agg_sig) -> fixed by shipping the agg-sig in SUBFACTORY_DONE (9e12d44).
+Signet to follow (cryptographic flow is network-independent; regtest is the gate).

--- a/docs/trustless-subfactory-hashlock-plan.md
+++ b/docs/trustless-subfactory-hashlock-plan.md
@@ -109,4 +109,12 @@ Validation: build OK + full unit suite 1510/1510 (incl. the new Phase-0 test). R
   21,667 sats sales-stock recaptured; anti-vacuity (no secret -> exit 5) enforced.
 The first e2e run caught a real N-party gap (only the LSP aggregates the sub poison; the
 client never had poison_agg_sig) -> fixed by shipping the agg-sig in SUBFACTORY_DONE (9e12d44).
+
+Adversarial-review hardening (736620f): the N-party agg-sig crosses the wire, so it is now
+VERIFIED before trust on BOTH sides (mirror of the leaf LSP verify at lsp_channels.c ~1782) --
+client verifies the LSP-supplied agg-sig vs its own poison sighash + untweaked sub agg key
+before persisting (a malicious LSP can't hand it worthless recourse); LSP self-verifies the
+aggregate before shipping (catches a bad co-signer partial -> degrade -> fail-closed abort).
+Honest flow unchanged; regtest T1+T2 RE-GREEN with the hardening.
+
 Signet to follow (cryptographic flow is network-independent; regtest is the gate).

--- a/docs/trustless-subfactory-hashlock-plan.md
+++ b/docs/trustless-subfactory-hashlock-plan.md
@@ -1,0 +1,61 @@
+# Sub-factory hashlock L-stock poison — plan (branch `trustless-subfactory-hashlock`)
+
+Extends the hashlock-gated L-stock poison (#387 leaf-advance + #388 crash/restart) to the
+**sub-factory (k≥2) multi-input ceremony**, where a canonical PS factory holds its channels.
+Without this, a k≥2 factory's sub-level sales-stock is still key-path → Scenario B open there.
+Stacked on `trustless-hashlock-reveal-crash` (#388).
+
+## What investigation found (corrects stale assumptions)
+- **The multi-input keyagg bug (#283/#61) is ALREADY FIXED.** lsp_channels.c:3712+ uses per-input
+  keyaggs (`sub->input_keyaggs[i]`: channel inputs 2-of-2, sales-stock N-of-N), per-input signing
+  sessions, `factory_session_get_input_signer_slot`. So #61 is NOT a blocker.
+- **The sub-factory multi-input poison ceremony EXISTS but is KEY-PATH.** The prepare call at
+  lsp_channels.c:3534-3537 passes `override_hash32 = NULL` with the literal placeholder
+  `/* #53-B3b: capture sub H_old when daemon hashlock on */` — the exact analog of the
+  leaf-advance placeholder filled in #387 Phase 1.
+- **The sub sales-stock IS hashlock-gated at INITIAL build**: setup_ps_leaf_with_subfactories →
+  setup_nway_leaf_outputs (factory.c:1266) → set_leaf_l_stock_output (1399) → apply_l_stock_hashlock.
+  So for a hashlock factory `sub->has_l_stock_hash` is set + the prepare (factory.c:3151
+  `if (override_hash32 || sub->has_l_stock_hash)`) already takes the hashlock path.
+- **PREREQUISITE GAP — the sub sales-stock hash is STATIC across sub states.** The sub-advance
+  `factory_subfactory_chain_advance_unsigned` (factory.c:2616) → `rebuild_node_tx` (2195) rebuilds
+  the tx from existing output SPKs; it does NOT bump `l_stock_state_counter` or re-derive the
+  sales-stock SPK. So every sub state shares the state-0 hash. Revealing one sub secret would
+  compromise the hashlock for ALL sub states (reopening Scenario B). The leaf path avoids this via
+  `update_l_stock_for_leaf` (factory.c:2400, bumps counter + re-derives); the sub path needs the same.
+- The deterministic per-factory seed (#388) already covers sub nodes (seed is per-factory; secrets
+  are keyed by the sub node's agg xonly + state counter — distinct from leaves automatically).
+
+## Phases (mirror #387/#388; each committed + validated)
+- **Phase 0 — per-state sub sales-stock hash (PREREQUISITE).** On each sub-advance, bump
+  `sub->l_stock_state_counter` + re-derive the sales-stock SPK (apply_l_stock_hashlock) so each sub
+  state commits a DISTINCT hash. Likely: call the leaf-style update (or inline the bump+re-derive)
+  inside `factory_subfactory_chain_advance_unsigned` after the amounts mutate / inside
+  rebuild_node_tx for NODE_PS_SUBFACTORY. Unit-prove distinct hashes per sub state. CRITICAL — the
+  per-state revocation model depends on it.
+- **Phase 1 — H plumbing.** Capture sub H_old before the advance; pass as override at
+  lsp_channels.c:3537 (replace the NULL placeholder). Ship sub H_new in the sub-factory
+  PROPOSE_INTENT; client mirrors via factory_set_node_l_stock_hash before its sub-advance.
+- **Phase 2 — reveal.** After the sub-factory DONE, LSP reveals secret(sub_node, old_counter) via
+  MSG_LSTOCK_REVEAL (array API already supports it); client verifies + persists.
+- **Phase 3 — fail-closed guard.** Mirror the leaf guard: when use_hashlock_poison, the sub-advance
+  must abort if the sub poison wasn't co-signed (no revoke without recourse), gated on
+  poison_required (sub sales-stock non-dust).
+- **Phase 4 — client mirror.** The client's sub-factory multi-input handler mirrors Phases 0-3
+  (per-state hash, H_old/H_new, reveal recv+persist, guard).
+- **Phase 5 — e2e.** Sub-factory cheat harness with --enable-hashlock-poison: advance a sub channel
+  → reveal → persist → LSP broadcasts the stale sub state → client assembles the sub poison from the
+  persisted reveal → confirm + redistribution + anti-vacuity. Then signet.
+
+## Reuse (no rework)
+factory_derive_lstock_seed / factory_derive_l_stock_secret (sub nodes keyed by agg xonly automatically);
+factory_session_prepare_poison_tx_subfactory (already override-aware, factory.c:3151);
+factory_assemble_poison_from_template + superscalar_lstock_recover (node-indexed, works for sub nodes);
+MSG_LSTOCK_REVEAL[_REQUEST] array wire; persist l_stock_poison_reveals (keyed by node_idx); v39 flag.
+
+## Notes
+- This is a #387-scale effort (both sides + the Phase-0 prerequisite). The poison assembly +
+  recourse + persist + restart-resume all carry over unchanged (node-indexed).
+- The multi-input poison signs the sales-stock input against the sub N-of-N keyagg (correct — the
+  sales-stock IS the sub N-of-N output; the per-channel 2-of-2 keyaggs are for the CHANNEL inputs,
+  already handled by #283).

--- a/docs/trustless-subfactory-hashlock-plan.md
+++ b/docs/trustless-subfactory-hashlock-plan.md
@@ -59,3 +59,48 @@ MSG_LSTOCK_REVEAL[_REQUEST] array wire; persist l_stock_poison_reveals (keyed by
 - The multi-input poison signs the sales-stock input against the sub N-of-N keyagg (correct — the
   sales-stock IS the sub N-of-N output; the per-channel 2-of-2 keyaggs are for the CHANNEL inputs,
   already handled by #283).
+
+## Implementation status — DONE (commits 49383ba, 26dc6de, 6c6e2b9)
+
+What the build actually required, vs the plan above (some plan steps turned out to be no-ops
+because the existing infra was already generic):
+
+- **Phase 0 (49383ba):** `factory_subfactory_chain_advance_unsigned` bumps the counter +
+  re-derives the sales-stock SPK when `sub->has_l_stock_hash` (factory.c). Unit-proven by
+  `test_factory_subfactory_lstock_per_state_hash` (distinct H per state + superseded-secret
+  stability + a non-hashlock STATIC-SPK control).
+- **Phase 1 (26dc6de):** LSP ships H_new in `SUBFACTORY_PROPOSE_INTENT` (multi at
+  lsp_channels.c ~3605, single too); client mirrors at the parent-handler top (covers both
+  paths). The H_old-capture in the plan is UNNECESSARY: sub poison-prep runs BEFORE the advance,
+  so the NULL override already snapshots H_old (unlike the leaf, which preps after the advance and
+  must pass H_old explicitly). `factory_set_node_l_stock_hash` updates only `node_l_stock_hashes[]`,
+  not `sub->l_stock_hash`, so prep still sees H_old even with the mirror set first.
+- **Signing:** NO new code. `factory_session_finalize_node_poison` / `_complete_node_poison`
+  are node-generic + already scriptpath-aware (untweaked agg) from #387; once Phase 0 makes
+  prep set `poison_is_scriptpath`, the sub poison co-signs correctly.
+- **Phase 2 (26dc6de + 9e12d44):** LSP reveals secret_old to EVERY sub client after DONE
+  (sales-stock is N-of-N; all are beneficiaries). **N-party agg-sig gap (9e12d44):** unlike the
+  2-party leaf (whose client aggregates the poison locally), only the LSP aggregates the N-party
+  sub poison, so the client never had `poison_agg_sig`. Fix: the LSP ships the aggregated 64-byte
+  poison sig in `SUBFACTORY_DONE` (optional field). The client captures it on DONE, persists the
+  recourse TEMPLATE (agg-sig present, secret NULL), then verify-persists the secret from the
+  reveal; the poison-session reset is deferred past both. Crash recovery is then symmetric with
+  the leaf: template durable pre-reveal, 0x8D `MSG_LSTOCK_REVEAL_REQUEST` (#388, node-generic)
+  re-fetches the secret.
+- **Phase 3 (26dc6de):** LSP + client fail-closed abort when a poison was economically REQUIRED
+  (non-dust sales-stock) but NOT co-signed. `poison_required` is decoupled from the
+  watchtower/operational prep gate, mirroring the leaf guard.
+- **Phase 4:** folded into the client edits above (per-state hash is shared advance code; H_new
+  mirror, reveal recv+persist, guard all added to the client multi handler).
+- **Defense-in-depth:** the single-input sub paths are unreachable for real (k>=1) subs
+  (n_outputs>1 always dispatches multi). The LSP refuses single-input under hashlock; the client
+  refuses a single-input PROPOSE for a hashlock sub (closes a malicious-LSP downgrade vector).
+- **Phase 5 (6c6e2b9):** `test_regtest_hashlock_poison_subfactory_e2e.sh` — the existing
+  `--cheat-daemon-sub` already drives the stateless multi path (`lsp_subfactory_chain_advance`
+  forwards unconditionally to `..._stateless`), so combining it with `--enable-hashlock-poison`
+  exercises Phases 0-4 over the LIVE wire ceremony. Then client-driven recourse: assemble the sub
+  poison from the persisted reveal, broadcast vs the cheat's stale chain[N-1], assert CONFIRM +
+  non-dust sales-stock recapture + anti-vacuity.
+
+Validation: build OK + full unit suite 1510/1510 (incl. the new Phase-0 test). Regtest
+no-regression (non-hashlock multi sub advance) + the hashlock e2e run on the VPS. Signet to follow.

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -552,6 +552,11 @@ void factory_set_node_l_stock_hash(factory_t *f, size_t node_idx,
 int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
                       unsigned char *spk_out34);
 
+/* Recovery helper: L-stock taptree merkle root for a leaf/sub node (the taptweak
+   to key-path-spend that L-stock output in an offline residual sweep). */
+int factory_l_stock_merkle(const factory_t *f, const factory_node_t *node,
+                           unsigned char merkle_out32[32]);
+
 /* #53: hashlock-gated L-stock poison over the Leaf-P SCRIPT-path (replaces the
    key-path poison, which is vulnerable to Scenario B).  Builds the per-client
    redistribution outputs, N-of-N MuSig-signs the UNtweaked agg key over the

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -1117,6 +1117,13 @@ int wire_parse_subfactory_psig(const cJSON *json,
 
 /* LSP → sub clients: SUBFACTORY_DONE {leaf_side, sub_idx, chain_len} */
 cJSON *wire_build_subfactory_done(int leaf_side, int sub_idx, uint32_t chain_len);
+/* #53 sub-factory hashlock: optional aggregated poison Schnorr sig carried in DONE
+   (the N-party sub poison is aggregated only by the LSP; the client needs it for its
+   persisted recourse template).  No-op when poison_agg_sig64 is NULL / field absent. */
+void wire_subfactory_done_set_poison_aggsig(cJSON *done,
+                                            const unsigned char *poison_agg_sig64);
+int wire_subfactory_done_get_poison_aggsig(const cJSON *json,
+                                           unsigned char *poison_agg_sig64_out);
 int wire_parse_subfactory_done(const cJSON *json,
                                  int *leaf_side, int *sub_idx,
                                  uint32_t *chain_len);

--- a/src/client.c
+++ b/src/client.c
@@ -2868,11 +2868,15 @@ static int client_handle_subfactory_advance_stateless_multi(
        Snapshot the OLD chain[N-1] state BEFORE advance_unsigned mutates it. */
     const uint64_t POISON_FEE_SATS = 1000;
     int poison_prepared_c = 0;
+    /* #53 Phase 3: economic poison requirement (decoupled from prep), used by the
+       fail-closed guard below — the OLD sub state has a non-dust sales-stock to protect. */
+    int poison_required_c = 0;
     {
         size_t old_n_chans = (sub->n_outputs > 0) ? sub->n_outputs - 1 : 0;
         uint64_t old_sstock = (sub->n_outputs > 0)
             ? sub->outputs[sub->n_outputs - 1].amount_sats : 0;
-        if (old_sstock > POISON_FEE_SATS + (uint64_t)old_n_chans * 330u) {
+        poison_required_c = (old_sstock > POISON_FEE_SATS + (uint64_t)old_n_chans * 330u);
+        if (poison_required_c) {
             unsigned char old_chain_txid[32];
             memcpy(old_chain_txid, sub->txid, 32);
             if (factory_session_prepare_poison_tx_subfactory(
@@ -3173,6 +3177,19 @@ static int client_handle_subfactory_advance_stateless_multi(
         }
     }
 
+    /* #53 Phase 3 fail-closed: hashlock ON + a sales-stock poison was economically
+       REQUIRED but NOT co-signed -> do NOT ship FINAL.  Shipping would revoke the old
+       sub state with no recourse against a cheating LSP that later broadcasts it
+       (Scenario B at the sub level).  Stay on the old, still-recourse-able state.
+       Mirrors the leaf client guard (client.c ~3947); non-hashlock subs unaffected.
+       goto fail handles every free + the poison reset cleanly. */
+    if (sub->has_l_stock_hash && poison_required_c && !poison_prepared_c) {
+        fprintf(stderr, "Client-stateless MULTI %u: hashlock ON + sales-stock poison "
+                        "REQUIRED but NOT co-signed -- ABORTING sub-advance (no revoke "
+                        "without recourse)\n", my_index);
+        goto fail;
+    }
+
     free(lsp_pn_flat); free(lsp_psig_flat); free(all_pn_per_input);
     free(my_secnonces);  /* all entries already zeroed by create_partial_sig */
 
@@ -3187,7 +3204,25 @@ static int client_handle_subfactory_advance_stateless_multi(
         return 0;
     }
     cJSON_Delete(fp_json);
-    if (poison_prepared_c) factory_session_reset_poison(factory, sub_node_i);
+
+    /* #59/#53 Phase 2: FINAL is sent -> the sub-advance is committed + the old sub state
+       superseded.  Persist the poison TEMPLATE now (revocation_secret NULL), BEFORE
+       awaiting DONE + a reveal that may never arrive (LSP crash / dropped link), so a
+       restart can detect the missing secret and re-request it.  Keyed by node_idx +
+       superseded state.  Do NOT reset the poison session yet -- the template persist, the
+       reveal verify, and the reveal persist below all read sub->poison_* (the next
+       advance's prep resets it, mirroring the leaf client). */
+    persist_t *persist = g_client_persist;
+    if (persist && sub->poison_is_scriptpath && sub->poison_has_agg_sig) {
+        uint32_t superseded_state = (sub->l_stock_state_counter > 0)
+                                    ? sub->l_stock_state_counter - 1u : 0u;
+        persist_save_l_stock_poison(persist, /* factory_id */ 0,
+            (uint32_t)sub_node_i, superseded_state, sub->poison_l_stock_hash,
+            sub->poison_agg_sig,
+            sub->poison_unsigned_tx.data, sub->poison_unsigned_tx.len,
+            sub->poison_leaf_script, sub->poison_leaf_script_len,
+            sub->poison_control_block, sub->poison_control_block_len);
+    }
 
     /* Wait for DONE. */
     wire_msg_t done_msg;
@@ -3195,9 +3230,55 @@ static int client_handle_subfactory_advance_stateless_multi(
         fprintf(stderr, "Client-stateless MULTI %u: expected DONE, got 0x%02x\n",
                 my_index, done_msg.json ? done_msg.msg_type : 0);
         if (done_msg.json) cJSON_Delete(done_msg.json);
+        if (poison_prepared_c) factory_session_reset_poison(factory, sub_node_i);
         return 0;
     }
     if (done_msg.json) cJSON_Delete(done_msg.json);
+
+    /* #53 Phase 2: receive + verify + persist the SUPERSEDED sub state's sales-stock
+       revocation secret, so this client (or its standalone WT) can spend the Leaf-P sub
+       poison if the LSP later broadcasts that stale sub state.  Only when this advance
+       co-signed a script-path poison (hashlock on).  Verify-before-persist (fail-closed),
+       mirroring the leaf path (client.c ~3999).  Always recv when scriptpath (even if
+       persist is NULL) so the wire stays in sync with the LSP's post-DONE reveal. */
+    if (sub->poison_is_scriptpath && sub->poison_has_agg_sig) {
+        wire_msg_t rev_msg;
+        if (wire_recv(fd, &rev_msg) && rev_msg.msg_type == MSG_LSTOCK_REVEAL) {
+            uint32_t rn[1], rs[1];
+            unsigned char rsec[1][32];
+            size_t rcount = 0;
+            if (wire_parse_lstock_reveal(rev_msg.json, rn, rs, rsec, 1, &rcount) &&
+                rcount == 1) {
+                unsigned char chk[32];
+                sha256(rsec[0], 32, chk);
+                if (persist && memcmp(chk, sub->poison_l_stock_hash, 32) == 0) {
+                    persist_save_l_stock_poison(persist, /* factory_id */ 0,
+                        (uint32_t)sub_node_i, rs[0], sub->poison_l_stock_hash,
+                        sub->poison_agg_sig,
+                        sub->poison_unsigned_tx.data, sub->poison_unsigned_tx.len,
+                        sub->poison_leaf_script, sub->poison_leaf_script_len,
+                        sub->poison_control_block, sub->poison_control_block_len);
+                    persist_update_l_stock_secret(persist, 0, (uint32_t)sub_node_i, rs[0],
+                                                  rsec[0]);
+                    printf("Client-stateless MULTI %u: sub L-stock secret verified + "
+                           "persisted (node %zu state %u) -> poison recourse durable\n",
+                           my_index, sub_node_i, rs[0]);
+                } else {
+                    fprintf(stderr, "Client-stateless MULTI %u: sub L-stock reveal FAILED "
+                            "verify (SHA256 != committed H_old) -- rejecting (LSP "
+                            "misbehaving)\n", my_index);
+                }
+                memset(rsec, 0, sizeof(rsec));
+            }
+            if (rev_msg.json) cJSON_Delete(rev_msg.json);
+        } else {
+            if (rev_msg.json) cJSON_Delete(rev_msg.json);
+            fprintf(stderr, "Client-stateless MULTI %u: expected MSG_LSTOCK_REVEAL after "
+                    "DONE -- recourse for the superseded sub state NOT persisted\n",
+                    my_index);
+        }
+    }
+    if (poison_prepared_c) factory_session_reset_poison(factory, sub_node_i);
 
     printf("Client-stateless subfactory MULTI-INPUT %u: advance done (sub_node=%zu, n_inputs=%zu)\n",
            my_index, sub_node_i, n_inputs);
@@ -3236,6 +3317,21 @@ static int client_handle_subfactory_advance_stateless(int fd,
     size_t sub_node_i = (size_t)sub_node_id;
     factory_node_t *sub = &factory->nodes[sub_node_i];
 
+    /* #53 sub-factory hashlock: mirror the sub's NEW-state H from PROPOSE_INTENT (the
+       client has no seed) BEFORE the local sub-advance.  Both single- and multi-input
+       paths route through factory_subfactory_chain_advance_unsigned -> Phase 0, which
+       reads this via apply_l_stock_hashlock's client-mirror branch to build the SAME
+       sales-stock SPK as the LSP (else the chain tx diverges + the co-sign fails).
+       Set here, not in poison-prep: factory_set_node_l_stock_hash updates only
+       f->node_l_stock_hashes[], NOT sub->l_stock_hash, so the poison-prep below still
+       snapshots H_old.  Absent field (hashlock off) -> no-op.  Mirrors leaf client.c ~3607. */
+    {
+        cJSON *lh = cJSON_GetObjectItem(propose_msg->json, "l_stock_hash");
+        unsigned char h_new[32];
+        if (lh && cJSON_IsString(lh) && hex_decode(lh->valuestring, h_new, 32) == 32)
+            factory_set_node_l_stock_hash(factory, sub_node_i, h_new);
+    }
+
     /* Phase 1e.1.e: MULTI-INPUT now runs through the STATELESS path too.
        Dispatch to the looped-per-input handler; single-input keeps the
        existing flow below. */
@@ -3243,6 +3339,23 @@ static int client_handle_subfactory_advance_stateless(int fd,
         return client_handle_subfactory_advance_stateless_multi(
             fd, ctx, keypair, factory, my_index, sub_node_i, sub,
             n_inputs, leaf_side, sub_idx, channel_idx, delta_sats);
+    }
+
+    /* #53 fail-closed downgrade guard: the hashlock sales-stock poison is wired ONLY in
+       the multi-input ceremony.  A real sub-advance is always multi-input, so an honest
+       LSP never sends a single-input PROPOSE_INTENT for a hashlock sub.  Refuse here so a
+       MALICIOUS LSP cannot force the single-input path (which has no fail-closed guard /
+       reveal) to make this client revoke the old sub state without recourse. */
+    /* NOTE: use sub->has_l_stock_hash, NOT factory->use_hashlock_poison -- the latter is
+       LSP-only (set by factory_enable_hashlock_poison); the client learns hashlock is on
+       purely from the LSP-shipped per-node hash that apply_l_stock_hashlock mirrored onto
+       sub->has_l_stock_hash at factory build.  This is also why the multi-input client
+       guard keys on has_l_stock_hash. */
+    if (sub->has_l_stock_hash) {
+        fprintf(stderr, "Client-stateless subfactory %u: hashlock poison ON but LSP sent a "
+                        "single-input PROPOSE_INTENT -- REFUSING (downgrade attempt; "
+                        "hashlock sub poison is multi-input only)\n", my_index);
+        return 0;
     }
 
     /* k>=2 (multi-client sub-factory) is supported: the LSP forwards the full

--- a/src/client.c
+++ b/src/client.c
@@ -3205,13 +3205,35 @@ static int client_handle_subfactory_advance_stateless_multi(
     }
     cJSON_Delete(fp_json);
 
-    /* #59/#53 Phase 2: FINAL is sent -> the sub-advance is committed + the old sub state
-       superseded.  Persist the poison TEMPLATE now (revocation_secret NULL), BEFORE
-       awaiting DONE + a reveal that may never arrive (LSP crash / dropped link), so a
-       restart can detect the missing secret and re-request it.  Keyed by node_idx +
-       superseded state.  Do NOT reset the poison session yet -- the template persist, the
-       reveal verify, and the reveal persist below all read sub->poison_* (the next
-       advance's prep resets it, mirroring the leaf client). */
+    /* Wait for DONE.  #53: when this advance co-signed a script-path (hashlock) poison,
+       DONE carries the LSP's AGGREGATED poison Schnorr sig -- the client cannot aggregate
+       the N-party sub poison locally (unlike the 2-party leaf, which calls
+       factory_session_complete_node_poison itself).  Capture it BEFORE persisting the
+       recourse template; the secret follows in the reveal. */
+    wire_msg_t done_msg;
+    if (!wire_recv(fd, &done_msg) || done_msg.msg_type != MSG_SUBFACTORY_DONE) {
+        fprintf(stderr, "Client-stateless MULTI %u: expected DONE, got 0x%02x\n",
+                my_index, done_msg.json ? done_msg.msg_type : 0);
+        if (done_msg.json) cJSON_Delete(done_msg.json);
+        if (poison_prepared_c) factory_session_reset_poison(factory, sub_node_i);
+        return 0;
+    }
+    if (sub->poison_is_scriptpath) {
+        unsigned char agg64[64];
+        if (wire_subfactory_done_get_poison_aggsig(done_msg.json, agg64)) {
+            memcpy(sub->poison_agg_sig, agg64, 64);
+            sub->poison_has_agg_sig = 1;
+        }
+    }
+    if (done_msg.json) cJSON_Delete(done_msg.json);
+
+    /* #59/#53 Phase 2: the advance is committed + the old sub state superseded.  Persist
+       the poison TEMPLATE now (agg-sig from DONE; revocation_secret still NULL), BEFORE
+       awaiting the reveal that may never arrive (LSP crash / dropped link), so a restart
+       can detect the missing secret and re-request it (0x8D).  Keyed by node_idx +
+       superseded state.  Do NOT reset the poison session yet -- the template persist + the
+       reveal persist below read sub->poison_* (the next advance's prep resets it,
+       mirroring the leaf client). */
     persist_t *persist = g_client_persist;
     if (persist && sub->poison_is_scriptpath && sub->poison_has_agg_sig) {
         uint32_t superseded_state = (sub->l_stock_state_counter > 0)
@@ -3223,17 +3245,6 @@ static int client_handle_subfactory_advance_stateless_multi(
             sub->poison_leaf_script, sub->poison_leaf_script_len,
             sub->poison_control_block, sub->poison_control_block_len);
     }
-
-    /* Wait for DONE. */
-    wire_msg_t done_msg;
-    if (!wire_recv(fd, &done_msg) || done_msg.msg_type != MSG_SUBFACTORY_DONE) {
-        fprintf(stderr, "Client-stateless MULTI %u: expected DONE, got 0x%02x\n",
-                my_index, done_msg.json ? done_msg.msg_type : 0);
-        if (done_msg.json) cJSON_Delete(done_msg.json);
-        if (poison_prepared_c) factory_session_reset_poison(factory, sub_node_i);
-        return 0;
-    }
-    if (done_msg.json) cJSON_Delete(done_msg.json);
 
     /* #53 Phase 2: receive + verify + persist the SUPERSEDED sub state's sales-stock
        revocation secret, so this client (or its standalone WT) can spend the Leaf-P sub

--- a/src/client.c
+++ b/src/client.c
@@ -3221,8 +3221,26 @@ static int client_handle_subfactory_advance_stateless_multi(
     if (sub->poison_is_scriptpath) {
         unsigned char agg64[64];
         if (wire_subfactory_done_get_poison_aggsig(done_msg.json, agg64)) {
-            memcpy(sub->poison_agg_sig, agg64, 64);
-            sub->poison_has_agg_sig = 1;
+            /* #53 verify-before-trust: the N-party sub poison agg-sig comes from the LSP
+               over the wire (the client can't aggregate it locally).  VERIFY it against
+               OUR own poison sighash + the untweaked sub agg key BEFORE persisting it as
+               recourse -- else a malicious LSP (or a bad co-signer partial that the LSP
+               aggregated) could hand us a WORTHLESS sig, silently neutering recourse for
+               the superseded state.  The poison session is finalized + un-reset here, so
+               its cache is the raw agg key and msg32 is the poison sighash (mirrors the
+               leaf LSP verify at lsp_channels.c ~1782). */
+            secp256k1_pubkey ppk; secp256k1_xonly_pubkey pxpk;
+            if (secp256k1_musig_pubkey_get(ctx, &ppk, &sub->poison_signing_session.cache) &&
+                secp256k1_xonly_pubkey_from_pubkey(ctx, &pxpk, NULL, &ppk) &&
+                secp256k1_schnorrsig_verify(ctx, agg64,
+                                            sub->poison_signing_session.msg32, 32, &pxpk)) {
+                memcpy(sub->poison_agg_sig, agg64, 64);
+                sub->poison_has_agg_sig = 1;
+            } else {
+                fprintf(stderr, "Client-stateless MULTI %u: LSP-supplied sub poison agg-sig "
+                        "FAILED verify -- NOT persisting (recourse for the superseded sub "
+                        "state is unavailable; LSP or a co-signer misbehaved)\n", my_index);
+            }
         }
     }
     if (done_msg.json) cJSON_Delete(done_msg.json);

--- a/src/client.c
+++ b/src/client.c
@@ -3248,11 +3248,12 @@ static int client_handle_subfactory_advance_stateless_multi(
 
     /* #53 Phase 2: receive + verify + persist the SUPERSEDED sub state's sales-stock
        revocation secret, so this client (or its standalone WT) can spend the Leaf-P sub
-       poison if the LSP later broadcasts that stale sub state.  Only when this advance
-       co-signed a script-path poison (hashlock on).  Verify-before-persist (fail-closed),
-       mirroring the leaf path (client.c ~3999).  Always recv when scriptpath (even if
-       persist is NULL) so the wire stays in sync with the LSP's post-DONE reveal. */
-    if (sub->poison_is_scriptpath && sub->poison_has_agg_sig) {
+       poison if the LSP later broadcasts that stale sub state.  Recv whenever we prepped a
+       script-path poison (hashlock on) -- the EXACT mirror of the LSP's reveal-send gate
+       (use_hashlock_poison && poison_prepared) -- so the wire stays in sync even if the
+       agg-sig was somehow absent from DONE; the persist below additionally requires the
+       agg-sig.  Verify-before-persist (fail-closed), mirroring the leaf path (~3999). */
+    if (sub->poison_is_scriptpath) {
         wire_msg_t rev_msg;
         if (wire_recv(fd, &rev_msg) && rev_msg.msg_type == MSG_LSTOCK_REVEAL) {
             uint32_t rn[1], rs[1];
@@ -3262,7 +3263,8 @@ static int client_handle_subfactory_advance_stateless_multi(
                 rcount == 1) {
                 unsigned char chk[32];
                 sha256(rsec[0], 32, chk);
-                if (persist && memcmp(chk, sub->poison_l_stock_hash, 32) == 0) {
+                if (persist && sub->poison_has_agg_sig &&
+                    memcmp(chk, sub->poison_l_stock_hash, 32) == 0) {
                     persist_save_l_stock_poison(persist, /* factory_id */ 0,
                         (uint32_t)sub_node_i, rs[0], sub->poison_l_stock_hash,
                         sub->poison_agg_sig,

--- a/src/factory.c
+++ b/src/factory.c
@@ -2667,6 +2667,20 @@ int factory_subfactory_chain_advance_unsigned(
     sub->outputs[sstock_vout].amount_sats =
         sstock_amount - delta_sats - f->fee_per_tx;
 
+    /* #53 sub-factory hashlock: each sub state must commit a DISTINCT per-(sub,state)
+       L-stock hash, so revealing one superseded state's secret never compromises
+       another (the per-state revocation model; the leaf path does this via
+       update_l_stock_for_leaf, the sub path did not -> the hash was static).
+       Re-derive the sales-stock SPK BEFORE rebuild_node_tx so the new SPK lands in
+       the tx.  No-op unless hashlock poison is on (has_l_stock_hash is set at build
+       only then); LSP derives from the seed, client mirrors the wire-shipped H_new. */
+    if (sub->has_l_stock_hash) {
+        sub->l_stock_state_counter++;
+        if (!set_leaf_l_stock_output(f, sub, sub->outputs[sstock_vout].script_pubkey))
+            return 0;
+        sub->outputs[sstock_vout].script_pubkey_len = 34;
+    }
+
     if (!rebuild_node_tx(f, (size_t)sub_node_i)) {
         /* On failure, roll back the chain state (chain_len already bumped;
            leave it — the caller is expected to retry with a different

--- a/src/factory.c
+++ b/src/factory.c
@@ -287,6 +287,17 @@ static int build_l_stock_taptree(const factory_t *f,
     return 1;
 }
 
+/* Recovery helper: return the L-stock taptree merkle root for a leaf/sub node
+   (the taptweak needed to key-path-spend that L-stock output).  Thin public
+   wrapper over build_l_stock_taptree so an offline residual-sweep tool can
+   reconstruct the exact taptweak without re-deriving the leaves itself. */
+int factory_l_stock_merkle(const factory_t *f, const factory_node_t *node,
+                           unsigned char merkle_out32[32]) {
+    if (!f || !node || !merkle_out32) return 0;
+    tapscript_leaf_t lp, ll;
+    return build_l_stock_taptree(f, node, NULL, &lp, &ll, merkle_out32, NULL);
+}
+
 int build_l_stock_spk(const factory_t *f, const factory_node_t *leaf_node,
                        unsigned char *spk_out34) {
     if (!f || !leaf_node || !spk_out34) return 0;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4013,8 +4013,14 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         return 0;
     }
 
-    /* Step 9: DONE to each client. */
+    /* Step 9: DONE to each client.  #53: when the poison was co-signed, attach the
+       AGGREGATED poison Schnorr sig so each sub client can persist a complete recourse
+       template (it cannot aggregate the N-party poison locally, unlike the 2-party
+       leaf).  The secret follows in the reveal below. */
     cJSON *done = wire_build_subfactory_done(leaf_side, sub_idx_in_leaf, sub->ps_chain_len);
+    if (f->use_hashlock_poison && poison_prepared && sub->poison_is_scriptpath &&
+        sub->poison_has_agg_sig)
+        wire_subfactory_done_set_poison_aggsig(done, sub->poison_agg_sig);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_DONE, done);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3529,12 +3529,18 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         memcpy(wt_old_chain_spk, sub->outputs[0].script_pubkey,
                wt_old_chain_spk_len);
     uint32_t wt_old_csv_delay = (uint32_t)(sub->nsequence & 0xFFFFu);
-    if (mgr->watchtower &&
-        wt_old_sstock_amount > POISON_FEE_SATS + (uint64_t)wt_old_n_chans * 330u) {
+    /* #53 Phase 3: economic poison requirement, DECOUPLED from the watchtower/
+       operational prep gate — the OLD sub state has a protectable, non-dust
+       sales-stock.  The fail-closed guard below (before DONE) fires whenever a
+       required poison was not co-signed, but never when no poison was ever needed. */
+    int poison_required = (wt_old_sstock_amount > POISON_FEE_SATS +
+                           (uint64_t)wt_old_n_chans * 330u);
+    if (mgr->watchtower && poison_required) {
         if (factory_session_prepare_poison_tx_subfactory(
                 f, sub_node_i, wt_old_chain_txid, (uint32_t)wt_old_n_chans,
                 wt_old_sstock_amount, POISON_FEE_SATS,
-                NULL /* #53-B3b: capture sub H_old when daemon hashlock on */)) {
+                NULL /* prep-before-advance: sub->l_stock_hash is still H_old here,
+                        so NULL override naturally targets the superseded state */)) {
             poison_prepared = 1;
         } else {
             fprintf(stderr, "LSP-stateless subfactory MULTI: poison TX prep "
@@ -3592,6 +3598,12 @@ static int lsp_subfactory_chain_advance_stateless_multi(
     cJSON *propose = wire_build_subfactory_propose_intent(
         (uint32_t)sub_node_i, (uint32_t)n_inputs,
         leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);
+    /* #53 sub-factory hashlock: ship the sub's NEW-state H (set by Phase 0 of the
+       advance above) so the seedless client mirrors it via factory_set_node_l_stock_hash
+       and builds the IDENTICAL sales-stock SPK before its own sub-advance. Absent when
+       hashlock poison off -> client no-ops. Mirrors the leaf path (lsp_channels.c ~1497). */
+    if (f->use_hashlock_poison && sub->has_l_stock_hash)
+        wire_json_add_hex(propose, "l_stock_hash", sub->l_stock_hash, 32);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_PROPOSE_INTENT, propose)) {
@@ -3983,6 +3995,24 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         poison_prepared = 0;
     }
 
+    /* #53 Phase 3 fail-closed: hashlock ON + a sales-stock poison was economically
+       REQUIRED but NOT co-signed -> ABORT before DONE.  Advancing would revoke the old
+       sub state with no recourse (Scenario B at the sub level).  The new state is
+       assembled in memory only (not persisted / DONE-sent yet), so resetting it here
+       keeps BOTH sides on the old, still-recourse-able state.  Subsumes every
+       degrade-and-continue site above (any leaves poison_prepared==0) plus the case
+       where prep never ran.  Mirrors the leaf guard (lsp_channels.c ~1821); legacy
+       (flag off) keeps the prior degrade-and-continue behavior unchanged. */
+    if (f->use_hashlock_poison && poison_required && !poison_prepared) {
+        fprintf(stderr, "LSP-stateless MULTI: hashlock ON + sales-stock poison REQUIRED "
+                        "but NOT co-signed -- ABORTING sub-advance (no revoke without "
+                        "recourse)\n");
+        sub->is_signed = 0;
+        tx_buf_reset(&sub->signed_tx);
+        factory_session_reset_poison(f, sub_node_i);
+        return 0;
+    }
+
     /* Step 9: DONE to each client. */
     cJSON *done = wire_build_subfactory_done(leaf_side, sub_idx_in_leaf, sub->ps_chain_len);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
@@ -3990,6 +4020,34 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_DONE, done);
     }
     cJSON_Delete(done);
+
+    /* #53 Phase 2: reveal the SUPERSEDED sub state's sales-stock revocation secret to
+       EVERY sub client (targeted, not broadcast).  Each client verifies + persists it
+       so it (or its standalone WT) can spend the Leaf-P sub poison if the LSP later
+       broadcasts that stale sub state -- closing Scenario B at the sub level in the live
+       protocol.  Gated on hashlock + a poison having been co-signed; the secret is
+       re-derived from the seed, keyed by the sub node's agg xonly + the OLD state
+       counter (which Phase 0 bumped during this advance, so current-1 = superseded). */
+    if (f->use_hashlock_poison && poison_prepared && sub->has_l_stock_hash) {
+        uint32_t old_counter = (sub->l_stock_state_counter > 0)
+                               ? sub->l_stock_state_counter - 1u : 0u;
+        unsigned char reveal_secret[1][32];
+        if (factory_derive_l_stock_secret(f, sub, old_counter, reveal_secret[0])) {
+            uint32_t rn = (uint32_t)sub_node_i;
+            cJSON *rev = wire_build_lstock_reveal(&rn, &old_counter, reveal_secret, 1);
+            if (rev) {
+                for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
+                    size_t fd_idx = (size_t)(sub_clients[ci] - 1);
+                    wire_send(lsp->client_fds[fd_idx], MSG_LSTOCK_REVEAL, rev);
+                }
+                cJSON_Delete(rev);
+                printf("LSP-stateless MULTI: revealed sub sales-stock secret for "
+                       "node %zu state %u to %zu clients\n",
+                       sub_node_i, old_counter, n_clients_in_sub);
+            }
+            memset(reveal_secret, 0, sizeof(reveal_secret));
+        }
+    }
 
     lsp_crash_checkpoint("subfactory_multi_finalize_partial");
 
@@ -4162,6 +4220,19 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
             leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);
     }
 
+    /* #53 fail-closed: the hashlock sales-stock poison (per-state H, reveal, fail-closed
+       guard) is wired ONLY in the multi-input ceremony above.  Any real sub-factory
+       (k>=1 channels -> n_outputs > 1) dispatches there; this single-input tail is only
+       reachable for a degenerate 0-channel sub (whose channel advance fails the bounds
+       check anyway).  Refuse rather than run a single-input advance that would revoke the
+       old sub state with no hashlock recourse.  Non-hashlock subs keep the legacy flow. */
+    if (f->use_hashlock_poison && sub->has_l_stock_hash) {
+        fprintf(stderr, "LSP-stateless subfactory advance: hashlock poison ON but reached "
+                        "the single-input path (n_outputs=%zu) -- REFUSING (hashlock sub "
+                        "poison is multi-input only)\n", sub->n_outputs);
+        return 0;
+    }
+
     /* Step 1.5 (poison prep): snapshot the soon-to-be-stale chain[N-1] state
        (txid + per-channel amounts + sales-stock) BEFORE advance_unsigned
        mutates sub->txid / sub->outputs[], then build the unsigned L-stock
@@ -4251,6 +4322,11 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
             cer_persisted = 1;
     }
     cJSON *propose = wire_build_subfactory_propose_intent((uint32_t)sub_node_i, 1, leaf_side, sub_idx_in_leaf, channel_idx_in_sub, delta_sats);
+    /* #53 sub-factory hashlock: ship the sub's NEW-state H (Phase 0 of the advance
+       above) so the seedless client mirrors it before its own sub-advance. No-op when
+       hashlock poison off. Mirrors the leaf path + the multi-input branch above. */
+    if (f->use_hashlock_poison && sub->has_l_stock_hash)
+        wire_json_add_hex(propose, "l_stock_hash", sub->l_stock_hash, 32);
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         if (!wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_PROPOSE_INTENT, propose)) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3995,6 +3995,24 @@ static int lsp_subfactory_chain_advance_stateless_multi(
         poison_prepared = 0;
     }
 
+    /* #53 verify-the-aggregate: before trusting (and shipping to clients) the poison
+       agg-sig, the LSP verifies it against the untweaked sub agg key + poison sighash --
+       catching a bad co-signer partial that aggregated into a worthless sig (BIP-327
+       identifiable-abort spirit; mirrors the leaf LSP verify at ~1782).  On failure
+       degrade -> the fail-closed guard below aborts (no revoke without VALID recourse). */
+    if (poison_prepared && sub->poison_is_scriptpath) {
+        secp256k1_pubkey ppk; secp256k1_xonly_pubkey pxpk;
+        if (!(secp256k1_musig_pubkey_get(lsp->ctx, &ppk, &sub->poison_signing_session.cache) &&
+              secp256k1_xonly_pubkey_from_pubkey(lsp->ctx, &pxpk, NULL, &ppk) &&
+              secp256k1_schnorrsig_verify(lsp->ctx, sub->poison_agg_sig,
+                                          sub->poison_signing_session.msg32, 32, &pxpk))) {
+            fprintf(stderr, "LSP-stateless MULTI: sub poison agg-sig FAILED self-verify "
+                            "(bad co-signer partial?) -- degrading\n");
+            factory_session_reset_poison(f, sub_node_i);
+            poison_prepared = 0;
+        }
+    }
+
     /* #53 Phase 3 fail-closed: hashlock ON + a sales-stock poison was economically
        REQUIRED but NOT co-signed -> ABORT before DONE.  Advancing would revoke the old
        sub state with no recourse (Scenario B at the sub level).  The new state is

--- a/src/wire.c
+++ b/src/wire.c
@@ -2873,6 +2873,25 @@ cJSON *wire_build_subfactory_done(int leaf_side, int sub_idx, uint32_t chain_len
     return j;
 }
 
+/* #53 sub-factory hashlock: carry the LSP's AGGREGATED poison Schnorr sig in
+   SUBFACTORY_DONE.  Unlike the 2-party leaf (where the client aggregates the poison
+   locally), the N-party sub poison is aggregated ONLY by the LSP — so the LSP must
+   hand each sub client the 64-byte agg-sig for its persisted recourse template (the
+   client builds the rest of the template deterministically + receives the secret in
+   the reveal).  Optional field (absent when hashlock poison is off); mutator/getter
+   pattern mirrors wire_subfactory_propose_set_inputs (no DONE signature churn). */
+void wire_subfactory_done_set_poison_aggsig(cJSON *done,
+                                            const unsigned char *poison_agg_sig64) {
+    if (!done || !poison_agg_sig64) return;
+    wire_json_add_hex(done, "poison_agg_sig", poison_agg_sig64, 64);
+}
+
+int wire_subfactory_done_get_poison_aggsig(const cJSON *json,
+                                           unsigned char *poison_agg_sig64_out) {
+    if (!json || !poison_agg_sig64_out) return 0;
+    return wire_json_get_hex(json, "poison_agg_sig", poison_agg_sig64_out, 64) == 64;
+}
+
 /* --- Multi-input sub-factory chain advance helpers (#207 phase 2c) ---
    See include/superscalar/wire.h for the design rationale.  All these
    helpers MUTATE an existing PROPOSE/NONCE/ALL_NONCES/PSIG cJSON by

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6046,6 +6046,127 @@ int test_factory_lstock_client_mirror(void) {
     return 1;
 }
 
+/* #53 sub-factory Phase 0 (in-process, no regtest): each sub-factory state must commit a
+   DISTINCT per-(sub,state) L-stock (sales-stock) hash, so revealing one superseded state's
+   secret never compromises the hashlock of another sub state.  This is the per-state
+   revocation model the leaf path already has (update_l_stock_outputs); the sub path was
+   STATIC before this work.  Proves: (a) creation commits H0 = SHA256(secret(sub,0));
+   (b) each advance bumps the counter + re-commits H_n = SHA256(secret(sub,n)) != H_{n-1}
+   (and rewrites the sales-stock SPK); (c) a superseded secret stays seed-re-derivable so
+   the LSP's post-advance reveal verifies against the poison's H_old; (d) CONTROL — a
+   non-hashlock sub keeps a STATIC sales-stock SPK across advances (Phase 0 gated off). */
+int test_factory_subfactory_lstock_per_state_hash(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[5];
+    for (int i = 0; i < 5; i++) {
+        unsigned char sk[32] = {0};
+        sk[31] = (unsigned char)(i + 1);
+        sk[0]  = 0xEE;
+        TEST_ASSERT(secp256k1_keypair_create(ctx, &kps[i], sk), "keypair");
+    }
+    unsigned char fund_spk[34];
+    {
+        secp256k1_pubkey pks[5];
+        for (int i = 0; i < 5; i++)
+            secp256k1_keypair_pub(ctx, &pks[i], &kps[i]);
+        musig_keyagg_t ka;
+        musig_aggregate_keys(ctx, &ka, pks, 5);
+        unsigned char ser[32];
+        secp256k1_xonly_pubkey_serialize(ctx, ser, &ka.agg_pubkey);
+        unsigned char tweak[32];
+        sha256_tagged("TapTweak", ser, 32, tweak);
+        secp256k1_pubkey tweaked_pk;
+        secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tweaked_pk, &ka.cache, tweak);
+        secp256k1_xonly_pubkey fund_tw;
+        secp256k1_xonly_pubkey_from_pubkey(ctx, &fund_tw, NULL, &tweaked_pk);
+        build_p2tr_script_pubkey(fund_spk, &fund_tw);
+    }
+    unsigned char fake_txid[32];
+    memset(fake_txid, 0xFE, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+    factory_init(f, ctx, kps, 5, 6, 10);
+    factory_set_arity(f, FACTORY_ARITY_PS);
+    factory_set_ps_subfactory_arity(f, 2);
+    factory_set_funding(f, fake_txid, 0, 1000000, fund_spk, 34);
+
+    /* Hashlock ON: seed + enable BEFORE build so the sub sales-stock commits H0. */
+    unsigned char seed[32];
+    for (int i = 0; i < 32; i++) seed[i] = (unsigned char)(0xA5 ^ i);
+    factory_set_shachain_seed(f, seed);
+    TEST_ASSERT(factory_enable_hashlock_poison(f), "enable hashlock");
+    TEST_ASSERT(factory_build_tree(f), "build k^2 PS tree (hashlock)");
+
+    size_t leaf_idx = f->leaf_node_indices[0];
+    factory_node_t *leaf = &f->nodes[leaf_idx];
+    int sub0_node_idx = leaf->subfactory_node_indices[0];
+    factory_node_t *sub = &f->nodes[sub0_node_idx];
+
+    /* (a) creation committed H0 = SHA256(secret(sub,0)). */
+    TEST_ASSERT(sub->has_l_stock_hash, "sub carries the hashlock at creation");
+    TEST_ASSERT_EQ((int)sub->l_stock_state_counter, 0, "sub counter starts at 0");
+    unsigned char h0[32];
+    memcpy(h0, sub->l_stock_hash, 32);
+    unsigned char sec0[32], chk[32];
+    TEST_ASSERT(factory_derive_l_stock_secret(f, sub, 0, sec0), "derive secret(sub,0)");
+    sha256(sec0, 32, chk);
+    TEST_ASSERT(memcmp(chk, h0, 32) == 0, "H0 == SHA256(secret(sub,0))");
+    unsigned char spk0[34];
+    memcpy(spk0, sub->outputs[sub->n_outputs - 1].script_pubkey, 34);
+
+    /* (b) advance #1 -> counter 1, H1 != H0, H1 == SHA256(secret(sub,1)), SPK rewritten. */
+    TEST_ASSERT_EQ(factory_subfactory_chain_advance_unsigned(f, 0, 0, 0, 50000), 1,
+                   "sub advance #1");
+    TEST_ASSERT_EQ((int)sub->l_stock_state_counter, 1, "counter -> 1");
+    unsigned char h1[32];
+    memcpy(h1, sub->l_stock_hash, 32);
+    TEST_ASSERT(memcmp(h1, h0, 32) != 0, "H1 != H0 (distinct per state)");
+    unsigned char sec1[32];
+    TEST_ASSERT(factory_derive_l_stock_secret(f, sub, 1, sec1), "derive secret(sub,1)");
+    sha256(sec1, 32, chk);
+    TEST_ASSERT(memcmp(chk, h1, 32) == 0, "H1 == SHA256(secret(sub,1))");
+    TEST_ASSERT(memcmp(sub->outputs[sub->n_outputs - 1].script_pubkey, spk0, 34) != 0,
+                "sales-stock SPK rewritten across the advance");
+
+    /* (c) the SUPERSEDED secret(sub,0) is still seed-re-derivable -> the LSP can reveal it
+       and the client's poison (built vs H0) verifies. */
+    unsigned char sec0b[32];
+    TEST_ASSERT(factory_derive_l_stock_secret(f, sub, 0, sec0b), "re-derive secret(sub,0)");
+    TEST_ASSERT(memcmp(sec0b, sec0, 32) == 0, "secret(sub,0) stable (reveal verifies)");
+
+    /* (b') advance #2 -> H2 distinct from H0 and H1. */
+    TEST_ASSERT_EQ(factory_subfactory_chain_advance_unsigned(f, 0, 0, 0, 50000), 1,
+                   "sub advance #2");
+    TEST_ASSERT_EQ((int)sub->l_stock_state_counter, 2, "counter -> 2");
+    unsigned char h2[32];
+    memcpy(h2, sub->l_stock_hash, 32);
+    TEST_ASSERT(memcmp(h2, h0, 32) != 0 && memcmp(h2, h1, 32) != 0, "H2 distinct from H0,H1");
+    factory_free(f); free(f);
+
+    /* (d) CONTROL: a non-hashlock sub keeps a STATIC sales-stock SPK across advances. */
+    factory_t *g = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(g, "alloc control factory");
+    factory_init(g, ctx, kps, 5, 6, 10);
+    factory_set_arity(g, FACTORY_ARITY_PS);
+    factory_set_ps_subfactory_arity(g, 2);
+    factory_set_funding(g, fake_txid, 0, 1000000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(g), "build control tree (no hashlock)");
+    factory_node_t *gsub = &g->nodes[g->nodes[g->leaf_node_indices[0]].subfactory_node_indices[0]];
+    TEST_ASSERT(!gsub->has_l_stock_hash, "control sub has NO hashlock");
+    unsigned char gspk0[34];
+    memcpy(gspk0, gsub->outputs[gsub->n_outputs - 1].script_pubkey, 34);
+    TEST_ASSERT_EQ(factory_subfactory_chain_advance_unsigned(g, 0, 0, 0, 50000), 1,
+                   "control sub advance");
+    TEST_ASSERT(memcmp(gsub->outputs[gsub->n_outputs - 1].script_pubkey, gspk0, 34) == 0,
+                "control sales-stock SPK STATIC across advance (Phase 0 gated off)");
+    factory_free(g); free(g);
+
+    secp256k1_context_destroy(ctx);
+    printf("  sub-factory per-state L-stock hash: distinct H per state + superseded reveal stable\n");
+    return 1;
+}
+
 /* Derive the bech32m address for a 32-byte taproot output key via a rawtr()
    descriptor (mirrors the funding path in test_tapscript.c). */
 static int derive_p2tr_addr_from_outputkey(regtest_t *rt,

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1764,6 +1764,7 @@ extern int test_factory_ps_subfactory_chain_tx_validity(void);
 extern int test_factory_ps_subfactory_poison_tx_k2_n4(void);
 extern int test_factory_lstock_client_mirror(void);
 extern int test_factory_lstock_seed_derivation(void);
+extern int test_factory_subfactory_lstock_per_state_hash(void);
 extern int test_factory_ps_leaf_build_n64(void);
 extern int test_factory_ps_build_n128(void);
 extern int test_factory_ps_leaf_advance(void);
@@ -3646,6 +3647,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_ps_subfactory_poison_tx_k2_n4);
     RUN_TEST(test_factory_lstock_client_mirror);
     RUN_TEST(test_factory_lstock_seed_derivation);
+    RUN_TEST(test_factory_subfactory_lstock_per_state_hash);
     RUN_TEST(test_factory_ps_leaf_build_n64);
     RUN_TEST(test_factory_ps_build_n128);
     RUN_TEST(test_factory_ps_leaf_advance);

--- a/tools/superscalar_factory_residual_sweep.c
+++ b/tools/superscalar_factory_residual_sweep.c
@@ -175,36 +175,39 @@ int main(int argc, char **argv) {
         int m = match_output(f, spk, signers, &n_sig, merkle, &has_merkle, what, sizeof(what));
         if (m != 1) { printf("[%s:%u] NO MATCH in tree (%d sats) -- skipping\n", p_txid, in_vout, (int)in_amt); free(d); continue; }
 
-        /* reconstruct SPK from (signers, merkle) and ASSERT == on-chain spk */
+        /* tweaked output key parsed from the matched on-chain SPK (P2TR 0x5120||xonly).
+           match_output already confirmed spk == a rebuilt tree output (identifies the
+           output); the MuSig self-verify below confirms our (participants,merkle)
+           reproduce a VALID key-path sig for it -> a wrong derivation fails the verify
+           and is NEVER broadcast (no wasted fee). */
         secp256k1_pubkey pks[64]; secp256k1_keypair sgn_kps[64];
         for (size_t k=0;k<n_sig;k++){ pks[k]=f->pubkeys[signers[k]]; sgn_kps[k]=kps[signers[k]]; }
         musig_keyagg_t ka; if (!musig_aggregate_keys(ctx,&ka,pks,n_sig)){fprintf(stderr,"keyagg fail\n");free(d);continue;}
-        secp256k1_xonly_pubkey tw; int par;
-        if (!taproot_tweak_pubkey(ctx,&tw,&par,&ka.agg_pubkey, has_merkle?merkle:NULL)){fprintf(stderr,"tweak fail\n");free(d);continue;}
-        unsigned char rspk[34]; build_p2tr_script_pubkey(rspk,&tw);
-        char a[69],b[69]; hex_encode(rspk,34,a); a[68]=0; hex_encode(spk,34,b); b[68]=0;
-        int spk_ok = (memcmp(rspk,spk,34)==0);
-        printf("[%s:%u] %s  signers=%zu merkle=%d  amount=%llu\n  on-chain spk: %s\n  rebuilt  spk: %s  -> %s\n",
-               p_txid, in_vout, what, n_sig, has_merkle, (unsigned long long)in_amt, b, a, spk_ok?"MATCH":"MISMATCH");
-        if (!spk_ok) { printf("  SPK MISMATCH -> NOT signing (reconstruction wrong)\n"); free(d); continue; }
-        n_ok++;
-        if (!do_broadcast) { free(d); continue; }
+        secp256k1_xonly_pubkey tw;
+        if (spk[0]!=0x51 || spk[1]!=0x20 || !secp256k1_xonly_pubkey_parse(ctx,&tw,spk+2)){fprintf(stderr,"  not a p2tr spk\n");free(d);continue;}
+        char b[69]; hex_encode(spk,34,b); b[68]=0;
+        printf("[%s:%u] %s  signers=%zu merkle=%d  amount=%llu  spk=%s\n",
+               p_txid,in_vout,what,n_sig,has_merkle,(unsigned long long)in_amt,b);
 
-        /* build sweep tx + key-path MuSig sign with the taptweak */
+        /* build sweep tx + key-path MuSig sign with the taptweak (always; the system()
+           broadcast at the end is gated by --broadcast, so dry-run = sign + self-verify). */
         unsigned char in_txid_le[32]; memcpy(in_txid_le,in_txid,32); reverse_bytes(in_txid_le,32);
         tx_output_t o; memset(&o,0,sizeof o); o.amount_sats = in_amt - fee;
         memcpy(o.script_pubkey,dest_spk,dest_len); o.script_pubkey_len=dest_len;
         tx_buf_t utx; tx_buf_init(&utx,256);
         if (!build_unsigned_tx(&utx,NULL,in_txid_le,in_vout,0xFFFFFFFEu,&o,1)){fprintf(stderr,"  build_unsigned fail\n");free(d);continue;}
         unsigned char sighash[32];
-        if (!compute_taproot_sighash(sighash,utx.data,utx.len,0,rspk,34,in_amt,0xFFFFFFFEu)){fprintf(stderr,"  sighash fail\n");free(d);continue;}
+        if (!compute_taproot_sighash(sighash,utx.data,utx.len,0,spk,34,in_amt,0xFFFFFFFEu)){fprintf(stderr,"  sighash fail\n");free(d);continue;}
         unsigned char sig[64];
         if (!musig_sign_taproot(ctx,sig,sighash,sgn_kps,n_sig,&ka, has_merkle?merkle:NULL)){fprintf(stderr,"  musig_sign fail\n");free(d);continue;}
-        if (!secp256k1_schnorrsig_verify(ctx,sig,sighash,32,&tw)){fprintf(stderr,"  self-verify FAIL -- not broadcasting\n");free(d);continue;}
+        if (!secp256k1_schnorrsig_verify(ctx,sig,sighash,32,&tw)){printf("  SELF-VERIFY FAIL -> (participants,merkle) wrong, NOT broadcasting\n");free(d);continue;}
+        printf("  self-verify OK\n");
+        n_ok++;
         tx_buf_t stx; tx_buf_init(&stx,256);
         if (!finalize_signed_tx(&stx,utx.data,utx.len,sig)){fprintf(stderr,"  finalize fail\n");free(d);continue;}
         char *txh = malloc(stx.len*2+1); hex_encode(stx.data,stx.len,txh); txh[stx.len*2]=0;
         printf("  signed (%zu B)\n  hex: %s\n", stx.len, txh);
+        if (!do_broadcast) { free(txh); free(d); continue; }
         char cmd[200000];
         const char *rpc = !strcmp(network,"signet") ? "-signet -rpcuser=signetrpc -stdinrpcpass -rpcport=38332"
                         : "-regtest -rpcuser=rpcuser -rpcpassword=rpcpass -rpcport=18443";

--- a/tools/superscalar_factory_residual_sweep.c
+++ b/tools/superscalar_factory_residual_sweep.c
@@ -49,9 +49,12 @@ static int match_output(const factory_t *f, const unsigned char *spk34,
                         uint32_t *signers_out, size_t *n_signers_out,
                         unsigned char merkle_out[32], int *has_merkle_out,
                         char *what, size_t whatcap) {
+    /* Pass 1: node funding outputs (spending_spk) -- N-of-N, the node's own merkle.
+       Done across ALL nodes FIRST so a leaf's sub-funding output (which equals the sub
+       node's spending_spk) matches the SUB node's N-of-N here, instead of being
+       mis-classified as a channel by the leaf's output loop in pass 2. */
     for (size_t ni = 0; ni < f->n_nodes; ni++) {
         const factory_node_t *n = &f->nodes[ni];
-        /* node funding output (its spending_spk, as spent by the parent) */
         if (n->spending_spk_len == 34 && memcmp(spk34, n->spending_spk, 34) == 0) {
             memcpy(signers_out, n->signer_indices, n->n_signers * sizeof(uint32_t));
             *n_signers_out = n->n_signers;
@@ -60,7 +63,10 @@ static int match_output(const factory_t *f, const unsigned char *spk34,
             snprintf(what, whatcap, "node %zu funding (n_signers=%zu)", ni, n->n_signers);
             return 1;
         }
-        /* this node's own outputs (channels + L-stock for leaf/sub nodes) */
+    }
+    /* Pass 2: each node's own outputs -- channels (v<last) + L-stock (last). */
+    for (size_t ni = 0; ni < f->n_nodes; ni++) {
+        const factory_node_t *n = &f->nodes[ni];
         for (size_t v = 0; v < n->n_outputs; v++) {
             if (n->outputs[v].script_pubkey_len != 34 ||
                 memcmp(spk34, n->outputs[v].script_pubkey, 34) != 0) continue;

--- a/tools/superscalar_factory_residual_sweep.c
+++ b/tools/superscalar_factory_residual_sweep.c
@@ -1,0 +1,223 @@
+/*
+ * superscalar_factory_residual_sweep: recover the MuSig/CLTV/L-stock residual
+ * outputs of a (test) factory whose tree was broadcast (e.g. after a breach),
+ * by reconstructing the factory IN-PROCESS from the seckeys + funding + params,
+ * matching each on-chain output to its tree node, and producing a BIP-341
+ * key-path MuSig2 signature with the node's exact keyagg + taptweak.
+ *
+ * We hold every participant's seckey (test factories), so each N-of-N / 2-of-2
+ * key-path is signable offline.  The merkle/taptweak per output type:
+ *   - node funding (sub spending_spk): keyagg = node signers, merkle = node->merkle_root
+ *   - channel output i               : keyagg = [client_i, LSP], merkle = factory-CLTV leaf
+ *   - L-stock (last output)          : keyagg = node signers, merkle = L-stock taptree
+ * The reconstructed SPK is ASSERTED == the on-chain SPK BEFORE signing, so a
+ * wrong key/merkle/funding-order fails safe (no wasted fee), never a bad sig.
+ *
+ * Usage:
+ *   superscalar_factory_residual_sweep \
+ *     --lsp-seckey HEX64 --client-seckeys HEX64,HEX64,... \
+ *     --funding-txid HEX64 --funding-vout N --funding-amount SATS \
+ *     --cltv-timeout N --ps-sub-arity K \
+ *     --dest-spk HEX --fee SATS \
+ *     --sweep TXID:VOUT:AMOUNT:SPKHEX  [--sweep ...] \
+ *     [--broadcast] [--network signet|regtest]
+ */
+#include "superscalar/factory.h"
+#include "superscalar/musig.h"
+#include "superscalar/tapscript.h"
+#include "superscalar/tx_builder.h"
+#include "superscalar/sha256.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void hex_encode(const unsigned char *data, size_t len, char *out);
+extern int  hex_decode(const char *hex, unsigned char *out, size_t out_len);
+extern void reverse_bytes(unsigned char *data, size_t len);
+extern void build_p2tr_script_pubkey(unsigned char *spk_out34,
+                                     const secp256k1_xonly_pubkey *output_key);
+
+#define MAXSW 32
+
+static int parse_hex32(const char *h, unsigned char out[32]) {
+    return h && strlen(h) == 64 && hex_decode(h, out, 32) == 32;
+}
+
+/* Find the tree output matching spk34.  On success fill signer participant
+   indices (into f->pubkeys) + the merkle root (has_merkle=0 -> empty). */
+static int match_output(const factory_t *f, const unsigned char *spk34,
+                        uint32_t *signers_out, size_t *n_signers_out,
+                        unsigned char merkle_out[32], int *has_merkle_out,
+                        char *what, size_t whatcap) {
+    for (size_t ni = 0; ni < f->n_nodes; ni++) {
+        const factory_node_t *n = &f->nodes[ni];
+        /* node funding output (its spending_spk, as spent by the parent) */
+        if (n->spending_spk_len == 34 && memcmp(spk34, n->spending_spk, 34) == 0) {
+            memcpy(signers_out, n->signer_indices, n->n_signers * sizeof(uint32_t));
+            *n_signers_out = n->n_signers;
+            if (n->has_taptree) { memcpy(merkle_out, n->merkle_root, 32); *has_merkle_out = 1; }
+            else *has_merkle_out = 0;
+            snprintf(what, whatcap, "node %zu funding (n_signers=%zu)", ni, n->n_signers);
+            return 1;
+        }
+        /* this node's own outputs (channels + L-stock for leaf/sub nodes) */
+        for (size_t v = 0; v < n->n_outputs; v++) {
+            if (n->outputs[v].script_pubkey_len != 34 ||
+                memcmp(spk34, n->outputs[v].script_pubkey, 34) != 0) continue;
+            if (v == n->n_outputs - 1) {
+                /* L-stock: N-of-N keyagg + L-stock taptree */
+                memcpy(signers_out, n->signer_indices, n->n_signers * sizeof(uint32_t));
+                *n_signers_out = n->n_signers;
+                if (!factory_l_stock_merkle(f, n, merkle_out)) return -1;
+                *has_merkle_out = 1;
+                snprintf(what, whatcap, "node %zu L-stock", ni);
+            } else {
+                /* channel v: keyagg = [client_v, LSP], merkle = factory CLTV leaf */
+                signers_out[0] = n->signer_indices[1 + v];
+                signers_out[1] = n->signer_indices[0];
+                *n_signers_out = 2;
+                if (f->cltv_timeout > 0) {
+                    secp256k1_xonly_pubkey lsp_xonly;
+                    tapscript_leaf_t cltv_leaf;
+                    if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL, &f->pubkeys[0]) ||
+                        !tapscript_build_cltv_timeout(&cltv_leaf, f->cltv_timeout, &lsp_xonly, f->ctx) ||
+                        !tapscript_merkle_root(merkle_out, &cltv_leaf, 1)) return -1;
+                    *has_merkle_out = 1;
+                } else *has_merkle_out = 0;
+                snprintf(what, whatcap, "node %zu channel vout %zu", ni, v);
+            }
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    const char *lsp_sk_hex = NULL, *clients_csv = NULL, *fund_txid_hex = NULL;
+    const char *dest_spk_hex = NULL, *network = "signet";
+    uint32_t fund_vout = 0, ps_sub_arity = 2; long cltv_timeout = 0;
+    uint64_t fund_amount = 0, fee = 0;
+    int do_broadcast = 0;
+    char *sweeps[MAXSW]; size_t n_sweeps = 0;
+    for (int i = 1; i < argc; i++) {
+        if      (!strcmp(argv[i],"--lsp-seckey")    && i+1<argc) lsp_sk_hex = argv[++i];
+        else if (!strcmp(argv[i],"--client-seckeys")&& i+1<argc) clients_csv = argv[++i];
+        else if (!strcmp(argv[i],"--funding-txid")  && i+1<argc) fund_txid_hex = argv[++i];
+        else if (!strcmp(argv[i],"--funding-vout")  && i+1<argc) fund_vout = (uint32_t)strtoul(argv[++i],NULL,10);
+        else if (!strcmp(argv[i],"--funding-amount")&& i+1<argc) fund_amount = strtoull(argv[++i],NULL,10);
+        else if (!strcmp(argv[i],"--cltv-timeout")  && i+1<argc) cltv_timeout = strtol(argv[++i],NULL,10);
+        else if (!strcmp(argv[i],"--ps-sub-arity")  && i+1<argc) ps_sub_arity = (uint32_t)strtoul(argv[++i],NULL,10);
+        else if (!strcmp(argv[i],"--dest-spk")      && i+1<argc) dest_spk_hex = argv[++i];
+        else if (!strcmp(argv[i],"--fee")           && i+1<argc) fee = strtoull(argv[++i],NULL,10);
+        else if (!strcmp(argv[i],"--sweep")         && i+1<argc && n_sweeps<MAXSW) sweeps[n_sweeps++] = argv[++i];
+        else if (!strcmp(argv[i],"--broadcast")) do_broadcast = 1;
+        else if (!strcmp(argv[i],"--network")       && i+1<argc) network = argv[++i];
+        else { fprintf(stderr,"unknown arg %s\n", argv[i]); return 2; }
+    }
+    if (!lsp_sk_hex || !clients_csv || !fund_txid_hex || !dest_spk_hex || !n_sweeps) {
+        fprintf(stderr,"missing required args\n"); return 2;
+    }
+
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN|SECP256K1_CONTEXT_VERIFY);
+
+    /* keys: [0]=LSP, [1..]=clients */
+    unsigned char sk[64][32]; secp256k1_keypair kps[64]; size_t n_part = 0;
+    if (!parse_hex32(lsp_sk_hex, sk[0]) || !secp256k1_keypair_create(ctx, &kps[0], sk[0])) {
+        fprintf(stderr,"bad lsp seckey\n"); return 2; }
+    n_part = 1;
+    { char *csv = strdup(clients_csv), *tok = strtok(csv, ",");
+      while (tok && n_part < 64) {
+        if (!parse_hex32(tok, sk[n_part]) || !secp256k1_keypair_create(ctx, &kps[n_part], sk[n_part])) {
+            fprintf(stderr,"bad client seckey %zu\n", n_part-1); return 2; }
+        n_part++; tok = strtok(NULL, ",");
+      } free(csv); }
+    size_t n_clients = n_part - 1;
+    printf("participants: %zu (1 LSP + %zu clients)\n", n_part, n_clients);
+
+    unsigned char fund_txid[32];
+    if (!parse_hex32(fund_txid_hex, fund_txid)) { fprintf(stderr,"bad funding-txid\n"); return 2; }
+
+    /* Rebuild the factory deterministically (same keys/arity/cltv/funding/hashlock
+       -> identical keyaggs/merkles/SPKs as on-chain). */
+    factory_t *f = calloc(1, sizeof(factory_t));
+    factory_init(f, ctx, kps, n_part, 64, 16);
+    factory_set_arity(f, FACTORY_ARITY_PS);
+    factory_set_ps_subfactory_arity(f, ps_sub_arity);
+    unsigned char fund_spk_dummy[34] = {0x51,0x20};
+    factory_set_funding(f, fund_txid, fund_vout, fund_amount, fund_spk_dummy, 34);
+    f->cltv_timeout = (uint32_t)cltv_timeout;
+    /* hashlock: derive the per-factory seed from the LSP master key + funding (the
+       same derivation the LSP used), enable, so L-stock SPKs reproduce. */
+    unsigned char seed[32];
+    factory_derive_lstock_seed(sk[0], fund_txid, fund_vout, seed);
+    factory_set_shachain_seed(f, seed);
+    factory_enable_hashlock_poison(f);
+    if (!factory_build_tree(f)) { fprintf(stderr,"factory_build_tree failed\n"); return 1; }
+    printf("rebuilt tree: %zu nodes, cltv_timeout=%u\n", f->n_nodes, f->cltv_timeout);
+
+    size_t dest_len = strlen(dest_spk_hex)/2; unsigned char dest_spk[64];
+    if (dest_len > 64 || !hex_decode(dest_spk_hex, dest_spk, dest_len)) { fprintf(stderr,"bad dest-spk\n"); return 2; }
+
+    int n_ok = 0, n_bcast = 0;
+    for (size_t s = 0; s < n_sweeps; s++) {
+        /* parse TXID:VOUT:AMOUNT:SPK */
+        char *d = strdup(sweeps[s]);
+        char *p_txid = strtok(d, ":"), *p_vout = strtok(NULL, ":");
+        char *p_amt = strtok(NULL, ":"), *p_spk = strtok(NULL, ":");
+        if (!p_txid || !p_vout || !p_amt || !p_spk) { fprintf(stderr,"bad --sweep %s\n", sweeps[s]); free(d); continue; }
+        unsigned char in_txid[32]; uint32_t in_vout = (uint32_t)strtoul(p_vout,NULL,10);
+        uint64_t in_amt = strtoull(p_amt,NULL,10);
+        unsigned char spk[34];
+        if (!parse_hex32(p_txid, in_txid) || strlen(p_spk)!=68 || hex_decode(p_spk, spk, 34)!=34) {
+            fprintf(stderr,"bad --sweep fields %s\n", sweeps[s]); free(d); continue; }
+
+        uint32_t signers[64]; size_t n_sig=0; unsigned char merkle[32]; int has_merkle=0; char what[64];
+        int m = match_output(f, spk, signers, &n_sig, merkle, &has_merkle, what, sizeof(what));
+        if (m != 1) { printf("[%s:%u] NO MATCH in tree (%d sats) -- skipping\n", p_txid, in_vout, (int)in_amt); free(d); continue; }
+
+        /* reconstruct SPK from (signers, merkle) and ASSERT == on-chain spk */
+        secp256k1_pubkey pks[64]; secp256k1_keypair sgn_kps[64];
+        for (size_t k=0;k<n_sig;k++){ pks[k]=f->pubkeys[signers[k]]; sgn_kps[k]=kps[signers[k]]; }
+        musig_keyagg_t ka; if (!musig_aggregate_keys(ctx,&ka,pks,n_sig)){fprintf(stderr,"keyagg fail\n");free(d);continue;}
+        secp256k1_xonly_pubkey tw; int par;
+        if (!taproot_tweak_pubkey(ctx,&tw,&par,&ka.agg_pubkey, has_merkle?merkle:NULL)){fprintf(stderr,"tweak fail\n");free(d);continue;}
+        unsigned char rspk[34]; build_p2tr_script_pubkey(rspk,&tw);
+        char a[69],b[69]; hex_encode(rspk,34,a); a[68]=0; hex_encode(spk,34,b); b[68]=0;
+        int spk_ok = (memcmp(rspk,spk,34)==0);
+        printf("[%s:%u] %s  signers=%zu merkle=%d  amount=%llu\n  on-chain spk: %s\n  rebuilt  spk: %s  -> %s\n",
+               p_txid, in_vout, what, n_sig, has_merkle, (unsigned long long)in_amt, b, a, spk_ok?"MATCH":"MISMATCH");
+        if (!spk_ok) { printf("  SPK MISMATCH -> NOT signing (reconstruction wrong)\n"); free(d); continue; }
+        n_ok++;
+        if (!do_broadcast) { free(d); continue; }
+
+        /* build sweep tx + key-path MuSig sign with the taptweak */
+        unsigned char in_txid_le[32]; memcpy(in_txid_le,in_txid,32); reverse_bytes(in_txid_le,32);
+        tx_output_t o; memset(&o,0,sizeof o); o.amount_sats = in_amt - fee;
+        memcpy(o.script_pubkey,dest_spk,dest_len); o.script_pubkey_len=dest_len;
+        tx_buf_t utx; tx_buf_init(&utx,256);
+        if (!build_unsigned_tx(&utx,NULL,in_txid_le,in_vout,0xFFFFFFFEu,&o,1)){fprintf(stderr,"  build_unsigned fail\n");free(d);continue;}
+        unsigned char sighash[32];
+        if (!compute_taproot_sighash(sighash,utx.data,utx.len,0,rspk,34,in_amt,0xFFFFFFFEu)){fprintf(stderr,"  sighash fail\n");free(d);continue;}
+        unsigned char sig[64];
+        if (!musig_sign_taproot(ctx,sig,sighash,sgn_kps,n_sig,&ka, has_merkle?merkle:NULL)){fprintf(stderr,"  musig_sign fail\n");free(d);continue;}
+        if (!secp256k1_schnorrsig_verify(ctx,sig,sighash,32,&tw)){fprintf(stderr,"  self-verify FAIL -- not broadcasting\n");free(d);continue;}
+        tx_buf_t stx; tx_buf_init(&stx,256);
+        if (!finalize_signed_tx(&stx,utx.data,utx.len,sig)){fprintf(stderr,"  finalize fail\n");free(d);continue;}
+        char *txh = malloc(stx.len*2+1); hex_encode(stx.data,stx.len,txh); txh[stx.len*2]=0;
+        printf("  signed (%zu B)\n  hex: %s\n", stx.len, txh);
+        char cmd[200000];
+        const char *rpc = !strcmp(network,"signet") ? "-signet -rpcuser=signetrpc -stdinrpcpass -rpcport=38332"
+                        : "-regtest -rpcuser=rpcuser -rpcpassword=rpcpass -rpcport=18443";
+        if (!strcmp(network,"signet")) {
+            const char *pw = getenv("SIGNET_RPCPASS");
+            snprintf(cmd,sizeof cmd,"echo '%s' | bitcoin-cli %s sendrawtransaction %s", pw?pw:"", rpc, txh);
+        } else {
+            snprintf(cmd,sizeof cmd,"bitcoin-cli %s sendrawtransaction %s", rpc, txh);
+        }
+        int rc = system(cmd);
+        if (rc==0) { printf("  BROADCAST ok\n"); n_bcast++; } else printf("  broadcast rc=%d\n", rc);
+        free(txh); free(d);
+    }
+    printf("\nSUMMARY: %zu sweeps, %d SPK-matched, %d broadcast\n", n_sweeps, n_ok, n_bcast);
+    return (n_ok == (int)n_sweeps) ? 0 : 1;
+}

--- a/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
+++ b/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# test_regtest_hashlock_poison_subfactory_e2e.sh — #53 sub-factory hashlock
+# L-stock (sales-stock) poison end-to-end on regtest, through the LIVE
+# LSP<->client daemon ceremony.  Sub-factory sibling of
+# test_regtest_hashlock_poison_e2e.sh (the leaf-advance variant).
+#
+# Proof that the sub-factory hashlock phases work together over the wire:
+#   1. LSP runs --enable-hashlock-poison --cheat-daemon-sub: it builds a
+#      hashlock-gated k>=2 PS factory, then advances a SUB-factory chain over
+#      the REAL multi-input wire ceremony with running clients.  During the
+#      advance:
+#        - Phase 0: the sub bumps its per-state counter + re-commits H_new on
+#          the sales-stock SPK (each sub state a DISTINCT hash),
+#        - Phase 1: the LSP ships H_new in SUBFACTORY_PROPOSE_INTENT; the
+#          seedless client mirrors it (builds the same sales-stock SPK),
+#        - the prep-before-advance NULL override targets the superseded H_old,
+#        - both sides co-sign the Leaf-P sub poison against H_old (script-path,
+#          untweaked sub N-of-N agg),
+#        - Phase 2: after DONE the LSP reveals secret_old to EVERY sub client;
+#          each verifies SHA256(secret)==H_old and PERSISTS the row
+#          (l_stock_poison_reveals) with the template + the revealed secret.
+#   2. The cheating LSP broadcasts the SUPERSEDED chain[N-1] sub state on-chain
+#      (trying to over-claim the sub sales-stock at a revoked state).
+#   3. The CLIENT recourse tool (superscalar_lstock_recover) loads the persisted
+#      reveal for the SUB node, assembles the Leaf-P poison [agg_sig, secret,
+#      script, control block], and we broadcast it.
+#   4. ASSERT: the poison CONFIRMS on-chain and redistributes the sales-stock
+#      to the sub clients (a real, non-dust output) — the economic outcome.
+#   5. ANTI-VACUITY: with the revealed secret removed, the tool REFUSES (exit 5)
+#      — no reveal, no recourse (the #53 security property).
+#
+# Models the client-driven recourse (the secret-less standalone WT cannot
+# assemble a hashlock poison alone — see #62).
+
+set -euo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+REC_BIN="$BUILD_DIR/superscalar_lstock_recover"
+
+N_CLIENTS="${N_CLIENTS:-4}"          # k^2 = 4 for k=2
+PS_SUB_ARITY="${PS_SUB_ARITY:-2}"
+
+FUNDING_SATS="${FUNDING_SATS:-400000}"
+LSP_PORT=29958                # distinct from leaf hashlock e2e (29957)
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "0000000000000000000000000000000000000000000000000000000000000005"
+    "0000000000000000000000000000000000000000000000000000000000000006"
+    "0000000000000000000000000000000000000000000000000000000000000007"
+    "0000000000000000000000000000000000000000000000000000000000000008"
+    "0000000000000000000000000000000000000000000000000000000000000009"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+
+. "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
+
+# ASan preload only when the binaries are actually ASan-linked.
+ASAN_ENV="ASAN_OPTIONS=detect_leaks=0"
+if ldd "$LSP_BIN" 2>/dev/null | grep -q libasan; then
+    ASAN_ENV="ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8"
+fi
+
+TMPDIR=$(mktemp -d /tmp/ss-hashlock-sub-e2e.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"
+LSP_LOG="$TMPDIR/lsp.log"
+WT_DB="$TMPDIR/wt.db"
+MINER_WALLET="ss_cheat_leaf_miner"
+
+PIDS=()
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+    sleep 1
+    for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
+    cp "$LSP_LOG" /tmp/hashlock_sub_e2e_last_lsp.log 2>/dev/null || true
+    for i in $(seq 0 $((N_CLIENTS - 1))); do
+        cp "$TMPDIR/client_${i}.log" "/tmp/hashlock_sub_e2e_last_client_${i}.log" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "=== HASHLOCK SUB-FACTORY L-STOCK POISON E2E (regtest, #53) ==="
+echo "  build dir : $BUILD_DIR"
+echo "  N clients : $N_CLIENTS   k(sub arity): $PS_SUB_ARITY   funding: $FUNDING_SATS sats"
+echo "  bitcoind  : $REGTEST_CONF"
+echo
+
+# --- bitcoind ---
+echo "--- bitcoind regtest check ---"
+if ! $BCLI getblockchaininfo >/dev/null 2>&1; then
+    bitcoind -regtest -conf="$REGTEST_CONF" -daemon
+    for i in $(seq 1 30); do sleep 1; $BCLI getblockchaininfo >/dev/null 2>&1 && break; done
+fi
+echo "  bitcoind reachable, height $($BCLI getblockcount)"
+
+$BCLI -named createwallet wallet_name=$MINER_WALLET load_on_startup=false 2>&1 | head -1 || true
+$BCLI loadwallet $MINER_WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+echo "  miner wallet ready, 101 blocks mined"
+
+# --- LSP daemon (hashlock poison + sub-factory cheat) ---
+echo
+echo "--- LSP daemon (--enable-hashlock-poison --cheat-daemon-sub) ---"
+env $ASAN_ENV \
+"$LSP_BIN" \
+    --network regtest \
+    --port $LSP_PORT \
+    --clients $N_CLIENTS \
+    --arity 3 \
+    --ps-subfactory-arity $PS_SUB_ARITY \
+    --amount $FUNDING_SATS \
+    --fee-rate 1000 \
+    --confirm-timeout 600 \
+    --step-blocks 1 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser ${RPCUSER:-rpcuser} \
+    --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET \
+    --db "$LSP_DB" \
+    --wt-db "$WT_DB" \
+    --cli-path "$(which bitcoin-cli)" \
+    --enable-hashlock-poison \
+    --demo --cheat-daemon-sub \
+    --lsp-balance-pct 50 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+PIDS+=($LSP_PID)
+
+for i in $(seq 1 60); do
+    sleep 1
+    grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && { echo "  LSP listening (PID=$LSP_PID)"; break; }
+    kill -0 $LSP_PID 2>/dev/null || { echo "FAIL: LSP died before listening"; tail -20 "$LSP_LOG"; exit 1; }
+done
+
+# --- Clients ---
+echo
+echo "--- Starting $N_CLIENTS clients ---"
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    env $ASAN_ENV \
+    "$CLIENT_BIN" \
+        --network regtest \
+        --host 127.0.0.1 --port $LSP_PORT \
+        --seckey "${CLIENT_SECKEYS[$i]}" \
+        --fee-rate 1000 \
+        --lsp-pubkey "$LSP_PUBKEY" \
+        --participant-id $((i + 1)) \
+        --daemon \
+        --rpcuser ${RPCUSER:-rpcuser} \
+        --rpcpassword ${RPCPASSWORD:-rpcpass} \
+        --wallet $MINER_WALLET \
+        --cli-path "$(which bitcoin-cli)" \
+        --db "$TMPDIR/client_${i}.db" \
+        > "$TMPDIR/client_${i}.log" 2>&1 &
+    PIDS+=($!)
+    echo "  client[$i] PID=$!"
+    sleep 0.5
+done
+
+# --- Background miner ---
+( while kill -0 $LSP_PID 2>/dev/null; do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 2; done ) &
+PIDS+=($!)
+
+# --- Wait for CHEAT DAEMON COMPLETE ---
+echo
+echo "--- Waiting for sub advance + stale broadcast + CHEAT DAEMON COMPLETE (timeout 420s) ---"
+READY=0
+for i in $(seq 1 210); do
+    sleep 2
+    grep -q "CHEAT DAEMON COMPLETE" "$LSP_LOG" 2>/dev/null && { READY=1; echo "  CHEAT DAEMON COMPLETE after ${i}*2s"; break; }
+    [ $((i % 15)) -eq 0 ] && echo "  ... ${i}*2s elapsed"
+    kill -0 $LSP_PID 2>/dev/null || { echo "  LSP exited at iter $i"; break; }
+done
+[ $READY -eq 1 ] || { echo "FAIL: no CHEAT DAEMON COMPLETE in 420s"; tail -60 "$LSP_LOG"; exit 1; }
+
+# Factory creation has run by now — assert the hashlock feature actually engaged.
+grep -q "hashlock-gated L-stock poison ENABLED" "$LSP_LOG" || { echo "FAIL: hashlock poison was NOT enabled"; tail -40 "$LSP_LOG"; exit 1; }
+echo "  hashlock poison ENABLED confirmed in LSP log"
+
+# Assert the sub-factory hashlock reveal (Phase 2) actually fired over the wire.
+grep -q "revealed sub sales-stock secret for" "$LSP_LOG" || { echo "FAIL: LSP never revealed the sub sales-stock secret (Phase 2 did not fire)"; grep -iE "subfactory|poison|reveal" "$LSP_LOG" | tail -30; exit 1; }
+echo "  sub sales-stock secret REVEAL fired in LSP log"
+
+STALE_TXID=$(grep -E "Stale chain\[N-1\] broadcast" "$LSP_LOG" | head -1 | grep -oE "[0-9a-f]{64}" | head -1)
+echo "  Stale (superseded) sub chain[N-1] broadcast txid: ${STALE_TXID:-(unknown)}"
+[ -n "$STALE_TXID" ] || { echo "FAIL: no stale sub broadcast txid"; tail -30 "$LSP_LOG"; exit 1; }
+
+# Stop clients so their SQLite DBs are flushed before we read them.
+echo "  Stopping clients so their persist DBs flush..."
+for pid in "${PIDS[@]:-}"; do kill -TERM "$pid" 2>/dev/null || true; done
+sleep 3
+
+# --- Find the client that persisted the SUB reveal ---
+echo
+echo "=== Locating the client-persisted sub reveal (l_stock_poison_reveals) ==="
+REVEAL_DB=""; REVEAL_NODE=""; REVEAL_STATE=""
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    row=$(sqlite3 "$TMPDIR/client_${i}.db" \
+        "SELECT node_idx||' '||state_counter FROM l_stock_poison_reveals WHERE revocation_secret IS NOT NULL ORDER BY node_idx DESC, state_counter ASC LIMIT 1;" 2>/dev/null || true)
+    if [ -n "$row" ]; then
+        REVEAL_DB="$TMPDIR/client_${i}.db"
+        REVEAL_NODE=$(echo "$row" | awk '{print $1}')
+        REVEAL_STATE=$(echo "$row" | awk '{print $2}')
+        echo "  reveal persisted by client[$i]: node=$REVEAL_NODE state=$REVEAL_STATE db=$REVEAL_DB"
+        break
+    fi
+done
+[ -n "$REVEAL_DB" ] || { echo "FAIL: NO client persisted an l_stock_poison_reveals row — the sub reveal wire (Phase 2) did not persist"; exit 1; }
+
+# --- Mine the stale state to maturity, then assemble + broadcast the poison ---
+echo
+echo "=== CLIENT recourse: assemble hashlock sub poison from persisted reveal ==="
+$BCLI generatetoaddress 3 "$MINE_ADDR" >/dev/null 2>&1
+POISON_HEX=$("$REC_BIN" --db "$REVEAL_DB" --node-idx "$REVEAL_NODE" --state "$REVEAL_STATE" 2>/tmp/_recsub.err) || {
+    echo "FAIL: superscalar_lstock_recover failed (rc=$?)"; cat /tmp/_recsub.err; exit 1; }
+echo "  assembled sub poison (${#POISON_HEX} hex chars)"
+POISON_TXID=$($BCLI sendrawtransaction "$POISON_HEX" 2>/tmp/_sendsub.err) || {
+    echo "FAIL: sub poison sendrawtransaction REJECTED"; cat /tmp/_sendsub.err
+    echo "  (mempool reject means the persisted template/secret did not yield a spend of the stale sales-stock)"; exit 1; }
+echo "  SUB POISON broadcast txid: $POISON_TXID"
+
+# --- Confirm + amount ---
+echo
+echo "=== Verifying sub poison CONFIRMS + redistributes sales-stock ==="
+PRAW=""
+for n in $(seq 1 10); do
+    $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 1
+    PRAW=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null || true)
+    echo "$PRAW" | grep -q '"confirmations"' && break
+done
+echo "$PRAW" | grep -q '"confirmations"' || { echo "FAIL: sub poison $POISON_TXID never CONFIRMED"; exit 1; }
+PV=$(echo "$PRAW" | grep -oE '"value": *[0-9.]+' | grep -oE '[0-9.]+' | sort -rn | head -1)
+PSATS=$(awk "BEGIN{printf \"%d\", ($PV+0)*100000000}")
+echo "  sub poison CONFIRMED; largest output ${PSATS:-0} sats"
+[ "${PSATS:-0}" -ge 1000 ] || { echo "FAIL: poison output ${PSATS} sats <= dust — not a real sales-stock recapture"; exit 1; }
+
+# --- Anti-vacuity: no revealed secret -> no recourse ---
+echo
+echo "=== Anti-vacuity: tool must REFUSE when the secret is absent ==="
+cp "$REVEAL_DB" "$TMPDIR/novax.db"
+sqlite3 "$TMPDIR/novax.db" "UPDATE l_stock_poison_reveals SET revocation_secret=NULL;" 2>/dev/null
+set +e
+"$REC_BIN" --db "$TMPDIR/novax.db" --node-idx "$REVEAL_NODE" --state "$REVEAL_STATE" >/dev/null 2>/tmp/_nvsub.err
+NRC=$?
+set -e
+echo "  no-secret recourse exit=$NRC (expect 5)"; cat /tmp/_nvsub.err 2>/dev/null || true
+[ "$NRC" = "5" ] || { echo "FAIL: tool did NOT refuse a missing reveal (anti-vacuity broken)"; exit 1; }
+
+echo
+echo "=== PASS: hashlock SUB-FACTORY L-stock poison E2E ==="
+echo "  multi-input advance->reveal->persist->assemble->broadcast->CONFIRM proven on regtest"
+echo "  sub poison $POISON_TXID confirmed, ${PSATS} sats recaptured; no-reveal refused (exit 5)"
+exit 0

--- a/tools/test_signet_hashlock_poison_subfactory.sh
+++ b/tools/test_signet_hashlock_poison_subfactory.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# test_signet_hashlock_poison_subfactory.sh — #53 sub-factory hashlock L-stock
+# (sales-stock) poison on REAL SIGNET.  Signet sibling of the regtest e2e
+# (test_regtest_hashlock_poison_subfactory_e2e.sh); proves the cryptographic
+# flow confirms on the real network, not just a private chain.
+#
+# Flow (LSP --enable-hashlock-poison --cheat-daemon-sub, multi-input ceremony):
+#   1. LSP self-funds a k>=2 PS factory (hashlock on) + advances a sub-factory chain
+#      over the REAL wire ceremony; the LSP reveals secret_old, each sub client
+#      verify-persists it (l_stock_poison_reveals).
+#   2. The cheating LSP broadcasts the SUPERSEDED chain[N-1] sub state on-chain.
+#   3. CLIENT recourse: superscalar_lstock_recover assembles the Leaf-P poison from
+#      the persisted reveal; we broadcast it to spend the stale sales-stock.
+#   4. ASSERT: the poison CONFIRMS on signet + redistributes the sales-stock to the
+#      sub clients (non-dust per-client P2TR outputs).
+#   5. Anti-vacuity: with the secret removed the tool REFUSES (exit 5).
+#
+# STRONG KEYS (signet_strong_keygen.py): the poison redistributes to per-client
+# keys, so they MUST NOT be publicly-derivable weak keys (else anyone sweeps the
+# recaptured sats).  The run seed is saved for our own post-run recovery.
+# Sat-careful: --fee-rate 110, modest AMOUNT, residual recoverable from the seed.
+set -uo pipefail
+BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"; CLIENT_BIN="$BUILD_DIR/superscalar_client"; REC_BIN="$BUILD_DIR/superscalar_lstock_recover"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+N_CLIENTS="${N_CLIENTS:-4}"; PS_SUB_ARITY="${PS_SUB_ARITY:-2}"; AMOUNT="${AMOUNT:-200000}"; FEE_RATE="${FEE_RATE:-110}"
+LSP_PORT="${LSP_PORT:-29968}"; WALLET="${WALLET:-superscalar_lsp}"; CONFIRM_TIMEOUT="${CONFIRM_TIMEOUT:-21600}"
+TAG="${TAG:-hashsub}"
+SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
+RU=$(awk -F= '/^[[:space:]]*rpcuser/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")
+RP=$(awk -F= '/^[[:space:]]*rpcpassword/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")
+RPORT=$(awk -F= '/^[[:space:]]*rpcport/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF"); RPORT=${RPORT:-38332}
+BCLI="bitcoin-cli -signet -rpcuser=$RU -rpcpassword=$RP -rpcport=$RPORT"
+TMPDIR=$(mktemp -d /tmp/ss-signet-hashsub.XXXXXX); LSP_DB="$TMPDIR/lsp.db"; WT_DB="$TMPDIR/wt.db"; LSP_LOG="$TMPDIR/lsp.log"
+PIDS=()
+cleanup(){ for p in "${PIDS[@]:-}"; do kill -9 "$p" 2>/dev/null||true; done; cp "$LSP_LOG" /tmp/hashsub_signet_lsp.log 2>/dev/null||true; for i in $(seq 0 $((N_CLIENTS-1))); do cp "$TMPDIR/client_${i}.log" "/tmp/hashsub_signet_client_${i}.log" 2>/dev/null||true; done; }
+trap cleanup EXIT
+green(){ printf '\033[32m%s\033[0m\n' "$*"; }; red(){ printf '\033[31m%s\033[0m\n' "$*"; }; fail(){ red "FAIL: $*"; recov; exit 1; }
+ts(){ date -u +%H:%M:%S; }; tip(){ $BCLI getblockcount 2>/dev/null; }
+confirm_height(){ local txid="$1" bh; bh=$($BCLI getrawtransaction "$txid" true 2>/dev/null | grep -oE '"blockhash": *"[0-9a-f]{64}"' | grep -oE "[0-9a-f]{64}" | head -1); [ -z "$bh" ] && return 1; $BCLI getblockheader "$bh" 2>/dev/null | grep -oE '"height": *[0-9]+' | grep -oE "[0-9]+" | head -1; }
+wait_confirm(){ local txid="$1" budget="$2" waited=0 h; while [ "$waited" -lt "$budget" ]; do h=$(confirm_height "$txid") && { echo "$h"; return 0; }; sleep 60; waited=$((waited+60)); done; return 1; }
+recov(){ echo "--- RECOVERY: strong keys -> RUN_SEED_FILE=${RUN_SEED_FILE:-?} (re-derive client keys to sweep the poison's per-client P2TR outputs via PSBT, cf reference_signet_sweep_method). $AMOUNT sats locked in the factory tree from $WALLET; residual sub/leaf/channel outputs sweepable via LSP/client keys. dbs $TMPDIR (preserved /tmp/hashsub_signet_*.log). ---"; }
+
+echo "=== SIGNET: #53 sub-factory HASHLOCK L-stock poison (client recourse) ==="
+echo "  [$(ts)] height $(tip), amount=$AMOUNT, k=$PS_SUB_ARITY, fee=$FEE_RATE. signet ~10min/block — multi-hour."
+
+# --- strong per-run keys ---
+eval "$(python3 "$SCRIPT_DIR/signet_strong_keygen.py" "$N_CLIENTS" "$TAG")"
+[ -n "${LSP_SECKEY:-}" ] && [ -n "${LSP_PUBKEY:-}" ] && [ -f "${CLIENT_KEYS_FILE:-/nonexistent}" ] || fail "strong keygen failed"
+echo "  [$(ts)] strong keys: LSP_PUBKEY=$LSP_PUBKEY  seed=$RUN_SEED_FILE"
+mapfile -t CLIENT_SECKEYS < "$CLIENT_KEYS_FILE"
+[ "${#CLIENT_SECKEYS[@]}" -ge "$N_CLIENTS" ] || fail "client keys file short (${#CLIENT_SECKEYS[@]} < $N_CLIENTS)"
+
+pkill -9 -f "superscalar_lsp.*--port $LSP_PORT" 2>/dev/null||true; sleep 1
+
+# --- LSP (hashlock poison + sub cheat), self-funds from the signet wallet ---
+"$LSP_BIN" --network signet --cli-path bitcoin-cli --rpcuser "$RU" --rpcpassword "$RP" \
+    --port $LSP_PORT --clients $N_CLIENTS --arity 3 --ps-subfactory-arity $PS_SUB_ARITY \
+    --amount $AMOUNT --fee-rate $FEE_RATE --confirm-timeout $CONFIRM_TIMEOUT \
+    --seckey "$LSP_SECKEY" --wallet "$WALLET" --db "$LSP_DB" --wt-db "$WT_DB" \
+    --enable-hashlock-poison --demo --lsp-balance-pct 50 --cheat-daemon-sub > "$LSP_LOG" 2>&1 &
+LSP_PID=$!; PIDS+=($LSP_PID)
+for i in $(seq 1 120); do sleep 2; grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && { echo "  [$(ts)] LSP listening + self-funding"; break; }; kill -0 $LSP_PID 2>/dev/null||{ tail -25 "$LSP_LOG"; fail "LSP died before listening"; }; done
+
+# --- clients (strong keys) ---
+for i in $(seq 0 $((N_CLIENTS-1))); do
+    "$CLIENT_BIN" --network signet --cli-path bitcoin-cli --rpcuser "$RU" --rpcpassword "$RP" \
+        --host 127.0.0.1 --port $LSP_PORT --seckey "${CLIENT_SECKEYS[$i]}" --fee-rate $FEE_RATE \
+        --lsp-pubkey "$LSP_PUBKEY" --participant-id $((i+1)) --daemon --wallet "$WALLET" \
+        --db "$TMPDIR/client_${i}.db" > "$TMPDIR/client_${i}.log" 2>&1 &
+    PIDS+=($!); sleep 1
+done
+
+echo "  [$(ts)] LSP driving hashlock sub advance (reveal) + cheat broadcast over real blocks..."
+for i in $(seq 1 $((CONFIRM_TIMEOUT/10))); do sleep 10; grep -qE "CHEAT DAEMON COMPLETE" "$LSP_LOG" 2>/dev/null && { echo "  [$(ts)] cheat broadcast complete"; break; }; kill -0 $LSP_PID 2>/dev/null||{ echo "  [$(ts)] LSP exited"; break; }; done
+grep -qE "CHEAT DAEMON COMPLETE" "$LSP_LOG" || fail "cheat-daemon-sub never completed"
+grep -q "hashlock-gated L-stock poison ENABLED" "$LSP_LOG" || fail "hashlock poison was NOT enabled"
+grep -q "revealed sub sales-stock secret for" "$LSP_LOG" || { grep -iE "subfactory|poison|reveal" "$LSP_LOG" | tail -20; fail "LSP never revealed the sub sales-stock secret (Phase 2)"; }
+echo "  [$(ts)] hashlock ENABLED + sub secret REVEAL confirmed in LSP log"
+STALE_TXID=$(grep -E "Stale chain\[N-1\] broadcast" "$LSP_LOG" | head -1 | grep -oE "[0-9a-f]{64}" | head -1)
+[ -n "$STALE_TXID" ] || fail "no stale sub broadcast txid"
+echo "  [$(ts)] stale (superseded) sub chain[N-1]: $STALE_TXID"
+
+echo "  [$(ts)] stopping LSP + clients (SIGTERM) so client persist DBs flush..."
+for p in "${PIDS[@]:-}"; do kill -TERM "$p" 2>/dev/null||true; done; sleep 5
+
+# --- find the client that persisted the sub reveal ---
+REVEAL_DB=""; REVEAL_NODE=""; REVEAL_STATE=""
+for i in $(seq 0 $((N_CLIENTS-1))); do
+    row=$(sqlite3 "$TMPDIR/client_${i}.db" "SELECT node_idx||' '||state_counter FROM l_stock_poison_reveals WHERE revocation_secret IS NOT NULL ORDER BY node_idx DESC, state_counter ASC LIMIT 1;" 2>/dev/null || true)
+    [ -n "$row" ] && { REVEAL_DB="$TMPDIR/client_${i}.db"; REVEAL_NODE=$(echo "$row"|awk '{print $1}'); REVEAL_STATE=$(echo "$row"|awk '{print $2}'); echo "  [$(ts)] reveal persisted by client[$i]: node=$REVEAL_NODE state=$REVEAL_STATE"; break; }
+done
+[ -n "$REVEAL_DB" ] || fail "NO client persisted an l_stock_poison_reveals row (Phase 2 client persist)"
+
+# --- the stale chain[N-1] must be on-chain before the poison can spend its sales-stock ---
+echo "  [$(ts)] waiting for stale chain[N-1] $STALE_TXID to confirm (budget ${CONFIRM_TIMEOUT}s)..."
+H_STALE=$(wait_confirm "$STALE_TXID" "$CONFIRM_TIMEOUT") || fail "stale chain[N-1] $STALE_TXID never confirmed"
+echo "  [$(ts)] stale chain[N-1] confirmed @ $H_STALE"
+
+# --- CLIENT recourse: assemble + broadcast the hashlock sub poison ---
+POISON_HEX=$("$REC_BIN" --db "$REVEAL_DB" --node-idx "$REVEAL_NODE" --state "$REVEAL_STATE" 2>/tmp/_recsig.err) || { cat /tmp/_recsig.err; fail "superscalar_lstock_recover failed"; }
+echo "  [$(ts)] assembled sub poison (${#POISON_HEX} hex chars)"
+POISON_TXID=$($BCLI sendrawtransaction "$POISON_HEX" 2>/tmp/_sendsig.err) || { cat /tmp/_sendsig.err; fail "sub poison sendrawtransaction REJECTED"; }
+echo "  [$(ts)] SUB POISON broadcast: $POISON_TXID — confirming (budget ${CONFIRM_TIMEOUT}s)..."
+H_POISON=$(wait_confirm "$POISON_TXID" "$CONFIRM_TIMEOUT") || fail "sub poison $POISON_TXID broadcast but NOT confirmed (re-check getrawtransaction $POISON_TXID before concluding failure)"
+echo "  [$(ts)] sub poison CONFIRMED @ $H_POISON"
+
+# --- redistribution assertion: N per-client P2TR outputs, smallest above dust ---
+SRAW=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null)
+SPINFO=$(echo "$SRAW" | python3 -c 'import json,sys
+try:
+ d=json.load(sys.stdin); vs=[int(round(v["value"]*1e8)) for v in d["vout"] if v["scriptPubKey"].get("type")=="witness_v1_taproot"]
+ print(min(vs) if vs else 0, len(vs), sum(vs))
+except Exception: print("0 0 0")')
+SP_MIN=$(echo "$SPINFO"|awk '{print $1}'); SP_NUM=$(echo "$SPINFO"|awk '{print $2}'); SP_TOT=$(echo "$SPINFO"|awk '{print $3}')
+echo "  [$(ts)] sales-stock redistribution: $SP_NUM P2TR output(s), smallest ${SP_MIN:-0} sats, total ${SP_TOT:-0} sats"
+[ "${SP_NUM:-0}" -ge 1 ] || fail "poison has no P2TR redistribution output"
+[ "${SP_MIN:-0}" -ge 330 ] || fail "a per-client output ${SP_MIN} sats <= dust"
+
+# --- anti-vacuity: no revealed secret -> no recourse ---
+cp "$REVEAL_DB" "$TMPDIR/novax.db"; sqlite3 "$TMPDIR/novax.db" "UPDATE l_stock_poison_reveals SET revocation_secret=NULL;" 2>/dev/null
+set +e; "$REC_BIN" --db "$TMPDIR/novax.db" --node-idx "$REVEAL_NODE" --state "$REVEAL_STATE" >/dev/null 2>/tmp/_nvsig.err; NRC=$?; set -e
+[ "$NRC" = "5" ] || fail "anti-vacuity broken: tool exit=$NRC (expect 5) with the secret removed"
+echo "  [$(ts)] anti-vacuity OK (no secret -> exit 5)"
+
+green "PASS (signet): #53 sub-factory hashlock poison — poison $POISON_TXID confirmed @ $H_POISON, $SP_NUM-way sales-stock redistribution (smallest ${SP_MIN} sats); anti-vacuity exit 5."
+recov
+exit 0


### PR DESCRIPTION
Extends the hashlock-gated L-stock poison (#387 leaf-advance daemon integration,
#388 crash/restart durability) to the **sub-factory multi-input ceremony** — where a
canonical Pseudo-Spilman factory (k≥2) actually holds its channels. Before this, a
sub-factory's sales-stock was still key-path, so **Scenario B was open at the sub
level**: a sub-factory client could co-sign the sales-stock poison, then broadcast
`live-state + poison` to steal the LSP's sales-stock. The hashlock gates the poison
on the LSP-revealed per-(sub,state) secret, closing that hole the same way #387 did
for leaves.

## Design (mirrors the proven leaf path)

- **Phase 0 — per-state sub hash (the prerequisite).** `factory_subfactory_chain_advance_unsigned`
  now bumps `l_stock_state_counter` + re-derives the sales-stock SPK on each advance when
  the sub carries a hashlock, so every sub state commits a *distinct* `H = SHA256(secret(sub,state))`.
  Before this the sub hash was static across states → revealing one superseded secret would
  have compromised them all. Unit-proven by `test_factory_subfactory_lstock_per_state_hash`
  (distinct H per state + superseded-secret stability + a non-hashlock STATIC-SPK control).

- **Phase 1 — H plumbing.** LSP ships `H_new` in `SUBFACTORY_PROPOSE_INTENT`; the seedless
  client mirrors it (`factory_set_node_l_stock_hash`) so both sides build the identical
  sales-stock SPK. The NULL poison-override already targets `H_old` because sub poison-prep
  runs *before* the advance (unlike the leaf, which preps after and passes H_old explicitly).

- **Signing — no new code.** The poison-signing primitives are node-generic and already
  script-path-aware (untweaked agg key) from #387; once Phase 0 makes prep set
  `poison_is_scriptpath`, the N-party sub poison co-signs correctly.

- **Phase 2 — reveal.** After DONE the LSP reveals `secret_old` to *every* sub client (the
  sales-stock is N-of-N; all are poison beneficiaries). The client persists the recourse
  template then verify-persists the secret. Crash recovery reuses #388's node-generic 0x8D
  `MSG_LSTOCK_REVEAL_REQUEST` handler.
  - **N-party agg-sig distribution.** Unlike the 2-party leaf (whose client aggregates the
    poison locally), only the LSP aggregates the N-party sub poison — so the LSP now ships the
    aggregated 64-byte poison Schnorr sig in `SUBFACTORY_DONE` (optional field, mutator/getter
    pattern, no signature churn). The client captures it, persists the template *with* the
    agg-sig, then adds the secret from the reveal — matching the leaf's crash story.

- **Phase 3 — fail-closed.** LSP + client abort the sub-advance if a poison was economically
  REQUIRED (non-dust sales-stock) but NOT co-signed: no revoke without recourse. `poison_required`
  is decoupled from the watchtower/operational prep gate.

- **Defense-in-depth.** The hashlock sub poison is wired only in the multi-input ceremony
  (every real k≥1 sub-advance is multi-input). The LSP refuses the degenerate single-input path
  under hashlock, and the client refuses a single-input `PROPOSE_INTENT` for a hashlock sub —
  closing a malicious-LSP downgrade vector.

## Validation (regtest, on the VPS)

- Full unit suite **1510/1510** (incl. the new Phase-0 test); build clean.
- **T1 — no-regression**: non-hashlock k=2 multi-input sub advance still PASSES (the new code is
  gated, inert for non-hashlock subs).
- **T2 — hashlock e2e** (`tools/test_regtest_hashlock_poison_subfactory_e2e.sh`): live wire
  ceremony via `--enable-hashlock-poison --cheat-daemon-sub` →
  advance → per-state H → reveal → client verify-persist → assemble poison from the persisted
  reveal → broadcast vs the cheat's stale chain[N-1] → **CONFIRM, 21,667 sats sales-stock
  recaptured**; anti-vacuity (no secret → tool exit 5) enforced.

The first e2e run *caught* the N-party agg-sig gap (LSP revealed but no client persisted) — fixed
+ re-proven green.

## Follow-ups (not blockers)

- Signet proof (the crypto is network-independent; regtest is the gate).
- The narrow FINAL→DONE crash window for the sub leaves that one advance without a persisted
  poison template (the agg-sig arrives in DONE); the DW/CLTV override still prevents theft, so
  this is degraded-punishment, not a theft window.

Stacked on #388 (`trustless-hashlock-reveal-crash`).
