### PR TITLE
feat(persist): seal the remaining at-rest secret columns (key-at-rest hardening)

### DIFF
--- a/src/persist.c
+++ b/src/persist.c
@@ -4514,21 +4514,26 @@ int persist_save_departed_client(persist_t *p, uint32_t factory_id,
 
     char key_hex[65];
     hex_encode(extracted_key32, 32, key_hex);
+    char *dc_sealed = persist_seal_text(p, key_hex);   /* #327b: seal at rest (client privkey) */
+    memset(key_hex, 0, sizeof key_hex);
+    if (!dc_sealed) return 0;
 
     const char *sql =
         "INSERT OR REPLACE INTO departed_clients "
         "(factory_id, client_idx, extracted_key) VALUES (?, ?, ?);";
 
     sqlite3_stmt *stmt;
-    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
-        return 0;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        memset(dc_sealed, 0, strlen(dc_sealed)); free(dc_sealed); return 0;
+    }
 
     sqlite3_bind_int(stmt, 1, (int)factory_id);
     sqlite3_bind_int(stmt, 2, (int)client_idx);
-    sqlite3_bind_text(stmt, 3, key_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, dc_sealed, -1, SQLITE_TRANSIENT);
 
     int ok3 = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
+    memset(dc_sealed, 0, strlen(dc_sealed)); free(dc_sealed);
     return ok3;
 }
 
@@ -4551,12 +4556,17 @@ size_t persist_load_departed_clients(persist_t *p, uint32_t factory_id,
     size_t count = 0;
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         uint32_t cidx = (uint32_t)sqlite3_column_int(stmt, 0);
-        const char *key_hex = (const char *)sqlite3_column_text(stmt, 1);
+        const char *stored = (const char *)sqlite3_column_text(stmt, 1);
 
         if (cidx < max_clients) {
             if (departed_out) departed_out[cidx] = 1;
-            if (keys_out && key_hex)
-                hex_decode(key_hex, keys_out[cidx], 32);
+            if (keys_out && stored) {
+                char *key_pt = NULL;                       /* #327b: open at rest */
+                if (persist_open_text(p, stored, &key_pt) && key_pt) {
+                    hex_decode(key_pt, keys_out[cidx], 32);
+                    memset(key_pt, 0, strlen(key_pt)); free(key_pt);
+                }
+            }
         }
         count++;
     }
@@ -4975,19 +4985,24 @@ int persist_save_anchor_key(persist_t *p, const unsigned char *seckey32) {
 
     char key_hex[65];
     hex_encode(seckey32, 32, key_hex);
+    char *ak_sealed = persist_seal_text(p, key_hex);   /* #327b: seal at rest (anchor seckey) */
+    memset(key_hex, 0, sizeof key_hex);
+    if (!ak_sealed) return 0;
 
     const char *sql =
         "INSERT OR REPLACE INTO watchtower_keys (key_name, key_hex) "
         "VALUES ('anchor', ?);";
 
     sqlite3_stmt *stmt;
-    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK)
-        return 0;
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        memset(ak_sealed, 0, strlen(ak_sealed)); free(ak_sealed); return 0;
+    }
 
-    sqlite3_bind_text(stmt, 1, key_hex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 1, ak_sealed, -1, SQLITE_TRANSIENT);
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
+    memset(ak_sealed, 0, strlen(ak_sealed)); free(ak_sealed);
     return ok;
 }
 
@@ -5006,10 +5021,13 @@ int persist_load_anchor_key(persist_t *p, unsigned char *seckey32_out) {
         return 0;
     }
 
-    const char *hex = (const char *)sqlite3_column_text(stmt, 0);
+    const char *stored = (const char *)sqlite3_column_text(stmt, 0);
     int ok = 0;
-    if (hex && hex_decode(hex, seckey32_out, 32) == 32)
+    char *hex = NULL;                                  /* #327b: open at rest */
+    if (stored && persist_open_text(p, stored, &hex) && hex &&
+        hex_decode(hex, seckey32_out, 32) == 32)
         ok = 1;
+    if (hex) { memset(hex, 0, strlen(hex)); free(hex); }
 
     sqlite3_finalize(stmt);
     return ok;

