### PR TITLE
Trustless fee-race hardening: adversarial agg-sig drill, CPFP poison race, commitment CPFP anchor

### DIFF
--- a/docs/trustless-completion-plan.md
+++ b/docs/trustless-completion-plan.md
@@ -35,7 +35,8 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
   DoD: a regtest test where the LSP ships a CORRUPTED poison agg-sig in
   SUBFACTORY_DONE (env-gated cheat); the client's verify-before-trust REJECTS it
   and does NOT persist a worthless reveal row; assert the loud abort. "Prove the
-  negative" on the N-party agg-sig verify. STATUS: pending.
+  negative" on the N-party agg-sig verify. STATUS: **DONE + PROVEN** (regtest green:
+  LSP shipped corrupt sig, 2 clients D2-rejected, 0 worthless rows).
 - **P2 — Layer 3: recourse WINS the fee-race (#60).** DoD: a regtest harness where
   after a breach the recourse must confirm despite a competing low-fee mempool /
   the LSP's L&CSV fallback; prove it confirms (fee-bumping via #52 if needed).
@@ -83,3 +84,6 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
   (competing low-fee mempool or a manual high-feerate floor), and prove the escalator bumps
   the package to CONFIRM before the CSV/CLTV `deadline_block`. The mechanism exists (#52);
   P2 proves it WINS the contested race. Resume here when the network is back.
+- 2026-06-22: network restored (fail2ban ban aged out). **P1 VALIDATED GREEN** on regtest
+  (LSP shipped corrupt agg-sig; 2 clients D2-rejected; 0 worthless reveal rows). P1 closed.
+  Starting **P2** (Layer-3 fee-race).

--- a/docs/trustless-completion-plan.md
+++ b/docs/trustless-completion-plan.md
@@ -70,10 +70,24 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
     while the LSP's cltv_timeout claim is live-signed (freely bumpable). So a client
     exiting near cltv_timeout under sustained high fees could lose the race.
   - **DECISION (user, 2026-06-23): add commitment + tree anchors** (the gold-standard
-    per-client unilateral CPFP). Increment 1 = commitment P2A anchor (commit d3005a9):
-    keyless P2A appended last, 240 sats moved out of to_remote (fee + to_local + WT
-    parsers unchanged), deterministic across co-signers. Validating unit suite, then
-    tree anchors (increment 2), then a regtest CPFP-the-commitment proof.
+    per-client unilateral CPFP).
+  - **Increment 1 = commitment P2A anchor — CODED + VALIDATED** (commit c755d13). Made
+    it a negotiated per-channel feature `use_cpfp_anchor` (option_anchors style): keyless
+    P2A appended last, 240 sats moved out of to_remote (fee + to_local + the count-bounded
+    WT parsers unchanged), deterministic across co-signers; default OFF (legacy/unit
+    channels unchanged), set ON at all 4 production channel_init sites (client/lsp/jit/
+    db-restore). Validation ALL GREEN: **unit 1511/1511** (incl. a new differential test
+    proving the anchor is gated, P2A-shaped, to_remote-funded); **breach/penalty regtest**
+    -- a standalone WT confirms a penalty (11843 sats swept) against an ANCHORED revoked
+    commitment (anchor transparent to the penalty path); **mass-exit N=4** -- all clients
+    self-exit, conservation now EXACTLY 100.0% (46992/46992; anchor deducts from to_remote
+    so to_local == channel balance precisely). Increment 1 is production-safe + DONE.
+    Remaining for full rigor: a CPFP-the-commitment e2e proof (deprioritise a force-closed
+    commitment, bump via its P2A anchor + a funded input, confirm) -- analogous to P2b.
+  - **Increment 2 = tree anchors** -- harder: the 240-sat anchor can't come from a tree
+    node's child output (it would invalidate that child's pre-signed sig, which commits
+    to the full parent amount), so it needs a construction-level fee reservation that
+    ripples through conservation + re-signing. Scoped as a careful follow-up.
 - **P4 — Remaining wt_db recourse paths (#55, R6).** DoD: e2e the L-stock burn
   kind0 + JIT-channel recourse via the standalone (secret-less) WT — arm in wt_db
   + fire + confirm. (kind=3 force-close already corrected as NOT a gap.) STATUS: pending.

--- a/docs/trustless-completion-plan.md
+++ b/docs/trustless-completion-plan.md
@@ -66,3 +66,20 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
 
 - 2026-06-22: plan created. Baseline = #53 sub-factory hashlock proven (regtest +
   signet) + recovered; no known theft gap. Starting P1.
