### PR TITLE
harden(bridge): secure-by-default transport + CLN-bridge security signoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,17 @@ jobs:
         run: |
           ulimit -s unlimited 2>/dev/null || ulimit -s 65520 2>/dev/null || true
           ./build/test_inproc_scale 4
+      - name: CLN-bridge secure-by-default (#5 finding 1)
+        # The bridge must REFUSE to start without --lsp-pubkey (unauthenticated NN
+        # is MITM-exposed) unless --insecure-no-auth is explicitly passed.
+        if: ${{ runner.os == 'Linux' && !matrix.sanitizers && !matrix.tsan }}
+        run: |
+          if ./build/superscalar_bridge >/tmp/br.out 2>&1; then
+            echo "FAIL: bridge started WITHOUT --lsp-pubkey"; cat /tmp/br.out; exit 1
+          fi
+          grep -q "refusing to start without --lsp-pubkey" /tmp/br.out || {
+            echo "FAIL: missing secure-by-default refusal"; cat /tmp/br.out; exit 1; }
+          echo "OK: bridge refuses unauthenticated NN startup by default"
 
   arm64-build-test:
     runs-on: ubuntu-latest

--- a/docs/cln-bridge-security-review.md
+++ b/docs/cln-bridge-security-review.md
@@ -1,0 +1,58 @@
+# CLN-bridge security review — signoff (task #330 / #5)
+
+Scope: the `superscalar_bridge` daemon (`tools/superscalar_bridge.c`, `src/bridge.c`)
+and the LSP-side bridge handling (`src/lsp_bridge.c`).  The bridge relays
+BOLT-2 HTLCs between an external CLN node and the SuperScalar LSP over a Noise
+transport.
+
+Reviewed 2026-06-27 against the current code (post #9/#54 merges).
+
+## Finding 1 — bridge↔LSP transport was not secure-by-default — FIXED
+
+**Was:** without `--lsp-pubkey`, `src/bridge.c:62-68` silently fell back to the
+**unauthenticated NN** Noise handshake (MITM-exposed) with only a `WARNING`.
+The runbook says the bridge MUST use `--lsp-pubkey`, but it was not enforced —
+a misconfigured production bridge would run unauthenticated.
+
+**Fix (this PR):** `superscalar_bridge` now **refuses to start without
+`--lsp-pubkey`** (authenticated NK) unless the operator explicitly passes the
+new `--insecure-no-auth` flag (testing only).  Mirrors the secure-by-default
+mainnet guards (#327a refuse-cmdline-seckey, #9 refuse-cheat-flags).  A CI step
+(`CLN-bridge secure-by-default`) asserts the refusal + message.
+
+## Finding 2 — LSP does not authenticate the bridge — SCOPED (low severity)
+
+**Observation:** `src/lsp_bridge.c:581` (`MSG_BRIDGE_HELLO`) replies `HELLO_ACK`
+without pinning/verifying the bridge's identity.  The LSP's responder handshake
+is NK (it authenticates the LSP *to* the bridge, not the bridge to the LSP) or
+NN, and `BRIDGE_HELLO` carries a cleartext (post-Noise) `bridge_pubkey` that is
+not proof-of-possession.  So any peer that completes the handshake can claim to
+be the bridge and submit `MSG_BRIDGE_ADD_HTLC`.
+
+**Severity: low**, bounded by existing mitigations:
+- the bridge port is normally **localhost-only** (bridge runs on the LSP host;
+  the runbook firewall section keeps it off the public interface);
+- **#10** already validates every bridge-relayed HTLC's provenance
+  (payment_hash / cltv / funding-depth), so a rogue bridge cannot forge
+  arbitrary HTLCs — it can only relay what passes provenance checks.
+
+**Proper fix (follow-on, not this PR):** mutual auth = Noise **KK** (the bridge's
+static key authenticated *in* the handshake) + an LSP-side `--bridge-pubkey`
+pin that rejects unknown bridges.  This is a transport-protocol change worth
+doing for defense-in-depth, but it is not a standalone theft vector given the
+localhost + #10 mitigations.  Tracked as a follow-on.
+
+## Finding 3 — bridge-relayed HTLC input validation — REVIEWED, no new gap
+
+`src/lsp_bridge.c:104+` (`MSG_BRIDGE_ADD_HTLC`) already rejects malformed /
+unauthorized HTLCs along many paths (`MSG_BRIDGE_FAIL_HTLC` at 138/148/159/169/
+188/218/309), and **#10** added payment_hash/cltv provenance + LSP funding-depth
+checks.  No new validation gap found in this review.
+
+## Signoff
+
+Finding 1 (the only one that left the production bridge unauthenticated by
+default) is **closed**.  Finding 2 is a **low-severity defense-in-depth
+follow-on** (mutual KK auth) with the rogue-bridge vector already bounded by
+localhost + #10.  Finding 3 is **already covered** by #10.  The bridge is signed
+off for v0.2.0 with Finding 2 documented as a tracked follow-on.

--- a/tools/superscalar_bridge.c
+++ b/tools/superscalar_bridge.c
@@ -16,6 +16,8 @@ static void usage(const char *prog) {
             "  --lsp-port PORT       LSP port (default: 9735)\n"
             "  --plugin-port PORT    Plugin listen port (default: 9736)\n"
             "  --lsp-pubkey HEX      LSP static pubkey (33-byte hex) for NK authentication\n"
+            "  --insecure-no-auth    allow UNAUTHENTICATED NN transport (MITM-exposed;\n"
+            "                        testing only -- production MUST use --lsp-pubkey)\n"
             "  --tor-proxy HOST:PORT SOCKS5 proxy for Tor (default: 127.0.0.1:9050)\n"
             "  --version             Show version and exit\n"
             "  --help                Show this help\n", prog);
@@ -27,6 +29,7 @@ int main(int argc, char *argv[]) {
     int plugin_port = 9736;
     const char *lsp_pubkey_hex = NULL;
     const char *tor_proxy_arg = NULL;
+    int insecure_no_auth = 0;   /* #5: explicit opt-in to unauthenticated NN */
 
     static struct option long_options[] = {
         {"lsp-host",    required_argument, 0, 'h'},
@@ -34,6 +37,7 @@ int main(int argc, char *argv[]) {
         {"plugin-port", required_argument, 0, 'p'},
         {"lsp-pubkey",  required_argument, 0, 'k'},
         {"tor-proxy",   required_argument, 0, 't'},
+        {"insecure-no-auth", no_argument,  0, 'I'},
         {"version",     no_argument,       0, 'v'},
         {"help",        no_argument,       0, '?'},
         {0, 0, 0, 0}
@@ -47,6 +51,7 @@ int main(int argc, char *argv[]) {
         case 'p': plugin_port = atoi(optarg); break;
         case 'k': lsp_pubkey_hex = optarg; break;
         case 't': tor_proxy_arg = optarg; break;
+        case 'I': insecure_no_auth = 1; break;
         case 'v':
             printf("superscalar_bridge %s\n", SUPERSCALAR_VERSION);
             return 0;
@@ -95,6 +100,20 @@ int main(int argc, char *argv[]) {
         printf("Bridge: NK authentication enabled (pinned LSP pubkey)\n");
         lsp_pubkey_set = 1;
         secp256k1_context_destroy(ctx);
+    }
+
+    /* #5 (CLN-bridge audit, finding 1): secure-by-default transport.  Without a
+       pinned LSP pubkey the bridge<->LSP channel is unauthenticated NN, which is
+       MITM-exposed.  Refuse to start unless the operator explicitly opts into the
+       insecure mode -- production MUST pass --lsp-pubkey (the LSP prints it at
+       startup).  Mirrors the secure-by-default mainnet guards (#327a/#9). */
+    if (!lsp_pubkey_set && !insecure_no_auth) {
+        fprintf(stderr,
+            "Error: refusing to start without --lsp-pubkey -- unauthenticated NN\n"
+            "transport is MITM-exposed.  Pass --lsp-pubkey HEX (the LSP prints it at\n"
+            "startup) for authenticated NK transport, or --insecure-no-auth to override\n"
+            "for testing only.\n");
+        return 1;
     }
 
     /* Supervisor loop: restart bridge on failure with escalating backoff.


### PR DESCRIPTION
## What

CLN-bridge security review signoff (task #330). I conducted the audit from the code; three findings, full writeup in **`docs/cln-bridge-security-review.md`**.

## Findings

1. **(FIXED) bridge↔LSP transport was not secure-by-default.** Without `--lsp-pubkey`, `src/bridge.c:62-68` silently fell back to **unauthenticated NN** (MITM-exposed) with only a warning — despite the runbook calling it mandatory. `superscalar_bridge` now **refuses to start without `--lsp-pubkey`** unless the operator passes the new `--insecure-no-auth` (testing only). Mirrors the `#327a`/`#9` secure-by-default guards. A CI step asserts the refusal.
2. **(SCOPED, low severity) LSP does not authenticate the bridge** — bounded by the localhost-only bridge port + `#10`'s HTLC-provenance validation. Proper fix = Noise KK + LSP `--bridge-pubkey` pin; tracked as a defense-in-depth follow-on.
3. **(REVIEWED, covered) bridge-relayed HTLC validation** — already handled by `#10`.

## Validation
- New CI step `CLN-bridge secure-by-default` runs `superscalar_bridge` with no `--lsp-pubkey` and asserts it exits non-zero with the refusal message (Linux plain config).
- Build compiles across the matrix.

Closes the bridge secure-by-default hole and signs off the bridge for v0.2.0 with finding 2 documented as a tracked follow-on.