--- a/src/persist.c
+++ b/src/persist.c
@@ -1765,17 +1765,23 @@ int persist_update_l_stock_secret(persist_t *p, uint32_t factory_id, uint32_t no
                                   const unsigned char *secret32) {
     if (!p || !p->db || !secret32) return 0;
     char s_hex[65]; hex_encode(secret32, 32, s_hex);
+    char *ls_sealed = persist_seal_text(p, s_hex);   /* #327b: seal at rest */
+    memset(s_hex, 0, sizeof s_hex);
+    if (!ls_sealed) return 0;
     sqlite3_stmt *stmt;
     const char *sql =
         "UPDATE l_stock_poison_reveals SET revocation_secret = ? "
         "WHERE factory_id = ? AND node_idx = ? AND state_counter = ?;";
-    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) return 0;
-    sqlite3_bind_text(stmt, 1, s_hex, -1, SQLITE_TRANSIENT);
+    if (sqlite3_prepare_v2(p->db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        memset(ls_sealed, 0, strlen(ls_sealed)); free(ls_sealed); return 0;
+    }
+    sqlite3_bind_text(stmt, 1, ls_sealed, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int (stmt, 2, (int)factory_id);
     sqlite3_bind_int (stmt, 3, (int)node_idx);
     sqlite3_bind_int (stmt, 4, (int)state_counter);
     int ok = (sqlite3_step(stmt) == SQLITE_DONE) && (sqlite3_changes(p->db) > 0);
     sqlite3_finalize(stmt);
+    memset(ls_sealed, 0, strlen(ls_sealed)); free(ls_sealed);
     return ok;
 }
 
@@ -1826,7 +1832,13 @@ int persist_load_l_stock_poison(persist_t *p, uint32_t factory_id, uint32_t node
             hex_decode(cb, control_block_out, n); *control_block_len_out = n;
         }
         if (out_has_secret) *out_has_secret = (sec != NULL);
-        if (sec && secret_out32) hex_decode(sec, secret_out32, 32);
+        if (sec && secret_out32) {                          /* #327b: open at rest */
+            char *sec_pt = NULL;
+            if (persist_open_text(p, sec, &sec_pt) && sec_pt) {
+                hex_decode(sec_pt, secret_out32, 32);
+                memset(sec_pt, 0, strlen(sec_pt)); free(sec_pt);
+            }
+        }
     }
     sqlite3_finalize(stmt);
     return found;
@@ -2840,10 +2852,13 @@ int persist_save_revocation(persist_t *p, uint32_t channel_id,
 
     sqlite3_bind_int(stmt, 1, (int)channel_id);
     sqlite3_bind_int64(stmt, 2, (sqlite3_int64)commitment_number);
-    sqlite3_bind_text(stmt, 3, secret_hex, -1, SQLITE_TRANSIENT);
+    char *rs_sealed = persist_seal_text(p, secret_hex);   /* #327b: seal at rest */
+    if (!rs_sealed) { sqlite3_finalize(stmt); return 0; }
+    sqlite3_bind_text(stmt, 3, rs_sealed, -1, SQLITE_TRANSIENT);
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
+    memset(rs_sealed, 0, strlen(rs_sealed)); free(rs_sealed);
     return ok;
 }
 
