### PR TITLE
feat(watchtower): mirror PTLC revocation-penalty sweeps into wt_db

### DIFF
--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -844,6 +844,79 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
                         persist_rollback(wt->db);
                 }
             }
+
+            /* G2 #45 (PTLC): mirror the PTLC revocation-penalty sweep into
+               wt_db so a SECRET-LESS standalone WT also sweeps in-flight PTLCs
+               on a commitment breach (without this it penalizes to_local + HTLCs
+               but leaks PTLC value).  Mirror of the HTLC wt_db block above: build
+               the sweep now (ch still holds the received revocation secret) and
+               store the signed bytes keyed on the breach txid.  Uses the same
+               ch->ptlcs[0] shim the watchtower_check lazy-build path uses. */
+            if (wt->wt_db && wt->wt_db->db && entry->n_ptlc_outputs > 0 && ch) {
+                int use_anchor_p = fee_should_use_anchor(wt->fee);
+                size_t wt_saved_np = ch->n_ptlcs;
+                ptlc_t wt_saved_p0 = {0};
+                if (wt_saved_np > 0 && ch->ptlcs)
+                    wt_saved_p0 = ch->ptlcs[0];
+                if (!ch->ptlcs) {
+                    ch->ptlcs = (ptlc_t *)calloc(1, sizeof(ptlc_t));
+                    ch->ptlcs_cap = 1;
+                }
+                for (size_t p = 0; ch->ptlcs && p < entry->n_ptlc_outputs; p++) {
+                    watchtower_htlc_t *wp_p = &entry->ptlc_outputs[p];
+                    ch->n_ptlcs = 1;
+                    memset(&ch->ptlcs[0], 0, sizeof(ptlc_t));
+                    ch->ptlcs[0].direction = (ptlc_direction_t)wp_p->direction;
+                    ch->ptlcs[0].cltv_expiry = wp_p->cltv_expiry;
+                    ch->ptlcs[0].state = PTLC_STATE_ACTIVE;
+                    /* payment_hash[32] holds the xonly payment_point; prepend
+                       even-parity to parse a 33-byte pubkey (parity immaterial —
+                       channel_build_ptlc_penalty_tx uses the xonly form). */
+                    {
+                        unsigned char pp33[33];
+                        pp33[0] = 0x02;
+                        memcpy(pp33 + 1, wp_p->payment_hash, 32);
+                        secp256k1_ec_pubkey_parse(ch->ctx,
+                            &ch->ptlcs[0].payment_point, pp33, 33);
+                    }
+                    tx_buf_t psweep;
+                    tx_buf_init(&psweep, 512);
+                    if (channel_build_ptlc_penalty_tx(ch, &psweep,
+                            old_txid, wp_p->htlc_vout, wp_p->htlc_amount,
+                            wp_p->htlc_spk, 34, old_commit_num, 0,
+                            use_anchor_p ? wt->anchor_spk : NULL,
+                            use_anchor_p ? wt->anchor_spk_len : 0)) {
+                        unsigned char p_resp_txid[32];
+                        sha256_double(psweep.data, psweep.len, p_resp_txid);
+                        char *p_hex = (char *)malloc(psweep.len * 2 + 1);
+                        if (p_hex) {
+                            hex_encode(psweep.data, psweep.len, p_hex);
+                            int64_t pwid = persist_wt_register_watch(
+                                wt->wt_db, WT_KIND_CHANNEL_COMMITMENT,
+                                channel_id, old_txid,
+                                wp_p->htlc_vout, wp_p->htlc_amount,
+                                wp_p->htlc_spk, 34,
+                                ch->to_self_delay,
+                                p_hex, p_resp_txid, 0, 0);
+                            free(p_hex);
+                            if (pwid <= 0)
+                                fprintf(stderr, "LSP-WT-TRUSTLESS: WARN — wt_db "
+                                    "PTLC-sweep register failed (ch %u vout %u)\n",
+                                    channel_id, wp_p->htlc_vout);
+                        }
+                    } else {
+                        fprintf(stderr,
+                                "watchtower: failed to build PTLC sweep TX "
+                                "(vout %u) at registration time — standalone-WT "
+                                "PTLC recourse unavailable for this output\n",
+                                wp_p->htlc_vout);
+                    }
+                    tx_buf_free(&psweep);
+                }
+                ch->n_ptlcs = wt_saved_np;
+                if (wt_saved_np > 0 && ch->ptlcs)
+                    ch->ptlcs[0] = wt_saved_p0;
+            }
         }
     }
 

--- a/tests/test_client_watchtower.c
+++ b/tests/test_client_watchtower.c
@@ -8,6 +8,7 @@
 
 #include "superscalar/channel.h"
 #include "superscalar/watchtower.h"
+#include "superscalar/persist_wt.h"
 #include "superscalar/wire.h"
 #include "superscalar/fee.h"
 #include "superscalar/regtest.h"