+- 2026-06-22: **P1 CODED** (awaiting validation) — `SS_CHEAT_BAD_POISON_AGGSIG` env
+  cheat (lsp_channels.c, regtest-only via superscalar_cheat_allowed; #9 gate refuses
+  SS_CHEAT* on mainnet) corrupts the agg-sig shipped in SUBFACTORY_DONE;
+  `tools/test_regtest_hashlock_aggsig_reject.sh` asserts the client D2-rejects + persists
+  no worthless reveal row. Committed locally.
+- 2026-06-22: **BLOCKED on local network outage** — GitHub HTTPS + VPS SSH both timing
+  out from this machine (`curl https://github.com` -> 000; ssh port 22 -> banner-exchange
+  abort). Can't push or build/test on the VPS until connectivity returns. All work is
+  committed locally on `trustless-completion`.
+- 2026-06-22: **P2 design note** (read-only investigation while blocked): the standalone
+  WT already carries a deadline-driven CPFP fee-bump escalator (watchtower.c +
+  htlc_fee_bump.h: `watchtower_build_cpfp_tx`, per-pending `fee_bump` = {start_block,
+  deadline_block, budget_sat, start_feerate, last_feerate}, `max_bump_fee_sat` ceiling).
+  So P2's harness = register a recourse/penalty at a LOW start feerate, apply fee pressure
+  (competing low-fee mempool or a manual high-feerate floor), and prove the escalator bumps
+  the package to CONFIRM before the CSV/CLTV `deadline_block`. The mechanism exists (#52);
+  P2 proves it WINS the contested race. Resume here when the network is back.

--- a/docs/trustless-completion-plan.md
+++ b/docs/trustless-completion-plan.md
@@ -1,0 +1,68 @@
+# Trustless-model completion plan
+
+Living tracker for closing out every remaining gap in SuperScalar's trustless
+self-custody model. Created 2026-06-22 after the #53 sub-factory hashlock poison
+landed + was proven on regtest + real signet. Branch: `trustless-completion`.
+
+## Verdict (2026-06-22)
+
+The **breach-recourse** trust model — a client / standalone watchtower recovers
+funds WITHOUT trusting the LSP — is **PROVEN for the main paths** (factory,
+sub-factory, channel-commitment, PTLC) on regtest AND real signet. This session
+closed the last KNOWN *theft* vector (co-signed-poison, "Scenario B") at the
+sub-factory level (#53, PR #390). **There is no known "the LSP can steal" gap.**
+
+The frontier has moved from *theft prevention* to: recourse **winning the
+fee-race**, **operational** self-custody, **coverage** completeness, **harness
+rigor**, and the **external audit**.
+
+## The 5-layer model
+
+| Layer | Question | Status |
+|---|---|---|
+| 1 Detect | Standalone WT sees the breach? | PROVEN (regtest + signet) |
+| 2 Respond | Builds + broadcasts recourse? | PROVEN — factory/sub/commitment/PTLC penalties + #53 hashlock poison fire, confirm, redistribute |
+| 3 **Win** | Recourse confirms BEFORE the attacker's tx, under fee pressure? | **FRONTIER** — fee-bump exists (#52), contested race UNPROVEN (P2/P3) |
+| 4 Afford | Client with all funds in-factory can pay the exit/bump fee? | OPEN (P7 / #63) |
+| 5 Operate | Who runs the WT; secret backup; migration? | OPEN (P7 / #62,#64) |
+
+## Execution plan (one piece at a time, each committed + validated)
+
+Order chosen for value + de-risking: a fast warm-up that closes tonight's loop,
+then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
+
+- **P1 — Adversarial agg-sig drill (validate this session's D1/D2 hardening).**
+  DoD: a regtest test where the LSP ships a CORRUPTED poison agg-sig in
+  SUBFACTORY_DONE (env-gated cheat); the client's verify-before-trust REJECTS it
+  and does NOT persist a worthless reveal row; assert the loud abort. "Prove the
+  negative" on the N-party agg-sig verify. STATUS: pending.
+- **P2 — Layer 3: recourse WINS the fee-race (#60).** DoD: a regtest harness where
+  after a breach the recourse must confirm despite a competing low-fee mempool /
+  the LSP's L&CSV fallback; prove it confirms (fee-bumping via #52 if needed).
+  Recourse that fires but loses the race isn't trustless. STATUS: pending.
+- **P3 — Mass-exit thundering herd (#56).** DoD: N clients exit at the shared
+  factory CLTV simultaneously; prove no client is stranded by the fee-race, or
+  document + implement the mitigation. STATUS: pending.
+- **P4 — Remaining wt_db recourse paths (#55, R6).** DoD: e2e the L-stock burn
+  kind0 + JIT-channel recourse via the standalone (secret-less) WT — arm in wt_db
+  + fire + confirm. (kind=3 force-close already corrected as NOT a gap.) STATUS: pending.
+- **P5 — Harness rigor Tier 2/3/4 (#35).** DoD: audit the back-catalog breach
+  tests; upgrade machinery-asserts ("penalty broadcast") to economic-outcome
+  asserts (real txid -> confirm -> amount/net-delta). Are our trustless PROOFS
+  rigorous? STATUS: pending.
+- **P6 — Liveness / escalation (#48-51, #54).** DoD: bounded-retry -> proactive
+  exit on a stalled advance (not blind-until-expiry); ABORT_ADVANCE advisory +
+  local timeout; intent-to-exit NOTICE. Safety holds via the DW/CLTV override;
+  this is graceful degradation. STATUS: pending.
+- **P7 — Operational self-custody (#62,#63,#64).** DoD: fee-reserve /
+  deposit-insurance so a fully-in-factory client can pay to exit; WT operational
+  model doc; secret backup/restore + construction migration. Part design, part
+  code. STATUS: pending.
+- **P8 — External audit (#328).** CANNOT be closed here (funding-gated, the
+  mainnet long pole). Keep the audit-prep package current as the layers close.
+  STATUS: external/blocked.
+
+## Progress log
+
+- 2026-06-22: plan created. Baseline = #53 sub-factory hashlock proven (regtest +
+  signet) + recovered; no known theft gap. Starting P1.

--- a/docs/trustless-completion-plan.md
+++ b/docs/trustless-completion-plan.md
@@ -54,7 +54,26 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
     poison provably beats the LSP's CSV fallback.
 - **P3 — Mass-exit thundering herd (#56).** DoD: N clients exit at the shared
   factory CLTV simultaneously; prove no client is stranded by the fee-race, or
-  document + implement the mitigation. STATUS: pending.
+  document + implement the mitigation. STATUS: **in progress** (baseline GREEN +
+  finding + fix underway).
+  - Baseline GREEN: `test_regtest_mass_exit.sh` N=4 on this branch -- LSP vanishes,
+    all 4 clients self-exit (topological root->leaf over ~17 CSV-maturation passes),
+    100%+ conservation. The #313 mechanism works.
+  - Block space is NOT the herd bottleneck: the whole unwind is ~127 commitments +
+    ~127 sweeps + ~tree-nodes ~= 57 kvB even at N=127 -> fits in 1-2 blocks (shared
+    tree dedups). The real risk is GENERAL fee pressure vs the pre-signed fixed fee.
+  - **FINDING (real):** the mass-exit cascade has NO unilateral CPFP path for a
+    force-closing client. Tree txs are nVersion=2 + no anchor (factory.c:2224);
+    the commitment is v3/TRUC but had NO anchor (channel.c, to_local CSV-locked);
+    the CPFP-able distribution-TX backstop (P2A anchor, factory.c:4083) is NOT
+    persisted in the daemon `--demo` flow (empirically distribution_txs=0). Mean-
+    while the LSP's cltv_timeout claim is live-signed (freely bumpable). So a client
+    exiting near cltv_timeout under sustained high fees could lose the race.
+  - **DECISION (user, 2026-06-23): add commitment + tree anchors** (the gold-standard
+    per-client unilateral CPFP). Increment 1 = commitment P2A anchor (commit d3005a9):
+    keyless P2A appended last, 240 sats moved out of to_remote (fee + to_local + WT
+    parsers unchanged), deterministic across co-signers. Validating unit suite, then
+    tree anchors (increment 2), then a regtest CPFP-the-commitment proof.
 - **P4 — Remaining wt_db recourse paths (#55, R6).** DoD: e2e the L-stock burn
   kind0 + JIT-channel recourse via the standalone (secret-less) WT — arm in wt_db
   + fire + confirm. (kind=3 force-close already corrected as NOT a gap.) STATUS: pending.

--- a/docs/trustless-completion-plan.md
+++ b/docs/trustless-completion-plan.md
@@ -87,3 +87,19 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
 - 2026-06-22: network restored (fail2ban ban aged out). **P1 VALIDATED GREEN** on regtest
   (LSP shipped corrupt agg-sig; 2 clients D2-rejected; 0 worthless reveal rows). P1 closed.
   Starting **P2** (Layer-3 fee-race).
+- 2026-06-23: **P2a (WT-driven fee-bump) VALIDATED GREEN** on regtest. The #52 BUMP PROOF
+  (`SS_HIFEE_BUMP=1 test_regtest_trustless_commitment_breach.sh`): a standalone WT hydrated
+  24 commitment watches, the penalty was deprioritised -3000 sats (bare tx unmineable), and
+  the WT's deadline-driven CPFP escalator ramped feerates 5501->6898->9071->11399 until the
+  penalty CONFIRMED (69 blocks). WT-driven Layer-3 (factory/sub/commitment penalties) PROVEN.
+  (Infra note: the VPS regtest bitcoind was simply down — the commitment harness assumes it
+  is up; my hashlock harnesses start it. Runner now ensures bitcoind up before the test.)
+- 2026-06-23: **P2b (client-driven poison fee-race) CODED**. Key architectural finding: the
+  #53 poison is CLIENT-driven (the secret-less WT can't assemble it) and is a PRE-SIGNED,
+  FIXED-FEE tx -- the N-of-N agg-sig binds its outputs, so it is **NOT RBF-able**. Its only
+  fee-bump is **CPFP on a client's own P2TR output** (every poison output is `tr(client_key)`,
+  factory.c:3555-3585 -- Zmn: "any client can trivially CPFP the poisoning transaction"). The
+  first-line defense is the **144-block L_STOCK CSV head-start** (the LSP's Leaf-L fallback
+  can't mature before then). New gated branch `SS_POISON_CPFP_RACE=1` in the sub-factory e2e:
+  deprioritise the bare poison (control-prove it stuck), then the client CPFPs via a fat-fee
+  child on its poison output and the poison CONFIRMS << 144 blocks. Awaiting validation.

--- a/docs/trustless-completion-plan.md
+++ b/docs/trustless-completion-plan.md
@@ -22,7 +22,7 @@ rigor**, and the **external audit**.
 |---|---|---|
 | 1 Detect | Standalone WT sees the breach? | PROVEN (regtest + signet) |
 | 2 Respond | Builds + broadcasts recourse? | PROVEN — factory/sub/commitment/PTLC penalties + #53 hashlock poison fire, confirm, redistribute |
-| 3 **Win** | Recourse confirms BEFORE the attacker's tx, under fee pressure? | **FRONTIER** — fee-bump exists (#52), contested race UNPROVEN (P2/P3) |
+| 3 **Win** | Recourse confirms BEFORE the attacker's tx, under fee pressure? | **PROVEN for single-breach** (P2a WT-CPFP + P2b client-CPFP poison); mass-exit herd still open (P3) |
 | 4 Afford | Client with all funds in-factory can pay the exit/bump fee? | OPEN (P7 / #63) |
 | 5 Operate | Who runs the WT; secret backup; migration? | OPEN (P7 / #62,#64) |
 
@@ -40,7 +40,18 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
 - **P2 — Layer 3: recourse WINS the fee-race (#60).** DoD: a regtest harness where
   after a breach the recourse must confirm despite a competing low-fee mempool /
   the LSP's L&CSV fallback; prove it confirms (fee-bumping via #52 if needed).
-  Recourse that fires but loses the race isn't trustless. STATUS: pending.
+  Recourse that fires but loses the race isn't trustless. STATUS: **DONE + PROVEN**
+  (both halves green on regtest):
+  - P2a (WT-driven): `SS_HIFEE_BUMP=1` commitment breach — the standalone WT's
+    deadline CPFP escalator bumped a deprioritised penalty (feerates 5501->11399)
+    to CONFIRM at 69 blocks. Covers factory/sub/commitment penalties.
+  - P2b (client-driven #53 poison): `SS_POISON_CPFP_RACE=1` in the sub-factory e2e.
+    The poison is pre-signed/fixed-fee (agg-sig binds outputs => NOT RBF-able); its
+    only bump is CPFP on a client's own `tr(client_key)` poison output. Deprioritise
+    -3000 (control: bare poison STUCK), client CPFP child (12000-sat fee) -> poison
+    CONFIRMED in 1 block, << the 144-block Leaf-L CSV head-start (Leaf-L is a genuine
+    relative timelock, factory.c:240/268, so it can't even be broadcast first). The
+    poison provably beats the LSP's CSV fallback.
 - **P3 — Mass-exit thundering herd (#56).** DoD: N clients exit at the shared
   factory CLTV simultaneously; prove no client is stranded by the fee-race, or
   document + implement the mitigation. STATUS: pending.
@@ -103,3 +114,14 @@ then the Layer-3 frontier, then coverage, rigor, liveness, ops, audit-prep.
   can't mature before then). New gated branch `SS_POISON_CPFP_RACE=1` in the sub-factory e2e:
   deprioritise the bare poison (control-prove it stuck), then the client CPFPs via a fat-fee
   child on its poison output and the poison CONFIRMS << 144 blocks. Awaiting validation.
+- 2026-06-23: **P2b VALIDATED GREEN** on regtest (commit 3a12ae7). Poison broadcast, -3000
+  deprioritise => control proved the bare poison STUCK; client output located by address-match
+  (vout=0, 21,667 sats); client CPFP child (12000-sat fee) => poison CONFIRMED in 1 block
+  (<< 144-block head-start). signrawtransactionwithwallet signed the taproot key-path cleanly.
+  Two bugs found+fixed en route: (1) set -euo pipefail tripped on the no-match `getrawtransaction
+  | grep '"confirmations"'` in the EXPECTED-unconfirmed control state (added `|| true`); (2) the
+  descriptor checksum was extracted with `grep -oE '[0-9a-z]{8}'`, which matched the literal word
+  "checksum" -> tr(WIF)#checksum rejected -> empty wallet (now parses the JSON `checksum` field).
+  **P2 (Layer-3 fee-race) is DONE + PROVEN for single-breach.** Tasks #60 + #68 closed.
+  NEXT: P3 (mass-exit thundering herd, #56) -- the OTHER fee-race: N clients contending for
+  block space at the SHARED factory CLTV deadline simultaneously.

--- a/include/superscalar/channel.h
+++ b/include/superscalar/channel.h
@@ -123,6 +123,10 @@ typedef struct {
     uint64_t fee_rate_sat_per_kvb;  /* sat/kvB for penalty/HTLC txs (default 1000) */
     int funder_is_local;  /* 1 if local side is the channel funder (pays commit fee) */
     int use_revocation_leaf;  /* 1 = 2-leaf taptree with revocation checksig script-path */
+    int use_cpfp_anchor;  /* 1 = append a keyless P2A CPFP anchor to commitments (#56);
+                             negotiated like option_anchors -- BOTH parties must set it
+                             identically or the co-signed commitment sighash diverges.
+                             Default 0 (raw channel_init); production sets it on. */
 
     /* Splicing state (Phase G) */
     int           channel_quiescent;       /* 1 if in quiescence for splice */

--- a/src/channel.c
+++ b/src/channel.c
@@ -927,8 +927,10 @@ static int channel_build_commitment_tx_impl(const channel_t *ch,
        untouched.  Presence + funding source are a pure function of the shared
        channel fee-rate + balances, so both co-signers build an identical tx
        (matching sighash).  Appended LAST: to_local[0]/to_remote[1]/HTLC indices
-       and the count-bounded watchtower output parsers are unaffected. */
-    if (ch->fee_rate_sat_per_kvb >= 1000) {
+       and the count-bounded watchtower output parsers are unaffected.  Gated on a
+       negotiated per-channel flag (option_anchors style) so both co-signers agree
+       and legacy/unit channels keep the anchorless format. */
+    if (ch->use_cpfp_anchor && ch->fee_rate_sat_per_kvb >= 1000) {
         uint64_t anchor = ANCHOR_OUTPUT_AMOUNT;
         int placed = 0;
         if (outputs[1].amount_sats > anchor + CHANNEL_DUST_LIMIT_SATS) {

--- a/src/channel.c
+++ b/src/channel.c
@@ -757,7 +757,8 @@ static int channel_build_commitment_tx_impl(const channel_t *ch,
             n_active_ptlcs++;
     }
 
-    tx_output_t *outputs = calloc(2 + n_active_htlcs + n_active_ptlcs, sizeof(tx_output_t));
+    /* +1 slot for the optional P2A CPFP anchor (appended last, see step 7c). */
+    tx_output_t *outputs = calloc(3 + n_active_htlcs + n_active_ptlcs, sizeof(tx_output_t));
     if (!outputs) return 0;
 
     int ret = 0;
@@ -912,6 +913,33 @@ static int channel_build_commitment_tx_impl(const channel_t *ch,
                                      &ptlc_tweaked);
             outputs[out_idx].script_pubkey_len = 34;
             outputs[out_idx].amount_sats = ch->ptlcs[i].amount_sats;
+            out_idx++;
+        }
+    }
+
+    /* 7c. P2A anchor for CPFP fee-bumping the commitment (#56: trustless exit
+       under fee pressure).  The commitment is pre-signed at a fixed fee and is
+       not RBF-able once both parties sign; a keyless Pay-to-Anchor output lets
+       whoever force-closes attach a high-fee child to pull the commitment into a
+       block.  The 240-sat cost is moved OUT of the funder's (to_remote) output,
+       so the output sum -- and thus the implicit ~154-sat miner fee -- is
+       unchanged and to_local (the broadcaster's recoverable balance) is
+       untouched.  Presence + funding source are a pure function of the shared
+       channel fee-rate + balances, so both co-signers build an identical tx
+       (matching sighash).  Appended LAST: to_local[0]/to_remote[1]/HTLC indices
+       and the count-bounded watchtower output parsers are unaffected. */
+    if (ch->fee_rate_sat_per_kvb >= 1000) {
+        uint64_t anchor = ANCHOR_OUTPUT_AMOUNT;
+        int placed = 0;
+        if (outputs[1].amount_sats > anchor + CHANNEL_DUST_LIMIT_SATS) {
+            outputs[1].amount_sats -= anchor; placed = 1;   /* funder (to_remote) funds it */
+        } else if (outputs[0].amount_sats > anchor + CHANNEL_DUST_LIMIT_SATS) {
+            outputs[0].amount_sats -= anchor; placed = 1;   /* fallback: to_local funds it */
+        }
+        if (placed) {
+            memcpy(outputs[out_idx].script_pubkey, P2A_SPK, P2A_SPK_LEN);
+            outputs[out_idx].script_pubkey_len = P2A_SPK_LEN;
+            outputs[out_idx].amount_sats = anchor;
             out_idx++;
         }
     }

--- a/src/client.c
+++ b/src/client.c
@@ -285,6 +285,7 @@ int client_init_channel(channel_t *ch, secp256k1_context *ctx,
         return 0;
     }
     ch->funder_is_local = 0;  /* LSP (remote) is the funder */
+    ch->use_cpfp_anchor = 1;  /* #56: P2A CPFP anchor on commitments (matches LSP side) */
 
     /* Set local basepoints from caller-provided random secrets */
     channel_set_local_basepoints(ch, local_pay_sec32, local_delay_sec32, local_revoc_sec32);

--- a/src/jit_channel.c
+++ b/src/jit_channel.c
@@ -371,6 +371,7 @@ int jit_channel_create(void *mgr_ptr, void *lsp_ptr,
         return 0;
     }
     jit->channel.funder_is_local = 1;
+    jit->channel.use_cpfp_anchor = 1;  /* #56: P2A CPFP anchor (matches client side) */
     if (jit_fe) channel_set_fee_rate(&jit->channel, jit_fe->get_rate(jit_fe, FEE_TARGET_NORMAL));
 
     /* Generate random basepoints */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -4037,8 +4037,21 @@ static int lsp_subfactory_chain_advance_stateless_multi(
        leaf).  The secret follows in the reveal below. */
     cJSON *done = wire_build_subfactory_done(leaf_side, sub_idx_in_leaf, sub->ps_chain_len);
     if (f->use_hashlock_poison && poison_prepared && sub->poison_is_scriptpath &&
-        sub->poison_has_agg_sig)
-        wire_subfactory_done_set_poison_aggsig(done, sub->poison_agg_sig);
+        sub->poison_has_agg_sig) {
+        unsigned char aggsig_to_send[64];
+        memcpy(aggsig_to_send, sub->poison_agg_sig, 64);
+        /* P1 adversarial drill: a MALICIOUS LSP ships a CORRUPTED agg-sig so the client
+           would persist a worthless poison (neutering its recourse).  The client's
+           verify-before-trust (client.c ~3221) MUST reject it.  Env-gated + regtest-only
+           (superscalar_cheat_allowed); the #9 mainnet gate refuses any SS_CHEAT* env, so
+           this is unreachable on mainnet.  The LSP's own poison_agg_sig stays intact. */
+        if (superscalar_cheat_allowed() && getenv("SS_CHEAT_BAD_POISON_AGGSIG")) {
+            aggsig_to_send[0] ^= 0xff;
+            fprintf(stderr, "SS_CHEAT_BAD_POISON_AGGSIG: shipping a CORRUPTED poison agg-sig "
+                            "to sub clients (expect client verify to reject)\n");
+        }
+        wire_subfactory_done_set_poison_aggsig(done, aggsig_to_send);
+    }
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
         wire_send(lsp->client_fds[fd_idx], MSG_SUBFACTORY_DONE, done);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -270,6 +270,7 @@ int lsp_channels_init(lsp_channel_mgr_t *mgr,
                            CHANNEL_DEFAULT_CSV_DELAY))
             return 0;
         entry->channel.funder_is_local = 1;  /* LSP is funder and local */
+        entry->channel.use_cpfp_anchor = 1;  /* #56: P2A CPFP anchor (matches client side) */
         /* Attach persistence so revocation secrets land in revocation_secrets
            and a standalone watchtower can hydrate this channel. */
         channel_set_persist(&entry->channel, mgr->persist, (uint32_t)c);

--- a/src/lsp_init_from_db.c
+++ b/src/lsp_init_from_db.c
@@ -151,6 +151,7 @@ int lsp_channels_init_from_db(lsp_channel_mgr_t *mgr,
                            CHANNEL_DEFAULT_CSV_DELAY))
             return 0;
         entry->channel.funder_is_local = 1;
+        entry->channel.use_cpfp_anchor = 1;  /* #56: P2A CPFP anchor (matches client; restore parity) */
         /* Attach persistence (see lsp_channels_init for rationale). */
         channel_set_persist(&entry->channel, mgr->persist, (uint32_t)c);
         /* fee_rate stays at channel_init default (1000); commit_fee above is

--- a/tests/test_htlc_commit.c
+++ b/tests/test_htlc_commit.c
@@ -593,6 +593,56 @@ int test_htlc_commit_mixed_dust_counted(void) {
 }
 
 /* ================================================================== */
+/* HC13 — #56 P2A CPFP anchor: gated, appended last, funded by to_remote */
+/* ================================================================== */
+
+int test_htlc_commit_cpfp_anchor_present(void) {
+    secp256k1_context *ctx = secp256k1_context_create(
+        SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    ASSERT(ctx, "ctx");
+
+    channel_t ch;
+    ASSERT(hc_setup_channel(&ch, ctx, 1000000, 200000), "setup channel");
+
+    /* Non-anchor tx layout (no segwit marker in the unsigned tx):
+       nVersion(4)+in_count(1)+input(41)=46, out_count[46], then 43-byte P2TR
+       outputs (amount8+len1+spk34).  to_remote = output[1] amount at [90..97]. */
+    unsigned char txid[32];
+
+    /* Flag OFF: anchorless 2-output commitment (legacy/unit default). */
+    ch.use_cpfp_anchor = 0;
+    tx_buf_t tx0; tx_buf_init(&tx0, 512);
+    ASSERT(channel_build_commitment_tx(&ch, &tx0, txid), "build (anchor off)");
+    ASSERT(tx0.data[46] == 2, "anchor off: 2 outputs");
+    uint64_t to_remote_off = 0;
+    for (int i = 0; i < 8; i++) to_remote_off |= ((uint64_t)tx0.data[90 + i]) << (i * 8);
+    tx_buf_free(&tx0);
+
+    /* Flag ON: 3 outputs; output[2] is the keyless P2A (240 sats); the 240-sat
+       cost comes out of to_remote so the output sum (hence the miner fee) and
+       to_local are unchanged. */
+    ch.use_cpfp_anchor = 1;
+    tx_buf_t tx1; tx_buf_init(&tx1, 512);
+    ASSERT(channel_build_commitment_tx(&ch, &tx1, txid), "build (anchor on)");
+    ASSERT(tx1.data[46] == 3, "anchor on: 3 outputs (to_local, to_remote, P2A)");
+    uint64_t to_remote_on = 0;
+    for (int i = 0; i < 8; i++) to_remote_on |= ((uint64_t)tx1.data[90 + i]) << (i * 8);
+    ASSERT(to_remote_on == to_remote_off - ANCHOR_OUTPUT_AMOUNT,
+           "anchor cost (240) deducted from to_remote");
+    /* output[2] (anchor) at offset 46+1+43+43 = 133. */
+    uint64_t anchor_amt = 0;
+    for (int i = 0; i < 8; i++) anchor_amt |= ((uint64_t)tx1.data[133 + i]) << (i * 8);
+    ASSERT(anchor_amt == ANCHOR_OUTPUT_AMOUNT, "P2A anchor amount = 240");
+    ASSERT(tx1.data[141] == P2A_SPK_LEN, "P2A spk len = 4");
+    ASSERT(memcmp(&tx1.data[142], P2A_SPK, P2A_SPK_LEN) == 0, "P2A spk = OP_1 0x4e73");
+    tx_buf_free(&tx1);
+
+    secp256k1_context_destroy(ctx);
+    channel_cleanup(&ch);
+    return 1;
+}
+
+/* ================================================================== */
 /* HC12 — update_fee byte layout                                      */
 /* ================================================================== */
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -920,6 +920,7 @@ extern int test_htlc_commit_dust_excluded_from_tx(void);
 extern int test_htlc_commit_dust_tx_output_count(void);
 extern int test_htlc_commit_above_dust_counted(void);
 extern int test_htlc_commit_mixed_dust_counted(void);
+extern int test_htlc_commit_cpfp_anchor_present(void);
 /* PR #21 Phase 5: update_fee */
 extern int test_htlc_commit_update_fee_layout(void);
 extern int test_htlc_commit_recv_update_fee_accepts(void);
@@ -2838,6 +2839,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_htlc_commit_dust_tx_output_count);
     RUN_TEST(test_htlc_commit_above_dust_counted);
     RUN_TEST(test_htlc_commit_mixed_dust_counted);
+    RUN_TEST(test_htlc_commit_cpfp_anchor_present);
     printf("\n=== PR #21 Phase 5: update_fee ===\n");
     RUN_TEST(test_htlc_commit_update_fee_layout);
     RUN_TEST(test_htlc_commit_recv_update_fee_accepts);

--- a/tools/test_regtest_hashlock_aggsig_reject.sh
+++ b/tools/test_regtest_hashlock_aggsig_reject.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test_regtest_hashlock_aggsig_reject.sh — #53 / trustless-completion P1.
+# Adversarial drill proving the NEGATIVE of the N-party poison agg-sig verify:
+# a MALICIOUS LSP (SS_CHEAT_BAD_POISON_AGGSIG) ships a corrupted poison agg-sig in
+# SUBFACTORY_DONE; the sub client's verify-before-trust (D2) must REJECT it and
+# persist NO worthless recourse row.  (Honest path is the sibling e2e test.)
+#
+# Asserts:
+#   1. LSP logged the cheat (shipped a corrupted agg-sig).
+#   2. EVERY participating client logged the D2 verify rejection.
+#   3. NO client persisted an l_stock_poison_reveals row WITH a secret (the
+#      client refused to record neutered recourse).
+set -euo pipefail
+BUILD_DIR="${1:-/root/SuperScalar/build}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"; CLIENT_BIN="$BUILD_DIR/superscalar_client"
+N_CLIENTS="${N_CLIENTS:-4}"; PS_SUB_ARITY="${PS_SUB_ARITY:-2}"; AMOUNT="${AMOUNT:-400000}"
+LSP_PORT=29959
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+  0000000000000000000000000000000000000000000000000000000000000002
+  0000000000000000000000000000000000000000000000000000000000000003
+  0000000000000000000000000000000000000000000000000000000000000004
+  0000000000000000000000000000000000000000000000000000000000000005
+  0000000000000000000000000000000000000000000000000000000000000006
+  0000000000000000000000000000000000000000000000000000000000000007
+  0000000000000000000000000000000000000000000000000000000000000008
+  0000000000000000000000000000000000000000000000000000000000000009 )
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+. "$(dirname "$(realpath "$0")")"/regtest_test_helpers.sh
+ASAN_ENV="ASAN_OPTIONS=detect_leaks=0"
+ldd "$LSP_BIN" 2>/dev/null | grep -q libasan && ASAN_ENV="ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8"
+TMPDIR=$(mktemp -d /tmp/ss-aggsig-reject.XXXXXX); LSP_DB="$TMPDIR/lsp.db"; LSP_LOG="$TMPDIR/lsp.log"; WT_DB="$TMPDIR/wt.db"
+MINER_WALLET="ss_cheat_leaf_miner"
+PIDS=()
+cleanup(){ for p in "${PIDS[@]:-}"; do kill -9 "$p" 2>/dev/null||true; done; cp "$LSP_LOG" /tmp/aggsig_reject_lsp.log 2>/dev/null||true; rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+echo "=== HASHLOCK AGG-SIG REJECTION DRILL (regtest, P1) ==="
+$BCLI getblockchaininfo >/dev/null 2>&1 || { bitcoind -regtest -conf="$REGTEST_CONF" -daemon; for i in $(seq 1 30); do sleep 1; $BCLI getblockchaininfo >/dev/null 2>&1 && break; done; }
+$BCLI -named createwallet wallet_name=$MINER_WALLET load_on_startup=false 2>&1 | head -1 || true
+$BCLI loadwallet $MINER_WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
+$BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+
+echo "--- LSP (--enable-hashlock-poison --cheat-daemon-sub + SS_CHEAT_BAD_POISON_AGGSIG=1) ---"
+env $ASAN_ENV SS_CHEAT_BAD_POISON_AGGSIG=1 "$LSP_BIN" \
+    --network regtest --port $LSP_PORT --clients $N_CLIENTS --arity 3 --ps-subfactory-arity $PS_SUB_ARITY \
+    --amount $AMOUNT --fee-rate 1000 --confirm-timeout 600 --step-blocks 1 \
+    --seckey "$LSP_SECKEY" --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET --db "$LSP_DB" --wt-db "$WT_DB" --cli-path "$(which bitcoin-cli)" \
+    --enable-hashlock-poison --demo --cheat-daemon-sub --lsp-balance-pct 50 > "$LSP_LOG" 2>&1 &
+LSP_PID=$!; PIDS+=($LSP_PID)
+for i in $(seq 1 60); do sleep 1; grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && break; kill -0 $LSP_PID 2>/dev/null || { echo "FAIL: LSP died"; tail -20 "$LSP_LOG"; exit 1; }; done
+
+for i in $(seq 0 $((N_CLIENTS-1))); do
+  env $ASAN_ENV "$CLIENT_BIN" --network regtest --host 127.0.0.1 --port $LSP_PORT \
+      --seckey "${CLIENT_SECKEYS[$i]}" --fee-rate 1000 --lsp-pubkey "$LSP_PUBKEY" --participant-id $((i+1)) --daemon \
+      --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} --wallet $MINER_WALLET \
+      --cli-path "$(which bitcoin-cli)" --db "$TMPDIR/client_${i}.db" > "$TMPDIR/client_${i}.log" 2>&1 &
+  PIDS+=($!); sleep 0.5
+done
+( while kill -0 $LSP_PID 2>/dev/null; do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 2; done ) &
+PIDS+=($!)
+
+echo "--- waiting for the sub advance (CHEAT DAEMON COMPLETE, timeout 420s) ---"
+for i in $(seq 1 210); do sleep 2; grep -q "CHEAT DAEMON COMPLETE" "$LSP_LOG" 2>/dev/null && { echo "  advance complete"; break; }; kill -0 $LSP_PID 2>/dev/null || break; done
+grep -q "CHEAT DAEMON COMPLETE" "$LSP_LOG" || { echo "FAIL: advance never completed"; tail -40 "$LSP_LOG"; exit 1; }
+
+for p in "${PIDS[@]:-}"; do kill -TERM "$p" 2>/dev/null||true; done; sleep 3
+
+echo "=== ASSERTIONS ==="
+grep -q "SS_CHEAT_BAD_POISON_AGGSIG: shipping a CORRUPTED" "$LSP_LOG" || { echo "FAIL: LSP cheat did not fire (agg-sig not corrupted)"; exit 1; }
+echo "  [1/3] LSP shipped a corrupted agg-sig"
+REJECTS=0
+for i in $(seq 0 $((N_CLIENTS-1))); do
+  grep -q "LSP-supplied sub poison agg-sig FAILED verify" "$TMPDIR/client_${i}.log" 2>/dev/null && REJECTS=$((REJECTS+1))
+done
+[ "$REJECTS" -ge 1 ] || { echo "FAIL: NO client logged the D2 agg-sig rejection"; exit 1; }
+echo "  [2/3] $REJECTS client(s) rejected the corrupted agg-sig (D2 verify)"
+ROWS=0
+for i in $(seq 0 $((N_CLIENTS-1))); do
+  r=$(sqlite3 "$TMPDIR/client_${i}.db" "SELECT count(*) FROM l_stock_poison_reveals WHERE revocation_secret IS NOT NULL;" 2>/dev/null || echo 0)
+  ROWS=$((ROWS + ${r:-0}))
+done
+[ "$ROWS" -eq 0 ] || { echo "FAIL: a client persisted $ROWS worthless reveal row(s) despite the bad agg-sig"; exit 1; }
+echo "  [3/3] 0 worthless reveal rows persisted (recourse correctly refused)"
+echo "=== PASS: malicious-LSP corrupted agg-sig is REJECTED; no neutered recourse persisted ==="
+exit 0

--- a/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
+++ b/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
@@ -278,7 +278,7 @@ if [ "${SS_POISON_CPFP_RACE:-0}" = 1 ]; then
     echo "  poison deprioritised by $DEPRIO sats (bare fixed-fee poison now unmineable)"
     # CONTROL: the bare poison must STAY unconfirmed, else the CPFP proof is vacuous.
     for i in $(seq 1 4); do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 1; done
-    c0=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1)
+    c0=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
     { [ -z "$c0" ] || [ "$c0" -eq 0 ]; } || { echo "FAIL(control): poison confirmed despite -$DEPRIO deprioritise ($c0 confs) -- pressure not biting; CPFP proof vacuous"; exit 1; }
     echo "  CONTROL OK: bare poison STUCK unconfirmed under fee pressure (4 blocks, no CPFP)"
     # Locate the poison's client output in the pre-staged CPFP wallet (it ingested
@@ -290,11 +290,13 @@ except Exception: u=[]
 print(u[0]['vout'], format(u[0]['amount'],'.8f'), u[0]['scriptPubKey']) if u else print('')")
     [ -n "${CV:-}" ] || { echo "FAIL: CPFP wallet did not ingest the poison output (txid=$POISON_TXID)"; $BCLI -rpcwallet=$CPFP_WALLET listunspent 0 2>/dev/null | head -40; exit 1; }
     echo "  poison client output located: vout=$CV amount=$CA BTC"
-    # Build a fat-fee CPFP child: absolute 12000-sat fee (>> the $DEPRIO deficit) so the
-    # poison+child PACKAGE clears the floor.  Sweep the single explicit input to the miner.
+    # Build a fat-fee CPFP child whose absolute fee >> the $DEPRIO deficit so the
+    # poison+child PACKAGE clears the floor.  Adapt the fee down for a small output,
+    # but it must still exceed the deficit (else the package can't be mined at all).
     CA_SATS=$(python3 -c "print(int(round(float('$CA')*1e8)))")
     CHILD_FEE=12000
-    [ "$CA_SATS" -gt $((CHILD_FEE + 600)) ] || { echo "FAIL: poison output ${CA_SATS} sats too small to CPFP with a ${CHILD_FEE}-sat fee"; exit 1; }
+    [ "$CA_SATS" -gt $((CHILD_FEE + 1500)) ] || CHILD_FEE=$(( CA_SATS > 1500 ? CA_SATS - 1500 : 0 ))
+    [ "$CHILD_FEE" -gt $((DEPRIO + 2000)) ] || { echo "FAIL: poison output ${CA_SATS} sats too small to CPFP past the ${DEPRIO}-sat deficit"; exit 1; }
     OUT_SATS=$((CA_SATS - CHILD_FEE))
     OUT_BTC=$(python3 -c "print(format($OUT_SATS/1e8,'.8f'))")
     CHILD_DEST=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
@@ -308,9 +310,9 @@ except Exception: print('')")
     echo "  CPFP child broadcast: $CHILD_TXID (absolute fee ${CHILD_FEE} sats >> ${DEPRIO}-sat deficit)"
     # The package (poison+child) must now confirm -- and the poison output stays swept.
     PCONF=0; PBLKS=0
-    for i in $(seq 1 8); do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 1; PBLKS=$i; c=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1); [ -n "$c" ] && [ "$c" -ge 1 ] && { PCONF=$c; break; }; done
+    for i in $(seq 1 8); do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 1; PBLKS=$i; c=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1 || true); [ -n "$c" ] && [ "$c" -ge 1 ] && { PCONF=$c; break; }; done
     [ "$PCONF" -ge 1 ] || { echo "FAIL: poison did NOT confirm even after CPFP -- #60 race LOST"; exit 1; }
-    CC=$($BCLI getrawtransaction "$CHILD_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1)
+    CC=$($BCLI getrawtransaction "$CHILD_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
     echo "  poison CONFIRMED via CPFP after ${PBLKS} block(s) (${PCONF} confs); child confs=${CC:-0}"
     [ "$PBLKS" -lt 144 ] || { echo "FAIL: CPFP confirmation took $PBLKS blocks >= 144-block CSV head-start"; exit 1; }
     echo

--- a/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
+++ b/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
@@ -124,6 +124,7 @@ if [ "${SS_POISON_CPFP_RACE:-0}" = 1 ]; then
     echo "--- #60 pre-staging CPFP wallet ($CPFP_WALLET) over $N_CLIENTS client keys ---"
     $BCLI -named createwallet wallet_name=$CPFP_WALLET blank=true disable_private_keys=false load_on_startup=false 2>&1 | head -1 || true
     $BCLI loadwallet $CPFP_WALLET 2>/dev/null || true
+    IMPORTED=0
     for sk in "${CLIENT_SECKEYS[@]:0:$N_CLIENTS}"; do
         WIF=$(python3 - "$sk" <<'PY'
 import sys, hashlib
@@ -135,10 +136,15 @@ while n>0: n,r=divmod(n,58); s=A[r]+s
 print(s)
 PY
 )
-        CK=$($BCLI getdescriptorinfo "tr($WIF)" 2>/dev/null | grep -oE '"checksum": *"[0-9a-z]+"' | grep -oE '[0-9a-z]{8}' | head -1)
-        [ -n "$CK" ] && $BCLI -rpcwallet=$CPFP_WALLET importdescriptors "[{\"desc\":\"tr($WIF)#$CK\",\"timestamp\":\"now\",\"internal\":false}]" >/dev/null 2>&1
+        # checksum from the JSON 'checksum' field (NOT a grep -- the literal word
+        # "checksum" is itself 8 lowercase chars and would mis-match a regex).
+        CK=$($BCLI getdescriptorinfo "tr($WIF)" 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)['checksum'])" 2>/dev/null || true)
+        [ -n "$CK" ] || { echo "  WARN: no checksum for a client descriptor"; continue; }
+        R=$($BCLI -rpcwallet=$CPFP_WALLET importdescriptors "[{\"desc\":\"tr($WIF)#$CK\",\"timestamp\":\"now\",\"internal\":false}]" 2>/dev/null | python3 -c "import sys,json;print(sum(1 for x in json.load(sys.stdin) if x.get('success')))" 2>/dev/null || echo 0)
+        IMPORTED=$((IMPORTED + ${R:-0}))
     done
-    echo "  CPFP wallet staged (watching $N_CLIENTS client keys, ready to bump the poison)"
+    echo "  CPFP wallet staged ($IMPORTED/$N_CLIENTS client keys imported, ready to bump the poison)"
+    [ "$IMPORTED" -ge 1 ] || { echo "FAIL: no client descriptors imported into the CPFP wallet"; exit 1; }
 fi
 
 # --- LSP daemon (hashlock poison + sub-factory cheat) ---
@@ -281,15 +287,46 @@ if [ "${SS_POISON_CPFP_RACE:-0}" = 1 ]; then
     c0=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
     { [ -z "$c0" ] || [ "$c0" -eq 0 ]; } || { echo "FAIL(control): poison confirmed despite -$DEPRIO deprioritise ($c0 confs) -- pressure not biting; CPFP proof vacuous"; exit 1; }
     echo "  CONTROL OK: bare poison STUCK unconfirmed under fee pressure (4 blocks, no CPFP)"
-    # Locate the poison's client output in the pre-staged CPFP wallet (it ingested
-    # the unconfirmed output because tr(client_key) was imported pre-broadcast).
-    read CV CA CSPK < <($BCLI -rpcwallet=$CPFP_WALLET listunspent 0 9999999 2>/dev/null | python3 -c "
+    # Locate the poison's client output by ADDRESS-MATCH in the decoded poison tx.
+    # The CPFP wallet holds the keys; signrawtransactionwithwallet needs only the key
+    # (not UTXO ownership), so we don't depend on wallet mempool-ingestion timing.
+    POISON_JSON=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null || true)
+    CV=""; CA=""; CSPK=""
+    for sk in "${CLIENT_SECKEYS[@]:0:$N_CLIENTS}"; do
+        WIF=$(python3 - "$sk" <<'PY'
+import sys, hashlib
+A='123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+sk=bytes.fromhex(sys.argv[1]); p=b'\xef'+sk+b'\x01'
+chk=hashlib.sha256(hashlib.sha256(p).digest()).digest()[:4]
+n=int.from_bytes(p+chk,'big'); s=''
+while n>0: n,r=divmod(n,58); s=A[r]+s
+print(s)
+PY
+)
+        CK=$($BCLI getdescriptorinfo "tr($WIF)" 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)['checksum'])" 2>/dev/null || true)
+        [ -n "$CK" ] || continue
+        ADDR=$($BCLI deriveaddresses "tr($WIF)#$CK" 2>/dev/null | python3 -c "import sys,json;a=json.load(sys.stdin);print(a[0] if a else '')" 2>/dev/null || true)
+        [ -n "$ADDR" ] || continue
+        HIT=$(echo "$POISON_JSON" | python3 -c "
 import sys,json
-try: u=[x for x in json.load(sys.stdin) if x['txid']=='$POISON_TXID']
-except Exception: u=[]
-print(u[0]['vout'], format(u[0]['amount'],'.8f'), u[0]['scriptPubKey']) if u else print('')")
-    [ -n "${CV:-}" ] || { echo "FAIL: CPFP wallet did not ingest the poison output (txid=$POISON_TXID)"; $BCLI -rpcwallet=$CPFP_WALLET listunspent 0 2>/dev/null | head -40; exit 1; }
-    echo "  poison client output located: vout=$CV amount=$CA BTC"
+try: tx=json.load(sys.stdin)
+except Exception: sys.exit(0)
+for v in tx.get('vout',[]):
+    spk=v.get('scriptPubKey',{})
+    if spk.get('address')=='$ADDR':
+        print(v['n'], format(v['value'],'.8f'), spk.get('hex','')); break
+" 2>/dev/null || true)
+        if [ -n "$HIT" ]; then CV=$(echo "$HIT"|awk '{print $1}'); CA=$(echo "$HIT"|awk '{print $2}'); CSPK=$(echo "$HIT"|awk '{print $3}'); break; fi
+    done
+    if [ -z "$CV" ]; then
+        echo "FAIL: no poison output matched any imported client address; poison vout addrs:"
+        echo "$POISON_JSON" | python3 -c "import sys,json
+try: tx=json.load(sys.stdin)
+except Exception: tx={}
+for v in tx.get('vout',[]): print('   vout',v['n'],v['scriptPubKey'].get('address'),v['value'])" 2>/dev/null || true
+        exit 1
+    fi
+    echo "  poison client output located: vout=$CV amount=$CA BTC (addr-matched an imported client key)"
     # Build a fat-fee CPFP child whose absolute fee >> the $DEPRIO deficit so the
     # poison+child PACKAGE clears the floor.  Adapt the fee down for a small output,
     # but it must still exceed the deficit (else the package can't be mined at all).

--- a/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
+++ b/tools/test_regtest_hashlock_poison_subfactory_e2e.sh
@@ -76,6 +76,7 @@ LSP_DB="$TMPDIR/lsp.db"
 LSP_LOG="$TMPDIR/lsp.log"
 WT_DB="$TMPDIR/wt.db"
 MINER_WALLET="ss_cheat_leaf_miner"
+CPFP_WALLET="ss_cpfp_race"        # #60: spends ANY client's poison output to CPFP-bump it
 
 PIDS=()
 cleanup() {
@@ -88,6 +89,7 @@ cleanup() {
     for i in $(seq 0 $((N_CLIENTS - 1))); do
         cp "$TMPDIR/client_${i}.log" "/tmp/hashlock_sub_e2e_last_client_${i}.log" 2>/dev/null || true
     done
+    $BCLI unloadwallet "$CPFP_WALLET" 2>/dev/null || true
     rm -rf "$TMPDIR"
 }
 trap cleanup EXIT
@@ -111,6 +113,33 @@ $BCLI loadwallet $MINER_WALLET 2>/dev/null || true
 MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
 $BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
 echo "  miner wallet ready, 101 blocks mined"
+
+# --- #60 CPFP fee-race pre-stage (SS_POISON_CPFP_RACE=1) ---
+# The poison is a pre-signed, FIXED-FEE tx: the N-of-N agg-sig binds its outputs,
+# so it is NOT RBF-able.  Its ONLY fee-bump is a CPFP child on a client's own
+# P2TR(client_key) output (factory.c:3581 "any client can trivially CPFP").  We
+# pre-stage a wallet over tr(<each client WIF>) BEFORE the poison broadcasts, so
+# it ingests the unconfirmed poison output from the mempool and can spend it.
+if [ "${SS_POISON_CPFP_RACE:-0}" = 1 ]; then
+    echo "--- #60 pre-staging CPFP wallet ($CPFP_WALLET) over $N_CLIENTS client keys ---"
+    $BCLI -named createwallet wallet_name=$CPFP_WALLET blank=true disable_private_keys=false load_on_startup=false 2>&1 | head -1 || true
+    $BCLI loadwallet $CPFP_WALLET 2>/dev/null || true
+    for sk in "${CLIENT_SECKEYS[@]:0:$N_CLIENTS}"; do
+        WIF=$(python3 - "$sk" <<'PY'
+import sys, hashlib
+A='123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+sk=bytes.fromhex(sys.argv[1]); p=b'\xef'+sk+b'\x01'
+chk=hashlib.sha256(hashlib.sha256(p).digest()).digest()[:4]
+n=int.from_bytes(p+chk,'big'); s=''
+while n>0: n,r=divmod(n,58); s=A[r]+s
+print(s)
+PY
+)
+        CK=$($BCLI getdescriptorinfo "tr($WIF)" 2>/dev/null | grep -oE '"checksum": *"[0-9a-z]+"' | grep -oE '[0-9a-z]{8}' | head -1)
+        [ -n "$CK" ] && $BCLI -rpcwallet=$CPFP_WALLET importdescriptors "[{\"desc\":\"tr($WIF)#$CK\",\"timestamp\":\"now\",\"internal\":false}]" >/dev/null 2>&1
+    done
+    echo "  CPFP wallet staged (watching $N_CLIENTS client keys, ready to bump the poison)"
+fi
 
 # --- LSP daemon (hashlock poison + sub-factory cheat) ---
 echo
@@ -231,6 +260,66 @@ POISON_TXID=$($BCLI sendrawtransaction "$POISON_HEX" 2>/tmp/_sendsub.err) || {
     echo "FAIL: sub poison sendrawtransaction REJECTED"; cat /tmp/_sendsub.err
     echo "  (mempool reject means the persisted template/secret did not yield a spend of the stale sales-stock)"; exit 1; }
 echo "  SUB POISON broadcast txid: $POISON_TXID"
+
+# === #60 CPFP FEE-RACE (SS_POISON_CPFP_RACE=1) =============================
+# Prove the client WINS the L&CSV-fallback race under fee pressure.  The poison
+# is pre-signed at a FIXED fee and is NOT RBF-able (the agg-sig binds outputs);
+# under congestion its bare fee can be below the floor.  The trustless escape is
+# a CPFP child on the client's OWN P2TR output.  We (1) deprioritise the bare
+# poison so it cannot be mined alone, (2) CONTROL-prove it stays stuck, (3) the
+# client CPFPs via a fat-fee child on its poison output, (4) assert the poison
+# CONFIRMS -- well within the 144-block L_STOCK CSV head-start (Leaf-L can't
+# mature before then), so the poison beats the LSP's CSV fallback.
+if [ "${SS_POISON_CPFP_RACE:-0}" = 1 ]; then
+    echo
+    echo "=== #60 CPFP FEE-RACE: bump the FIXED-FEE pre-signed poison via a client-output CPFP ==="
+    DEPRIO=3000
+    $BCLI prioritisetransaction "$POISON_TXID" 0 -$DEPRIO >/dev/null 2>&1
+    echo "  poison deprioritised by $DEPRIO sats (bare fixed-fee poison now unmineable)"
+    # CONTROL: the bare poison must STAY unconfirmed, else the CPFP proof is vacuous.
+    for i in $(seq 1 4); do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 1; done
+    c0=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1)
+    { [ -z "$c0" ] || [ "$c0" -eq 0 ]; } || { echo "FAIL(control): poison confirmed despite -$DEPRIO deprioritise ($c0 confs) -- pressure not biting; CPFP proof vacuous"; exit 1; }
+    echo "  CONTROL OK: bare poison STUCK unconfirmed under fee pressure (4 blocks, no CPFP)"
+    # Locate the poison's client output in the pre-staged CPFP wallet (it ingested
+    # the unconfirmed output because tr(client_key) was imported pre-broadcast).
+    read CV CA CSPK < <($BCLI -rpcwallet=$CPFP_WALLET listunspent 0 9999999 2>/dev/null | python3 -c "
+import sys,json
+try: u=[x for x in json.load(sys.stdin) if x['txid']=='$POISON_TXID']
+except Exception: u=[]
+print(u[0]['vout'], format(u[0]['amount'],'.8f'), u[0]['scriptPubKey']) if u else print('')")
+    [ -n "${CV:-}" ] || { echo "FAIL: CPFP wallet did not ingest the poison output (txid=$POISON_TXID)"; $BCLI -rpcwallet=$CPFP_WALLET listunspent 0 2>/dev/null | head -40; exit 1; }
+    echo "  poison client output located: vout=$CV amount=$CA BTC"
+    # Build a fat-fee CPFP child: absolute 12000-sat fee (>> the $DEPRIO deficit) so the
+    # poison+child PACKAGE clears the floor.  Sweep the single explicit input to the miner.
+    CA_SATS=$(python3 -c "print(int(round(float('$CA')*1e8)))")
+    CHILD_FEE=12000
+    [ "$CA_SATS" -gt $((CHILD_FEE + 600)) ] || { echo "FAIL: poison output ${CA_SATS} sats too small to CPFP with a ${CHILD_FEE}-sat fee"; exit 1; }
+    OUT_SATS=$((CA_SATS - CHILD_FEE))
+    OUT_BTC=$(python3 -c "print(format($OUT_SATS/1e8,'.8f'))")
+    CHILD_DEST=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m)
+    RAWCHILD=$($BCLI -named createrawtransaction inputs="[{\"txid\":\"$POISON_TXID\",\"vout\":$CV}]" outputs="[{\"$CHILD_DEST\":$OUT_BTC}]")
+    SIGNED=$($BCLI -rpcwallet=$CPFP_WALLET signrawtransactionwithwallet "$RAWCHILD" "[{\"txid\":\"$POISON_TXID\",\"vout\":$CV,\"scriptPubKey\":\"$CSPK\",\"amount\":$CA}]" 2>/tmp/_cpfpsign.err)
+    SHEX=$(echo "$SIGNED" | python3 -c "import sys,json
+try: d=json.load(sys.stdin); print(d['hex'] if d.get('complete') else '')
+except Exception: print('')")
+    [ -n "$SHEX" ] || { echo "FAIL: CPFP child sign incomplete"; cat /tmp/_cpfpsign.err 2>/dev/null; echo "$SIGNED"; exit 1; }
+    CHILD_TXID=$($BCLI sendrawtransaction "$SHEX" 2>/tmp/_cpfpsend.err) || { echo "FAIL: CPFP child REJECTED"; cat /tmp/_cpfpsend.err; exit 1; }
+    echo "  CPFP child broadcast: $CHILD_TXID (absolute fee ${CHILD_FEE} sats >> ${DEPRIO}-sat deficit)"
+    # The package (poison+child) must now confirm -- and the poison output stays swept.
+    PCONF=0; PBLKS=0
+    for i in $(seq 1 8); do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 1; PBLKS=$i; c=$($BCLI getrawtransaction "$POISON_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1); [ -n "$c" ] && [ "$c" -ge 1 ] && { PCONF=$c; break; }; done
+    [ "$PCONF" -ge 1 ] || { echo "FAIL: poison did NOT confirm even after CPFP -- #60 race LOST"; exit 1; }
+    CC=$($BCLI getrawtransaction "$CHILD_TXID" true 2>/dev/null | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1)
+    echo "  poison CONFIRMED via CPFP after ${PBLKS} block(s) (${PCONF} confs); child confs=${CC:-0}"
+    [ "$PBLKS" -lt 144 ] || { echo "FAIL: CPFP confirmation took $PBLKS blocks >= 144-block CSV head-start"; exit 1; }
+    echo
+    echo "=== PASS: #60 CPFP FEE-RACE -- the pre-signed, NON-RBF-able poison was BUMPED to"
+    echo "    confirmation by a client-output CPFP under fee pressure, in ${PBLKS} block(s) <<"
+    echo "    the 144-block L_STOCK CSV head-start.  The poison BEATS the LSP's Leaf-L CSV"
+    echo "    fallback => Layer-3 (win-the-fee-race) PROVEN for the #53 sub-factory poison."
+    exit 0
+fi
 
 # --- Confirm + amount ---
 echo


### PR DESCRIPTION
Continues the trustless-model completion campaign (5-layer model: detect / respond / **win the fee-race** / afford / operate) on top of the sub-factory hashlock L-stock poison (PR #390). Closes the **Layer-3 "win the fee-race"** frontier for single-breach recourse and adds the first half of the mass-exit hardening.

All work is regtest-validated. Living tracker: `docs/trustless-completion-plan.md`.

## What's included

**Adversarial agg-sig drill** (`tools/test_regtest_hashlock_aggsig_reject.sh`)
A malicious LSP ships a CORRUPTED N-party poison agg-sig in `SUBFACTORY_DONE`; the client's verify-before-trust (D2) must reject it and persist NO worthless recourse row. Proves the negative of the agg-sig verification. **Green:** LSP shipped a corrupt sig, 2 clients rejected, 0 worthless reveal rows.

**Layer-3 fee-race proofs** (`tools/test_regtest_hashlock_poison_subfactory_e2e.sh` + commitment-breach harness)
- *WT-driven:* the standalone watchtower's deadline CPFP escalator confirms a deprioritised penalty (feerates ramp until it lands).
- *Client-driven poison (`SS_POISON_CPFP_RACE=1`):* the L-stock poison is pre-signed at a fixed fee and is NOT RBF-able (the agg-sig binds its outputs); its only bump is CPFP on a client's own `tr(client_key)` poison output. Deprioritise the bare poison (control: it stays stuck), then the client CPFPs via a fat-fee child → poison **confirms in 1 block**, far inside the 144-block L-stock CSV head-start. The poison provably beats the LSP's Leaf-L CSV fallback.

**Commitment CPFP anchor** (`channel.{c,h}`, `client.c`, `lsp_channels.c`, `jit_channel.c`, `lsp_init_from_db.c`)
A force-closing client (LSP gone) previously had no way to fee-bump its pre-signed, anchorless commitment under fee pressure. This adds a keyless **P2A anchor** to the commitment, gated behind a negotiated per-channel `use_cpfp_anchor` flag (option_anchors style):
- Default OFF, so raw-`channel_init` / legacy channels keep the anchorless format; set ON at all four production channel-init sites so LSP+client build matching anchored commitments.
- The anchor is appended last (to_local[0] / to_remote[1] / HTLC indices and the count-bounded watchtower parsers are unaffected), and its 240 sats come out of `to_remote` so the output sum — hence the implicit miner fee — and `to_local` are unchanged.

## Validation
- **Unit: 1511/1511** including a new differential test proving the anchor is gated, P2A-shaped, and to_remote-funded.
- **Breach/penalty regtest:** a standalone WT confirms a penalty (11843 sats swept) against an ANCHORED revoked commitment — the anchor is transparent to the penalty path.
- **Mass-exit N=4:** all clients self-exit with the LSP gone; conservation is now exactly **100.0%** (anchor deducts from to_remote, so on-chain to_local == channel balance).

## Follow-ups (not in this PR)
- Tree-tx anchors (the shared cascade txs still can't be unilaterally bumped) — needs a construction-level fee reservation; tracked as increment 2.
- A CPFP-the-commitment e2e proof (composition of the unit-proven anchor + the proven P2A-CPFP mechanism).