@@ -4858,10 +4873,20 @@ int persist_save_basepoints(persist_t *p, uint32_t channel_id,
         return 0;
 
     sqlite3_bind_int(stmt, 1, (int)channel_id);
-    sqlite3_bind_text(stmt, 2, pay_hex, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 3, delay_hex, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 4, revoc_hex, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 5, htlc_hex, -1, SQLITE_TRANSIENT);
+    /* #327b: seal the four local basepoint secrets at rest (remote bps are public). */
+    char *bp_pay   = persist_seal_text(p, pay_hex);
+    char *bp_delay = persist_seal_text(p, delay_hex);
+    char *bp_revoc = persist_seal_text(p, revoc_hex);
+    char *bp_htlc  = persist_seal_text(p, htlc_hex);
+    if (!bp_pay || !bp_delay || !bp_revoc || !bp_htlc) {
+        free(bp_pay); free(bp_delay); free(bp_revoc); free(bp_htlc);
+        sqlite3_finalize(stmt);
+        return 0;
+    }
+    sqlite3_bind_text(stmt, 2, bp_pay,   -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, bp_delay, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 4, bp_revoc, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 5, bp_htlc,  -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 6, rpay_hex, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 7, rdelay_hex, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 8, rrevoc_hex, -1, SQLITE_TRANSIENT);
@@ -4869,6 +4894,10 @@ int persist_save_basepoints(persist_t *p, uint32_t channel_id,
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
+    memset(bp_pay,0,strlen(bp_pay));     free(bp_pay);
+    memset(bp_delay,0,strlen(bp_delay)); free(bp_delay);
+    memset(bp_revoc,0,strlen(bp_revoc)); free(bp_revoc);
+    memset(bp_htlc,0,strlen(bp_htlc));   free(bp_htlc);
 
 #if BASEPOINT_DIAG
     if (ok)
@@ -5494,10 +5523,13 @@ int persist_save_flat_secrets(persist_t *p, uint32_t factory_id,
 
         sqlite3_bind_int(stmt, 1, (int)factory_id);
         sqlite3_bind_int(stmt, 2, (int)i);
-        sqlite3_bind_text(stmt, 3, hex, -1, SQLITE_TRANSIENT);
+        char *frs_sealed = persist_seal_text(p, hex);   /* #327b: seal at rest */
+        if (!frs_sealed) { sqlite3_finalize(stmt); if (own_txn) persist_rollback(p); return 0; }
+        sqlite3_bind_text(stmt, 3, frs_sealed, -1, SQLITE_TRANSIENT);
 
         int ok = (sqlite3_step(stmt) == SQLITE_DONE);
         sqlite3_finalize(stmt);
+        memset(frs_sealed, 0, strlen(frs_sealed)); free(frs_sealed);
         if (!ok) {
             if (own_txn) persist_rollback(p);
             return 0;
@@ -6945,10 +6977,15 @@ int persist_save_revocation_release(persist_t *p,
     sqlite3_bind_blob(st, 1, factory_instance_id32, 32, SQLITE_STATIC);
     sqlite3_bind_blob(st, 2, state_id32, 32, SQLITE_STATIC);
     sqlite3_bind_blob(st, 3, participant_pubkey33, 33, SQLITE_STATIC);
-    sqlite3_bind_blob(st, 4, revocation_secret32, 32, SQLITE_STATIC);
+    unsigned char *rr_sealed = NULL; size_t rr_slen = 0;   /* #327b: seal at rest */
+    if (!persist_seal_blob(p, revocation_secret32, 32, &rr_sealed, &rr_slen)) {
+        sqlite3_finalize(st); return 0;
+    }
+    sqlite3_bind_blob(st, 4, rr_sealed, (int)rr_slen, SQLITE_TRANSIENT);
     sqlite3_bind_int(st, 5, (int)received_at_block);
     int rc = sqlite3_step(st);
     sqlite3_finalize(st);
+    memset(rr_sealed, 0, rr_slen); free(rr_sealed);
     return rc == SQLITE_DONE ? 1 : 0;
 }
 

--- a/src/persist_crypto.c
+++ b/src/persist_crypto.c
@@ -216,17 +216,34 @@ int persist_open_blob(persist_t *p, const unsigned char *stored, size_t stored_l
 typedef struct { const char *table, *idcol, *col; int is_blob; } secret_col_t;
 static const secret_col_t SECRET_COLS[] = {
     /* The crown jewel: the HD wallet seed. A plaintext read of this row alone
-       lets an attacker derive every wallet key and drain all funds — so it is
-       sealed first and on its own (fully wrapped at runtime + tested).
+       lets an attacker derive every wallet key and drain all funds. */
+    { "hd_wallet_state",            "id",         "seed_hex",                0 },
 
-       FAST-FOLLOW (same pattern, each needs its runtime accessor wrapped +
-       an enc_version bump so existing rows re-migrate):
-         revocation_secrets.secret, factory_revocation_secrets.secret,
-         channels.local_{payment,delayed,revocation,htlc}_secret,
-         revocation_releases.revocation_secret (BLOB).
+    /* #327b fast-follow — the remaining at-rest secrets.  Per-commitment and
+       per-factory revocation secrets, the four per-channel basepoint secrets,
+       and received revocation releases.  The migrate id is `rowid` for the
+       composite-PK tables (revocation_secrets, factory_revocation_secrets,
+       revocation_releases are ordinary rowid tables — a single PK column would
+       not uniquely address a row); channel_basepoints keys on its channel_id
+       PK.  Runtime read/write accessors are sealed/opened to match (writers in
+       persist.c, readers in persist_secrets.c).  The migration pass is
+       idempotent (already-sealed rows are skipped) and runs on every keyed
+       open, so adding a column here auto-seals it on the next startup with no
+       schema/enc-version bump.
        v0.3 (payment-privacy tier): preimage / payment_secret / stateless_nonce
        across htlcs/ptlcs/ln_invoices/local_pcs. */
-    { "hd_wallet_state",            "id",         "seed_hex",                0 },
+    { "revocation_secrets",         "rowid",      "secret",                  0 },
+    { "factory_revocation_secrets", "rowid",      "secret",                  0 },
+    { "channel_basepoints",         "channel_id", "local_payment_secret",    0 },
+    { "channel_basepoints",         "channel_id", "local_delayed_secret",    0 },
+    { "channel_basepoints",         "channel_id", "local_revocation_secret", 0 },
+    { "channel_basepoints",         "channel_id", "local_htlc_secret",       0 },
+    { "revocation_releases",        "rowid",      "revocation_secret",       1 },
+    /* #53 revealed L-stock poison secret.  The column is declared BLOB but the
+       runtime accessors store/read it as a TEXT hex string, so it seals as text
+       (is_blob=0).  This is the column the l_stock_poison_reveals schema comment
+       promises is sealed at rest. */
+    { "l_stock_poison_reveals",     "rowid",      "revocation_secret",       0 },
 };
 static const size_t N_SECRET_COLS = sizeof(SECRET_COLS) / sizeof(SECRET_COLS[0]);
 
@@ -349,10 +366,15 @@ int persist_apply_encryption(persist_t *p) {
             fprintf(stderr, "persist: DB encryption verification token mismatch — refusing to open.\n");
             return 0;
         }
-        return 1;
+        /* DEK verified.  Fall through to the idempotent migration so that any
+           secret columns added to SECRET_COLS since this DB was first sealed
+           (#327b fast-follow) get sealed on this open. */
     }
 
-    /* No token yet: migrate existing plaintext rows + write the token, atomically. */
+    /* Seal any not-yet-sealed registered columns (idempotent — already-sealed
+       rows are skipped) and, on first encryption only, write the verify token.
+       Atomic.  Running on every keyed open auto-migrates newly-registered
+       columns without a schema/enc-version bump. */
     int own_txn = !persist_in_transaction(p);
     if (own_txn && !persist_begin(p)) return 0;
     int ok = 1;
@@ -362,7 +384,7 @@ int persist_apply_encryption(persist_t *p) {
         if (!ok) fprintf(stderr, "persist: encryption migration failed at %s.%s\n",
                          SECRET_COLS[i].table, SECRET_COLS[i].col);
     }
-    if (ok) {
+    if (ok && !have_token) {
         unsigned char *tok = NULL; size_t toklen = 0;
         ok = persist_seal_blob(p, (const unsigned char *)VERIFY_PLAINTEXT,
                                sizeof(VERIFY_PLAINTEXT) - 1, &tok, &toklen);
@@ -380,7 +402,8 @@ int persist_apply_encryption(persist_t *p) {
         free(tok);
     }
     if (own_txn) { if (ok) ok = persist_commit(p); else persist_rollback(p); }
-    if (ok) fprintf(stderr, "persist: at-rest field encryption active (%zu secret columns sealed).\n", N_SECRET_COLS);
+    if (ok) fprintf(stderr, "persist: at-rest field encryption active (%zu secret columns %s).\n",
+                    N_SECRET_COLS, have_token ? "verified" : "sealed");
     return ok;
 }
 

--- a/src/persist_crypto.c
+++ b/src/persist_crypto.c
@@ -244,6 +244,15 @@ static const secret_col_t SECRET_COLS[] = {
        (is_blob=0).  This is the column the l_stock_poison_reveals schema comment
        promises is sealed at rest. */
     { "l_stock_poison_reveals",     "rowid",      "revocation_secret",       0 },
+    /* #327b round-2 — two more at-rest PRIVATE KEYS flagged in review:
+       departed_clients.extracted_key is a 32-byte client privkey (fed to
+       secp256k1_keypair_create in ladder.c to sign a departed client's
+       cooperative close), and watchtower_keys.key_hex ('anchor') is the WT's
+       32-byte CPFP anchor seckey.  Both were hex-stored in the clear.  Both are
+       rowid tables (departed_clients has a composite PK, watchtower_keys a TEXT
+       PK), so the migrate id is `rowid`. */
+    { "departed_clients",           "rowid",      "extracted_key",           0 },
+    { "watchtower_keys",            "rowid",      "key_hex",                 0 },
 };
 static const size_t N_SECRET_COLS = sizeof(SECRET_COLS) / sizeof(SECRET_COLS[0]);
 

--- a/src/persist_secrets.c
+++ b/src/persist_secrets.c
@@ -53,13 +53,15 @@ int persist_load_revocations_flat(persist_t *p, uint32_t channel_id,
     size_t count = 0;
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         uint64_t commit_num = (uint64_t)sqlite3_column_int64(stmt, 0);
-        const char *hex = (const char *)sqlite3_column_text(stmt, 1);
-        if (!hex || commit_num >= max) continue;
-
+        const char *stored = (const char *)sqlite3_column_text(stmt, 1);
+        if (!stored || commit_num >= max) continue;
+        char *hex = NULL;                                  /* #327b: open at rest */
+        if (!persist_open_text(p, stored, &hex) || !hex) continue;
         if (hex_decode(hex, secrets_out[commit_num], 32) == 32) {
             valid_out[commit_num] = 1;
             count++;
         }
+        memset(hex, 0, strlen(hex)); free(hex);
     }
 
     sqlite3_finalize(stmt);
@@ -89,13 +91,18 @@ int persist_load_basepoints(persist_t *p, uint32_t channel_id,
         return 0;
     }
 
-    /* Decode 4 local secrets */
+    /* Decode 4 local secrets (#327b: opened from at-rest sealing; legacy
+       plaintext passes through). */
     for (int i = 0; i < 4; i++) {
-        const char *hex = (const char *)sqlite3_column_text(stmt, i);
-        if (!hex || hex_decode(hex, local_secrets[i], 32) != 32) {
+        const char *stored = (const char *)sqlite3_column_text(stmt, i);
+        char *hex = NULL;
+        if (!stored || !persist_open_text(p, stored, &hex) || !hex ||
+            hex_decode(hex, local_secrets[i], 32) != 32) {
+            if (hex) { memset(hex, 0, strlen(hex)); free(hex); }
             sqlite3_finalize(stmt);
             return 0;
         }
+        memset(hex, 0, strlen(hex)); free(hex);
     }
 
     /* Decode 4 remote pubkeys */
@@ -256,10 +263,12 @@ size_t persist_load_flat_secrets(persist_t *p, uint32_t factory_id,
     size_t count = 0;
     while (sqlite3_step(stmt) == SQLITE_ROW && count < max_secrets) {
         int epoch = sqlite3_column_int(stmt, 0);
-        const char *hex = (const char *)sqlite3_column_text(stmt, 1);
-        if (!hex || epoch < 0 || (size_t)epoch >= max_secrets) continue;
-        if (hex_decode(hex, secrets_out[epoch], 32) != 32) continue;
-        count++;
+        const char *stored = (const char *)sqlite3_column_text(stmt, 1);
+        if (!stored || epoch < 0 || (size_t)epoch >= max_secrets) continue;
+        char *hex = NULL;                                  /* #327b: open at rest */
+        if (!persist_open_text(p, stored, &hex) || !hex) continue;
+        if (hex_decode(hex, secrets_out[epoch], 32) == 32) count++;
+        memset(hex, 0, strlen(hex)); free(hex);
     }
     sqlite3_finalize(stmt);
     return count;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1255,6 +1255,7 @@ extern int test_persist_multi_channel(void);
 extern int test_persist_hd_seed_encryption_round_trip(void);
 extern int test_persist_encryption_wrong_key_refused(void);
 extern int test_persist_encryption_disabled_is_plaintext(void);
+extern int test_persist_secret_columns_sealed(void);
 
 /* Phase 14: CLN Bridge */
 extern int test_bridge_msg_round_trip(void);
@@ -3106,6 +3107,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_persist_hd_seed_encryption_round_trip);
     RUN_TEST(test_persist_encryption_wrong_key_refused);
     RUN_TEST(test_persist_encryption_disabled_is_plaintext);
+    RUN_TEST(test_persist_secret_columns_sealed);
     RUN_TEST(test_persist_ps_subfactory_chain_round_trip);
     RUN_TEST(test_persist_l_stock_poison_round_trip);
     RUN_TEST(test_persist_ps_subfactory_chain_v21_round_trip);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -5396,6 +5396,40 @@ int test_persist_secret_columns_sealed(void) {
                         NULL, NULL, back, &has), "load lstock");
         TEST_ASSERT(has && memcmp(back, lsec, 32) == 0, "lstock secret round-trip");
     }
+
+    /* departed_clients.extracted_key (#327b round-2): 32-byte client privkey.
+       seal-on-write -> sealed on disk -> accessor round-trip. */
+    {
+        unsigned char dk[32]; for (int i = 0; i < 32; i++) dk[i] = (unsigned char)(0x50 + i);
+        TEST_ASSERT(persist_save_departed_client(&db, 11, 2, dk), "save departed client");
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(db.db,
+            "SELECT extracted_key FROM departed_clients WHERE factory_id=11 AND client_idx=2;",
+            -1, &st, NULL) == SQLITE_OK, "prep dc");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "dc row");
+        const char *v = (const char *)sqlite3_column_text(st, 0);
+        TEST_ASSERT(v && strncmp(v, "ssenc1:", 7) == 0, "departed_clients.extracted_key sealed on write");
+        sqlite3_finalize(st);
+        int dep[8] = {0}; unsigned char gk[8][32];
+        TEST_ASSERT(persist_load_departed_clients(&db, 11, dep, gk, 8) >= 1, "load departed");
+        TEST_ASSERT(dep[2] && memcmp(gk[2], dk, 32) == 0, "departed extracted_key round-trip");
+    }
+
+    /* watchtower_keys.key_hex ('anchor', #327b round-2): 32-byte WT anchor seckey. */
+    {
+        unsigned char ak[32]; for (int i = 0; i < 32; i++) ak[i] = (unsigned char)(0x90 + i);
+        TEST_ASSERT(persist_save_anchor_key(&db, ak), "save anchor key");
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(db.db,
+            "SELECT key_hex FROM watchtower_keys WHERE key_name='anchor';", -1, &st, NULL) == SQLITE_OK, "prep wk");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "wk row");
+        const char *v = (const char *)sqlite3_column_text(st, 0);
+        TEST_ASSERT(v && strncmp(v, "ssenc1:", 7) == 0, "watchtower_keys.key_hex sealed on write");
+        sqlite3_finalize(st);
+        unsigned char gak[32];
+        TEST_ASSERT(persist_load_anchor_key(&db, gak), "load anchor key");
+        TEST_ASSERT(memcmp(gak, ak, 32) == 0, "anchor key round-trip");
+    }
     persist_close(&db);
     unlink(path);
 
