### PR TITLE
harden: refuse key-path L-stock poison for hashlock leaves

### DIFF
--- a/src/factory.c
+++ b/src/factory.c
@@ -3741,6 +3741,17 @@ int factory_sign_l_stock_poison_tx(
 {
     if (!f || !leaf_node || !signed_out) return 0;
     if (leaf_node->n_signers < 2) return 0;
+
+    /* #53-B2: defense against the Scenario B key-path bypass. When this leaf
+       carries a hashlock commitment (has_l_stock_hash), its L-stock poison
+       MUST be produced via the Leaf-P script path (which forces revealing the
+       per-(leaf,state) secret), never this key-path signer. build_l_stock_spk
+       sets the L-stock taproot internal key to the N-of-N agg pubkey, so a
+       co-signed KEY-PATH poison would spend the L-stock WITHOUT the secret --
+       exactly the co-signed-poison theft that #53 closes. Refuse loudly; the
+       caller must use the factory_*_l_stock_poison_scriptpath_* path. */
+    if (leaf_node->has_l_stock_hash) return 0;
+
     size_t n_clients = leaf_node->n_signers - 1;
 
     /* Compute per-client equal-split outputs (zmn's "10 to A, 10 to B"). */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1804,7 +1804,11 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             node->poison_is_signed = 1;
             printf("LSP-stateless: script-path poison agg sig stored (L-stock %llu sats)\n",
                    (unsigned long long)old_l_amount);
-        } else if (poison_verified &&
+        } else if (poison_verified && !node->has_l_stock_hash &&
+            /* #53-B2: a key-path poison must NEVER be finalized for a hashlock
+               leaf (it would spend the L-stock without revealing the secret).
+               poison_is_scriptpath is already set from has_l_stock_hash at prep,
+               so this is the inconsistent-state backstop: degrade, don't sign. */
             finalize_signed_tx(&node->poison_signed_tx,
                                 node->poison_unsigned_tx.data,
                                 node->poison_unsigned_tx.len,

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5923,6 +5923,22 @@ int test_factory_ps_subfactory_poison_tx_k2_n4(void) {
     TEST_ASSERT(dust_ok == 0, "rejects when per-client share below dust");
     tx_buf_free(&poison_dust);
 
+    /* #53-B2: when this node carries a hashlock commitment, the key-path
+       poison signer MUST refuse — the poison has to go via the Leaf-P script
+       path (reveal-the-secret).  build_l_stock_spk uses the N-of-N agg as the
+       L-stock taproot internal key, so a co-signed key-path poison would burn
+       the L-stock WITHOUT the secret, reopening the Scenario-B co-signed-poison
+       theft.  The guard reads node->has_l_stock_hash, so set it directly. */
+    sub->has_l_stock_hash = 1;
+    tx_buf_t poison_hl;
+    tx_buf_init(&poison_hl, 64);
+    int hl_refused = factory_sign_l_stock_poison_tx(
+        f, sub, sub->txid, sstock_vout, sstock_amount, fee, &poison_hl);
+    TEST_ASSERT(hl_refused == 0,
+                "B2: key-path poison REFUSED when node has hashlock");
+    tx_buf_free(&poison_hl);
+    sub->has_l_stock_hash = 0;  /* restore before free */
+
     factory_free(f);
     secp256k1_context_destroy(ctx);
     free(f);


### PR DESCRIPTION
## What

Closes the last remaining tail of the hashlock-gated L-stock poison work (task 53-B2): the **key-path bypass**.

## Why this is load-bearing (not cosmetic)

`build_l_stock_spk` sets the L-stock taproot **internal key to the N-of-N agg pubkey**, even when a per-(leaf,state) hashlock is committed. The hashlock lives in a script-tree leaf (Leaf-P), but the key-path is still spendable by the agg quorum. So a **co-signed key-path poison** would burn/redistribute the L-stock **without revealing the secret** — exactly the co-signed-poison theft (Scenario B) the hashlock is meant to close.

The construction already routes hashlock leaves to the script path (`poison_is_scriptpath` set from `has_l_stock_hash`), and a client signs over *its own* computed sighash, so a malicious LSP cannot substitute a key-path sighash in the multi-process ceremony. The one direct hole was the **single-process** signer `factory_sign_l_stock_poison_tx`, which would happily produce a key-path poison for a hashlock leaf if called.

## Changes

- **`src/factory.c`** — `factory_sign_l_stock_poison_tx` refuses when `leaf_node->has_l_stock_hash`. The cooperative spend (`factory_sign_l_stock_cooperative_spend`) and the legacy non-hashlock burn path are untouched.
- **`src/lsp_channels.c`** — defensive `!has_l_stock_hash` backstop on the multi-process key-path finalize branch: degrade rather than sign on the inconsistent (`has_l_stock_hash` set but `poison_is_scriptpath==0`) state.
- **`tests/test_factory.c`** — negative assertion in `test_factory_ps_subfactory_poison_tx_k2_n4` that the key-path signer refuses a hashlock node, alongside the existing positive (non-hashlock) signing case.

## Validation

- Unit: new negative assertion + existing positive case (CI `test_main`).
- Script-path recourse (reveal-the-secret) is unaffected — it remains the only way to poison a hashlock leaf. The leaf e2e (`test_regtest_hashlock_poison_e2e.sh`) exercises that path end to end.