### PR TITLE
feat(rotation): notify clients on ceremony abort / proactive exit

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -205,6 +205,31 @@ static int wire_recv_handle_ping(int fd, wire_msg_t *msg, int timeout_sec) {
             msg->json = NULL;
             continue;  /* notification, wait for next real message */
         }
+        if (msg->msg_type == MSG_CEREMONY_ABORT) {
+            /* #49/#51: advisory abort/intent-to-exit notice.  The LSP sends this
+               when a rotation/advance ceremony is aborted -- notably
+               RETRY_LIMIT_REACHED, where the LSP then proactively broadcasts the
+               distribution TX (unilateral exit) before the factory CLTV.  The
+               client's own persisted state + watchtower already protect its funds
+               (it can self-exit), so this is informational: log it loudly so the
+               client app/operator can stop waiting on a ceremony that will never
+               complete and confirm its watchtower is live.  Best-effort -- a
+               client offline during the failed ceremony simply won't receive it. */
+            unsigned char cer_id[8];
+            unsigned char reason = CEREMONY_ABORT_OTHER;
+            char *rtext = NULL;
+            if (msg->json &&
+                wire_parse_ceremony_abort(msg->json, cer_id, &reason, &rtext)) {
+                fprintf(stderr, "Client: MSG_CEREMONY_ABORT reason=0x%02x%s%s\n",
+                        reason, rtext ? " -- " : "", rtext ? rtext : "");
+                free(rtext);
+            } else {
+                fprintf(stderr, "Client: MSG_CEREMONY_ABORT (unparseable)\n");
+            }
+            if (msg->json) cJSON_Delete(msg->json);
+            msg->json = NULL;
+            continue;  /* advisory, wait for next real message */
+        }
         return 1;  /* real message */
     }
 }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -7271,6 +7271,35 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                            " — broadcasting distribution TX\n",
                                            mret, lf->factory_id);
                                     fflush(stdout);
+                                    /* #49/#51: notify all clients (best-effort) that
+                                       the rotation ceremony is aborted (retry limit)
+                                       and the LSP is proactively exiting via the
+                                       distribution TX before the factory CLTV.  The
+                                       clients' own persisted state + watchtower
+                                       protect their funds; this lets them stop
+                                       waiting and confirm their WT is live.  An
+                                       offline client simply won't receive it. */
+                                    {
+                                        unsigned char _cer_id[8] = {0};
+                                        _cer_id[0] = (unsigned char)(lf->factory_id & 0xff);
+                                        _cer_id[1] = (unsigned char)((lf->factory_id >> 8) & 0xff);
+                                        _cer_id[2] = (unsigned char)((lf->factory_id >> 16) & 0xff);
+                                        _cer_id[3] = (unsigned char)((lf->factory_id >> 24) & 0xff);
+                                        char _atext[200];
+                                        snprintf(_atext, sizeof(_atext),
+                                            "rotation retry limit (%u) reached at height %u; "
+                                            "LSP broadcasting distribution TX (proactive exit) "
+                                            "-- ensure your watchtower is live",
+                                            mret, (unsigned)height);
+                                        cJSON *_ab = wire_build_ceremony_abort(_cer_id,
+                                            CEREMONY_ABORT_RETRY_LIMIT_REACHED, _atext);
+                                        if (_ab) {
+                                            for (size_t _aci = 0; _aci < lsp->n_clients; _aci++)
+                                                wire_send(lsp->client_fds[_aci],
+                                                          MSG_CEREMONY_ABORT, _ab);
+                                            cJSON_Delete(_ab);
+                                        }
+                                    }
                                     if (lf->distribution_tx.len > 0 &&
                                         mgr->chain_be) {
                                         chain_backend_t *_cb =

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1122,6 +1122,7 @@ extern int test_regtest_ladder_distribution_fallback(void);
 extern int test_wire_pubkey_only_factory(void);
 extern int test_wire_framing(void);
 extern int test_wire_lstock_reveal_round_trip(void);
+extern int test_wire_ceremony_abort_round_trip(void);
 extern int test_wire_lstock_reveal_request_round_trip(void);
 extern int test_wire_crypto_serialization(void);
 extern int test_wire_nonce_bundle(void);
@@ -3079,6 +3080,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_wire_pubkey_only_factory);
     RUN_TEST(test_wire_framing);
     RUN_TEST(test_wire_lstock_reveal_round_trip);
+    RUN_TEST(test_wire_ceremony_abort_round_trip);
     RUN_TEST(test_wire_lstock_reveal_request_round_trip);
     RUN_TEST(test_wire_crypto_serialization);
     RUN_TEST(test_wire_nonce_bundle);

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -542,6 +542,48 @@ int test_wire_lstock_reveal_round_trip(void) {
     return 1;
 }
 
