### PR TITLE
feat: distributed MuSig co-signing of the distribution TX (foundation)

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -429,7 +429,17 @@ typedef struct {
        The "inverted timeout default": if nobody acts, clients get money. */
     tx_buf_t dist_unsigned_tx;     /* unsigned distribution TX */
     unsigned char dist_sighash[32]; /* BIP-341 sighash for distributed signing */
-    int dist_tx_ready;             /* 1 = unsigned TX built + sighash computed */
+    int dist_tx_ready;             /* 1 = unsigned TX built + sighash computed;
+                                      2 = fully co-signed (#54 G1) */
+    /* #54 G1: distributed MuSig co-signing of the distribution TX, so the
+       offline-forever recovery net (dist TX, nLockTime = cltv_timeout) exists in
+       the stateless creation path.  Key-path spend of the funding output over
+       nodes[0].keyagg (no taptree), message = dist_sighash.  Mirrors the per-node
+       session helpers but targets the funding output instead of a tree node. */
+    musig_signing_session_t dist_signing_session;
+    secp256k1_musig_partial_sig dist_partial_sigs[FACTORY_MAX_SIGNERS];
+    int dist_partial_sigs_received;
+    tx_buf_t dist_signed_tx;       /* fully-signed distribution TX (dist_tx_ready==2) */
 } factory_t;
 
 int factory_init(factory_t *f, secp256k1_context *ctx,
@@ -1125,6 +1135,27 @@ int factory_build_distribution_tx_unsigned(
     const tx_output_t *outputs,
     size_t n_outputs,
     uint32_t nlocktime);
+
+/* #54 G1: distributed MuSig co-signing of the distribution TX (the offline-forever
+   recovery net) so it exists in the stateless creation path.  The dist TX is a
+   key-path spend of the funding output over nodes[0].keyagg (same agg key as the
+   root kickoff, no taptree), message = f->dist_sighash.  Requires
+   factory_build_distribution_tx_unsigned() to have run first (dist_tx_ready>=1).
+   Usage (per signer, mirroring the per-node session helpers):
+     1. factory_session_init_dist          — init the all-N session
+     2. factory_session_set_nonce_dist      — set each signer's pubnonce (slot order)
+     3. factory_session_finalize_dist       — nonce_process over dist_sighash
+     4. factory_session_set_partial_sig_dist— set each signer's partial sig
+     5. factory_session_complete_dist       — aggregate -> finalize f->dist_signed_tx,
+                                              set dist_tx_ready=2
+   All return 1 on success, 0 on failure. */
+int factory_session_init_dist(factory_t *f);
+int factory_session_set_nonce_dist(factory_t *f, size_t signer_slot,
+                                   const secp256k1_musig_pubnonce *pubnonce);
+int factory_session_finalize_dist(factory_t *f);
+int factory_session_set_partial_sig_dist(factory_t *f, size_t signer_slot,
+                                         const secp256k1_musig_partial_sig *psig);
+int factory_session_complete_dist(factory_t *f);
 
 /* Compute distribution TX outputs: each participant gets P2TR(their_pubkey).
    LSP (pubkeys[0]) gets funding_amount - sum(client_amounts) - fee.

--- a/src/factory.c
+++ b/src/factory.c
@@ -4236,6 +4236,64 @@ int factory_build_distribution_tx_unsigned(
     return 1;
 }
 
+/* === #54 G1: distributed MuSig signing of the distribution TX ===
+   The dist TX is a key-path spend of the funding output (same N-of-N keyagg as
+   the root kickoff, nodes[0].keyagg) with message = f->dist_sighash.  These mirror
+   the per-node session helpers (factory_session_init_node etc.) but target the
+   funding output instead of a tree node, so the offline-forever recovery net can
+   be co-signed in the multi-party (stateless) creation ceremony.  Caller must run
+   factory_build_distribution_tx_unsigned() first. */
+int factory_session_init_dist(factory_t *f) {
+    if (!f || f->n_nodes == 0) return 0;
+    if (f->dist_tx_ready < 1 || f->dist_unsigned_tx.len == 0) return 0;
+    if (!f->nodes[0].is_built) return 0;
+    /* Same aggregate key as kickoff_root (factory_build_distribution_tx). */
+    musig_session_init(&f->dist_signing_session, &f->nodes[0].keyagg,
+                       f->n_participants);
+    f->dist_partial_sigs_received = 0;
+    return 1;
+}
+
+int factory_session_set_nonce_dist(factory_t *f, size_t signer_slot,
+                                   const secp256k1_musig_pubnonce *pubnonce) {
+    if (!f || !pubnonce) return 0;
+    return musig_session_set_pubnonce(&f->dist_signing_session, signer_slot,
+                                      pubnonce);
+}
+
+int factory_session_finalize_dist(factory_t *f) {
+    if (!f) return 0;
+    /* The funding output is key-path-only (no taptree), exactly like the root
+       kickoff node[0] — finalize with a NULL merkle root (no taptweak beyond the
+       BIP-341 empty-tree key tweak applied internally), matching the proven
+       single-process factory_build_distribution_tx (musig_sign_taproot ... NULL). */
+    return musig_session_finalize_nonces(f->ctx, &f->dist_signing_session,
+                                         f->dist_sighash, NULL, NULL);
+}
+
+int factory_session_set_partial_sig_dist(factory_t *f, size_t signer_slot,
+                                         const secp256k1_musig_partial_sig *psig) {
+    if (!f || !psig || signer_slot >= f->n_participants) return 0;
+    f->dist_partial_sigs[signer_slot] = *psig;
+    f->dist_partial_sigs_received++;
+    return 1;
+}
+
+int factory_session_complete_dist(factory_t *f) {
+    if (!f) return 0;
+    if (f->dist_partial_sigs_received != (int)f->n_participants) return 0;
+    unsigned char sig[64];
+    if (!musig_aggregate_partial_sigs(f->ctx, sig, &f->dist_signing_session,
+                                      f->dist_partial_sigs, f->n_participants))
+        return 0;
+    /* finalize_signed_tx resets the out buffer internally (tx_buf_reset). */
+    if (!finalize_signed_tx(&f->dist_signed_tx, f->dist_unsigned_tx.data,
+                            f->dist_unsigned_tx.len, sig))
+        return 0;
+    f->dist_tx_ready = 2;  /* fully co-signed */
+    return 1;
+}
+
 /* Inversion-of-timeout-default: the distribution TX spends the factory
    funding UTXO directly and pays everything to the clients, with nLockTime
    set to the factory's CLTV timeout. The LSP gets NOTHING — no output,
@@ -4676,6 +4734,7 @@ void factory_free(factory_t *f) {
        factory_build_distribution_tx_unsigned).  tx_buf_free is a no-op
        when never initialized. */
     tx_buf_free(&f->dist_unsigned_tx);
+    tx_buf_free(&f->dist_signed_tx);   /* #54 G1 */
     /* Zero node count so a second factory_free is a no-op (idempotent). */
     f->n_nodes = 0;
 }
