### PR TITLE
test(trustless): all-offline distribution-TX recovery e2e (offline-forever net)

### DIFF
--- a/docs/trustless-offline-tolerant-rollover-plan.md
+++ b/docs/trustless-offline-tolerant-rollover-plan.md
@@ -1,0 +1,227 @@
+# #54 — Offline-tolerant rollover: complete understanding + design
+
+**Status:** design (no code yet). Researched 2026-06-26 across `src/factory.c`, `src/lsp_channels.c`,
+`src/lsp_rotation.c`, `src/lsp.c`, `src/channel.c`, `src/tapscript.c`, and `docs/`. This supersedes the
+earlier (wrong) read that #54 needs a taproot construction redesign.
+
+---
+
+## TL;DR
+
+The construction is a **timeout-tree** and is *already* built for offline-tolerance. Offline-tolerance is
+**mostly present**, not absent:
+
+- **PS leaf advances are 2-of-2 (LSP + that one client)** — one offline client only blocks *its own* leaf,
+  never the others (`lsp_advance_leaf_stateless`, lsp_channels.c:1354/1455/1510).
+- **Sub-factory chain advances are N-of-N over the *sub*'s clients only** — other subs' clients can be
+  offline (`lsp_subfactory_chain_advance_stateless`, lsp_channels.c:4213/4243).
+- **Lifetime extension already tolerates offline via *partial rotation*** — Phase A skips offline clients,
+  and if not everyone is online it spins up a NEW factory for the online subset and leaves the absent client
+  to exit the old factory (`lsp_rotation.c:276-281, 537-564, 745-762, 886-918`).
+- **Every output except the funding root has an LSP-alone-after-timeout escape** (staggered CLTV on tree
+  nodes, CSV on L-stock) so the LSP can always recover after timeouts and clients race those timeouts
+  (factory.c:186-201, 219-269, 1467-1484).
+- **The overlap window is inherent** — an absent client's prior fully-signed branch stays valid; it can exit
+  or roll over later.
+
+So the only *strict all-N* spend in the whole construction is the **funding UTXO** (spent once by the
+pre-signed root kickoff at broadcast). There is **no construction-level barrier** to offline-tolerance.
+
+**The two real gaps are in the ceremony/lifecycle layer, not the construction:**
+
+- **G1 (SAFETY, keystone):** the **stateless** factory-creation path builds the distribution TX *unsigned*
+  and never co-signs it (`lsp.c:510-523`). The distribution TX is the **offline-forever auto-recovery net**
+  (nLockTime = factory CLTV; anyone broadcasts it at the deadline to pay every client their balance). Without
+  it, the partial-rotation story "leave the absent client to exit the old factory" has no automatic payout —
+  the client must come online before the CLTV and force-close, or its balance can be swept by the LSP's
+  CLTV-recovery leaf. The legacy creation path co-signs it; the stateless path (the validated default) does
+  not. **This is the heart of #54: an isolated/absent client must still get its money.**
+
+- **G2 (LIVENESS):** the **Tier-B root rollover** hard-aborts (`return 0`) on any offline client
+  (lsp_channels.c:2285-2295, 2544-2566) — the "strict all-N freeze" the design doc flags at
+  lsp_channels.c:1996/2176/2435. It does NOT threaten funds (it re-signs within the same CLTV; the old epoch
+  stays valid), but it's a blunt failure, and PS leaf advances *fall through* to it when the DW counter is
+  exhausted (lsp_channels.c:1445-1452), so a single offline client can then block other leaves' advances.
+
+No taproot/construction change is required for either gap.
+
+---
+
+## 1. The construction (what we're working with)
+
+### 1.1 Two independent on-chain time bounds (do not conflate)
+
+1. **DW relative-timelock state machine (nSequence)** — the root/intermediate `NODE_STATE` nodes form a
+   Decker-Wattenhofer counter; advances decrement nSequence so the newest tree confirms first. Finite
+   (`states_per_layer × step`); exhaustion triggers a **Tier-B rollover** (epoch++). *Within-lifetime
+   cycling, not lifetime extension.* PS leaves themselves set nSequence `0xFFFFFFFE` (BIP-68 disabled) and
+   order states by TX-chaining instead.
+
+2. **Absolute CLTV deadline (`f->cltv_timeout`)** — the hard deadline by which clients must exit. It is the
+   root state's nLockTime / longest CLTV, the CLTV-recovery leaf height on every channel/leaf output, and the
+   distribution TX's nLockTime. **Assigned only at creation/rotation/DB-load; never mutated in place**
+   (writers: lsp.c:428, persist.c:2404, client.c:1020/1994). The only way it moves out is rotation to a
+   *new* factory.
+
+### 1.2 The timeout-tree escapes (offline-tolerance is built in)
+
+| Output | Internal key | Timeout/subset escape |
+|---|---|---|
+| Funding UTXO | N-of-N (all) | **none** — all-N key-path (the one strict-all-N spend; pre-signed at setup) |
+| Tree node (non-root kickoff/state) | N-of-N (subtree) | **LSP alone after staggered CLTV** (factory.c:186-201, 1467-1484) |
+| PS sub-factory *entry* | N-of-N (sub) | none (key-path only) |
+| Per-client channel funding | **2-of-2 (LSP+client)** | + LSP alone after factory/node CLTV |
+| L-stock | N-of-N (leaf) | **LSP alone after CSV** (Leaf L, 144 blk) |
+| Distribution TX | pre-signed payout | nLockTime = CLTV; **anyone** broadcasts at deadline |
+
+### 1.3 Who signs each ceremony
+
+| Ceremony | Signers | Offline tolerance | Moves CLTV? |
+|---|---|---|---|
+| PS leaf advance | 2-of-2 (LSP + that leaf's client) | other clients offline OK | no |
+| Sub-factory chain advance | N-of-N over the *sub* | other subs' clients offline OK | no |
+| **Tier-B root rollover** | **N-of-N over whole factory** | **none — `return 0`** | no (re-signs within CLTV) |
+| Rotation / new-factory creation | N-of-N over the *new* factory | full close needs all; else **partial** | **yes (only here)** |
+
+---
+
+## 2. What offline-tolerance already exists
+
+- **Per-leaf / per-sub isolation** (1.3 rows 1-2): a stalled client only stalls its own leaf/sub.
+- **Partial rotation** (`lsp_rotation.c`): on rotation with absent clients — Phase A *skips* them
+  (276-281); full cooperative close requires all online, else downgrade to **partial** (537-564); partial =
+  old factory NOT closed, "expires naturally, distribution TX protects participants" (745-762); a brand-new
+  factory is created for the online subset only (886-918); absent client is left to exit the old factory.
+- **Proactive exit** (#50): bounded retry → broadcast distribution TX before the CLTV (lsp_channels.c:7234-7301).
+- **Abort/intent-to-exit notice** (#49/#51, PR #397): clients are told `MSG_CEREMONY_ABORT` (RETRY_LIMIT) so
+  they stop waiting + check their watchtower.
+- **Overlap window:** prior fully-signed branches remain valid; absent client can exit/roll over later.
+
+The documented client guarantee is **"safe as long as you come online before the factory CLTV"**
+(client-user-guide.md:125,129). Offline-*forever* recovery is the *bonus* delivered by the distribution TX
+(`test_regtest_all_offline_recovery`, testing-guide.md:318-322) — and that bonus is exactly what G1 breaks
+in the stateless path.
+
+---
+
+## 3. The gaps + design
+
+### G1 (keystone, SAFETY) — co-sign + persist the distribution TX in the stateless creation ceremony
+
+**Problem.** `lsp.c:510-523` builds the dist TX unsigned and never co-signs it under the stateless signer
+(the default). `lsp_rotation.c:1032-1040` only copies a *signed* dist TX "if available" — so partial
+rotations inherit no dist TX either. Net: in a stateless-path factory, an absent/abandoned client has no
+automatic payout at the CLTV; `factory_recovery_run` (factory_recovery.c:381) has nothing signed to
+broadcast. This makes the partial-rotation "leave the absent client to the dist TX" story unsound for the
+stateless path.
+
+**Design.** Add one more all-N MuSig signing pass to the stateless factory-creation ceremony (everyone is
+online at creation by definition), producing a fully-signed distribution TX, and persist it via the existing
+`persist_save_distribution_tx` (persist.c:6572). Mechanically identical to how the ceremony already
+co-signs each tree node; the dist TX is just one more transaction over the funding-output keyagg with
+nLockTime = `f->cltv_timeout`. Set `f->dist_tx_ready` so rotation (lsp_rotation.c:1034) copies it forward.
+Mirror into the rotation/new-factory creation path so partial-rotation subsets also get a signed dist TX.
+
+**Fund-safety.** The dist TX pays each participant their creation-time balance at the CLTV. Co-signing it at
+creation (all-N online) is safe — it is the canonical "everyone exits at the deadline" fallback and adds no
+new spend path (the outputs already exist as the construction's intended payout). It strictly *adds* recourse
+for absent clients; it removes none.
+
+**Caveat to design carefully:** the dist TX reflects *creation-time* balances. After PS leaf / sub-factory
+advances change balances, the creation-time dist TX is stale for the moved amounts. This is the same property
+the legacy path has, and the deeper guarantee remains the client's own force-close (current commitment) +
+CLTV-recovery. The dist TX is the *offline-forever* net at roughly creation-time allocation. Document this
+precisely; do not over-claim it tracks live balances. (A live-balance dist TX is a larger future item.)
+
+### G2 (LIVENESS) — Tier-B root rollover graceful degradation
+
+**Problem.** Tier-B aborts hard on any offline client (lsp_channels.c:2285-2295, 2544-2566). PS leaf advance
+falls through to Tier-B when the DW counter exhausts (1445-1452), so one offline client can then block other
+leaves.
+
+**Design (no construction change).** The root state is genuinely all-N, so we cannot *advance the root*
+without everyone — and we should not pretend to. Instead make the failure graceful:
+
+1. **Tolerate transient absence (overlap window):** on a Tier-B all-N shortfall, do NOT treat it as terminal.
+   The current epoch's tree remains valid; defer the DW-epoch refresh and keep serving per-leaf/per-sub
+   advances that don't need the absent client. (Today the hard `return 0` is what the design doc calls the
+   "freeze.")
+2. **Escalate to the existing partial-rotation path on *persistent* absence**, rather than just failing — i.e.
+   wire the Tier-B shortfall into the same DYING/`lsp_rotation` machinery that already isolates absentees and
+   builds a new factory for the online subset. This realizes "isolate/timeout absentees → unilateral exit"
+   using machinery that already exists (G3).
+3. **Break the leaf→Tier-B fall-through coupling under absence:** when a PS leaf advance would fall through to
+   a Tier-B that can't reach all-N, prefer extending the leaf's overlap window / deferring the root tick over
+   blocking the leaf, so other leaves keep advancing. (Bounds the blast radius to the absent client's own
+   leaf, matching the PS per-leaf isolation property.)
+
+**Fund-safety.** Pure liveness — no new spend path, no change to what's broadcastable. The old epoch stays
+valid; G1's signed dist TX + the timeout-tree escapes remain the recovery floor.
+
+### G3 (VERIFY + TEST) — partial-rotation offline path end-to-end with the signed dist TX
+
+Partial rotation already exists; with G1 landed it becomes *sound*. Deliverable: an e2e regtest drill —
+N-client factory, kill one client, drive a rollover/rotation, assert (a) the online subset continues in a new
+factory, (b) the absent client's funds are recoverable via the *signed* dist TX at the CLTV
+(`test_regtest_all_offline_recovery`-style, but stateless path), (c) never an all-N freeze / mass-exit of the
+online subset. Maps to the design doc's matrix row 5 (`rollover_offline_client_degrade`).
+
+---
+
+## 4. What we explicitly do NOT do (and why)
+
+- **No taproot / funding construction redesign.** The all-N funding root is fine: the timeout-tree already
+  gives every lower output an LSP-after-timeout escape, and the signed dist TX (G1) gives absent clients an
+  automatic payout. Continuing the *same* on-chain factory without an absent client is impossible (all-N
+  funding) and unnecessary — lifetime extension is rotation-to-a-new-factory, which already does partial.
+- **No "exclude + cash out + continue same factory."** That would require subset-spending of the funding —
+  not supported, and not needed given partial rotation.
+- **No live-balance distribution TX** (tracks post-advance balances). Larger future item; out of scope here.
+
+---
+
+## 5. Staging (each a reviewable PR; G1 first — it's the safety keystone)
+
+1. **G1a** — co-sign + persist the distribution TX in the stateless factory-creation ceremony; set
+   `dist_tx_ready`; unit + regtest (`test_regtest_all_offline_recovery` must pass on the *stateless* path).
+2. **G1b** — carry the signed dist TX through rotation / partial-rotation (new factory for the online subset
+   gets a signed dist TX).
+3. **G2** — Tier-B graceful degradation (overlap-window tolerance + escalate-to-partial-rotation + break the
+   leaf fall-through under absence).
+4. **G3** — e2e offline-rotation drill (matrix row 5) on the stateless path.
+
+Order rationale: G1 is fund-safety (do first); G2/G3 are liveness/coverage on top. Each is consensus-adjacent
+and lands with tests + a reviewable diff.
+
+---
+
+## 5a. CONFIRMED 2026-06-26: stateless IS the production creation path (G1 is critical-path)
+
+Verified, not assumed: `lsp_run_factory_creation` (lsp.c:778) **unconditionally** delegates to
+`lsp_run_factory_creation_stateless` (lsp.c:784) — there is no separate legacy creation path left — and the
+daemon sets `SS_MUSIG_STATELESS=1` itself (tools/superscalar_lsp.c:1867). So **every factory created in
+production today has an UNSIGNED distribution TX** (`dist_tx_ready` stays 1; reaches 2 = signed only via
+client.c:888 which never triggers because the LSP never sends a signed dist TX). The offline-forever
+auto-recovery net and partial-rotation's "absent client protected by the dist TX" are therefore **unsound as
+shipped**. G1 is on the critical path.
+
+**G1a scope (infra already half-present):** `factory_build_distribution_tx_unsigned` (factory.c:4185) already
+computes `f->dist_sighash` (factory.h:431, called at lsp.c:521); the single-process signed builder
+`factory_build_distribution_tx` (factory.c:4099) shows the witness/finalize shape; the client already applies
+`distribution_tx_hex` from `MSG_FACTORY_READY` -> `dist_tx_ready=2` (client.c:878-888). The missing middle is
+the **distributed MuSig co-signing over `dist_sighash`** using the funding keyagg (= node[0].keyagg), then
+attaching `distribution_tx_hex` to FACTORY_READY + persisting via `persist_save_distribution_tx`
+(persist.c:6572). **Design choice (recommend the safer one): an ISOLATED dist-TX signing round after the
+node-signing completes (one new nonce+psig message pair), rather than widening the proven 3-message creation
+ceremony** — isolates risk to the new code path.
+
+## 6. Open questions for review
+
+1. **Offline-forever scope:** is offline-forever auto-recovery (the dist TX) an intended guarantee for the
+   stateless path, or acceptable to keep as "come online before CLTV"? G1 assumes we want the dist TX net
+   restored (recommended — it's the canonical SuperScalar fallback and partial-rotation depends on it).
+2. **Tier-B escalation trigger:** escalate to partial rotation immediately on a confirmed-persistent absence,
+   or only once the factory is already DYING? (Leaning: only when DYING or DW-counter critically low, to
+   avoid churning rotations on transient blips.)
+3. **Dist-TX staleness:** confirm we're content with a creation-time-balance dist TX as the offline-forever
+   net (with the client's own force-close as the live-balance guarantee), deferring a live-balance dist TX.

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -507,11 +507,13 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
         return 0;
     }
 
-    /* Build unsigned distribution TX so the unsigned dist TX is attached to f
-       (legacy rotation re-signs it later).  Stateless MVP does NOT co-sign the
-       dist TX during creation -- matches the validated sub-factory / state-
-       advance stateless ceremonies which carry no dist TX.  FACTORY_READY
-       therefore omits distribution_tx_hex. */
+    /* Build the UNSIGNED distribution TX and attach it to f.  #54 G1a/G1b:
+       this dist TX is then CO-SIGNED below in the stateless creation ceremony
+       (the per-signer dist nonce + partial-sig exchange), so FACTORY_READY
+       ships a fully-signed distribution_tx_hex -- the offline-forever recovery
+       net that lets ANYONE broadcast at the factory CLTV to pay every client
+       when all parties go offline.  (Legacy rotation also re-signs it later.)
+       Proven e2e by tools/test_regtest_all_offline_recovery.sh (#54 G1c). */
     {
         tx_output_t dist_outputs[FACTORY_MAX_SIGNERS + 1];
         size_t n_dist = factory_compute_distribution_outputs_balanced(f,

--- a/tools/test_regtest_all_offline_recovery.sh
+++ b/tools/test_regtest_all_offline_recovery.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# test_regtest_all_offline_recovery.sh -- #54 G1c: all-offline distribution-TX
+# recovery (regtest end-to-end).
+#
+# Proves the "offline-forever recovery net" that G1a/G1b restored.  At factory
+# creation the LSP + every client now CO-SIGN the distribution TX (a single TX
+# that spends the funding UTXO and pays each client their balance, with
+# nLockTime = the factory CLTV).  If EVERYONE goes offline forever and nobody
+# ever does a per-leaf unilateral exit, ANYONE can broadcast that one co-signed
+# distribution TX at the factory CLTV and every client still gets paid.
+#
+# Flow:
+#   1. Build an N-client PS factory (LSP --demo + N daemon clients).
+#   2. Assert every client co-signed + PERSISTED the distribution TX
+#      (distribution_txs row, factory_id=0) and they all hold the SAME tx.
+#   3. EVERYONE VANISHES (LSP + all clients killed; no per-leaf exit).
+#   4. CLTV gate: the dist TX must be REJECTED before its nLockTime (non-final).
+#   5. Mine to the nLockTime, then ANYONE broadcasts the dist TX.
+#   6. Assert it confirms, spends the factory funding UTXO, has N client
+#      outputs, and conserves value (Sigma outputs == funding - fee).
+#
+# This is the on-chain e2e counterpart to the in-process distributed-signing
+# proof (tests/test_factory.c::test_factory_distribution_tx_distributed +
+# test_inproc_scale dist_tx_ready==2).
+set -uo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar/build-release}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+N_CLIENTS="${N_CLIENTS:-4}"
+AMOUNT="${AMOUNT:-200000}"
+PORT="${PORT:-29958}"
+FEE="${FEE:-1100}"
+DIST_FEE_SATS=500   # must match lsp.c factory_compute_distribution_outputs_balanced fee arg
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+LSP_PUB="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+RU=$(awk -F= '/^[[:space:]]*rpcuser/{gsub(/ /,"",$2);print $2;exit}' "$REGTEST_CONF"); RU=${RU:-rpcuser}
+RP=$(awk -F= '/^[[:space:]]*rpcpassword/{gsub(/ /,"",$2);print $2;exit}' "$REGTEST_CONF"); RP=${RP:-rpcpass}
+RPORT=$(awk -F= '/^[[:space:]]*rpcport/{gsub(/ /,"",$2);print $2;exit}' "$REGTEST_CONF"); RPORT=${RPORT:-18443}
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+WALLET="ss_cheat_leaf_miner"
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "FAIL: sqlite3 not found"; exit 1; }
+[ -x "$LSP_BIN" ] || { echo "FAIL: $LSP_BIN not found"; exit 1; }
+[ -x "$CLIENT_BIN" ] || { echo "FAIL: $CLIENT_BIN not found"; exit 1; }
+
+TMPDIR=$(mktemp -d /tmp/ss-offline-recovery.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"; LSP_LOG="$TMPDIR/lsp.log"
+PIDS=(); MINER_PID=""
+cleanup(){
+    [ -n "$MINER_PID" ] && kill -9 "$MINER_PID" 2>/dev/null || true
+    for p in "${PIDS[@]:-}"; do kill -9 "$p" 2>/dev/null || true; done
+    cp "$LSP_LOG" /tmp/offline_recovery_last_lsp.log 2>/dev/null || true
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+green(){ printf '\033[32m%s\033[0m\n' "$*"; }
+red(){ printf '\033[31m%s\033[0m\n' "$*"; }
+fail(){ red "FAIL: $*"; exit 1; }
+mine(){ $BCLI -rpcwallet=$WALLET generatetoaddress "${1:-1}" "$MINE_ADDR" >/dev/null 2>&1 || true; }
+sk(){ printf "00000000000000000000000000000000000000000000000000000000000000%02x" $(( $1 + 1 )); }
+jget(){ python3 -c "import json,sys; d=json.load(sys.stdin); print($1)"; }
+
+$BCLI getblockchaininfo >/dev/null 2>&1 || fail "regtest bitcoind unreachable ($REGTEST_CONF)"
+$BCLI -named createwallet wallet_name=$WALLET load_on_startup=false 2>/dev/null || $BCLI loadwallet $WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$WALLET -named getnewaddress address_type=bech32m)
+mine 101
+
+echo "=== #54 G1c: all-offline distribution-TX recovery (regtest, N=$N_CLIENTS, amount=$AMOUNT) ==="
+
+# --- build the factory (LSP --demo + N daemon clients) ---
+"$LSP_BIN" --network regtest --port $PORT --demo --lsp-balance-pct 50 \
+    --clients $N_CLIENTS --arity 3 --amount $AMOUNT --fee-rate $FEE --confirm-timeout 600 \
+    --seckey "$LSP_SECKEY" --rpcuser "$RU" --rpcpassword "$RP" --rpcport "$RPORT" \
+    --wallet "$WALLET" --db "$LSP_DB" > "$LSP_LOG" 2>&1 &
+LSP_PID=$!; PIDS+=($LSP_PID)
+for i in $(seq 1 60); do sleep 1; grep -q "listening" "$LSP_LOG" 2>/dev/null && { echo "  LSP listening"; break; }; kill -0 $LSP_PID 2>/dev/null || { tail -25 "$LSP_LOG"; fail "LSP died before listening"; }; done
+grep -q "listening" "$LSP_LOG" || fail "LSP never listened"
+
+for i in $(seq 0 $((N_CLIENTS-1))); do
+    "$CLIENT_BIN" --network regtest --host 127.0.0.1 --port $PORT --daemon \
+        --seckey "$(sk $i)" --fee-rate $FEE --lsp-balance-pct 50 --lsp-pubkey "$LSP_PUB" \
+        --participant-id $((i+1)) --rpcuser "$RU" --rpcpassword "$RP" --rpcport "$RPORT" \
+        --wallet "$WALLET" --db "$TMPDIR/c${i}.db" > "$TMPDIR/c${i}.log" 2>&1 &
+    PIDS+=($!); sleep 0.4
+done
+( while kill -0 $LSP_PID 2>/dev/null; do mine 1; sleep 2; done ) & MINER_PID=$!
+
+echo "--- building factory; waiting for 'channels ready' ---"
+for i in $(seq 1 150); do sleep 2; grep -q "channels ready" "$LSP_LOG" 2>/dev/null && { echo "  channels ready"; break; }; kill -0 $LSP_PID 2>/dev/null || { tail -40 "$LSP_LOG"; fail "LSP died before factory ready"; }; done
+grep -q "channels ready" "$LSP_LOG" || { tail -40 "$LSP_LOG"; fail "factory never reached 'channels ready'"; }
+
+# --- verify EVERY client co-signed + PERSISTED the distribution TX (G1a/G1b) ---
+# A populated distribution_txs row proves the dist TX was co-signed
+# (dist_tx_ready==2), shipped in FACTORY_READY, and durably persisted by the
+# client daemon (tools/superscalar_client.c persist_save_distribution_tx).
+echo "--- verifying every client co-signed + persisted the distribution TX ---"
+ALLD=0
+for i in $(seq 1 40); do
+    sleep 2; ALLD=1
+    for c in $(seq 0 $((N_CLIENTS-1))); do
+        d=$(sqlite3 "$TMPDIR/c${c}.db" "SELECT count(*) FROM distribution_txs;" 2>/dev/null || echo 0)
+        [ "${d:-0}" -ge 1 ] || ALLD=0
+    done
+    [ "$ALLD" = 1 ] && break
+done
+for c in $(seq 0 $((N_CLIENTS-1))); do
+    d=$(sqlite3 "$TMPDIR/c${c}.db" "SELECT count(*) FROM distribution_txs;" 2>/dev/null || echo 0)
+    echo "    c$c: distribution_txs rows=$d"
+done
+[ "$ALLD" = 1 ] || fail "not every client persisted the co-signed distribution TX (offline-net missing) -- check FACTORY_READY dist co-signing"
+green "  every client durably holds the co-signed distribution TX (offline-forever recovery net present)"
+
+# --- extract the dist TX; all clients must hold the SAME co-signed tx ---
+DIST_HEX=$(sqlite3 "$TMPDIR/c0.db" "SELECT signed_tx_hex FROM distribution_txs LIMIT 1;" 2>/dev/null)
+[ -n "$DIST_HEX" ] || fail "could not extract distribution TX hex from c0.db"
+for c in $(seq 1 $((N_CLIENTS-1))); do
+    h=$(sqlite3 "$TMPDIR/c${c}.db" "SELECT signed_tx_hex FROM distribution_txs LIMIT 1;" 2>/dev/null)
+    [ "$h" = "$DIST_HEX" ] || fail "client c$c holds a DIFFERENT distribution TX than c0 (must be the shared co-signed tx)"
+done
+green "  all $N_CLIENTS clients hold the IDENTICAL co-signed distribution TX"
+
+DIST_DECODE=$($BCLI decoderawtransaction "$DIST_HEX" 2>/dev/null) || fail "decoderawtransaction failed (dist TX malformed)"
+# single-pass field extraction: P2TR client outputs vs the #56 P2A CPFP anchor
+# (script 51024e73, 240 sats, appended when feerate >= 1000 sat/kvB so the
+# offline net can be CPFP-bumped to win the mass-exit fee race).
+eval "$(printf '%s\n' "$DIST_DECODE" | python3 -c '
+import json,sys
+d=json.load(sys.stdin); vout=d["vout"]
+tr =[o for o in vout if o.get("scriptPubKey",{}).get("type")=="witness_v1_taproot"]
+anc=[o for o in vout if o.get("scriptPubKey",{}).get("hex")=="51024e73"]
+print("DIST_TXID=%s"%d["txid"])
+print("DIST_NLOCK=%d"%d["locktime"])
+print("DIST_NOUT=%d"%len(vout))
+print("DIST_NIN=%d"%len(d["vin"]))
+print("DIST_VIN=%s:%d"%(d["vin"][0]["txid"],d["vin"][0]["vout"]))
+print("DIST_OUTSUM=%d"%int(round(sum(o["value"] for o in vout)*1e8)))
+print("DIST_TR_N=%d"%len(tr))
+print("DIST_ANCHOR_N=%d"%len(anc))
+print("DIST_ANCHOR_VAL=%d"%int(round(sum(o["value"] for o in anc)*1e8)))
+')"
+echo "  dist txid     : $DIST_TXID"
+echo "  dist nLockTime: $DIST_NLOCK   (== factory CLTV)"
+echo "  dist inputs   : $DIST_NIN  (spends $DIST_VIN -- the factory funding UTXO)"
+echo "  dist outputs  : $DIST_NOUT  ($DIST_TR_N P2TR client + $DIST_ANCHOR_N P2A anchor)  Sigma=$DIST_OUTSUM sats  (funding=$AMOUNT)"
+[ "$DIST_NLOCK" -gt 0 ] || fail "dist TX nLockTime is 0 -- not CLTV-gated"
+[ "$DIST_NIN" -eq 1 ] || fail "dist TX has $DIST_NIN inputs, expected 1 (the funding UTXO)"
+[ "$DIST_TR_N" -eq "$N_CLIENTS" ] || fail "dist TX has $DIST_TR_N P2TR outputs, expected $N_CLIENTS (one per client)"
+[ "$DIST_ANCHOR_N" -le 1 ] || fail "dist TX has $DIST_ANCHOR_N P2A anchors, expected 0 or 1"
+[ "$DIST_NOUT" -eq $((DIST_TR_N + DIST_ANCHOR_N)) ] || fail "dist TX outputs unaccounted (nout=$DIST_NOUT tr=$DIST_TR_N anchor=$DIST_ANCHOR_N)"
+if [ "$DIST_ANCHOR_N" -eq 1 ]; then
+    [ "$DIST_ANCHOR_VAL" -eq 240 ] || fail "P2A anchor value $DIST_ANCHOR_VAL, expected 240 (#56 CPFP anchor)"
+    green "  dist TX carries a #56 P2A CPFP anchor (240 sats) -- offline net is fee-bumpable at the deadline"
+fi
+
+# --- verify the funding UTXO is currently UNSPENT (factory still open) ---
+FUND_TXID=$(echo "$DIST_VIN" | cut -d: -f1); FUND_VOUT=$(echo "$DIST_VIN" | cut -d: -f2)
+UTXO=$($BCLI gettxout "$FUND_TXID" "$FUND_VOUT" 2>/dev/null)
+[ -n "$UTXO" ] || fail "funding UTXO $DIST_VIN already spent before recovery (factory was closed) -- cannot test offline net"
+green "  factory funding UTXO $DIST_VIN is UNSPENT (factory open, no per-leaf exit)"
+
+# --- EVERYONE VANISHES (offline forever) ---
+echo "--- EVERYONE VANISHES (LSP + all $N_CLIENTS clients killed; nobody does a per-leaf exit) ---"
+kill -9 "$MINER_PID" 2>/dev/null || true; MINER_PID=""
+for p in "${PIDS[@]}"; do kill -9 "$p" 2>/dev/null || true; done
+PIDS=(); sleep 2
+
+# --- CLTV gate: dist TX must be REJECTED before its nLockTime ---
+H=$($BCLI getblockcount)
+echo "--- CLTV gate check: height=$H, dist nLockTime=$DIST_NLOCK ---"
+if [ "$H" -lt "$DIST_NLOCK" ]; then
+    EARLY=$($BCLI sendrawtransaction "$DIST_HEX" 2>&1 || true)
+    echo "  early broadcast -> $EARLY"
+    if echo "$EARLY" | grep -qiE "non-final|nonfinal|non-BIP68"; then
+        green "  dist TX correctly REJECTED before nLockTime (CLTV gate holds)"
+    elif echo "$EARLY" | grep -qE "^[0-9a-f]{64}$"; then
+        fail "dist TX confirmed BEFORE its nLockTime -- CLTV gate BROKEN"
+    else
+        echo "  (early broadcast rejected for another reason; CLTV gate inconclusive: $EARLY)"
+    fi
+else
+    echo "  (chain already at/after nLockTime; skipping early-rejection check)"
+fi
+
+# --- mine to the nLockTime, then ANYONE broadcasts the dist TX ---
+H=$($BCLI getblockcount); NEED=$(( DIST_NLOCK - H ))
+if [ "$NEED" -gt 0 ]; then echo "--- mining $((NEED+1)) blocks to reach factory CLTV ($DIST_NLOCK) ---"; mine $((NEED+1)); fi
+H=$($BCLI getblockcount); echo "  height now $H (>= nLockTime $DIST_NLOCK)"
+
+echo "--- broadcasting the co-signed distribution TX (no LSP, no client online) ---"
+SENT=$($BCLI sendrawtransaction "$DIST_HEX" 2>&1 || true)
+echo "  sendrawtransaction -> $SENT"
+echo "$SENT" | grep -qE "^[0-9a-f]{64}$" || fail "dist TX broadcast rejected after nLockTime: $SENT"
+mine 2
+CONF=$($BCLI getrawtransaction "$DIST_TXID" true 2>/dev/null | jget "d.get('confirmations',0)" 2>/dev/null || echo 0)
+echo "  dist TX confirmations: $CONF"
+
+# --- assertions ---
+FEE_PAID=$(( AMOUNT - DIST_OUTSUM ))
+echo
+echo "=== offline-recovery accounting ==="
+echo "  dist TX confirmed         : ${CONF} confs"
+echo "  spent funding UTXO        : $DIST_VIN"
+echo "  client P2TR outputs       : $DIST_TR_N  (expected $N_CLIENTS)"
+echo "  P2A CPFP anchors          : $DIST_ANCHOR_N  (total vout $DIST_NOUT)"
+echo "  Sigma dist outputs        : $DIST_OUTSUM sats"
+echo "  on-chain fee (funding-Sigma): $FEE_PAID sats (expected $DIST_FEE_SATS)"
+if [ "${CONF:-0}" -ge 1 ] \
+   && [ "$DIST_TR_N" -eq "$N_CLIENTS" ] \
+   && [ "$DIST_OUTSUM" -eq $((AMOUNT - DIST_FEE_SATS)) ] \
+   && [ "$FEE_PAID" -eq "$DIST_FEE_SATS" ]; then
+    UTXO2=$($BCLI gettxout "$FUND_TXID" "$FUND_VOUT" 2>/dev/null)
+    [ -z "$UTXO2" ] || fail "funding UTXO still unspent after dist broadcast -- dist TX did not spend it"
+    green "PASS: with EVERYONE offline forever, the co-signed distribution TX confirmed at the factory CLTV,"
+    green "      spent the funding UTXO, and paid all $N_CLIENTS clients ($DIST_TR_N P2TR outputs + $DIST_ANCHOR_N anchor,"
+    green "      Sigma=$DIST_OUTSUM/$AMOUNT sats, fee=$FEE_PAID). #54 offline-forever recovery net PROVEN e2e on regtest. [#54 G1c]"
+    exit 0
+else
+    fail "offline-recovery assertions failed (conf=$CONF tr_n=$DIST_TR_N outsum=$DIST_OUTSUM expect=$((AMOUNT-DIST_FEE_SATS)) fee=$FEE_PAID)"
+fi


### PR DESCRIPTION
**G1c** — the regtest end-to-end proof for the offline-tolerant rollover work. G1a/G1b restored the **co-signed distribution TX** (the offline-forever recovery net) in the stateless factory-creation ceremony; this validates it on-chain.

### What it proves
`tools/test_regtest_all_offline_recovery.sh` builds an N-client PS factory, asserts **every client co-signed + durably persisted the IDENTICAL distribution TX**, then has **everyone vanish** (no per-leaf exit) and proves:
- **CLTV gate**: the dist TX is rejected `non-final` before its nLockTime;
- after mining to the factory CLTV, **anyone** can broadcast it and it **confirms**;
- it spends the funding UTXO, pays one P2TR output per client, carries the **P2A CPFP anchor** (fee-bumpable at the deadline), and **conserves value** (Σ outputs == funding − fee).

### Verified
PASS on the VPS regtest (N=4): dist TX confirmed 2 confs at the CLTV with all parties offline, Σ=199500/200000, fee=500. Complements the in-process distributed-signing proof already in CI (`test_factory_distribution_tx_distributed` + `test_inproc_scale` `dist_tx_ready==2`).

### Also
- `src/lsp.c`: replace the stale pre-G1b comment ("MVP does NOT co-sign the dist TX … FACTORY_READY omits distribution_tx_hex") with an accurate one — the dist TX **is** co-signed and shipped now.
- `docs/trustless-offline-tolerant-rollover-plan.md`: the corrected timeout-tree design + gap analysis this validates.

No production-code behavior change (comment + new test harness + design doc).