### PR TITLE
test(signet): strong per-run keys across the breach trio + payment E2E (no weak keys on signet)

### DIFF
--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -1327,6 +1327,12 @@ int main(int argc, char *argv[]) {
     const char *wallet_name = NULL;
     int64_t cltv_timeout_arg = -1;  /* -1 = auto */
     int breach_test = 0;
+    /* #38: strong per-run client seckeys for the breach re-sign, loaded from
+       --breach-client-keys-file.  Lets the commitment-breach cheat re-sign each
+       client's revoked 2-of-2 with the REAL client key (so it works with strong
+       keys on public signet) instead of the weak byte-fill scaffold. */
+    unsigned char breach_client_seckeys[128][32];
+    int n_breach_client_seckeys = 0;
     int test_expiry = 0;
     int test_distrib = 0;
     int test_turnover = 0;
@@ -1649,6 +1655,28 @@ int main(int argc, char *argv[]) {
             breach_test = 3;  /* 3 = client-commitment breach + NO in-process WT;
                                  leaves the on-chain breach for an external standalone
                                  WT (--wt-db only) to detect + penalize (isolation test) */
+        else if (strcmp(argv[i], "--breach-client-keys-file") == 0 && i + 1 < argc) {
+            /* #38: load strong per-run client seckeys (one 64-hex per line, line i =
+               channel i's client) so the breach re-sign uses the real client key,
+               not the byte-fill scaffold -> the commitment breach works with strong
+               keys on public signet.  No effect unless a breach mode is also set. */
+            FILE *bkf = fopen(argv[++i], "r");
+            if (!bkf) { fprintf(stderr, "Error: cannot open --breach-client-keys-file %s\n", argv[i]); return 1; }
+            char bkline[160];
+            while (n_breach_client_seckeys < 128 && fgets(bkline, sizeof bkline, bkf)) {
+                size_t bl = strlen(bkline);
+                while (bl > 0 && (bkline[bl-1] == '\n' || bkline[bl-1] == '\r' || bkline[bl-1] == ' ')) bkline[--bl] = '\0';
+                if (bl == 0) continue;
+                if (hex_decode(bkline, breach_client_seckeys[n_breach_client_seckeys], 32) != 32) {
+                    fprintf(stderr, "Error: --breach-client-keys-file line %d is not a 32-byte hex seckey\n",
+                            n_breach_client_seckeys + 1);
+                    fclose(bkf); return 1;
+                }
+                n_breach_client_seckeys++;
+            }
+            fclose(bkf);
+            printf("LSP: loaded %d strong client seckey(s) for the breach re-sign\n", n_breach_client_seckeys);
+        }
         else if (strcmp(argv[i], "--test-rebalance") == 0)
             test_rebalance = 1;
         else if (strcmp(argv[i], "--test-wire-leaf-advance") == 0)

--- a/tools/superscalar_lsp_post_daemon_tests.inc
+++ b/tools/superscalar_lsp_post_daemon_tests.inc
@@ -100,9 +100,16 @@
                 continue;
             }
 
-            /* Sign with both LSP + client keys */
+            /* Sign with both LSP + client keys.  #38: prefer the REAL strong
+               per-run client key (loaded via --breach-client-keys-file) so the
+               commitment breach re-signs validly with strong keys on public
+               signet; fall back to the byte-fill scaffold for legacy/regtest
+               weak-key runs (channel ci <-> client seckey line ci). */
             unsigned char cli_sec[32];
-            memset(cli_sec, client_fills[ci], 32);
+            if (n_breach_client_seckeys > (int)ci)
+                memcpy(cli_sec, breach_client_seckeys[ci], 32);
+            else
+                memset(cli_sec, client_fills[ci], 32);
             secp256k1_keypair cli_kp;
             if (!secp256k1_keypair_create(ctx, &cli_kp, cli_sec)) {
                 fprintf(stderr, "BREACH TEST: keypair create failed for channel %zu\n", ci);

--- a/tools/test_signet_scale_payments.sh
+++ b/tools/test_signet_scale_payments.sh
@@ -38,6 +38,12 @@ FEE_RATE="${FEE_RATE:-1000}"   # sat/kvB; regtest mempool floor is generous
 PORT="${PORT:-9951}"
 WALLET="${WALLET:-ss_sig_n127}"
 TAG="signet_scale_payments"
+# Each payment needs a sender+receiver pair, so 2*PAYMENTS must fit in N_CLIENTS.
+# The LSP is launched with --payments PAYMENTS and blocks until it sees that many;
+# if PAYMENTS exceeds floor(N/2) only floor(N/2) pairs are set up, the LSP waits
+# forever for the missing ones, and the event loop times out.  Clamp it.
+_MAXP=$(( N_CLIENTS / 2 )); [ "$_MAXP" -lt 1 ] && _MAXP=1
+[ "$PAYMENTS" -gt "$_MAXP" ] && { echo "[n64-pay] clamping PAYMENTS $PAYMENTS -> $_MAXP (need 2*PAYMENTS <= N_CLIENTS=$N_CLIENTS)"; PAYMENTS="$_MAXP"; }
 LSP_DB="/tmp/ss_${TAG}.db"
 LSP_LOG="/tmp/ss_${TAG}_lsp.log"
 # LSP keys are generated per-run below (STRONG, not weak) via the keygen eval.
@@ -159,7 +165,7 @@ done
 MINER_PID=""
 
 # --- Wait for the LSP to finish (creation -> payments -> close) ---
-info "waiting for ceremony + payments + close (up to ~10 min)..."
+info "waiting for ceremony + payments + close (signet: up to ~1h over real blocks)..."
 DEADLINE=$(( $(date +%s) + 3600 ))
 RESULT="TIMEOUT"
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do

--- a/tools/test_signet_scale_payments.sh
+++ b/tools/test_signet_scale_payments.sh
@@ -37,7 +37,7 @@ AMOUNT="${AMOUNT:-2750000}"
 FEE_RATE="${FEE_RATE:-1000}"   # sat/kvB; regtest mempool floor is generous
 PORT="${PORT:-9951}"
 WALLET="${WALLET:-ss_sig_n127}"
-TAG="signet_scale_payments"
+TAG="signet_scale_payments_$$"   # PID-suffixed: a re-run must NOT overwrite a prior run's seed file (the breach harnesses already do this). A fixed tag once clobbered a failed run's seed -> that factory's sats became unrecoverable on signet.
 # Each payment needs a sender+receiver pair, so 2*PAYMENTS must fit in N_CLIENTS.
 # The LSP is launched with --payments PAYMENTS and blocks until it sees that many;
 # if PAYMENTS exceeds floor(N/2) only floor(N/2) pairs are set up, the LSP waits

--- a/tools/test_signet_subfactory_breach.sh
+++ b/tools/test_signet_subfactory_breach.sh
@@ -8,9 +8,15 @@ BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"; CLIENT_BIN="$BUILD_DIR/superscalar_client"; WT_BIN="$BUILD_DIR/superscalar_watchtower"
 N_CLIENTS="${N_CLIENTS:-4}"; PS_SUB_ARITY="${PS_SUB_ARITY:-2}"; AMOUNT="${AMOUNT:-400000}"; FEE_RATE="${FEE_RATE:-100}"
 LSP_PORT="${LSP_PORT:-29967}"; WALLET="${WALLET:-superscalar_lsp}"; CONFIRM_TIMEOUT="${CONFIRM_TIMEOUT:-21600}"
-LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
-LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
-sk(){ local b; b=$(printf "%02x" $((34 + $1 * 17))); printf "${b}%.0s" {1..32}; }
+# Strong per-run keys (signet is PUBLIC — NO weak/deterministic keys). Seed-derived
+# + reproducible from the saved seed for recovery. Breach uses the launched
+# --seckey values via the normal ceremony, so strong keys work like the scaffold.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
+eval "$(python3 "$SCRIPT_DIR/signet_strong_keygen.py" "$N_CLIENTS" "subfactorybreach_$$")"
+[ -n "${LSP_SECKEY:-}" ] && [ -n "${LSP_PUBKEY:-}" ] && [ -f "${CLIENT_KEYS_FILE:-/nonexistent}" ] || { echo "FAIL: strong keygen failed"; exit 1; }
+mapfile -t CLIENT_SECKEYS < "$CLIENT_KEYS_FILE"
+sk(){ printf '%s' "${CLIENT_SECKEYS[$1]}"; }
 SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
 RU=$(awk -F= '/^[[:space:]]*rpcuser/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")
 RP=$(awk -F= '/^[[:space:]]*rpcpassword/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")

--- a/tools/test_signet_trustless_commitment_breach.sh
+++ b/tools/test_signet_trustless_commitment_breach.sh
@@ -21,12 +21,18 @@ LSP_BIN="$BUILD_DIR/superscalar_lsp"; CLIENT_BIN="$BUILD_DIR/superscalar_client"
 N_CLIENTS="${N_CLIENTS:-2}"; AMOUNT="${AMOUNT:-250000}"; FEE_RATE="${FEE_RATE:-100}"   # 100 sat/kvB = 0.1 sat/vB
 LSP_PORT="${LSP_PORT:-29959}"; WALLET="${WALLET:-superscalar_lsp}"
 CONFIRM_TIMEOUT="${CONFIRM_TIMEOUT:-14400}"
-LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
-LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
-# Canonical scaffold seckeys (client_fills 0x22/0x33/0x44/0x55) — REQUIRED: the
-# commitment re-sign in the breach path uses these; A's leaf-breach used
-# sequential keys (02..05) because it never re-signs a 2-of-2 commitment.
-sk(){ local b; b=$(printf "%02x" $((34 + $1 * 17))); printf "${b}%.0s" {1..32}; }
+# Strong per-run keys: signet is PUBLIC, so NO weak/deterministic keys (privkey
+# 1 / byte-fill are publicly sweepable). Keys are seed-derived (unpredictable to
+# outsiders, reproducible from the saved seed for our own recovery). The breach
+# goes through the normal ceremony + watchtower machinery using the launched
+# --seckey values, so strong keys work like the old byte-fill scaffold.
+# Seed saved to /tmp/ss_signet_seed_<TAG>.txt for residual recovery.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
+eval "$(python3 "$SCRIPT_DIR/signet_strong_keygen.py" "$N_CLIENTS" "commitbreach_$$")"
+[ -n "${LSP_SECKEY:-}" ] && [ -n "${LSP_PUBKEY:-}" ] && [ -f "${CLIENT_KEYS_FILE:-/nonexistent}" ] || { echo "FAIL: strong keygen failed"; exit 1; }
+mapfile -t CLIENT_SECKEYS < "$CLIENT_KEYS_FILE"
+sk(){ printf '%s' "${CLIENT_SECKEYS[$1]}"; }
 SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
 RU=$(awk -F= '/^[[:space:]]*rpcuser/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")
 RP=$(awk -F= '/^[[:space:]]*rpcpassword/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")

--- a/tools/test_signet_trustless_commitment_breach.sh
+++ b/tools/test_signet_trustless_commitment_breach.sh
@@ -57,7 +57,8 @@ pkill -9 -f "superscalar_lsp.*--port $LSP_PORT" 2>/dev/null||true; sleep 1
     --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
     --amount $AMOUNT --fee-rate $FEE_RATE \
     --confirm-timeout $CONFIRM_TIMEOUT --seckey "$LSP_SECKEY" --wallet "$WALLET" \
-    --db "$LSP_DB" --wt-db "$WT_DB" --demo --breach-standalone --lsp-balance-pct 50 > "$LSP_LOG" 2>&1 &
+    --db "$LSP_DB" --wt-db "$WT_DB" --demo --breach-standalone \
+    --breach-client-keys-file "$CLIENT_KEYS_FILE" --lsp-balance-pct 50 > "$LSP_LOG" 2>&1 &
 LSP_PID=$!; PIDS+=($LSP_PID)
 for i in $(seq 1 120); do sleep 2; grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && { echo "  [$(ts)] LSP listening + self-funding"; break; }; kill -0 $LSP_PID 2>/dev/null||{ tail -25 "$LSP_LOG"; fail "LSP died before listening"; }; done
 for i in $(seq 0 $((N_CLIENTS-1))); do

--- a/tools/test_signet_wt_restart_race.sh
+++ b/tools/test_signet_wt_restart_race.sh
@@ -35,14 +35,14 @@ WT_POLL="${WT_POLL:-30}"
 WALLET="${WALLET:-superscalar_lsp}"
 CONFIRM_TIMEOUT="${CONFIRM_TIMEOUT:-14400}"   # 4h budget for the LSP funding/lifecycle
 
-LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
-CLIENT_SECKEYS=(
-    "0000000000000000000000000000000000000000000000000000000000000002"
-    "0000000000000000000000000000000000000000000000000000000000000003"
-    "0000000000000000000000000000000000000000000000000000000000000004"
-    "0000000000000000000000000000000000000000000000000000000000000005"
-)
-LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+# Strong per-run keys (signet is PUBLIC — NO weak/deterministic keys). Seed-derived
+# + reproducible from the saved seed for recovery. Breach uses the launched
+# --seckey values via the normal ceremony, so strong keys work like the scaffold.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
+eval "$(python3 "$SCRIPT_DIR/signet_strong_keygen.py" "$N_CLIENTS" "wtrace_$$")"
+[ -n "${LSP_SECKEY:-}" ] && [ -n "${LSP_PUBKEY:-}" ] && [ -f "${CLIENT_KEYS_FILE:-/nonexistent}" ] || { echo "FAIL: strong keygen failed"; exit 1; }
+mapfile -t CLIENT_SECKEYS < "$CLIENT_KEYS_FILE"
 
 # --- signet RPC creds from the node conf (the bare -signet cookie path is wrong) ---
 SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"


### PR DESCRIPTION
Converts the signet validation suite to **strong per-run keys** (no publicly-sweepable weak/deterministic keys on the public signet chain) and fixes the two things that blocked it.

### Changes
1. **Strong keys in the breach trio** (`b6add8a`): commitment / sub-factory / wt-restart harnesses now use `signet_strong_keygen.py` (seed-saved for recovery) instead of hardcoded `0x01`/byte-fill keys. `sk()` returns the per-run key so call sites are unchanged.
2. **Payment harness clamp** (`8458fc0`): `scale_payments` now clamps `PAYMENTS` to `floor(N/2)` — the LSP's `--payments` must match the sender/receiver pairs that actually fit, else its event loop waits forever and times out.
3. **Breach cheat re-signs with real keys** (`99ff070`): the commitment-breach cheat re-signed each client's revoked 2-of-2 with a byte-fill scaffold seckey, so it only worked with weak keys. New `--breach-client-keys-file FILE` lets the LSP load the real per-run client seckeys and re-sign validly; falls back to the byte-fill scaffold for regtest/legacy (unaffected).

### Validated on REAL signet (all strong-key, all PASS)
- **payment E2E** — routed HTLCs → settle → cooperative close `e16bfdac…` confirmed, conservation exact (499,500 = 500,000 − 500), per-client reconciliation to the sat (4/4 joined close)
- **sub-factory breach** (kind=1) — standalone WT penalized
- **wt-restart race** — cold-restarted WT re-hydrated from wt.db (no secrets) and won the race
- **commitment breach** (kind=2) — breach `1e4f99c1…` → penalty confirmed @310725 (the cheat fix)

Test-harness + test-only cheat code (the `--breach-client-keys-file` path is gated behind the breach modes; production LSP path unaffected).