@@ -4698,4 +4757,5 @@ void factory_detach_txbufs(factory_t *f) {
         memset(&f->nodes[i].poison_signed_tx, 0, sizeof(tx_buf_t));
     }
     memset(&f->dist_unsigned_tx, 0, sizeof(tx_buf_t));
+    memset(&f->dist_signed_tx, 0, sizeof(tx_buf_t));   /* #54 G1 */
 }

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -1886,6 +1886,92 @@ int test_factory_distribution_tx(void) {
     return 1;
 }
 
+/* #54 G1: drive the DISTRIBUTED MuSig co-signing of the distribution TX (each
+   participant signs separately, as the multi-party stateless creation ceremony
+   does) via the new factory_session_*_dist helpers, and verify the resulting
+   signature is VALID against the funding output key.  Proves the offline-forever
+   recovery net can be co-signed in the stateless path (where it is currently
+   built unsigned). */
+int test_factory_distribution_tx_distributed(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[5];
+    if (!make_keypairs(ctx, kps)) return 0;
+
+    unsigned char fund_spk[34];
+    secp256k1_xonly_pubkey fund_tweaked;
+    TEST_ASSERT(compute_funding_spk(ctx, kps, fund_spk, &fund_tweaked),
+                "compute funding spk");
+
+    unsigned char fake_txid[32];
+    memset(fake_txid, 0xAA, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    if (!f) return 0;
+    factory_init(f, ctx, kps, 5, 2, 4);
+    factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+    TEST_ASSERT(factory_sign_all(f), "sign all");
+
+    /* Build the UNSIGNED distribution TX exactly as stateless creation does
+       (lsp.c:521) — computes f->dist_unsigned_tx + f->dist_sighash. */
+    uint32_t nlocktime = 5000;
+    tx_output_t dist_outputs[6];
+    size_t n_dist = factory_compute_distribution_outputs_balanced(
+        f, dist_outputs, 6, 500, NULL, 0);
+    TEST_ASSERT(n_dist > 0, "compute balanced dist outputs");
+    TEST_ASSERT(factory_build_distribution_tx_unsigned(f, dist_outputs, n_dist,
+                                                       nlocktime),
+                "build unsigned dist tx");
+    TEST_ASSERT(f->dist_tx_ready == 1, "dist_tx_ready==1 (unsigned)");
+
+    /* Distributed co-signing: all 5 participants sign separately. */
+    TEST_ASSERT(factory_session_init_dist(f), "init dist session");
+    secp256k1_musig_secnonce dist_secnonces[5];
+    for (size_t j = 0; j < 5; j++) {
+        unsigned char sk[32];
+        secp256k1_pubkey pk;
+        TEST_ASSERT(secp256k1_keypair_sec(ctx, sk, &kps[j]), "keypair sec");
+        TEST_ASSERT(secp256k1_keypair_pub(ctx, &pk, &kps[j]), "keypair pub");
+        secp256k1_musig_pubnonce pubnonce;
+        TEST_ASSERT(musig_generate_nonce(ctx, &dist_secnonces[j], &pubnonce,
+                                          sk, &pk, &f->nodes[0].keyagg.cache),
+                    "dist nonce gen");
+        memset(sk, 0, 32);
+        TEST_ASSERT(factory_session_set_nonce_dist(f, j, &pubnonce),
+                    "dist set nonce");
+    }
+    TEST_ASSERT(factory_session_finalize_dist(f), "finalize dist session");
+    for (size_t j = 0; j < 5; j++) {
+        secp256k1_musig_partial_sig psig;
+        TEST_ASSERT(musig_create_partial_sig(ctx, &psig, &dist_secnonces[j],
+                                              &kps[j], &f->dist_signing_session),
+                    "dist partial sig");
+        TEST_ASSERT(factory_session_set_partial_sig_dist(f, j, &psig),
+                    "dist set partial sig");
+    }
+    TEST_ASSERT(factory_session_complete_dist(f), "complete dist session");
+    TEST_ASSERT(f->dist_tx_ready == 2, "dist_tx_ready==2 (signed)");
+    TEST_ASSERT(f->dist_signed_tx.len >= 70, "signed dist tx long enough");
+
+    /* Extract the key-path witness sig (1 input -> witness = 0x01 0x40 <64 sig>
+       immediately before the 4-byte nLockTime) and verify it against the funding
+       output key + dist_sighash.  A wrong taptweak (e.g. signing the raw agg key
+       instead of the BIP-341-tweaked funding key) would fail this. */
+    size_t L = f->dist_signed_tx.len;
+    TEST_ASSERT(f->dist_signed_tx.data[L - 70] == 0x01 &&
+                f->dist_signed_tx.data[L - 69] == 0x40,
+                "key-path witness shape (1 item, 64 bytes)");
+    const unsigned char *sig64 = f->dist_signed_tx.data + (L - 68);
+    TEST_ASSERT(secp256k1_schnorrsig_verify(ctx, sig64, f->dist_sighash, 32,
+                                             &fund_tweaked) == 1,
+                "G1: distributed dist-TX sig VALID vs funding key + dist_sighash");
+
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* Test: Distribution tx with 5 outputs: each gets (funding - fee) / 5 */
 int test_factory_distribution_tx_default(void) {
     secp256k1_context *ctx = test_ctx();

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1107,6 +1107,7 @@ extern int test_regtest_ptlc_turnover(void);
 extern int test_factory_lifecycle_states(void);
 extern int test_factory_lifecycle_queries(void);
 extern int test_factory_distribution_tx(void);
+extern int test_factory_distribution_tx_distributed(void);
 extern int test_factory_distribution_tx_default(void);
 
 /* Phase 8: Ladder manager */
@@ -3068,6 +3069,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_lifecycle_states);
     RUN_TEST(test_factory_lifecycle_queries);
     RUN_TEST(test_factory_distribution_tx);
+    RUN_TEST(test_factory_distribution_tx_distributed);
     RUN_TEST(test_factory_distribution_tx_default);
 
     printf("\n=== Ladder Manager (Phase 8d) ===\n");


### PR DESCRIPTION
## What

Foundation (G1a) for the offline-tolerant-rollover work (`docs/trustless-offline-tolerant-rollover-plan.md`): the crypto to **co-sign the distribution TX in the multi-party ceremony**.

## Why

The distribution TX is SuperScalar's offline-forever recovery net — nLockTime = factory CLTV, anyone broadcasts it at the deadline to pay each client their balance. But **production always uses the stateless creation path** (`lsp_run_factory_creation` → `_stateless`; daemon sets `SS_MUSIG_STATELESS=1`), which builds it **unsigned** (`dist_tx_ready` stays 1, never reaches 2 = signed). Consequences as shipped:
- an abandoned / offline-forever client has **no automatic payout** at the CLTV;
- partial-rotation's "the absent client is protected by the distribution TX" is **unsound**.

(Clients that come online before the CLTV are still safe via their own force-close — the documented guarantee holds. This restores the *offline-forever* net + makes partial-rotation sound.)

## Changes (additive — no production behavior change yet)

- **`factory_t`**: `dist_signing_session`, `dist_partial_sigs[]`, `dist_partial_sigs_received`, `dist_signed_tx` (free/detach lifecycle mirrors `dist_unsigned_tx`).
- **5 helpers** mirroring the per-node session helpers but targeting the funding output (key-path spend over `nodes[0].keyagg`, message = `dist_sighash`): `factory_session_{init,set_nonce,finalize,set_partial_sig,complete}_dist`. `complete` aggregates → finalizes `dist_signed_tx` and sets `dist_tx_ready=2`.
- **Test** `test_factory_distribution_tx_distributed`: drives the full 5-party distributed signing single-process and **Schnorr-verifies** the extracted witness sig against the funding output key + `dist_sighash` (a wrong taptweak would fail it).

## Next (separate PRs)
- **G1b**: wire this into the stateless creation ceremony (collect dist nonces/psigs), attach `distribution_tx_hex` to `FACTORY_READY`, `persist_save_distribution_tx`; carry through (partial-)rotation.
- **G1c**: e2e all-offline-recovery drill on the stateless path.
- **G2**: Tier-B graceful degradation (liveness fast-follow).

The construction redesign I initially feared is **not** needed — SuperScalar is already a timeout-tree; this closes the one real offline-recovery gap.