### PR TITLE
feat(factory): bounded fresh-nonce retry across signing ceremonies (P6 liveness)

### DIFF
--- a/docs/p6-bounded-nonce-retry.md
+++ b/docs/p6-bounded-nonce-retry.md
@@ -102,6 +102,46 @@ must handle `musig_nonce_pool_next == 0` (pool exhaustion) by regenerating.
 - No nonce-reuse: assert (in the retry harness) that each attempt's pubnonce
   differs from the prior attempt's.
 
+## Status + C/D two-sided-retry protocol design (2026-06-28)
+
+PROGRESS:
+- Phase A (all-local sign retry): DONE, green (#407).
+- Phase B (ceremony-time detection, factory-creation + coop-close): DONE, green
+  (both regtest jobs pass -> the new verifies do not false-fail a valid ceremony).
+- P6 DoD core was ALREADY MET pre-#48: the rotation/rollover "stalled advance"
+  does bounded-retry -> proactive-exit (lsp_channels.c:7240-7305 -
+  lsp_rotation_should_retry up to 3x, then distribution-TX exit +
+  CEREMONY_ABORT_RETRY_LIMIT_REACHED + "ensure your watchtower is live" NOTICE).
+- User chose "go all the way" -> implement the C/D two-sided retry below.
+
+C/D TWO-SIDED RETRY PROTOCOL (no new wire message; the retry signal is a re-sent
+CLOSE_PROPOSE / re-sent factory nonce-request -- the client distinguishes it from
+CLOSE_DONE/FACTORY_READY):
+- LSP coop-close (lsp_run_cooperative_close): wrap session-init -> LSP nonce ->
+  CLOSE_PROPOSE -> collect CLOSE_NONCE -> ALL_NONCES -> finalize -> LSP psig ->
+  collect CLOSE_PSIG -> aggregate -> verify in a `for (attempt < SS_NONCE_RETRY_MAX)`
+  loop. The close OUTPUTS + sighash are built once (unchanged across attempts);
+  only nonces/psigs are fresh. On verify/aggregate fail: ceremony_prepare_retry on
+  close_nonce_cer/close_psig_cer, re-init the musig session + fresh LSP nonce, loop
+  (re-send CLOSE_PROPOSE). On success: break -> CLOSE_DONE. On exhaustion:
+  close_fail + the CEREMONY_ABORT_RETRY_LIMIT_REACHED NOTICE (mirror rotation).
+- Client (client_do_close_ceremony): wrap NONCE->PSIG->wait in a loop; after
+  sending CLOSE_PSIG, branch on the next msg -- CLOSE_DONE -> success;
+  CLOSE_PROPOSE (same outputs) -> retry with a fresh nonce; CEREMONY_ABORT ->
+  fail. Bounded by the same max so a wedged peer can't loop forever.
+- D (factory-creation): analogous -- LSP re-runs the client nonce-request on a
+  factory_verify_all fail; client re-enters the nonce/psig round.
+- Fault injection (regtest-only via superscalar_cheat_allowed; refused on mainnet
+  per the cheat-guard): SS_CHEAT_CLOSE_BAD_PSIG / SS_CHEAT_CREATE_BAD_PSIG -> a
+  client emits a corrupt psig on attempt 1 only (transient) or every attempt
+  (persistent).
+- Tests (before/after each step): normal ceremony stays green (no regression --
+  Phase B's passing regtest is the guard) + transient -> retry -> success +
+  persistent -> bounded abort + proactive-exit NOTICE + a pubnonce-differs check.
+RISK: this restructures the working close/creation ceremonies. Mitigation: keep
+the OUTPUTS/sighash build outside the loop (only re-randomise nonces); run the
+normal-path regtest before and after every commit.
+
 ## Open items / follow-ups
 
 - Pool exhaustion handling on retry for the two pool paths.

--- a/docs/p6-bounded-nonce-retry.md
+++ b/docs/p6-bounded-nonce-retry.md
@@ -142,6 +142,49 @@ RISK: this restructures the working close/creation ceremonies. Mitigation: keep
 the OUTPUTS/sighash build outside the loop (only re-randomise nonces); run the
 normal-path regtest before and after every commit.
 
+## Phase C + D RESULTS (2026-06-29) -- DONE + PROVEN on regtest
+
+**Phase C (coop-close)** -- two-sided protocol as designed. The LSP returns a
+distinct "retryable" code (no abort, no client disconnect) on a ceremony-time
+verify-fail; the daemon caller loops it bounded; `client_do_close_ceremony`
+recurses on a re-sent CLOSE_PROPOSE. Cheat-proof `tools/test_regtest_close_retry.sh`:
+=1 (transient) -> close RETRIES + the full lifecycle SUCCEEDS; =2 (persistent) ->
+close BOUNDS + aborts -> clients fall back to force-close. CLOSE_RETRY_TEST PASS.
+
+**Phase D (factory-creation)** -- implemented as a BUILD-ONCE INTERNAL LOOP, NOT
+the "caller re-invokes" sketch above. Rationale discovered during impl: the LSP
+re-invoke path rebuilds the whole tree (`factory_init_from_pubkeys` memsets f) and
+re-sends FACTORY_PROPOSE, and the old `fail_pre`'s `factory_free` is what silently
+broke the pre-existing 3x creation retry (config lost + clients disconnected). The
+clean design: build the tree + FACTORY_PROPOSE ONCE, then loop ONLY the signing
+rounds in `lsp_run_factory_creation_stateless` -- `factory_sessions_init`
+(re-callable; inline session structs; leak-free) -> PROPOSE_INTENT -> client
+pubnonces -> LSP nonces / LSP_RESPONSE -> client psigs -> `factory_sessions_complete`
+-> `factory_verify_all`. On verify-fail: re-init sessions + re-send PROPOSE_INTENT
+(NO abort, NO factory_free), up to SS_NONCE_RETRY_MAX, then `fail_pre`. Every
+per-round buffer (all_pn / lsp_* / client_*) is freed before the verify point, so
+the retry path is leak-free. The client mirrors it: build once, then a bounded loop
+calling `client_factory_creation_stateless_signing` with a new `intent_already_recvd`
+param so a retry (which already consumed the re-sent PROPOSE_INTENT to detect it)
+does not double-recv; on FACTORY_READY it applies + breaks, so the shared legacy
+FACTORY_READY recv is skipped for the stateless path. Cheat-proof
+`tools/test_regtest_create_retry.sh`: =1 (transient) -> creation RETRIES (2x) +
+lifecycle SUCCEEDS; =2 (persistent) -> creation BOUNDS + aborts before broadcast
+(nothing committed on-chain -> fallback is re-create). CREATE_RETRY_TEST PASS.
+
+**Test-design finding (flaky cheat, fixed 6dbb82b):** the creation cheat must
+corrupt EXACTLY ONE client. If every client XORs the low bit of its OWN node-0
+partial, the per-signer +-1 deltas can sum to zero in the MuSig2 aggregate
+(`s_agg = sum of partials`) ~37% of runs -> a VALID aggregate -> no failure to
+detect -> flaky no-op. A single bad partial cannot cancel; gated to my_index==1.
+
+**Regression (no-cutting-corners):** `client_factory_creation_stateless_signing`
+is shared with the rotation re-entry path (client.c, `rot_stateless`), which passes
+`intent_already_recvd=0` -> byte-identical to pre-#48 behavior (the new retry loop
+lives only in the initial-creation caller). Confirmed e2e by
+`test_regtest_rotation_restart_resume.sh` + a clean `test_regtest_n64_payments.sh`
++ the unit suite, all green on the integrated branch.
+
 ## Open items / follow-ups
 
 - Pool exhaustion handling on retry for the two pool paths.

--- a/docs/p6-bounded-nonce-retry.md
+++ b/docs/p6-bounded-nonce-retry.md
@@ -1,0 +1,109 @@
+# P6 — Bounded fresh-nonce retry for MuSig2 signing ceremonies (#48)
+
+Living design doc for the trustless-completion P6 liveness item. Branch:
+`feat/bounded-fresh-nonce-retry`. Created 2026-06-28.
+
+## Goal / DoD
+
+When a MuSig2 signing ceremony fails — a partial signature fails to verify, the
+aggregate Schnorr signature is invalid, or a counterparty's nonce/psig is
+rejected — the ceremony should **retry with a FRESH nonce a bounded number of
+times** before aborting, instead of aborting on the first failure or blocking
+until a timeout/expiry. On exhaustion it escalates via the existing P6 policy
+(proactive exit, `CEREMONY_ABORT_RETRY_LIMIT_REACHED`, intent-to-exit NOTICE),
+never "blind until expiry". Safety always holds via the DW/CLTV override; this is
+graceful **liveness** degradation, not a safety mechanism.
+
+## Security precondition — the gate (VERIFIED)
+
+Bounded retry is only safe if each attempt uses a genuinely **fresh** nonce.
+Reusing a secnonce across two different challenges leaks the secret key
+(Schnorr/MuSig2: two `s_i = k_i + e·a_i·x_i` with the same `k_i`, different `e`,
+solve for `x_i`). The codebase satisfies this:
+
+- All nonces draw fresh OS randomness per call via `fill_random()` →
+  `/dev/urandom` (`src/musig.c:9-15`), feeding the BIP-327 `session_id` (`rand`)
+  input in **every** nonce-gen entry point: `musig_sign_all_local`,
+  `musig_nonce_pool_generate` (also fresh `extra_input`), and
+  `musig_generate_nonce`. There is **no deterministic nonce derivation anywhere**.
+- A secnonce is **single-use**: `secp256k1_musig_partial_sign` zeroes it. So a
+  retry cannot re-sign with a held secnonce — it MUST restart from nonce
+  generation, which by construction yields a new, non-repeating nonce.
+- Secnonces are **per-attempt, stack-resident, never persisted** (stateless-signer
+  model). Re-entering an orchestrator on retry automatically gets a brand-new
+  secnonce; there is no cache to invalidate.
+
+**Conclusion: re-running a ceremony from nonce generation is nonce-reuse-safe.**
+The only resource concern is the two *pool*-based paths (channel commitment;
+stateless factory-creation client) — a retry consumes a pool slot, so retries
+must handle `musig_nonce_pool_next == 0` (pool exhaustion) by regenerating.
+
+## Architecture findings (from the ceremony map)
+
+1. Most ceremonies aggregate partial sigs **without** per-signer verification, then
+   verify the **final aggregate** Schnorr sig. Exceptions: `channel.c` verifies the
+   peer's partial sig; and — critically — **networked factory-creation and
+   cooperative-close verify NOTHING at ceremony time** (a bad psig surfaces only at
+   broadcast). `factory_verify_all` (`factory.c:2107`) exists but is called only
+   from tests/tools, never `src/`.
+2. Therefore bounded retry on factory-creation and coop-close **requires first
+   adding a ceremony-time detection point** (aggregate verify). This is also an
+   independent robustness win: fail fast + fall back cleanly rather than ship a
+   dud tx.
+3. Reusable scaffolding already present (unused in prod): `ceremony_prepare_retry()`
+   (`ceremony.c:79`); the proven all-local retry loop
+   (`tools/superscalar_lsp_pre_daemon_tests.inc:437`); and the rotation
+   attempt-counter + backoff (`lsp_rotation.c:33-68`).
+
+## Retry policy
+
+- `SS_NONCE_RETRY_MAX` attempts (default 3) per ceremony, then abort+escalate.
+- Each attempt: full nonce-gen → exchange → psig → aggregate → **verify** round.
+- Detection = verify the aggregate Schnorr sig (or per-signer where already done).
+- Transient fault (corruption, flaky peer that recovers) → retry succeeds.
+  Persistent fault (a signer that keeps sending bad psigs / stays absent) → the
+  bound is reached and we escalate; retry never masks a real fault.
+- N-of-N ceremonies (factory root/intermediate nodes): one bad/absent signer is
+  fatal — retries give transient-recovery chances, then proactive-exit. Quorum
+  ceremonies (coop-close): retry, and on the final attempt the existing
+  quorum/timeout exclusion (`ceremony_prepare_retry`) drops the faulty signer.
+
+## Per-ceremony plan (phases; each = a tested, reviewable increment)
+
+- **Phase A — reusable primitive + all-local path.** Lift the proven inc:437
+  loop into `factory_sign_all_with_retry()` (library) and call it at every
+  `factory_sign_all` site. Unit test: a verify-fail-then-retry-succeeds via fault
+  injection. Lowest risk.
+- **Phase B — detection.** Add ceremony-time aggregate verify to networked
+  factory-creation (`factory_verify_all` after `factory_sessions_complete`,
+  `lsp.c`) and coop-close (final-sig verify after aggregate, `lsp.c:~1174`). No
+  retry yet; abort-on-fail as today. Standalone verify-before-broadcast win.
+- **Phase C — coop-close bounded retry.** Wrap `lsp_run_cooperative_close`
+  (`lsp.c:890-1206`) in the bounded loop; reuse `ceremony_prepare_retry` on the
+  existing `close_*_cer` ceremony objects; re-run PROPOSE→NONCE→PSIG; escalate on
+  exhaustion. Highest production liveness value (avoids a needless force-close).
+- **Phase D — factory-creation bounded retry.** Wrap
+  `lsp_run_factory_creation_stateless`; loop back to client-nonce request on
+  verify-fail; `ceremony_prepare_retry`; escalate on exhaustion.
+- **Phase E — leaf / sub-factory / rollover.** These already return "retry next
+  tick" and are re-invoked by the daemon loop; add a **bounded attempt counter at
+  the daemon call site** (mirroring `lsp_rotation_should_retry`) with proactive
+  exit on exhaustion, plus an inner nonce-regen retry where cheap.
+
+## Testing
+
+- Unit: fault-injected verify-fail → retry → success (Phase A; and a unit-level
+  ceremony harness where feasible).
+- Regtest: the networked ceremonies (B–E) under a transient-fault cheat
+  (`SS_CHEAT_*`, regtest-only, refused on mainnet per the cheat-guard) that
+  corrupts one psig on attempt 1 only → assert the ceremony RETRIES and
+  SUCCEEDS, and that a persistent corruption hits the bound and escalates
+  (asserts `CEREMONY_ABORT_RETRY_LIMIT_REACHED` + proactive exit, not blind wait).
+- No nonce-reuse: assert (in the retry harness) that each attempt's pubnonce
+  differs from the prior attempt's.
+
+## Open items / follow-ups
+
+- Pool exhaustion handling on retry for the two pool paths.
+- Mainnet guard on any new fault-injection cheat (reuse `superscalar_cheat_allowed`).
+- Self-reviewed; flag for the external audit (P8).

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -692,6 +692,9 @@ int factory_verify_all(factory_t *f);
    docs/p6-bounded-nonce-retry.md), so retry is nonce-reuse-safe. */
 #define SS_NONCE_RETRY_MAX 3
 int factory_sign_all_with_retry(factory_t *f, int max_attempts);
