### PR TITLE
Anchor-aware L-stock vout: fix hashlock-poison leaf advance (P2A tree-anchor interaction)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -3716,8 +3716,18 @@ static int client_handle_leaf_advance_stateless(int fd,
     if (had_old_signed_c)
         memcpy(old_leaf_txid, ps_node->txid, 32);
     int old_n_outputs_c = ps_node->n_outputs;
-    uint64_t old_l_amount_c = (old_n_outputs_c >= 2)
-                              ? ps_node->outputs[old_n_outputs_c - 1].amount_sats
+    /* #53 x P3: a P2A tree anchor (4-byte SPK 0x51024e73) is appended as the LAST
+       output of every node when use_tree_anchor is on, shifting the L-stock to the
+       second-to-last output.  Detect it by SPK (a real L-stock is a 34-byte P2TR) so
+       the poison gate targets the L-stock, not the 240-sat anchor — else this client
+       omits its poison pubnonce and the LSP fail-closes the advance.  Mirrors the LSP. */
+    int old_anchor_outs_c = (old_n_outputs_c >= 2 &&
+        ps_node->outputs[old_n_outputs_c - 1].script_pubkey_len == P2A_SPK_LEN &&
+        memcmp(ps_node->outputs[old_n_outputs_c - 1].script_pubkey, P2A_SPK, P2A_SPK_LEN) == 0)
+        ? 1 : 0;
+    int old_l_vout_c = old_n_outputs_c - 1 - old_anchor_outs_c;
+    uint64_t old_l_amount_c = (old_l_vout_c >= 0 && (old_n_outputs_c - old_anchor_outs_c) >= 2)
+                              ? ps_node->outputs[old_l_vout_c].amount_sats
                               : 0;
 
     /* CL7: snapshot pre-advance leaf signed_tx for --cheat-client.
@@ -3800,7 +3810,7 @@ static int client_handle_leaf_advance_stateless(int fd,
     if (poison_required_c) {
         if (factory_session_prepare_poison_tx_leaf(
                 factory, node_idx,
-                old_leaf_txid, (uint32_t)(old_n_outputs_c - 1),
+                old_leaf_txid, (uint32_t)old_l_vout_c,
                 old_l_amount_c, LEAF_POISON_FEE_SATS_C,
                 /* #53-B3b Phase 1: target the SUPERSEDED state's output (H_old). */
                 have_old_l_hash_c ? old_l_stock_hash_c : NULL)) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1386,8 +1386,19 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (had_old_signed)
         memcpy(old_leaf_txid, f->nodes[pre_node_idx].txid, 32);
     int old_n_outputs = f->nodes[pre_node_idx].n_outputs;
-    uint64_t old_l_amount = (old_n_outputs >= 2)
-                            ? f->nodes[pre_node_idx].outputs[old_n_outputs - 1].amount_sats
+    /* #53 x P3 interaction: when use_tree_anchor is on, factory_append_tree_anchor
+       appends a P2A anchor (ANCHOR_OUTPUT_AMOUNT, SPK 0x51024e73) as the LAST output
+       of every node — so the L-stock is the SECOND-to-last output, not outputs[n-1].
+       Detect the anchor (flag + SPK) and target the real L-stock; otherwise the poison
+       gate below reads the 240-sat anchor and never fires (poison_required=0), so the
+       advance degrades + never reveals the recourse secret (caught by the leaf e2e). */
+    int old_anchor_outs = (old_n_outputs >= 2 &&
+        f->nodes[pre_node_idx].outputs[old_n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
+        memcmp(f->nodes[pre_node_idx].outputs[old_n_outputs - 1].script_pubkey,
+               P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
+    int old_l_vout = old_n_outputs - 1 - old_anchor_outs;
+    uint64_t old_l_amount = (old_l_vout >= 0 && (old_n_outputs - old_anchor_outs) >= 2)
+                            ? f->nodes[pre_node_idx].outputs[old_l_vout].amount_sats
                             : 0;
     /* SF-WT-TRUSTLESS Phase 1b.4 (#248): also snapshot the OLD chain
      * output (vout=0)'s value + scriptpubkey + the nsequence-encoded
@@ -1461,7 +1472,7 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (mgr->watchtower && poison_required && !getenv("SS_CHEAT_OMIT_POISON")) {
         if (factory_session_prepare_poison_tx_leaf(
                 f, pre_node_idx,
-                old_leaf_txid, (uint32_t)(old_n_outputs - 1),
+                old_leaf_txid, (uint32_t)old_l_vout,
                 old_l_amount, LEAF_POISON_FEE_SATS,
                 /* #53-B3b Phase 1: target the SUPERSEDED state's output (H_old captured
                    before the advance); NULL = legacy key-path when hashlock is off. */


### PR DESCRIPTION
## #53 leaf-path daemon fix — anchor-aware L-stock vout

The P3 tree-anchor work (`use_tree_anchor`) appends a 240-sat **P2A anchor as the LAST output**
of every node, shifting the L-stock to the second-to-last output. The #53 leaf poison gate read
`outputs[n-1]` (the 240-sat anchor, below the threshold) on **both** the LSP (`lsp_channels.c`)
and the client (`client.c`), so `poison_required` was false → the LSP degraded/aborted the
advance and the client omitted its poison pubnonce → the live leaf advance never co-signed or
revealed the recourse secret. (The subfactory path tracks the sales-stock amount explicitly and
was immune — which is why subfactory was proven but the leaf path silently regressed.)

This is a **cross-feature interaction** between two features landed in #393 (P3 anchors × #53
hashlock poison), surfaced by running the leaf e2e for the first time post-merge.

### Fix
Detect the P2A anchor by **SPK** (a real L-stock is a 34-byte P2TR; the anchor is the 4-byte
`0x51024e73`) on both sides and target `outputs[n-2]` for the L-stock amount and the
poison-prepare prevout vout. SPK-only detection (no reliance on the `use_tree_anchor` flag, which
the client's factory mirror may not carry).

### Proof
`test_regtest_hashlock_poison_e2e.sh` on regtest (VPS), with the fix:
`advance → reveal (MSG_LSTOCK_REVEAL) → client persist → assemble → broadcast → CONFIRM`,
recapturing **10730 sats** of L-stock, plus anti-vacuity (no revealed secret → recourse refused,
exit 5). The leaf path now matches the proven subfactory path. Along the way the e2e also
confirmed the B4 fail-closed guard fires correctly (advance aborts when the poison isn't
co-signed).

Inert when `use_hashlock_poison` is off (gated behind the existing `poison_required` path); also
corrects the legacy key-path leaf poison, which the anchor had broken the same way.
