### PR TITLE
test(signet): strong-key support in selfdrive harness (#11)

### DIFF
--- a/tools/test_signet_selfdrive.sh
+++ b/tools/test_signet_selfdrive.sh
@@ -11,9 +11,13 @@ BUILD_DIR="${BUILD_DIR:-/root/SuperScalar/build-release}"
 LSP_BIN="$BUILD_DIR/superscalar_lsp"; CLIENT_BIN="$BUILD_DIR/superscalar_client"
 N_CLIENTS="${N_CLIENTS:-2}"; AMOUNT="${AMOUNT:-250000}"; FEE_RATE="${FEE_RATE:-100}"
 WALLET="${WALLET:-superscalar_lsp}"; CONFIRM_TIMEOUT="${CONFIRM_TIMEOUT:-21600}"
-LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
-LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
-sk(){ local b; b=$(printf "%02x" $((34 + $1 * 17))); printf "${b}%.0s" {1..32}; }
+# #11: strong-key signet runs override these via env (signet_strong_keygen.py) so
+# the ceremony keys are NOT publicly-sweepable weak keys on public signet.
+LSP_SECKEY="${LSP_SECKEY:-0000000000000000000000000000000000000000000000000000000000000001}"
+LSP_PUBKEY="${LSP_PUBKEY:-0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798}"
+# sk i: per-client seckey. When CLIENT_KEYS_FILE is set, read line (i+1) from it
+# (strong keys); else the regtest scaffold byte = 0x22 + i*0x11.
+sk(){ if [ -n "${CLIENT_KEYS_FILE:-}" ]; then sed -n "$(($1+1))p" "$CLIENT_KEYS_FILE"; else local b; b=$(printf "%02x" $((34 + $1 * 17))); printf "${b}%.0s" {1..32}; fi; }
 SIGNET_CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
 RU=$(awk -F= '/^[[:space:]]*rpcuser/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")
 RP=$(awk -F= '/^[[:space:]]*rpcpassword/{gsub(/ /,"",$2);print $2;exit}' "$SIGNET_CONF")
@@ -29,10 +33,15 @@ recov(){ echo "--- RECOVERY: $AMOUNT sats from $WALLET; residual factory/leaf/co
 echo "=== SIGNET self-drive: $FLAG (marker: '$MARKER') at 0.1 sat/vB ==="
 echo "  [$(ts)] height $(tip), amount=$AMOUNT, fee=$FEE_RATE sat/kvB. signet ~10min/block — multi-hour."
 pkill -9 -f "superscalar_lsp.*--port $LSP_PORT" 2>/dev/null||true; sleep 1
+# #11: pass the STRONG per-run client seckeys to the breach re-sign (mirrors the
+# #406 commitment-breach harness) so the injected breach validates with strong
+# keys; without it the re-sign falls back to the scaffold byte-fill and the breach
+# is an Invalid Schnorr that cannot broadcast on a strong-key factory.
+BREACH_KEYS_ARG=""; [ -n "${CLIENT_KEYS_FILE:-}" ] && BREACH_KEYS_ARG="--breach-client-keys-file ${CLIENT_KEYS_FILE}"
 "$LSP_BIN" --network signet --cli-path bitcoin-cli --rpcuser "$RU" --rpcpassword "$RP" \
     --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
     --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
-    --amount $AMOUNT --fee-rate $FEE_RATE \
+    --amount $AMOUNT --fee-rate $FEE_RATE $BREACH_KEYS_ARG \
     --confirm-timeout $CONFIRM_TIMEOUT --seckey "$LSP_SECKEY" --wallet "$WALLET" \
     --db "$LSP_DB" --wt-db "$WT_DB" --demo $FLAG --lsp-balance-pct 50 > "$LSP_LOG" 2>&1 &
 LSP_PID=$!; PIDS+=($LSP_PID)

--- a/tools/test_signet_selfdrive.sh
+++ b/tools/test_signet_selfdrive.sh
@@ -38,6 +38,12 @@ pkill -9 -f "superscalar_lsp.*--port $LSP_PORT" 2>/dev/null||true; sleep 1
 # keys; without it the re-sign falls back to the scaffold byte-fill and the breach
 # is an Invalid Schnorr that cannot broadcast on a strong-key factory.
 BREACH_KEYS_ARG=""; [ -n "${CLIENT_KEYS_FILE:-}" ] && BREACH_KEYS_ARG="--breach-client-keys-file ${CLIENT_KEYS_FILE}"
+# The #184 PTLC-breach-chain handler re-signs channel-0's revoked commit with the
+# CLIENT-0 key read from $SUPERSCALAR_TEST_CLIENT0_SECKEY (else 0x22 scaffold ->
+# Invalid Schnorr on a strong-key factory). The BREACH_KEYS_ARG above only feeds the
+# separate commitment-breach handler, so mirror the strong client-0 key into the LSP
+# env here too, or the PTLC breach broadcast fails on a strong-key signet factory.
+[ -n "${CLIENT_KEYS_FILE:-}" ] && export SUPERSCALAR_TEST_CLIENT0_SECKEY="$(sk 0)"
 "$LSP_BIN" --network signet --cli-path bitcoin-cli --rpcuser "$RU" --rpcpassword "$RP" \
     --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
     --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
@@ -75,10 +81,15 @@ SWEEP_TXID=$(sqlite3 "$LSP_DB" "SELECT txid FROM broadcast_log WHERE result='ok'
 [ -z "$SWEEP_TXID" ] && SWEEP_TXID=$(sqlite3 "$LSP_DB" "SELECT txid FROM broadcast_log WHERE result='ok' AND length(txid)=64 ORDER BY id DESC LIMIT 1;" 2>/dev/null)
 [ -z "$SWEEP_TXID" ] && SWEEP_TXID=$(grep -aoiE "(penal|sweep|timeout|ptlc|htlc|punish|broadcast)[^0-9a-f]{0,40}[0-9a-f]{64}" "$LSP_LOG" 2>/dev/null | grep -oE "[0-9a-f]{64}" | tail -1)
 [ -n "$SWEEP_TXID" ] || { red "FAIL (signet): marker '$MARKER' seen but NO sweep/penalty txid in broadcast_log or LSP log — cannot verify the on-chain outcome (marker != confirmed funded tx)"; tail -25 "$LSP_LOG"; recov; exit 1; }
-echo "  verifying breach-response tx on-chain: $SWEEP_TXID"
-RAW=$(btc getrawtransaction "$SWEEP_TXID" true)
-CONF=$(echo "$RAW" | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1)
-{ [ -n "$CONF" ] && [ "${CONF:-0}" -ge 1 ]; } || { red "FAIL (signet): marker '$MARKER' seen but breach-response tx $SWEEP_TXID is NOT confirmed on-chain (self-report != outcome)"; recov; exit 1; }
+echo "  verifying breach-response tx on-chain (poll up to ~25min; the LAST-broadcast penalty needs its own signet block ~10min, so a single check right after the PASS marker races the block): $SWEEP_TXID"
+RAW=""; CONF=0
+for w in $(seq 1 25); do
+    RAW=$(btc getrawtransaction "$SWEEP_TXID" true)
+    CONF=$(echo "$RAW" | grep -oE '"confirmations": *[0-9]+' | grep -oE '[0-9]+' | head -1)
+    { [ -n "$CONF" ] && [ "${CONF:-0}" -ge 1 ]; } && { echo "  [$(ts)] breach-response confirmed (${CONF} conf)"; break; }
+    sleep 60
+done
+{ [ -n "$CONF" ] && [ "${CONF:-0}" -ge 1 ]; } || { red "FAIL (signet): marker '$MARKER' seen but breach-response tx $SWEEP_TXID did NOT confirm within ~25min (self-report != outcome)"; recov; exit 1; }
 SVAL=$(echo "$RAW" | grep -oE '"value": *[0-9.]+' | grep -oE '[0-9.]+' | sort -rn | head -1)
 SSATS=$(awk "BEGIN{printf \"%d\", ($SVAL+0)*100000000}")
 [ "${SSATS:-0}" -ge 330 ] || { red "FAIL (signet): breach-response $SWEEP_TXID confirmed but largest output ${SSATS} sats is dust — no real recovery"; recov; exit 1; }


### PR DESCRIPTION
Enables strong-key (no-weak-keys-on-public-signet) runs of test_signet_selfdrive.sh, including the PTLC breach chain. Wires --breach-client-keys-file (mirrors #406). DRAFT pending the strong-key signet PTLC breach-chain re-run confirming end-to-end.