+/* #49/#51: MSG_CEREMONY_ABORT round-trip (the abort / intent-to-exit notice). */
+int test_wire_ceremony_abort_round_trip(void) {
+    unsigned char cid[8];
+    for (int i = 0; i < 8; i++) cid[i] = (unsigned char)(0xA0 + i);
+
+    /* With reason_text. */
+    cJSON *j = wire_build_ceremony_abort(cid, CEREMONY_ABORT_RETRY_LIMIT_REACHED,
+                                         "retry limit reached; proactive exit");
+    TEST_ASSERT(j != NULL, "build ceremony_abort (with text)");
+    unsigned char cid_out[8];
+    unsigned char reason_out = 0;
+    char *text_out = NULL;
+    TEST_ASSERT(wire_parse_ceremony_abort(j, cid_out, &reason_out, &text_out),
+                "parse ceremony_abort");
+    TEST_ASSERT(memcmp(cid_out, cid, 8) == 0, "ceremony_id round-trips");
+    TEST_ASSERT(reason_out == CEREMONY_ABORT_RETRY_LIMIT_REACHED, "reason round-trips");
+    TEST_ASSERT(text_out && strcmp(text_out, "retry limit reached; proactive exit") == 0,
+                "reason_text round-trips");
+    free(text_out);
+    cJSON_Delete(j);
+
+    /* Without reason_text (NULL) — parse still succeeds, text NULL. */
+    cJSON *j2 = wire_build_ceremony_abort(cid, CEREMONY_ABORT_CLIENT_TIMEOUT, NULL);
+    TEST_ASSERT(j2 != NULL, "build ceremony_abort (no text)");
+    reason_out = 0; text_out = NULL;
+    TEST_ASSERT(wire_parse_ceremony_abort(j2, cid_out, &reason_out, &text_out),
+                "parse ceremony_abort (no text)");
+    TEST_ASSERT(reason_out == CEREMONY_ABORT_CLIENT_TIMEOUT, "reason (no text) round-trips");
+    TEST_ASSERT(text_out == NULL, "reason_text absent -> NULL");
+    cJSON_Delete(j2);
+
+    /* Malformed: object missing ceremony_id -> parse fails. */
+    cJSON *bad = cJSON_CreateObject();
+    cJSON_AddNumberToObject(bad, "x", 1);
+    TEST_ASSERT(wire_parse_ceremony_abort(bad, cid_out, &reason_out, &text_out) == 0,
+                "parse rejects malformed (missing ceremony_id)");
+    cJSON_Delete(bad);
+
+    printf("  MSG_CEREMONY_ABORT round-trips (text + no-text + malformed)\n");
+    return 1;
+}
+
 /* #59: MSG_LSTOCK_REVEAL_REQUEST round-trip (the restart re-request). */
 int test_wire_lstock_reveal_request_round_trip(void) {
     uint32_t nodes[3]  = { 2, 9, 99 };


### PR DESCRIPTION
## What

Wires the already-defined `MSG_CEREMONY_ABORT` (0x79) so clients are told directly when the LSP aborts a rotation ceremony and proactively exits — the advisory-notification half of the liveness phase (abort-advance notice + intent-to-exit deadline).

## Context

The LSP already does bounded rotation retries (`rot_max_retries`, default 3) and, on exhaustion, **proactively broadcasts the distribution TX** to exit before the factory CLTV (the escalation policy — already in place). But until now, clients only learned of this by observing the on-chain distribution TX. The `0x79` codec (`wire_build/parse_ceremony_abort`) existed but was never sent.

## Changes

- **`src/lsp_channels.c`** — at the retry-limit site (the `retry_act == -1` branch in the daemon poll loop), send `MSG_CEREMONY_ABORT` (`CEREMONY_ABORT_RETRY_LIMIT_REACHED`, with the height + intent-to-exit text) to all clients before broadcasting the distribution TX. Best-effort — a client offline during the failed ceremony simply won't receive it.
- **`src/client.c`** — handle `MSG_CEREMONY_ABORT` in `wire_recv_handle_ping` (the async recv wrapper, alongside PING/PONG/FUNDING_REORG): parse + log loudly + continue. **Advisory only** — the client's persisted state + watchtower already protect its funds (it can self-exit); this lets it stop waiting on a ceremony that will never complete and confirm its WT is live.
- **`tests/test_wire.c`** — `test_wire_ceremony_abort_round_trip` (with text, without text, malformed) + registered in `test_main.c`.

## Safety

Purely advisory — no change to fund safety or the on-chain escalation path. The bounded-retry → proactive-exit policy and the overlap-window (old state remains valid) are unchanged.