@@ -5436,6 +5470,17 @@ int test_persist_secret_columns_sealed(void) {
         sqlite3_bind_blob(ri, 4, rrs, 32, SQLITE_STATIC);   /* plaintext (keyless) */
         TEST_ASSERT(sqlite3_step(ri) == SQLITE_DONE, "insert rr plaintext");
         sqlite3_finalize(ri);
+    }
+
+    /* #327b round-2: a legacy plaintext departed_clients privkey to migrate
+       (exercises the rowid + text migrate path the new columns rely on). */
+    unsigned char dm[32]; for (int i = 0; i < 32; i++) dm[i] = (unsigned char)(0x60 + i);
+    {
+        char dmh[65]; hex_encode(dm, 32, dmh);
+        char dins[200];
+        snprintf(dins, sizeof dins,
+            "INSERT INTO departed_clients(factory_id,client_idx,extracted_key) VALUES(22,1,'%s');", dmh);
+        TEST_ASSERT(sqlite3_exec(kdb.db, dins, NULL, NULL, NULL) == SQLITE_OK, "insert departed plaintext");
     }
     persist_close(&kdb);
 
@@ -5478,6 +5523,20 @@ int test_persist_secret_columns_sealed(void) {
         TEST_ASSERT(persist_load_basepoints(&kdb2, 1, loc, rem), "load basepoints");
         TEST_ASSERT(memcmp(loc[0], pay_b, 32) == 0, "basepoint local secret round-trip");
         TEST_ASSERT(memcmp(rem[0], rpb_b, 33) == 0, "remote basepoint round-trip (plaintext)");
+    }
+    /* departed_clients legacy plaintext sealed by migration (rowid+text path) + round-trip */
+    {
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(kdb2.db,
+            "SELECT extracted_key FROM departed_clients WHERE factory_id=22 AND client_idx=1;",
+            -1, &st, NULL) == SQLITE_OK, "prep dc-mig");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "dc-mig row");
+        const char *v = (const char *)sqlite3_column_text(st, 0);
+        TEST_ASSERT(v && strncmp(v, "ssenc1:", 7) == 0, "departed_clients sealed by migration");
+        sqlite3_finalize(st);
+        int dep[8] = {0}; unsigned char gk[8][32];
+        TEST_ASSERT(persist_load_departed_clients(&kdb2, 22, dep, gk, 8) >= 1, "load departed migrated");
+        TEST_ASSERT(dep[1] && memcmp(gk[1], dm, 32) == 0, "departed migrated round-trip");
     }
     persist_close(&kdb2);
     unlink(path2);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -5339,6 +5339,151 @@ int test_persist_encryption_disabled_is_plaintext(void) {
     return 1;
 }
 