@@ -493,6 +494,27 @@ int test_htlc_penalty_watch(void) {
    watchtower_watch_revoked_commitment PTLC feed populates entry->ptlc_outputs
    so the existing sweep loop at watchtower.c:1039+ can broadcast a PTLC
    penalty TX on breach. */
+/* G2 #45 probe: scan wt_db CHANNEL_COMMITMENT watches for one matching a target
+   (vout, amount) that carries response bytes — proves the PTLC sweep was mirrored
+   into wt_db for a secret-less standalone WT (not just the in-memory entry). */
+struct g2_ptlc_probe { uint32_t want_vout; uint64_t want_amt; int found; };
+static int g2_ptlc_probe_cb(uint32_t factory_id,
+        const unsigned char parent_txid32[32], uint32_t parent_vout,
+        uint64_t parent_value_sat, const unsigned char *parent_spk,
+        size_t parent_spk_len, uint32_t csv_delay,
+        const char *response_tx_hex, const unsigned char response_txid32[32],
+        uint64_t fee_bump_budget_sat, uint32_t fee_bump_deadline_height,
+        void *user) {
+    (void)factory_id; (void)parent_txid32; (void)parent_spk;
+    (void)parent_spk_len; (void)csv_delay; (void)response_txid32;
+    (void)fee_bump_budget_sat; (void)fee_bump_deadline_height;
+    struct g2_ptlc_probe *pr = (struct g2_ptlc_probe *)user;
+    if (parent_vout == pr->want_vout && parent_value_sat == pr->want_amt &&
+        response_tx_hex && response_tx_hex[0])
+        pr->found = 1;
+    return 1; /* continue */
+}
+
 int test_ptlc_penalty_watch(void) {
     extern void ptlc_safety_set_enabled(int);
     ptlc_safety_set_enabled(1);
@@ -514,6 +536,15 @@ int test_ptlc_penalty_watch(void) {
     fee_estimator_static_t fee;
     fee_estimator_static_init(&fee, 1000);
     watchtower_init(&wt, 1, NULL, (fee_estimator_t *)&fee, NULL);
+
+    /* G2 #45: attach a wt_db so the breach registration ALSO mirrors sweeps for a
+       secret-less standalone WT (the path this test now exercises for PTLCs). */
+    const char *g2_wtdb_path = "/tmp/test_g2_ptlc_wtdb.db";
+    remove(g2_wtdb_path);
+    persist_wt_t g2_pwt;
+    TEST_ASSERT(persist_wt_open(&g2_pwt, g2_wtdb_path) == 1,
+                "open wt_db for G2 PTLC mirror");
+    watchtower_set_wt_db(&wt, &g2_pwt);
 
     /* Build a payment_point from a known secret */
     secp256k1_pubkey payment_pt;
@@ -592,6 +623,22 @@ int test_ptlc_penalty_watch(void) {
         TEST_ASSERT(memcmp(entry->ptlc_outputs[0].payment_hash, expected_ser, 32) == 0,
                     "payment_hash should be xonly form of payment_point");
     }
+
+    /* G2 #45: the PTLC penalty sweep must ALSO be mirrored into wt_db (keyed on
+       the breach txid) so a SECRET-LESS standalone WT can rebroadcast it.  Before
+       this fix the PTLC block populated only the in-memory entry + legacy db, so
+       a standalone WT swept to_local + HTLCs but LEAKED in-flight PTLC value.
+       Assert a CHANNEL_COMMITMENT watch exists for the PTLC vout (2) with bytes. */
+    {
+        struct g2_ptlc_probe pr = { 2, 5000, 0 };
+        int nrows = persist_wt_list_watches_by_kind(&g2_pwt,
+                        WT_KIND_CHANNEL_COMMITMENT, g2_ptlc_probe_cb, &pr);
+        TEST_ASSERT(nrows >= 1, "wt_db holds >=1 CHANNEL_COMMITMENT watch");
+        TEST_ASSERT(pr.found == 1,
+                    "G2 #45: PTLC sweep mirrored to wt_db (vout 2, 5000 sat, has bytes)");
+    }
+    persist_wt_close(&g2_pwt);
+    remove(g2_wtdb_path);
 
     channel_cleanup(&lsp_ch);
     channel_cleanup(&client_ch);


### PR DESCRIPTION
## What

Completes the **G2** standalone-watchtower recourse coverage for revoked-commitment breaches.

## The gap

When a revoked commitment is registered, the HTLC penalty sweep is already mirrored into `wt_db` (`persist_wt_register_watch`, `WT_KIND_CHANNEL_COMMITMENT`) so a **secret-less standalone watchtower** can rebroadcast it. The PTLC block, however, only populated the in-memory `entry->ptlc_outputs` and the legacy `wt->db` — it never wrote to `wt_db`. Result: a standalone WT swept `to_local` + HTLCs but **leaked in-flight PTLC value** on a breach.

## Fix

`watchtower_watch_revoked_commitment` now builds the PTLC revocation-penalty at registration (while `ch` still holds the received revocation secret) and stores the signed bytes in `wt_db`, keyed on the breach txid. It's a faithful mirror of the HTLC `wt_db` block, reusing the same `ch->ptlcs[0]` shim that the `watchtower_check` lazy-build path uses (even-parity reconstruction of the payment_point xonly; parity is immaterial because `channel_build_ptlc_penalty_tx` consumes the xonly form).

## Test

`test_ptlc_penalty_watch` now attaches a `wt_db` before the breach registration and asserts (via `persist_wt_list_watches_by_kind`) that a `CHANNEL_COMMITMENT` watch exists for the PTLC vout (2, 5000 sat) and carries response bytes — proving the standalone-WT recourse, not just the in-memory entry. The pre-existing in-memory assertions are unchanged.

## Scope

`watchtower.c` + one unit test. Disjoint from the in-flight key-path-poison hardening PR. The revocation-path sweep means this works identically for the secret-less WT (it rebroadcasts stored bytes; it does not rebuild).