+/* #48: ceremony-time verify of a cooperative-close aggregate sig (see factory.c). */
+int factory_verify_close_sig(const factory_t *f, const unsigned char sig64[64],
+                             const unsigned char sighash[32]);
 extern int g_factory_test_force_verify_fail;   /* TEST-ONLY seam; always 0 in production */
 
 int factory_advance(factory_t *f);

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -686,6 +686,14 @@ void factory_set_funding(factory_t *f,
 int factory_build_tree(factory_t *f);
 int factory_sign_all(factory_t *f);
 int factory_verify_all(factory_t *f);
+
+/* Bounded fresh-nonce retry (#48): max sign+verify attempts per ceremony before
+   abort. Each attempt re-draws fresh nonces (never reused — see
+   docs/p6-bounded-nonce-retry.md), so retry is nonce-reuse-safe. */
+#define SS_NONCE_RETRY_MAX 3
+int factory_sign_all_with_retry(factory_t *f, int max_attempts);
+extern int g_factory_test_force_verify_fail;   /* TEST-ONLY seam; always 0 in production */
+
 int factory_advance(factory_t *f);
 
 /* Advance only one leaf subtree. leaf_side: 0..n_leaf_nodes-1.

--- a/src/client.c
+++ b/src/client.c
@@ -941,7 +941,7 @@ static int client_apply_factory_ready(factory_t *f, const cJSON *json) {
    same (stateless, #272 default) protocol. */
 static int client_factory_creation_stateless_signing(
         int fd, secp256k1_context *ctx, const secp256k1_keypair *keypair,
-        factory_t *factory, uint32_t my_index);
+        factory_t *factory, uint32_t my_index, int intent_already_recvd);
 
 int client_do_factory_rotation(int fd, secp256k1_context *ctx,
                                 const secp256k1_keypair *keypair,
@@ -1126,7 +1126,7 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
 
     if (rot_stateless) {
         if (!client_factory_creation_stateless_signing(fd, ctx, keypair,
-                                                        factory_out, my_index))
+                                                        factory_out, my_index, 0))
             return 0;
     } else {
     /* Generate nonces */
@@ -1512,30 +1512,35 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
    Returns 1 on success, 0 on failure. */
 static int client_factory_creation_stateless_signing(
         int fd, secp256k1_context *ctx, const secp256k1_keypair *keypair,
-        factory_t *factory, uint32_t my_index) {
+        factory_t *factory, uint32_t my_index, int intent_already_recvd) {
     secp256k1_pubkey my_pubkey;
     secp256k1_keypair_pub(ctx, &my_pubkey, keypair);
 
-    /* Recv PROPOSE_INTENT (0x85) -- begin reversed flow. */
-    wire_msg_t imsg;
-    if (!wire_recv_handle_ping(fd, &imsg, 0) || check_msg_error(&imsg) ||
-        imsg.msg_type != MSG_FACTORY_PROPOSE_INTENT) {
-        fprintf(stderr, "Client-stateless %u: expected PROPOSE_INTENT, got 0x%02x\n",
-                my_index, imsg.json ? imsg.msg_type : 0);
-        if (imsg.json) cJSON_Delete(imsg.json);
-        return 0;
-    }
-    uint32_t intent_n_nodes = 0;
-    if (!wire_parse_factory_propose_intent(imsg.json, &intent_n_nodes)) {
-        fprintf(stderr, "Client-stateless %u: parse PROPOSE_INTENT failed\n", my_index);
+    /* Recv PROPOSE_INTENT (0x85) -- begin reversed flow.  On a #48 Phase D
+       retry the caller has already consumed the re-sent PROPOSE_INTENT (to
+       detect the retry) and validated n_nodes, so it passes
+       intent_already_recvd=1 and we skip the recv here. */
+    if (!intent_already_recvd) {
+        wire_msg_t imsg;
+        if (!wire_recv_handle_ping(fd, &imsg, 0) || check_msg_error(&imsg) ||
+            imsg.msg_type != MSG_FACTORY_PROPOSE_INTENT) {
+            fprintf(stderr, "Client-stateless %u: expected PROPOSE_INTENT, got 0x%02x\n",
+                    my_index, imsg.json ? imsg.msg_type : 0);
+            if (imsg.json) cJSON_Delete(imsg.json);
+            return 0;
+        }
+        uint32_t intent_n_nodes = 0;
+        if (!wire_parse_factory_propose_intent(imsg.json, &intent_n_nodes)) {
+            fprintf(stderr, "Client-stateless %u: parse PROPOSE_INTENT failed\n", my_index);
+            cJSON_Delete(imsg.json);
+            return 0;
+        }
         cJSON_Delete(imsg.json);
-        return 0;
-    }
-    cJSON_Delete(imsg.json);
-    if (intent_n_nodes != (uint32_t)factory->n_nodes) {
-        fprintf(stderr, "Client-stateless %u: n_nodes mismatch (intent=%u local=%zu)\n",
-                my_index, intent_n_nodes, factory->n_nodes);
-        return 0;
+        if (intent_n_nodes != (uint32_t)factory->n_nodes) {
+            fprintf(stderr, "Client-stateless %u: n_nodes mismatch (intent=%u local=%zu)\n",
+                    my_index, intent_n_nodes, factory->n_nodes);
+            return 0;
+        }
     }
 
     size_t nn = factory->n_nodes;
@@ -2275,9 +2280,66 @@ int client_run_with_channels(secp256k1_context *ctx,
        The stateless path leaves it NULL (free(NULL) is a no-op). */
     wire_bundle_entry_t *nonce_entries = NULL;
     if (ss_stateless_creation) {
-        if (!client_factory_creation_stateless_signing(fd, ctx, keypair,
-                                                        factory, my_index))
+        /* #48 Phase D: bounded fresh-nonce retry for factory creation.  If the
+           LSP's ceremony-time factory_verify_all fails (e.g. a bad client psig),
+           it re-inits sessions and re-sends PROPOSE_INTENT instead of aborting;
+           we mirror that -- re-init our sessions and re-sign with a FRESH nonce,
+           up to SS_NONCE_RETRY_MAX times, then give up.  The signing function
+           consumes the FIRST PROPOSE_INTENT itself; on a retry we have already
+           consumed the re-sent one (to detect it), so we pass
+           intent_already_recvd=1.  On success it also consumes + applies
+           FACTORY_READY, so the shared recv below is skipped for this path. */
+        int created = 0;
+        int intent_held = 0;
+        for (int fc_attempt = 0; fc_attempt <= SS_NONCE_RETRY_MAX; fc_attempt++) {
+            if (fc_attempt > 0 && !factory_sessions_init(factory)) {
+                fprintf(stderr, "Client %u: re-init sessions (creation retry) failed\n",
+                        my_index);
+                goto fail;
+            }
+            if (!client_factory_creation_stateless_signing(fd, ctx, keypair,
+                                                            factory, my_index,
+                                                            intent_held))
+                goto fail;
+            intent_held = 0;
+            /* Result: FACTORY_READY (done) or a re-sent PROPOSE_INTENT (retry). */
+            if (!wire_recv(fd, &msg) || check_msg_error(&msg)) {
+                fprintf(stderr, "Client %u: recv after creation psigs failed\n", my_index);
+                if (msg.json) cJSON_Delete(msg.json);
+                goto fail;
+            }
+            if (msg.msg_type == MSG_FACTORY_READY) {
+                client_apply_factory_ready(factory, msg.json);
+                cJSON_Delete(msg.json);
+                created = 1;
+                break;
+            } else if (msg.msg_type == MSG_FACTORY_PROPOSE_INTENT &&
+                       fc_attempt < SS_NONCE_RETRY_MAX) {
+                uint32_t rn = 0;
+                if (!wire_parse_factory_propose_intent(msg.json, &rn) ||
+                    rn != (uint32_t)factory->n_nodes) {
+                    fprintf(stderr, "Client %u: bad retry PROPOSE_INTENT\n", my_index);
+                    cJSON_Delete(msg.json);
+                    goto fail;
+                }
+                cJSON_Delete(msg.json);
+                fprintf(stderr, "Client %u: factory creation retry %d/%d "
+                        "(LSP requested fresh nonces)\n",
+                        my_index, fc_attempt + 2, SS_NONCE_RETRY_MAX + 1);
+                intent_held = 1;
+                continue;
+            } else {
+                fprintf(stderr, "Client %u: expected FACTORY_READY, got 0x%02x\n",
+                        my_index, msg.msg_type);
+                if (msg.json) cJSON_Delete(msg.json);
+                goto fail;
+            }
+        }
+        if (!created) {
+            fprintf(stderr, "Client %u: factory creation failed after %d attempts\n",
+                    my_index, SS_NONCE_RETRY_MAX + 1);
             goto fail;
+        }
     } else {
     /* Generate nonces via pool */
     unsigned char my_seckey[32];
@@ -2514,14 +2576,18 @@ int client_run_with_channels(secp256k1_context *ctx,
     }
     }  /* end else (legacy round-1-first nonce/psig path) */
 
-    /* Receive FACTORY_READY */
-    if (!wire_recv(fd, &msg) || check_msg_error(&msg) || msg.msg_type != MSG_FACTORY_READY) {
-        fprintf(stderr, "Client: expected FACTORY_READY\n");
-        if (msg.json) cJSON_Delete(msg.json);
-        goto fail;
+    /* Receive FACTORY_READY.  The stateless creation path (above) already
+       consumed + applied FACTORY_READY inside its bounded retry loop, so only
+       the legacy path recvs it here. */
+    if (!ss_stateless_creation) {
+        if (!wire_recv(fd, &msg) || check_msg_error(&msg) || msg.msg_type != MSG_FACTORY_READY) {
+            fprintf(stderr, "Client: expected FACTORY_READY\n");
+            if (msg.json) cJSON_Delete(msg.json);
+            goto fail;
+        }
+        client_apply_factory_ready(factory, msg.json);
+        cJSON_Delete(msg.json);
     }
-    client_apply_factory_ready(factory, msg.json);
-    cJSON_Delete(msg.json);
 
     /* Log expected distribution amount.  The distribution TX is a fallback
        (used only if the factory expires without cooperative rotation), so

--- a/src/client.c
+++ b/src/client.c
@@ -1805,6 +1805,33 @@ static int client_factory_creation_stateless_signing(
     }
     free(my_secnonces); free(my_slot);
 
+    /* #48 Phase D test seam: fault-inject a bad CREATION psig to exercise the
+       LSP's factory-creation bounded retry. Gated on superscalar_cheat_allowed()
+       (regtest only; #9 proves SS_CHEAT_* is inert on mainnet). =1 corrupts only
+       the FIRST creation ceremony (transient); =2 every ceremony (persistent).
+       Corrupts the first signed node's psig (first non-zero 32B chunk). */
+    {
+        const char *_cp = getenv("SS_CHEAT_CREATE_BAD_PSIG");
+        if (_cp && superscalar_cheat_allowed()) {
+            static int _create_cheat_uses = 0;
+            int _mode = atoi(_cp);
+            if (_mode == 2 || (_mode == 1 && _create_cheat_uses == 0)) {
+                for (size_t _n = 0; _n < nn; _n++) {
+                    int _nz = 0;
+                    for (int _b = 0; _b < 32; _b++) if (my_psig_per_node[_n*32+_b]) { _nz = 1; break; }
+                    if (_nz) {
+                        my_psig_per_node[_n*32+31] ^= 0x01;
+                        fprintf(stderr, "Client-stateless %u: [CHEAT] corrupting creation psig "
+                                "node %zu (SS_CHEAT_CREATE_BAD_PSIG=%d, use=%d)\n",
+                                my_index, _n, _mode, _create_cheat_uses);
+                        break;
+                    }
+                }
+            }
+            _create_cheat_uses++;
+        }
+    }
+
     /* Send CLIENT_FINAL_PSIGS (per-node; unsigned nodes carry zero psig). */
     {
         cJSON *fp = wire_build_factory_client_final_psigs(my_psig_per_node, (uint32_t)nn);

--- a/src/client.c
+++ b/src/client.c
@@ -809,6 +809,26 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
     unsigned char psig_ser[32];
     musig_partial_sig_serialize(ctx, psig_ser, &close_psig);
 
+    /* #48 Phase C test seam: fault-inject a bad close psig to exercise the LSP's
+       bounded fresh-nonce retry. Gated on superscalar_cheat_allowed() (regtest
+       only; #9 proves SS_CHEAT_* is inert on mainnet). =1 corrupts only the FIRST
+       close attempt (transient -> the retry must recover); =2 corrupts every
+       attempt (persistent -> the LSP must bound + abort). The static counter
+       distinguishes attempts because each retry is a fresh ceremony call. */
+    {
+        const char *_bp = getenv("SS_CHEAT_CLOSE_BAD_PSIG");
+        if (_bp && superscalar_cheat_allowed()) {
+            static int _close_cheat_uses = 0;
+            int _mode = atoi(_bp);
+            if (_mode == 2 || (_mode == 1 && _close_cheat_uses == 0)) {
+                psig_ser[31] ^= 0x01;   /* still a valid scalar, wrong value -> agg verify fails */
+                fprintf(stderr, "Client: [CHEAT] corrupting close psig "
+                        "(SS_CHEAT_CLOSE_BAD_PSIG=%d, use=%d)\n", _mode, _close_cheat_uses);
+            }
+            _close_cheat_uses++;
+        }
+    }
+
     cJSON *psig_msg = wire_build_close_psig(psig_ser);
     if (!wire_send(fd, MSG_CLOSE_PSIG, psig_msg)) {
         fprintf(stderr, "Client: send CLOSE_PSIG failed\n");

--- a/src/client.c
+++ b/src/client.c
@@ -838,12 +838,29 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
     }
     cJSON_Delete(psig_msg);
 
-    /* Receive CLOSE_DONE */
+    /* Receive CLOSE_DONE -- or a re-CLOSE_PROPOSE if the LSP is re-running the
+       close with fresh nonces after an invalid aggregate (#48 Phase C). On a
+       re-PROPOSE, re-run the close ceremony fresh (fresh nonce) by recursing with
+       the new proposal; bounded by the LSP's retry cap (it sends finitely many
+       re-PROPOSEs, then CLOSE_DONE or a terminal error -> MSG_ERROR). */
     wire_msg_t done_msg;
-    if (!wire_recv(fd, &done_msg) || check_msg_error(&done_msg) ||
-        done_msg.msg_type != MSG_CLOSE_DONE) {
-        fprintf(stderr, "Client: expected CLOSE_DONE\n");
+    if (!wire_recv(fd, &done_msg) || check_msg_error(&done_msg)) {
+        fprintf(stderr, "Client: close failed (LSP error / no CLOSE_DONE)\n");
         if (done_msg.json) cJSON_Delete(done_msg.json);
+        tx_buf_free(&close_unsigned);
+        return 0;
+    }
+    if (done_msg.msg_type == MSG_CLOSE_PROPOSE) {
+        fprintf(stderr, "Client: LSP re-proposing cooperative close -- retrying with a fresh nonce\n");
+        tx_buf_free(&close_unsigned);
+        int _r = client_do_close_ceremony(fd, ctx, keypair, my_pubkey, factory,
+                                           n_participants, &done_msg, current_height, ch);
+        cJSON_Delete(done_msg.json);
+        return _r;
+    }
+    if (done_msg.msg_type != MSG_CLOSE_DONE) {
+        fprintf(stderr, "Client: expected CLOSE_DONE, got 0x%02x\n", done_msg.msg_type);
+        cJSON_Delete(done_msg.json);
         tx_buf_free(&close_unsigned);
         return 0;
     }

--- a/src/client.c
+++ b/src/client.c
@@ -1814,10 +1814,16 @@ static int client_factory_creation_stateless_signing(
        LSP's factory-creation bounded retry. Gated on superscalar_cheat_allowed()
        (regtest only; #9 proves SS_CHEAT_* is inert on mainnet). =1 corrupts only
        the FIRST creation ceremony (transient); =2 every ceremony (persistent).
-       Corrupts the first signed node's psig (first non-zero 32B chunk). */
+       Corrupts the first signed node's psig (first non-zero 32B chunk).
+
+       ONLY client my_index==1 corrupts.  If every client XORed the low bit of its
+       OWN node-0 partial, the per-signer deltas (each +-1) can sum to zero in the
+       MuSig2 aggregate (s_agg = sum of partials), leaving a VALID aggregate ~37%
+       of the time -- a flaky no-op.  A single bad partial cannot cancel, so the
+       aggregate is reliably invalid and the LSP's verify+retry always fires. */
     {
         const char *_cp = getenv("SS_CHEAT_CREATE_BAD_PSIG");
-        if (_cp && superscalar_cheat_allowed()) {
+        if (_cp && superscalar_cheat_allowed() && my_index == 1) {
             static int _create_cheat_uses = 0;
             int _mode = atoi(_cp);
             if (_mode == 2 || (_mode == 1 && _create_cheat_uses == 0)) {

--- a/src/factory.c
+++ b/src/factory.c
@@ -2104,7 +2104,13 @@ int factory_advance_and_rebuild_path(factory_t *f, int leaf_side) {
 }
 
 
+/* TEST-ONLY seam (always 0 in production; set only by unit tests): forces the
+   next N aggregate verifications to fail, to exercise the bounded fresh-nonce
+   retry path in factory_sign_all_with_retry. */
+int g_factory_test_force_verify_fail = 0;
+
 int factory_verify_all(factory_t *f) {
+    if (g_factory_test_force_verify_fail > 0) { g_factory_test_force_verify_fail--; return 0; }
     for (size_t i = 0; i < f->n_nodes; i++) {
         factory_node_t *node = &f->nodes[i];
         if (!node->is_signed) continue;
@@ -2208,6 +2214,28 @@ fail:
     return 0;
 }
 
+/* Bounded fresh-nonce retry around factory_sign_all (#48).  factory_sign_all is
+   safely re-callable: factory_sessions_init re-initialises every node's signing
+   session and each nonce is freshly drawn from /dev/urandom (see musig.c), so
+   each attempt uses a brand-new, non-repeating nonce (no nonce-reuse key leak).
+   A transient sign/verify failure re-signs with fresh nonces up to max_attempts;
+   a persistent failure still aborts (bounded).  factory_verify_all runs only
+   when factory_sign_all reported success, so a partial sign short-circuits to a
+   retry rather than a misleading verify. */
+int factory_sign_all_with_retry(factory_t *f, int max_attempts) {
+    if (!f) return 0;
+    if (max_attempts < 1) max_attempts = 1;
+    for (int attempt = 1; attempt <= max_attempts; attempt++) {
+        if (factory_sign_all(f) && factory_verify_all(f))
+            return 1;
+        if (attempt < max_attempts)
+            fprintf(stderr, "factory: sign+verify attempt %d/%d failed; "
+                            "retrying with fresh nonces\n", attempt, max_attempts);
+    }
+    fprintf(stderr, "factory: sign+verify failed after %d attempt(s)\n", max_attempts);
+    return 0;
+}
+
 int factory_advance(factory_t *f) {
     if (!dw_counter_advance(&f->counter))
         return 0;
@@ -2218,7 +2246,7 @@ int factory_advance(factory_t *f) {
     if (!build_all_unsigned_txs(f))
         return 0;
 
-    return factory_sign_all(f);
+    return factory_sign_all_with_retry(f, SS_NONCE_RETRY_MAX);
 }
 
 /* Rebuild unsigned tx for a single node.
@@ -2472,7 +2500,7 @@ int factory_advance_leaf(factory_t *f, int leaf_side) {
         /* Full rebuild needed when root advances */
         if (!update_l_stock_outputs(f)) return 0;
         if (!build_all_unsigned_txs(f)) return 0;
-        return factory_sign_all(f);
+        return factory_sign_all_with_retry(f, SS_NONCE_RETRY_MAX);
     }
 
     /* Only rebuild + re-sign the leaf node */

--- a/src/factory.c
+++ b/src/factory.c
@@ -2133,6 +2133,22 @@ int factory_verify_all(factory_t *f) {
     return 1;
 }
 
+/* #48: verify a cooperative-close aggregate signature at ceremony time.  The
+   close spends the same funding output the root node spends, so it verifies
+   against the funding aggregate key (node[0].tweaked_pubkey) under the close
+   sighash.  Returns 1 (do NOT abort) when the signature is valid, OR when the
+   funding carries a taptree whose key-path tweak we cannot reconstruct here (the
+   close finalises with no taptree tweak) -- in that case the caller keeps
+   today's broadcast-time detection rather than risk false-failing a valid close.
+   Returns 0 only when the signature was definitively checked and is INVALID. */
+int factory_verify_close_sig(const factory_t *f, const unsigned char sig64[64],
+                             const unsigned char sighash[32]) {
+    if (!f || f->n_nodes == 0) return 0;
+    if (f->nodes[0].has_taptree) return 1;   /* mr=NULL close key can't be matched; skip */
+    return secp256k1_schnorrsig_verify(f->ctx, sig64, sighash, 32,
+                                       &f->nodes[0].tweaked_pubkey);
+}
+
 
 int factory_sign_all(factory_t *f) {
     /* Step 1: Initialize sessions */

--- a/src/ladder.c
+++ b/src/ladder.c
@@ -73,7 +73,7 @@ int ladder_create_factory(ladder_t *lad,
     for (uint32_t i = 0; i < lf->factory.counter.total_states - 1; i++)
         dw_counter_advance(&lf->factory.counter);
 
-    if (!factory_sign_all(&lf->factory)) {
+    if (!factory_sign_all_with_retry(&lf->factory, SS_NONCE_RETRY_MAX)) {
         tx_buf_free(&lf->distribution_tx);
         return 0;
     }

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1188,6 +1188,17 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         goto close_fail;
     }
 
+    /* #48 Phase B (detection): verify the aggregate close signature at ceremony
+       time, before CLOSE_DONE/broadcast.  Until now an invalid aggregate (e.g. a
+       bad client psig) surfaced only at broadcast; fail fast here so we can abort
+       (and, in Phase C, retry with fresh nonces).  factory_verify_close_sig never
+       false-fails a valid close (guards on the funding being key-path-only). */
+    if (!factory_verify_close_sig(f, sig64, sighash)) {
+        fprintf(stderr, "LSP: cooperative-close aggregate signature INVALID at "
+                "ceremony time -- aborting before CLOSE_DONE\n");
+        goto close_fail;
+    }
+
     /* Finalize signed close tx */
     if (!finalize_signed_tx(close_tx_out, unsigned_tx.data, unsigned_tx.len, sig64)) {
         fprintf(stderr, "LSP: close finalize_signed_tx failed\n");

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1194,9 +1194,14 @@ int lsp_run_cooperative_close(lsp_t *lsp,
        (and, in Phase C, retry with fresh nonces).  factory_verify_close_sig never
        false-fails a valid close (guards on the funding being key-path-only). */
     if (!factory_verify_close_sig(f, sig64, sighash)) {
-        fprintf(stderr, "LSP: cooperative-close aggregate signature INVALID at "
-                "ceremony time -- aborting before CLOSE_DONE\n");
-        goto close_fail;
+        /* #48 Phase C: invalid aggregate (e.g. a transient bad client psig).
+           RETRYABLE -- do NOT abort (that disconnects the clients); free our tx
+           and return 2 so the caller re-invokes with a fresh CLOSE_PROPOSE. The
+           clients stay blocked on CLOSE_DONE and re-enter on the re-PROPOSE. */
+        fprintf(stderr, "LSP: cooperative-close aggregate signature INVALID -- "
+                "retryable (fresh-nonce re-run; clients kept)\n");
+        tx_buf_free(&unsigned_tx);
+        return 2;
     }
 
     /* Finalize signed close tx */

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -502,11 +502,6 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     fflush(stdout);
     cJSON_Delete(propose);
 
-    if (!factory_sessions_init(f)) {
-        fprintf(stderr, "LSP-stateless: factory_sessions_init failed\n");
-        return 0;
-    }
-
     /* Build the UNSIGNED distribution TX and attach it to f.  #54 G1a/G1b:
        this dist TX is then CO-SIGNED below in the stateless creation ceremony
        (the per-signer dist nonce + partial-sig exchange), so FACTORY_READY
@@ -525,6 +520,28 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     }
 
     /* ---- Reversed stateless signing exchange ---- */
+
+    /* #48 Phase D: bounded fresh-nonce retry.  The tree + FACTORY_PROPOSE are
+       built/sent ONCE (above); only the signing rounds (sessions_init ->
+       PROPOSE_INTENT -> client pubnonces -> LSP nonces/psigs -> client psigs ->
+       verify) repeat.  If factory_verify_all fails at ceremony time (e.g. a bad
+       client partial sig) we re-init sessions and re-send PROPOSE_INTENT so all
+       parties re-sign with FRESH nonces, up to SS_NONCE_RETRY_MAX times, before
+       aborting.  Every per-round buffer (all_pn / lsp_* / client_*) is freed
+       before the verify point, so a retry re-enters the loop with nothing to
+       clean up.  dist_active is hoisted so the post-loop dist completion sees the
+       final round's value. */
+    int dist_active = 0;
+    int verify_ok = 0;
+    for (int fc_attempt = 0; fc_attempt <= SS_NONCE_RETRY_MAX; fc_attempt++) {
+        if (fc_attempt > 0)
+            fprintf(stderr, "LSP-stateless: factory creation retry %d/%d "
+                    "(re-running with fresh nonces)\n",
+                    fc_attempt + 1, SS_NONCE_RETRY_MAX + 1);
+        if (!factory_sessions_init(f)) {
+            fprintf(stderr, "LSP-stateless: factory_sessions_init failed\n");
+            goto fail_pre;
+        }
 
     /* Step A: PROPOSE_INTENT(n_nodes) to all clients (begin reversed flow). */
     {
@@ -558,8 +575,8 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     unsigned char *all_pn = calloc(f->n_nodes + 1, mtx_stride);
     if (!all_pn) goto fail_pre;
     size_t dist_row = (size_t)f->n_nodes * mtx_stride;  /* byte offset of the dist row */
-    int dist_active = (f->dist_tx_ready >= 1 && f->dist_unsigned_tx.len > 0 &&
-                       factory_session_init_dist(f));
+    dist_active = (f->dist_tx_ready >= 1 && f->dist_unsigned_tx.len > 0 &&
+                   factory_session_init_dist(f));
 
     lsp_crash_checkpoint("factory_creation_propose");
 
@@ -827,9 +844,20 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
        Phase D, retry with fresh nonces -- before shipping a dud FACTORY_READY.
        A valid ceremony always passes (no behaviour change); only a genuinely
        invalid aggregate aborts. */
-    if (!factory_verify_all(f)) {
+        if (factory_verify_all(f)) {
+            verify_ok = 1;
+            break;  /* aggregate valid -- exit the bounded retry loop */
+        }
         fprintf(stderr, "LSP-stateless: factory aggregate signature INVALID at "
-                "ceremony time (bad client psig?) -- aborting before broadcast\n");
+                "ceremony time (bad client psig?)%s\n",
+                fc_attempt < SS_NONCE_RETRY_MAX
+                    ? " -- re-running with fresh nonces"
+                    : " -- retry limit reached");
+    }  /* end #48 Phase D bounded retry loop */
+    if (!verify_ok) {
+        fprintf(stderr, "LSP-stateless: factory creation failed after %d attempts "
+                "(persistent bad psig) -- aborting before broadcast\n",
+                SS_NONCE_RETRY_MAX + 1);
         goto fail_pre;
     }
 

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -821,6 +821,18 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
         goto fail_pre;
     }
 
+    /* #48 Phase B (detection): verify the aggregated factory signatures at
+       ceremony time.  Until now an invalid aggregate (e.g. a bad client partial
+       sig) surfaced only at broadcast; fail fast here so we can abort -- and, in
+       Phase D, retry with fresh nonces -- before shipping a dud FACTORY_READY.
+       A valid ceremony always passes (no behaviour change); only a genuinely
+       invalid aggregate aborts. */
+    if (!factory_verify_all(f)) {
+        fprintf(stderr, "LSP-stateless: factory aggregate signature INVALID at "
+                "ceremony time (bad client psig?) -- aborting before broadcast\n");
+        goto fail_pre;
+    }
+
     /* #54 G1b: aggregate the dist partial sigs into the signed distribution TX
        (the offline-forever recovery net), setting dist_tx_ready=2 so
        wire_build_factory_ready ships distribution_tx_hex.  NON-FATAL: the factory

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -246,6 +246,50 @@ int test_factory_sign_all(void) {
     return 1;
 }
 
+/* ---- Unit test: #48 bounded fresh-nonce retry ---- */
+
+int test_factory_sign_all_retry(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[5];
+    if (!make_keypairs(ctx, kps)) return 0;
+
+    unsigned char fund_spk[34];
+    secp256k1_xonly_pubkey fund_tweaked;
+    TEST_ASSERT(compute_funding_spk(ctx, kps, fund_spk, &fund_tweaked), "compute funding spk");
+    unsigned char fake_txid[32]; memset(fake_txid, 0xAA, 32);
+
+    factory_t *f = calloc(1, sizeof(factory_t));
+    if (!f) return 0;
+    factory_init(f, ctx, kps, 5, 2, 4);
+    factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+
+    /* 1. Normal: succeeds on the first attempt and verifies. */
+    TEST_ASSERT(factory_sign_all_with_retry(f, SS_NONCE_RETRY_MAX), "retry helper signs+verifies");
+    TEST_ASSERT(factory_verify_all(f), "result verifies");
+
+    /* 2. Re-callable: a second full call also succeeds — factory_sessions_init
+       re-inits each session + fresh nonces, so no stale state leaks from attempt 1. */
+    TEST_ASSERT(factory_sign_all_with_retry(f, SS_NONCE_RETRY_MAX), "retry helper is re-callable");
+
+    /* 3. Transient verify-fail on attempt 1 -> retry -> succeeds on attempt 2.
+       Attempt 2 succeeding is itself proof the retry re-signs with FRESH nonces
+       (a reused/stale session would fail identically). */
+    g_factory_test_force_verify_fail = 1;
+    TEST_ASSERT(factory_sign_all_with_retry(f, SS_NONCE_RETRY_MAX), "recovers from a transient verify-fail");
+    TEST_ASSERT(g_factory_test_force_verify_fail == 0, "exactly one forced fail consumed (it retried)");
+
+    /* 4. Persistent verify-fail beyond the bound -> bounded abort (no infinite loop). */
+    g_factory_test_force_verify_fail = SS_NONCE_RETRY_MAX + 2;
+    TEST_ASSERT(!factory_sign_all_with_retry(f, SS_NONCE_RETRY_MAX), "bounded: persistent fail aborts");
+    g_factory_test_force_verify_fail = 0;   /* reset global so sibling tests are unaffected */
+
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* ---- Unit test: advance DW counter ---- */
 
 int test_factory_advance(void) {

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -97,6 +97,7 @@ extern int test_regtest_nsequence_edge(void);
 
 extern int test_factory_build_tree(void);
 extern int test_factory_sign_all(void);
+extern int test_factory_sign_all_retry(void);
 extern int test_factory_advance(void);
 extern int test_factory_sign_split_round_step_by_step(void);
 extern int test_factory_split_round_with_pool(void);
@@ -2037,6 +2038,7 @@ static void run_unit_tests(void) {
     printf("\n=== Factory Tree ===\n");
     RUN_TEST(test_factory_build_tree);
     RUN_TEST(test_factory_sign_all);
+    RUN_TEST(test_factory_sign_all_retry);
     RUN_TEST(test_factory_advance);
 
     printf("\n=== Factory Split-Round ===\n");

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -4717,19 +4717,23 @@ accept_new_factory:
        loop forever; on exhaustion we fall through to the no-broadcast path below
        (safe: clients keep their pre-signed commitment + watchtower and can
        force-close). */
-    int _close_ok = 0;
+    int _close_ok = 0, _rc = 0;
     for (int _ca = 1; _ca <= SS_NONCE_RETRY_MAX; _ca++) {
-        if (lsp_run_cooperative_close(lsp_p, &close_tx, close_outputs, n_close_outputs,
-                                      chain_be ? (uint32_t)chain_be->get_block_height(chain_be) :
-                                      (uint32_t)regtest_get_block_height(&rt))) {
-            _close_ok = 1;
-            break;
-        }
+        _rc = lsp_run_cooperative_close(lsp_p, &close_tx, close_outputs, n_close_outputs,
+                                        chain_be ? (uint32_t)chain_be->get_block_height(chain_be) :
+                                        (uint32_t)regtest_get_block_height(&rt));
+        if (_rc == 1) { _close_ok = 1; break; }   /* success */
+        if (_rc != 2) break;                        /* terminal failure (clients already aborted) */
+        /* _rc == 2: retryable invalid aggregate -- clients are NOT aborted, still
+           blocked on CLOSE_DONE; re-invoking re-sends CLOSE_PROPOSE and they
+           re-enter with fresh nonces. */
         if (_ca < SS_NONCE_RETRY_MAX)
-            fprintf(stderr, "LSP: cooperative close attempt %d/%d failed; "
-                    "retrying with fresh nonces\n", _ca, SS_NONCE_RETRY_MAX);
+            fprintf(stderr, "LSP: cooperative close attempt %d/%d had an invalid "
+                    "aggregate; re-running with fresh nonces\n", _ca, SS_NONCE_RETRY_MAX);
     }
     if (!_close_ok) {
+        if (_rc == 2)   /* clients still waiting -- abort so they fall back to force-close */
+            lsp_abort_ceremony(lsp_p, "cooperative close failed after fresh-nonce retries");
         fprintf(stderr, "LSP: cooperative close failed after %d attempts "
                 "(clients fall back to force-close)\n", SS_NONCE_RETRY_MAX);
         tx_buf_free(&close_tx);

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -4708,10 +4708,30 @@ accept_new_factory:
     tx_buf_t close_tx;
     tx_buf_init(&close_tx, 512);
 
-    if (!lsp_run_cooperative_close(lsp_p, &close_tx, close_outputs, n_close_outputs,
+    /* #48 Phase C: bounded fresh-nonce retry for the cooperative close. A
+       ceremony-time verify failure (Phase B) returns 0 after a SOFT abort
+       (MSG_ERROR; connections survive) that returns each client to its main loop;
+       re-invoking the ceremony re-sends CLOSE_PROPOSE and the clients re-enter
+       with FRESH nonces (their daemon loop re-dispatches CLOSE_PROPOSE -> a new
+       client_do_close_ceremony). Bounded so a persistently-faulty signer cannot
+       loop forever; on exhaustion we fall through to the no-broadcast path below
+       (safe: clients keep their pre-signed commitment + watchtower and can
+       force-close). */
+    int _close_ok = 0;
+    for (int _ca = 1; _ca <= SS_NONCE_RETRY_MAX; _ca++) {
+        if (lsp_run_cooperative_close(lsp_p, &close_tx, close_outputs, n_close_outputs,
                                       chain_be ? (uint32_t)chain_be->get_block_height(chain_be) :
                                       (uint32_t)regtest_get_block_height(&rt))) {
-        fprintf(stderr, "LSP: cooperative close failed\n");
+            _close_ok = 1;
+            break;
+        }
+        if (_ca < SS_NONCE_RETRY_MAX)
+            fprintf(stderr, "LSP: cooperative close attempt %d/%d failed; "
+                    "retrying with fresh nonces\n", _ca, SS_NONCE_RETRY_MAX);
+    }
+    if (!_close_ok) {
+        fprintf(stderr, "LSP: cooperative close failed after %d attempts "
+                "(clients fall back to force-close)\n", SS_NONCE_RETRY_MAX);
         tx_buf_free(&close_tx);
         lsp_cleanup(lsp_p);
         secp256k1_context_destroy(ctx);

--- a/tools/test_regtest_close_retry.sh
+++ b/tools/test_regtest_close_retry.sh
@@ -20,7 +20,7 @@ red(){ printf '\033[31m%s\033[0m\n' "$*"; }; green(){ printf '\033[32m%s\033[0m\
 echo "=== [1/2] transient (SS_CHEAT_CLOSE_BAD_PSIG=1): close must RETRY then SUCCEED ==="
 N_CLIENTS=$N PAYMENTS=$P SS_CHEAT_CLOSE_BAD_PSIG=1 bash "$DIR/test_regtest_n64_payments.sh" "$BUILD_DIR"
 rc1=$?
-nretry=$(grep -c "retrying with fresh nonces" "$LOG" 2>/dev/null || echo 0)
+nretry=$(grep -cE "re-running with fresh nonces|retrying with fresh nonces" "$LOG" 2>/dev/null || echo 0)
 ncheat=$(grep -c "CHEAT] corrupting close psig" "$LOG" 2>/dev/null || echo 0)   # LSP log won't have it; clients do
 [ "$rc1" -eq 0 ] || { red "FAIL transient: lifecycle rc=$rc1 (close did not recover)"; exit 1; }
 [ "$nretry" -ge 1 ] || { red "FAIL transient: LSP never logged a retry (nretry=$nretry)"; exit 1; }

--- a/tools/test_regtest_close_retry.sh
+++ b/tools/test_regtest_close_retry.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# test_regtest_close_retry.sh -- #48 Phase C proof. The LSP's bounded fresh-nonce
+# retry must (1) RECOVER a cooperative close from a TRANSIENT bad partial sig, and
+# (2) BOUNDED-ABORT a PERSISTENT one (clients then fall back to force-close).
+#
+# Drives the existing N-channel payment+close lifecycle (test_regtest_n64_payments.sh,
+# small N) with the gated SS_CHEAT_CLOSE_BAD_PSIG fault injection (regtest-only via
+# superscalar_cheat_allowed() -- inert on mainnet, #9):
+#   =1 -> each client corrupts ONLY its first close psig  (transient)
+#   =2 -> each client corrupts EVERY close psig           (persistent)
+#
+# Usage: bash tools/test_regtest_close_retry.sh [BUILD_DIR]
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${1:-/root/SuperScalar/build-release}"
+LOG=/tmp/ss_regtest_n64_payments_lsp.log
+N="${N_CLIENTS:-4}"; P="${PAYMENTS:-2}"
+red(){ printf '\033[31m%s\033[0m\n' "$*"; }; green(){ printf '\033[32m%s\033[0m\n' "$*"; }
+
+echo "=== [1/2] transient (SS_CHEAT_CLOSE_BAD_PSIG=1): close must RETRY then SUCCEED ==="
+N_CLIENTS=$N PAYMENTS=$P SS_CHEAT_CLOSE_BAD_PSIG=1 bash "$DIR/test_regtest_n64_payments.sh" "$BUILD_DIR"
+rc1=$?
+nretry=$(grep -c "retrying with fresh nonces" "$LOG" 2>/dev/null || echo 0)
+ncheat=$(grep -c "CHEAT] corrupting close psig" "$LOG" 2>/dev/null || echo 0)   # LSP log won't have it; clients do
+[ "$rc1" -eq 0 ] || { red "FAIL transient: lifecycle rc=$rc1 (close did not recover)"; exit 1; }
+[ "$nretry" -ge 1 ] || { red "FAIL transient: LSP never logged a retry (nretry=$nretry)"; exit 1; }
+green "PASS transient: close RETRIED ($nretry x) and the full lifecycle SUCCEEDED"
+
+echo "=== [2/2] persistent (SS_CHEAT_CLOSE_BAD_PSIG=2): close must BOUND then ABORT ==="
+N_CLIENTS=$N PAYMENTS=$P SS_CHEAT_CLOSE_BAD_PSIG=2 bash "$DIR/test_regtest_n64_payments.sh" "$BUILD_DIR"
+rc2=$?
+nbound=$(grep -c "cooperative close failed after" "$LOG" 2>/dev/null || echo 0)
+[ "$rc2" -ne 0 ] || { red "FAIL persistent: lifecycle unexpectedly succeeded (close should bound+abort)"; exit 1; }
+[ "$nbound" -ge 1 ] || { red "FAIL persistent: LSP never logged the bounded abort (nbound=$nbound)"; exit 1; }
+green "PASS persistent: close BOUNDED + ABORTED after the retry limit (clients fall back to force-close)"
+echo "CLOSE_RETRY_TEST PASS"

--- a/tools/test_regtest_create_retry.sh
+++ b/tools/test_regtest_create_retry.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# test_regtest_create_retry.sh -- #48 Phase D proof. The factory-CREATION bounded
+# fresh-nonce retry must (1) RECOVER creation from a TRANSIENT bad client partial
+# sig (re-init sessions + re-send PROPOSE_INTENT -> clients re-sign with fresh
+# nonces -> aggregate verifies -> full lifecycle proceeds), and (2) BOUNDED-ABORT
+# a PERSISTENT one (after SS_NONCE_RETRY_MAX rounds the LSP aborts before
+# broadcast; nothing is committed on-chain, so the fallback is simply re-create).
+#
+# Drives the existing N-channel creation+payment+close lifecycle
+# (test_regtest_n64_payments.sh, small N) with the gated SS_CHEAT_CREATE_BAD_PSIG
+# fault injection (regtest-only via superscalar_cheat_allowed() -- inert on
+# mainnet, #9):
+#   =1 -> each client corrupts ONLY its first creation psig  (transient)
+#   =2 -> each client corrupts EVERY creation psig           (persistent)
+#
+# Usage: bash tools/test_regtest_create_retry.sh [BUILD_DIR]
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${1:-/root/SuperScalar/build-release}"
+LOG=/tmp/ss_regtest_n64_payments_lsp.log
+N="${N_CLIENTS:-4}"; P="${PAYMENTS:-2}"
+red(){ printf '\033[31m%s\033[0m\n' "$*"; }; green(){ printf '\033[32m%s\033[0m\n' "$*"; }
+
+echo "=== [1/2] transient (SS_CHEAT_CREATE_BAD_PSIG=1): creation must RETRY then SUCCEED ==="
+N_CLIENTS=$N PAYMENTS=$P SS_CHEAT_CREATE_BAD_PSIG=1 bash "$DIR/test_regtest_n64_payments.sh" "$BUILD_DIR"
+rc1=$?
+nretry=$(grep -cE "re-running with fresh nonces|factory creation retry" "$LOG" 2>/dev/null); nretry=${nretry:-0}
+[ "$rc1" -eq 0 ] || { red "FAIL transient: lifecycle rc=$rc1 (creation did not recover)"; exit 1; }
+[ "$nretry" -ge 1 ] || { red "FAIL transient: LSP never logged a creation retry (nretry=$nretry)"; exit 1; }
+green "PASS transient: creation RETRIED ($nretry x) and the full lifecycle SUCCEEDED"
+
+echo "=== [2/2] persistent (SS_CHEAT_CREATE_BAD_PSIG=2): creation must BOUND then ABORT ==="
+N_CLIENTS=$N PAYMENTS=$P SS_CHEAT_CREATE_BAD_PSIG=2 bash "$DIR/test_regtest_n64_payments.sh" "$BUILD_DIR"
+rc2=$?
+nbound=$(grep -c "factory creation failed after" "$LOG" 2>/dev/null); nbound=${nbound:-0}
+[ "$rc2" -ne 0 ] || { red "FAIL persistent: lifecycle unexpectedly succeeded (creation should bound+abort)"; exit 1; }
+[ "$nbound" -ge 1 ] || { red "FAIL persistent: LSP never logged the bounded abort (nbound=$nbound)"; exit 1; }
+green "PASS persistent: creation BOUNDED + ABORTED after the retry limit (fallback: re-create)"
+echo "CREATE_RETRY_TEST PASS"


### PR DESCRIPTION
P6 (liveness) of the trustless-completion roadmap (internal task 48). When a
MuSig2 signing ceremony fails (a partial sig fails to verify / the aggregate is
invalid), retry with a **fresh nonce** a bounded number of times
(`SS_NONCE_RETRY_MAX=3`) before aborting and escalating — instead of aborting on
the first failure or blocking until expiry. Safety always holds via the DW/CLTV
override; this is graceful **liveness** degradation, not a safety change.

**Security precondition (verified):** every nonce draws fresh `/dev/urandom` (no
deterministic derivation anywhere); secnonces are single-use (zeroed by
partial-sign) and never persisted, so re-running a ceremony from nonce generation
is nonce-reuse-safe. Full analysis in `docs/p6-bounded-nonce-retry.md`.

### Phases (each tested before/after)

- **A — all-local path:** `factory_sign_all_with_retry()`, called at every
  `factory_sign_all` site.
- **B — ceremony-time detection:** `factory_verify_all` after
  `factory_sessions_complete` (creation) + close-sig verify (close). Previously a
  bad client psig surfaced only at broadcast; now it's caught before shipping a dud
  tx — an independent robustness win.
- **C — cooperative-close bounded retry:** two-sided protocol (LSP returns a
  retryable code, no abort/disconnect; client recurses on a re-sent CLOSE_PROPOSE).
  Proven by `tools/test_regtest_close_retry.sh`: `=1` transient → retry + full
  lifecycle succeeds; `=2` persistent → bounded abort → clients fall back to
  force-close. **CLOSE_RETRY_TEST PASS.**
- **D — factory-creation bounded retry:** build the tree + FACTORY_PROPOSE **once**,
  then loop only the signing rounds (`sessions_init` → PROPOSE_INTENT → client
  pubnonces → LSP nonces/psigs → client psigs → `factory_verify_all`). On
  verify-fail: re-init sessions + re-send PROPOSE_INTENT (no abort, no
  `factory_free`), bounded. Leak-free — every per-round buffer is freed before the
  verify point. The client mirrors it with a new `intent_already_recvd` param so a
  retry (which already consumed the re-sent PROPOSE_INTENT to detect it) does not
  double-recv. Proven by `tools/test_regtest_create_retry.sh`: `=1` → retry +
  succeed; `=2` → bounded abort before broadcast → re-create fallback.
  **CREATE_RETRY_TEST PASS.**

### Fault injection (regtest-only)

`SS_CHEAT_CLOSE_BAD_PSIG` / `SS_CHEAT_CREATE_BAD_PSIG`, gated by
`superscalar_cheat_allowed()` (refused on mainnet). The creation cheat corrupts
**exactly one** client's partial: if every client XORed the low bit of its own
node-0 partial, the per-signer ±1 deltas can sum to zero in the MuSig2 aggregate
(`s_agg = Σ partials`) ~37% of runs → a valid aggregate → a flaky no-op. A single
bad partial cannot cancel.

### Regression

`client_factory_creation_stateless_signing` is shared with the rotation re-entry
path, which passes `intent_already_recvd=0` → byte-identical to prior behavior (the
retry loop lives only in the initial-creation caller). Confirmed by a clean
`n64_payments` lifecycle + the unit suite + all CI jobs green.