+/* #327b: the fast-follow secret columns must seal at rest + round-trip through
+   their runtime accessors; the migration pass must seal legacy plaintext rows;
+   and the PUBLIC remote basepoints must stay plaintext (selective sealing). */
+int test_persist_secret_columns_sealed(void) {
+    const char *path = "/tmp/test_ss_enc_cols.db";
+    unlink(path);
+    unsigned char root[32]; memset(root, 0x3c, sizeof root);
+
+    /* ---- Part A: runtime write+read accessors on a keyed-from-start DB ---- */
+    persist_t db;
+    TEST_ASSERT(persist_open(&db, path), "open keyed");
+    TEST_ASSERT(persist_set_encryption_key(&db, root), "set key");
+    TEST_ASSERT(persist_apply_encryption(&db), "apply (fresh)");
+
+    /* revocation_secrets: save (seal-on-write) -> sealed on disk -> load (open) */
+    unsigned char rsec[32]; for (int i = 0; i < 32; i++) rsec[i] = (unsigned char)(0x10 + i);
+    TEST_ASSERT(persist_save_revocation(&db, 7, 3, rsec), "save revocation secret");
+    {
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(db.db,
+            "SELECT secret FROM revocation_secrets WHERE channel_id=7 AND commit_num=3;",
+            -1, &st, NULL) == SQLITE_OK, "prep rs");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "rs row");
+        const char *v = (const char *)sqlite3_column_text(st, 0);
+        TEST_ASSERT(v && strncmp(v, "ssenc1:", 7) == 0, "revocation_secrets sealed on write");
+        sqlite3_finalize(st);
+    }
+    {
+        unsigned char got[8][32]; uint8_t valid[8] = {0}; size_t cnt = 0;
+        TEST_ASSERT(persist_load_revocations_flat(&db, 7, got, valid, 8, &cnt), "load rev flat");
+        TEST_ASSERT(valid[3] && memcmp(got[3], rsec, 32) == 0, "revocation secret round-trip");
+    }
+
+    /* l_stock_poison_reveals: template (NULL secret) -> reveal via UPDATE
+       (seal-on-write) -> sealed on disk -> load (open).  Exercises the UPDATE
+       write path + the BLOB-column-stored-as-text seal. */
+    {
+        unsigned char h32[32], sig64[64], dummy[4] = {0xde, 0xad, 0xbe, 0xef};
+        memset(h32, 0xa1, 32); memset(sig64, 0xb2, 64);
+        TEST_ASSERT(persist_save_l_stock_poison(&db, 5, 2, 9, h32, sig64,
+                        dummy, sizeof dummy, dummy, sizeof dummy, dummy, sizeof dummy),
+                    "save lstock template");
+        unsigned char lsec[32]; for (int i = 0; i < 32; i++) lsec[i] = (unsigned char)(0x40 + i);
+        TEST_ASSERT(persist_update_l_stock_secret(&db, 5, 2, 9, lsec), "reveal lstock secret");
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(db.db,
+            "SELECT revocation_secret FROM l_stock_poison_reveals "
+            "WHERE factory_id=5 AND node_idx=2 AND state_counter=9;", -1, &st, NULL) == SQLITE_OK, "prep ls");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "ls row");
+        const char *v = (const char *)sqlite3_column_text(st, 0);
+        TEST_ASSERT(v && strncmp(v, "ssenc1:", 7) == 0, "l_stock secret sealed on update");
+        sqlite3_finalize(st);
+        int has = 0; unsigned char back[32];
+        TEST_ASSERT(persist_load_l_stock_poison(&db, 5, 2, 9, NULL, NULL, NULL, NULL, NULL,
+                        NULL, NULL, back, &has), "load lstock");
+        TEST_ASSERT(has && memcmp(back, lsec, 32) == 0, "lstock secret round-trip");
+    }
+    persist_close(&db);
+    unlink(path);
+
+    /* ---- Part B: migration of legacy plaintext + selective sealing + BLOB ---- */
+    const char *path2 = "/tmp/test_ss_enc_cols_mig.db";
+    unlink(path2);
+    persist_t kdb;
+    TEST_ASSERT(persist_open(&kdb, path2), "open keyless");
+
+    /* build correctly-sized hex (32B locals, 33B remote pubkey) via hex_encode */
+    unsigned char pay_b[32], del_b[32], rev_b[32], htl_b[32], rpb_b[33];
+    memset(pay_b, 0x31, 32); memset(del_b, 0x32, 32);
+    memset(rev_b, 0x33, 32); memset(htl_b, 0x34, 32);
+    memset(rpb_b, 0xbb, 33); rpb_b[0] = 0x02;   /* 33B "pubkey" (public; stays plaintext) */
+    char pay[65], del[65], rev[65], htl[65], rpb[67];
+    hex_encode(pay_b, 32, pay); hex_encode(del_b, 32, del);
+    hex_encode(rev_b, 32, rev); hex_encode(htl_b, 32, htl);
+    hex_encode(rpb_b, 33, rpb);
+    char ins[1200];
+    snprintf(ins, sizeof ins,
+        "INSERT INTO channel_basepoints(channel_id,local_payment_secret,local_delayed_secret,"
+        "local_revocation_secret,local_htlc_secret,remote_payment_bp,remote_delayed_bp,"
+        "remote_revocation_bp,remote_htlc_bp) VALUES(1,'%s','%s','%s','%s','%s','%s','%s','%s');",
+        pay, del, rev, htl, rpb, rpb, rpb, rpb);
+    TEST_ASSERT(sqlite3_exec(kdb.db, ins, NULL, NULL, NULL) == SQLITE_OK, "insert basepoints plaintext");
+
+    unsigned char fii[32], sid[32], pp[33], rrs[32];
+    memset(fii, 0xaa, 32); memset(sid, 0xbb, 32); memset(pp, 0xcc, 33); pp[0] = 0x02;
+    for (int i = 0; i < 32; i++) rrs[i] = (unsigned char)(0x70 + i);
+    {
+        sqlite3_stmt *ri = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(kdb.db,
+            "INSERT INTO revocation_releases(factory_instance_id,state_id,participant_pubkey,"
+            "revocation_secret,received_at_block) VALUES(?,?,?,?,100);", -1, &ri, NULL) == SQLITE_OK, "prep rr");
+        sqlite3_bind_blob(ri, 1, fii, 32, SQLITE_STATIC);
+        sqlite3_bind_blob(ri, 2, sid, 32, SQLITE_STATIC);
+        sqlite3_bind_blob(ri, 3, pp, 33, SQLITE_STATIC);
+        sqlite3_bind_blob(ri, 4, rrs, 32, SQLITE_STATIC);   /* plaintext (keyless) */
+        TEST_ASSERT(sqlite3_step(ri) == SQLITE_DONE, "insert rr plaintext");
+        sqlite3_finalize(ri);
+    }
+    persist_close(&kdb);
+
+    persist_t kdb2;
+    TEST_ASSERT(persist_open(&kdb2, path2), "reopen keyed");
+    TEST_ASSERT(persist_set_encryption_key(&kdb2, root), "set key 2");
+    TEST_ASSERT(persist_apply_encryption(&kdb2), "migrate seals legacy rows");
+
+    /* local basepoint secret sealed by migration; remote bp stays plaintext */
+    {
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(kdb2.db,
+            "SELECT local_payment_secret,remote_payment_bp FROM channel_basepoints WHERE channel_id=1;",
+            -1, &st, NULL) == SQLITE_OK, "prep bp");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "bp row");
+        const char *loc = (const char *)sqlite3_column_text(st, 0);
+        const char *rem = (const char *)sqlite3_column_text(st, 1);
+        TEST_ASSERT(loc && strncmp(loc, "ssenc1:", 7) == 0, "local basepoint sealed by migration");
+        TEST_ASSERT(rem && strncmp(rem, "ssenc1:", 7) != 0, "remote basepoint stays plaintext (public)");
+        sqlite3_finalize(st);
+    }
+    /* revocation_releases BLOB sealed (SSE1 magic) + opens back to the 32B secret */
+    {
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(kdb2.db,
+            "SELECT revocation_secret FROM revocation_releases;", -1, &st, NULL) == SQLITE_OK, "prep rr2");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "rr2 row");
+        const unsigned char *bv = sqlite3_column_blob(st, 0);
+        int bl = sqlite3_column_bytes(st, 0);
+        TEST_ASSERT(bv && bl >= 4 && memcmp(bv, "SSE1", 4) == 0, "revocation_releases blob sealed");
+        unsigned char *op = NULL; size_t opl = 0;
+        TEST_ASSERT(persist_open_blob(&kdb2, bv, (size_t)bl, &op, &opl) && opl == 32, "rr blob opens to 32B");
+        TEST_ASSERT(op && memcmp(op, rrs, 32) == 0, "rr blob round-trip");
+        free(op);
+        sqlite3_finalize(st);
+    }
+    /* read accessor opens the migrated basepoints (round-trip) */
+    {
+        unsigned char loc[4][32], rem[4][33];
+        TEST_ASSERT(persist_load_basepoints(&kdb2, 1, loc, rem), "load basepoints");
+        TEST_ASSERT(memcmp(loc[0], pay_b, 32) == 0, "basepoint local secret round-trip");
+        TEST_ASSERT(memcmp(rem[0], rpb_b, 33) == 0, "remote basepoint round-trip (plaintext)");
+    }
+    persist_close(&kdb2);
+    unlink(path2);
+    return 1;
+}
+
 /* === End #327 at-rest field encryption tests ============================== */
 
 /* Phase 2: verification is enforced at the choke point and fails closed —


### PR DESCRIPTION
Extends the merged HD-seed at-rest sealing to **every remaining secret column** in lsp.db — closing the "a plaintext read of lsp.db steals funds" hole for the per-channel + revocation secrets.

## Columns now sealed
- `revocation_secrets.secret`, `factory_revocation_secrets.secret`
- `channel_basepoints.local_{payment,delayed,revocation,htlc}_secret` (the 4 per-channel basepoint secrets)
- `revocation_releases.revocation_secret` (BLOB)
- `l_stock_poison_reveals.revocation_secret` — the revealed poison secret whose schema comment **already claimed** at-rest sealing (now true)

Public remote basepoints stay plaintext.

## How
- Each column added to the `SECRET_COLS` registry; its runtime read/write accessors seal/open it (writers in `persist.c`, readers in `persist_secrets.c`).
- `rowid` is the migrate id for the composite-PK tables (a single-column id would not uniquely address a row).
- `persist_apply_encryption` now runs the **idempotent** migration on every keyed open (not only first-seal), so a newly-registered column auto-seals on the next startup — **no schema / enc-version bump**, no migration-ladder change.
- Keyless (regtest/test) DBs stay plaintext — existing suites unaffected.

## Validation
- VPS unit suite **1515/1515 pass** (incl. new `test_persist_secret_columns_sealed`), build clean.
- The new test proves: seal-on-write + open-on-read round-trips (revocation_secrets + the l_stock UPDATE path), migration of legacy plaintext rows, BLOB sealing (revocation_releases), and selective sealing (public remote basepoints stay plaintext).

## Review note
Sensitive crypto-persistence + a mainnet-gate item (not v0.2.0-critical) — opened for review rather than auto-merge.