### PR TITLE
harden: gate all defense-bypass cheats behind the network cheat-allowed gate

### DIFF
--- a/src/chan_open.c
+++ b/src/chan_open.c
@@ -14,6 +14,7 @@
 #include "superscalar/sha256.h"
 #include "superscalar/tx_builder.h"
 #include "superscalar/wallet_source.h"
+#include "superscalar/crash_inject.h"   /* #9 superscalar_cheat_allowed() */
 #include <secp256k1.h>
 #include <string.h>
 #include <stdlib.h>
@@ -474,8 +475,12 @@ int chan_reestablish(peer_mgr_t *mgr, int peer_idx,
     {
         secp256k1_pubkey local_pcp;
         uint64_t pcp_cn = ch->commitment_number;
+        /* #9: defense-bypass cheat (restore an OLD state = broadcast a revoked
+           commitment).  Gate on superscalar_cheat_allowed() so it is inert on any
+           non-regtest network even if the env var is set. */
         const char *cheat_env = getenv("SS_CHEAT_SCB_RESTORE");
-        if (cheat_env && cheat_env[0] != '0' && ch->commitment_number > 0) {
+        if (superscalar_cheat_allowed() &&
+            cheat_env && cheat_env[0] != '0' && ch->commitment_number > 0) {
             uint64_t offset = 1;
             const char *off_env = getenv("SS_CHEAT_SCB_OFFSET");
             if (off_env && off_env[0] != '\0') {

--- a/src/client.c
+++ b/src/client.c
@@ -6,6 +6,7 @@
 #include "superscalar/persist.h"
 #include "superscalar/shachain.h"
 #include "superscalar/tx_builder.h"
+#include "superscalar/crash_inject.h"   /* #9 superscalar_cheat_allowed() */
 #include "superscalar/regtest.h"  /* CL7: regtest_send_raw_tx + regtest_t */
 #include <stdio.h>
 #include <stdlib.h>
@@ -3879,7 +3880,9 @@ static int client_handle_leaf_advance_stateless(int fd,
     tx_buf_init(&cl7_cheat_tx, 0);
     {
         const char *cheat_env = getenv("SS_CHEAT_CLIENT_SIDE");
-        if (cheat_env && atoi(cheat_env) == leaf_side &&
+        /* #9: defense-bypass cheat (client broadcasts an OLD signed state).
+           Gate on superscalar_cheat_allowed() -> inert on non-regtest networks. */
+        if (superscalar_cheat_allowed() && cheat_env && atoi(cheat_env) == leaf_side &&
             had_old_signed_c && ps_node->signed_tx.len > 0) {
             tx_buf_init(&cl7_cheat_tx, (int)ps_node->signed_tx.len);
             memcpy(cl7_cheat_tx.data, ps_node->signed_tx.data,

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1469,7 +1469,10 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        prep so it co-signs the new state but NOT the Leaf-P poison — exercising
        the client's fail-closed "no revoke without recourse" abort.  Env-gated
        test path only (same pattern as SS_CHEAT_DAEMON_MODE). */
-    if (mgr->watchtower && poison_required && !getenv("SS_CHEAT_OMIT_POISON")) {
+    if (mgr->watchtower && poison_required &&
+        /* #9: the OMIT_POISON test hook (skip poison registration) only honoured
+           when cheats are allowed (regtest); on mainnet poison ALWAYS registers. */
+        !(superscalar_cheat_allowed() && getenv("SS_CHEAT_OMIT_POISON"))) {
         if (factory_session_prepare_poison_tx_leaf(
                 f, pre_node_idx,
                 old_leaf_txid, (uint32_t)old_l_vout,
@@ -2770,7 +2773,7 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
        Mirrors the legacy lsp_run_state_advance hook so the stateless path
        honours the same test contract (clean rc=0 right after the first
        state-advance ceremony completes). */
-    if (getenv("SS_KILL_AFTER_STATE_ADVANCE")) {
+    if (superscalar_cheat_allowed() && getenv("SS_KILL_AFTER_STATE_ADVANCE")) {  /* #9: gated */
         printf("CL5: SS_KILL_AFTER_STATE_ADVANCE set — clean exit after ceremony\n");
         fflush(stdout);
         exit(0);

--- a/tests/test_adversarial_verify.c
+++ b/tests/test_adversarial_verify.c
@@ -21,6 +21,7 @@
  */
 #include "superscalar/musig.h"
 #include "superscalar/sha256.h"
+#include "superscalar/crash_inject.h"   /* #9 cheat-gate */
 #include <secp256k1_musig.h>
 #include <stdio.h>
 #include <string.h>
@@ -71,6 +72,29 @@ int test_adversarial_keyagg_substitution(void) {
                 "FORGERY: AB sig must NOT verify under substituted keyagg[A,C]");
 
     secp256k1_context_destroy(ctx);
+    return 1;
+}
+
+/* #9 CHEAT-GATE FAIL-SAFE: every library defense-bypass cheat (SS_CHEAT_* /
+   SS_KILL_*) calls superscalar_cheat_allowed() IN ADDITION to its env var, and
+   that gate is OFF unless a regtest binary explicitly opts in.  So on mainnet /
+   signet / testnet4 the cheat env vars are inert regardless of the environment.
+   This proves the gate's fail-safe default + network behaviour. */
+int test_adversarial_cheat_gate_failsafe(void) {
+    /* Default (no superscalar_set_cheat_gate call) = cheats NOT allowed. */
+    TEST_ASSERT(superscalar_cheat_allowed() == 0,
+                "cheat gate defaults to OFF (fail-safe)");
+    /* Non-regtest networks (is_regtest=0) keep it OFF -- mainnet/signet/testnet4. */
+    superscalar_set_cheat_gate(0);
+    TEST_ASSERT(superscalar_cheat_allowed() == 0,
+                "cheat gate OFF on non-regtest (mainnet) network");
+    /* Only regtest opts in. */
+    superscalar_set_cheat_gate(1);
+    TEST_ASSERT(superscalar_cheat_allowed() == 1,
+                "cheat gate ON only when regtest opts in");
+    /* Restore OFF so the regtest state can't leak into other unit tests. */
+    superscalar_set_cheat_gate(0);
+    TEST_ASSERT(superscalar_cheat_allowed() == 0, "cheat gate restored OFF");
     return 1;
 }
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1243,6 +1243,7 @@ extern int test_client_verifies_lsp_revocation(void);         /* revocation-veri
 extern int test_cheat_gate(void);                             /* #9 cheat-gate */
 extern int test_lsp_forgery_response_parse(void);             /* item-1 escalation policy parse */
 extern int test_adversarial_keyagg_substitution(void);        /* ADV matrix */
+extern int test_adversarial_cheat_gate_failsafe(void);        /* #9 cheat-gate */
 extern int test_adversarial_final_sig_tamper(void);
 extern int test_adversarial_wrong_message_binding(void);
 extern int test_persist_watchtower_hydrate_round_trip(void);
@@ -3148,6 +3149,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_cheat_gate);
     RUN_TEST(test_lsp_forgery_response_parse);
     RUN_TEST(test_adversarial_keyagg_substitution);
+    RUN_TEST(test_adversarial_cheat_gate_failsafe);
     RUN_TEST(test_adversarial_final_sig_tamper);
     RUN_TEST(test_adversarial_wrong_message_binding);
     RUN_TEST(test_persist_watchtower_hydrate_round_trip);

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2362,6 +2362,22 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
         }
+        /* #9: also refuse cheat/kill/crash ENV vars on mainnet (not just args).
+           The library gate (superscalar_cheat_allowed) already makes them inert,
+           but fail LOUD so a misconfigured mainnet node never starts with a
+           defense-bypass or crash-injection knob lurking in its environment. */
+        {
+            extern char **environ;
+            for (char **e = environ; e && *e; e++) {
+                if (strncmp(*e, "SS_CHEAT", 8) == 0 ||
+                    strncmp(*e, "SS_KILL", 7) == 0 ||
+                    strncmp(*e, "SUPERSCALAR_CRASH_AT", 20) == 0) {
+                    fprintf(stderr, "Error: test/cheat env var (%.40s) is refused "
+                            "on mainnet.\n", *e);
+                    return 1;
+                }
+            }
+        }
     }
 
     /* Mainnet requires --db for revocation secret persistence */


### PR DESCRIPTION
## What

Closes the mainnet-cheat-unreachability release-gate item by making **every** defense-bypass / crash-injection cheat inert on mainnet — both at the library layer (the robust, network-derived gate) and the daemon layer (fail-fast).

## The gap

An audit found **4 library cheat sites reading `SS_CHEAT_*`/`SS_KILL_*` env without the `superscalar_cheat_allowed()` gate**, and the daemon's mainnet refusal only covered `--cheat-*`/`--test-*` **args**, not env vars. So on a mainnet node, setting (e.g.) `SS_CHEAT_SCB_RESTORE` (restore a revoked commitment) or `SS_CHEAT_CLIENT_SIDE` (broadcast an old signed state) would have **fired the theft cheat**.

## Fix

- **Library gate** (the real defense — `superscalar_cheat_allowed()` is network-derived, defaults OFF, set ON only for regtest): gate the 4 ungated sites — `chan_open` `SS_CHEAT_SCB_RESTORE`, `client` `SS_CHEAT_CLIENT_SIDE`, `lsp_channels` `SS_CHEAT_OMIT_POISON` + `SS_KILL_AFTER_STATE_ADVANCE`. (`htlc_commit` and the other `lsp_channels` sites were already gated.)
- **Daemon guard** (defense-in-depth): the LSP now refuses `SS_CHEAT*`/`SS_KILL*`/`SUPERSCALAR_CRASH_AT` **env vars** on mainnet (fail loud at startup), not just the args.
- **Test**: `test_adversarial_cheat_gate_failsafe` proves the gate defaults OFF, stays OFF on non-regtest, and is ON only when regtest opts in.

## Result

Every defense-bypass / crash cheat is inert on mainnet/signet/testnet4 regardless of the environment (library gate), **and** the daemon won't even start with such a knob set (daemon guard). Two independent layers.