### PR TITLE
fix(client): handle MSG_FUNDING_REORG/CEREMONY_ABORT in the client daemon dispatch

### DIFF
--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -169,6 +169,12 @@ int client_parse_forgery_response(const char *s);
    Returns 1 on success. */
 int client_handle_add_htlc(channel_t *ch, const wire_msg_t *msg);
 
+/* Handle async / unsolicited LSP->client notifications (MSG_FUNDING_REORG,
+   MSG_CEREMONY_ABORT).  Returns 1 if handled (caller still frees msg->json), 0
+   otherwise.  Shared by the ceremony recv path (wire_recv_handle_ping) and the
+   client daemon dispatch so both handle them identically. */
+int client_handle_async_msg(const wire_msg_t *msg);
+
 /* Send FULFILL_HTLC to LSP (reveal preimage for received HTLC).
    Returns 1 on success. */
 int client_fulfill_payment(int fd, channel_t *ch,

--- a/src/client.c
+++ b/src/client.c
@@ -153,10 +153,67 @@ static int g_client_funding_pending_reorg = 0;
  * src/client_reconnect.c (extracted) can write it on reconnect. */
 factory_t *g_client_active_factory = NULL;
 
-/* Wrapper around wire_recv_timeout that transparently handles
-   MSG_PING (responds with MSG_PONG), MSG_PONG (discards), and
-   MSG_FUNDING_REORG (updates local freeze mirror, discards).
-   Returns 1 on a real (non-keepalive) message, 0 on failure. */
+/* Handle async / unsolicited LSP->client notifications that can arrive at any
+   time between (or during) request/response exchanges:
+     - MSG_FUNDING_REORG: mirror the LSP's funding freeze state + reset stale
+       sub-factory chains (SF-followup #145 / reorg PR #208).
+     - MSG_CEREMONY_ABORT: advisory abort / intent-to-exit notice (#49/#51).
+   Returns 1 if msg was one of these (caller treats it as consumed but must still
+   free msg->json), 0 otherwise.  Shared by wire_recv_handle_ping (ceremony recv
+   path) AND the client daemon dispatch in tools/superscalar_client.c so BOTH
+   handle them identically.  Before this the daemon loop hit its "unexpected msg"
+   default on FUNDING_REORG, desynced, and livelocked reconnecting -- breaking
+   inbound bridge payments whenever the LSP sent a routine funding-reorg notice. */
+int client_handle_async_msg(const wire_msg_t *msg) {
+    if (msg->msg_type == MSG_FUNDING_REORG) {
+        int frozen = 0;
+        const char *txid_hex = "?";
+        if (msg->json) {
+            cJSON *fr = cJSON_GetObjectItem(msg->json, "frozen");
+            if (fr && cJSON_IsNumber(fr)) frozen = fr->valueint;
+            cJSON *tx = cJSON_GetObjectItem(msg->json, "funding_txid");
+            if (tx && cJSON_IsString(tx)) txid_hex = tx->valuestring;
+        }
+        g_client_funding_pending_reorg = frozen ? 1 : 0;
+        fprintf(stderr, "Client: MSG_FUNDING_REORG funding=%.16s "
+                "frozen=%d (LSP says funding %s)\n",
+                txid_hex, frozen,
+                frozen ? "reorged out" : "back on chain");
+        /* SF-followup #145: on frozen=1 the LSP has reset its in-memory
+           ps_chain_len for advanced sub-factories; mirror that so recovery /
+           force-close paths don't reference invalid chain[N] state. */
+        if (frozen && g_client_active_factory) {
+            int n_reset = factory_reset_all_subfactory_chains(
+                g_client_active_factory);
+            if (n_reset > 0)
+                fprintf(stderr, "Client: reset ps_chain_len on %d "
+                        "sub-factor(ies) after funding reorg\n", n_reset);
+        }
+        return 1;
+    }
+    if (msg->msg_type == MSG_CEREMONY_ABORT) {
+        /* #49/#51: advisory abort / intent-to-exit notice.  The client's own
+           persisted state + watchtower already protect its funds; log it loudly
+           so the operator can stop waiting on a ceremony that will never finish. */
+        unsigned char cer_id[8];
+        unsigned char reason = CEREMONY_ABORT_OTHER;
+        char *rtext = NULL;
+        if (msg->json &&
+            wire_parse_ceremony_abort(msg->json, cer_id, &reason, &rtext)) {
+            fprintf(stderr, "Client: MSG_CEREMONY_ABORT reason=0x%02x%s%s\n",
+                    reason, rtext ? " -- " : "", rtext ? rtext : "");
+            free(rtext);
+        } else {
+            fprintf(stderr, "Client: MSG_CEREMONY_ABORT (unparseable)\n");
+        }
+        return 1;
+    }
+    return 0;
+}
+
+/* Wrapper around wire_recv_timeout that transparently handles keepalives
+   (MSG_PING -> MSG_PONG, MSG_PONG discard) and async notifications (delegated to
+   client_handle_async_msg).  Returns 1 on a real message, 0 on failure. */
 static int wire_recv_handle_ping(int fd, wire_msg_t *msg, int timeout_sec) {
     for (;;) {
         if (!wire_recv_timeout(fd, msg, timeout_sec))
@@ -174,62 +231,10 @@ static int wire_recv_handle_ping(int fd, wire_msg_t *msg, int timeout_sec) {
             msg->json = NULL;
             continue;  /* discard pong, wait for real message */
         }
-        if (msg->msg_type == MSG_FUNDING_REORG) {
-            int frozen = 0;
-            const char *txid_hex = "?";
-            if (msg->json) {
-                cJSON *fr = cJSON_GetObjectItem(msg->json, "frozen");
-                if (fr && cJSON_IsNumber(fr)) frozen = fr->valueint;
-                cJSON *tx = cJSON_GetObjectItem(msg->json, "funding_txid");
-                if (tx && cJSON_IsString(tx)) txid_hex = tx->valuestring;
-            }
-            g_client_funding_pending_reorg = frozen ? 1 : 0;
-            fprintf(stderr, "Client: MSG_FUNDING_REORG funding=%.16s "
-                    "frozen=%d (LSP says funding %s)\n",
-                    txid_hex, frozen,
-                    frozen ? "reorged out" : "back on chain");
-            /* SF-followup #145: mirror LSP-side reset from PR #208.  When the
-               funding is reported reorged out, any in-memory sub-factory
-               chain advance state is stale and must not be referenced by
-               subsequent operations.  Reset only on frozen=1; the unfreeze
-               path (frozen=0, funding back on chain) leaves the now-empty
-               chain in place — caller can re-advance from chain[0] if
-               desired. */
-            if (frozen && g_client_active_factory) {
-                int n_reset = factory_reset_all_subfactory_chains(
-                    g_client_active_factory);
-                if (n_reset > 0)
-                    fprintf(stderr, "Client: reset ps_chain_len on %d "
-                            "sub-factor(ies) after funding reorg\n", n_reset);
-            }
+        if (client_handle_async_msg(msg)) {
             if (msg->json) cJSON_Delete(msg->json);
             msg->json = NULL;
-            continue;  /* notification, wait for next real message */
-        }
-        if (msg->msg_type == MSG_CEREMONY_ABORT) {
-            /* #49/#51: advisory abort/intent-to-exit notice.  The LSP sends this
-               when a rotation/advance ceremony is aborted -- notably
-               RETRY_LIMIT_REACHED, where the LSP then proactively broadcasts the
-               distribution TX (unilateral exit) before the factory CLTV.  The
-               client's own persisted state + watchtower already protect its funds
-               (it can self-exit), so this is informational: log it loudly so the
-               client app/operator can stop waiting on a ceremony that will never
-               complete and confirm its watchtower is live.  Best-effort -- a
-               client offline during the failed ceremony simply won't receive it. */
-            unsigned char cer_id[8];
-            unsigned char reason = CEREMONY_ABORT_OTHER;
-            char *rtext = NULL;
-            if (msg->json &&
-                wire_parse_ceremony_abort(msg->json, cer_id, &reason, &rtext)) {
-                fprintf(stderr, "Client: MSG_CEREMONY_ABORT reason=0x%02x%s%s\n",
-                        reason, rtext ? " -- " : "", rtext ? rtext : "");
-                free(rtext);
-            } else {
-                fprintf(stderr, "Client: MSG_CEREMONY_ABORT (unparseable)\n");
-            }
-            if (msg->json) cJSON_Delete(msg->json);
-            msg->json = NULL;
-            continue;  /* advisory, wait for next real message */
+            continue;  /* async notification consumed; wait for real message */
         }
         return 1;  /* real message */
     }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1329,6 +1329,7 @@ extern int test_client_persist_reload(void);
 extern int test_reconnect_commitment_mismatch_rollback(void);
 extern int test_reconnect_commitment_mismatch_reject(void);
 extern int test_reconnect_htlc_replay(void);
+extern int test_client_handle_async_msg(void);  /* fix/client-daemon-async-msg */
 
 /* Security hardening */
 extern int test_secure_zero_basic(void);
@@ -3230,6 +3231,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_reconnect_commitment_mismatch_rollback);
     RUN_TEST(test_reconnect_commitment_mismatch_reject);
     RUN_TEST(test_reconnect_htlc_replay);
+    RUN_TEST(test_client_handle_async_msg);
 
     printf("\n=== Security Hardening ===\n");
     RUN_TEST(test_secure_zero_basic);

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -44,6 +44,45 @@ static secp256k1_context *test_ctx(void) {
         SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 }
 
+/* Regression (fix/client-daemon-async-msg): the client daemon dispatch must
+   handle MSG_FUNDING_REORG + MSG_CEREMONY_ABORT via client_handle_async_msg
+   rather than treating them as "unexpected" -- which desynced the wire stream and
+   livelocked inbound bridge payments on reconnect.  Assert the shared helper
+   claims those two async notices and declines everything else. */
+int test_client_handle_async_msg(void) {
+    wire_msg_t m;
+
+    /* MSG_FUNDING_REORG {frozen:1} is claimed (handled) */
+    memset(&m, 0, sizeof m);
+    m.msg_type = MSG_FUNDING_REORG;
+    m.json = cJSON_CreateObject();
+    cJSON_AddNumberToObject(m.json, "frozen", 1);
+    cJSON_AddStringToObject(m.json, "funding_txid",
+        "aa11bb22cc33dd44ee55ff66aa77bb88cc99dd00ee11ff2233445566778899aa");
+    TEST_ASSERT_EQ(client_handle_async_msg(&m), 1,
+                   "MSG_FUNDING_REORG must be handled by client_handle_async_msg");
+    cJSON_Delete(m.json);
+
+    /* MSG_CEREMONY_ABORT is claimed (handled) even with an empty body */
+    memset(&m, 0, sizeof m);
+    m.msg_type = MSG_CEREMONY_ABORT;
+    m.json = cJSON_CreateObject();
+    TEST_ASSERT_EQ(client_handle_async_msg(&m), 1,
+                   "MSG_CEREMONY_ABORT must be handled by client_handle_async_msg");
+    cJSON_Delete(m.json);
+
+    /* A non-async message is NOT claimed (daemon falls through to "unexpected") */
+    memset(&m, 0, sizeof m);
+    m.msg_type = MSG_HELLO;
+    m.json = cJSON_CreateObject();
+    TEST_ASSERT_EQ(client_handle_async_msg(&m), 0,
+                   "non-async msg must NOT be claimed by client_handle_async_msg");
+    cJSON_Delete(m.json);
+
+    printf("  PASS: test_client_handle_async_msg\n");
+    return 1;
+}
+
 /* Test 1: MSG_RECONNECT and MSG_RECONNECT_ACK wire round-trip */
 int test_reconnect_wire(void) {
     secp256k1_context *ctx = test_ctx();

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -2227,6 +2227,15 @@ handle_message:
         }
 
         default:
+            /* Async / unsolicited LSP notifications (MSG_FUNDING_REORG,
+               MSG_CEREMONY_ABORT) can arrive here in daemon mode.  Route them
+               through the shared handler so we mirror the freeze state / log the
+               advisory instead of treating them as "unexpected", desyncing, and
+               livelocking on reconnect (the inbound-bridge-payment bug). */
+            if (client_handle_async_msg(&msg)) {
+                cJSON_Delete(msg.json);
+                break;
+            }
             fprintf(stderr, "Client %u: daemon got unexpected msg 0x%02x\n",
                     my_index, msg.msg_type);
             cJSON_Delete(msg.json);

--- a/tools/test_bridge_econ_signet.sh
+++ b/tools/test_bridge_econ_signet.sh
@@ -31,21 +31,28 @@ LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 BRIDGE_BIN="$BUILD_DIR/superscalar_bridge"
 
-LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
-CLIENT0_SK="0000000000000000000000000000000000000000000000000000000000000002"
-CLIENT_SECKEYS=(
-    "$CLIENT0_SK"
-    "0000000000000000000000000000000000000000000000000000000000000003"
-    "0000000000000000000000000000000000000000000000000000000000000004"
-    "0000000000000000000000000000000000000000000000000000000000000005"
-)
+# Keys: env-overridable so signet runs use STRONG keys (tools/signet_strong_keygen.py).
+# The weak privkey defaults are regtest/dev ONLY -- never fund them on public signet.
+LSP_SECKEY="${LSP_SECKEY:-0000000000000000000000000000000000000000000000000000000000000001}"
+if [ -n "${CLIENT_KEYS_FILE:-}" ]; then
+    # One hex seckey per line (see signet_strong_keygen.py output).
+    CLIENT_SECKEYS=()
+    while IFS= read -r _k; do [ -n "$_k" ] && CLIENT_SECKEYS+=("$_k"); done < "$CLIENT_KEYS_FILE"
+else
+    CLIENT_SECKEYS=(
+        "0000000000000000000000000000000000000000000000000000000000000002"
+        "0000000000000000000000000000000000000000000000000000000000000003"
+        "0000000000000000000000000000000000000000000000000000000000000004"
+        "0000000000000000000000000000000000000000000000000000000000000005"
+    )
+fi
 
 # --- Signet bitcoind ---
 SIGNET_CONF="/var/lib/bitcoind-signet/bitcoin.conf"
 BCLI="bitcoin-cli -conf=$SIGNET_CONF"
 
 # --- Persistent CLN nodes ---
-PLUGIN_CLN_DIR="/var/lib/cln-signet"           # has SS plugin
+PLUGIN_CLN_DIR="${PLUGIN_CLN_DIR:-/var/lib/cln-signet}"           # has SS plugin (env-overridable)
 VANILLA_CLN_DIR="${VANILLA_DIR:-/var/lib/cln-signet-c}"
 CLN_NET="signet"
 LCLI_PLUGIN="lightning-cli --network=$CLN_NET --lightning-dir=$PLUGIN_CLN_DIR"
@@ -60,6 +67,7 @@ LSP_DB="$TMPDIR/lsp.db"
 PIDS=()
 cleanup() {
     echo "=== Cleaning up (signet state preserved) ==="
+    $LCLI_PLUGIN plugin stop "${SS_PLUGIN:-$PROJECT_DIR/tools/cln_plugin.py}" 2>/dev/null || true
     kill "${FIFO_HOLDER_PID:-}" 2>/dev/null || true
     for pid in "${PIDS[@]:-}"; do
         kill "$pid" 2>/dev/null || true
@@ -67,6 +75,7 @@ cleanup() {
     done
     cp "$TMPDIR/lsp.log" /tmp/bridge_signet_last_lsp.log 2>/dev/null || true
     cp "$TMPDIR/bridge.log" /tmp/bridge_signet_last_bridge.log 2>/dev/null || true
+    cp "$TMPDIR/lsp.db" /tmp/bridge_signet_last_lsp.db 2>/dev/null || true
     rm -rf "$TMPDIR"
     echo "  Preserved logs: /tmp/bridge_signet_last_{lsp,bridge}.log"
 }
@@ -155,11 +164,12 @@ for i in $(seq 1 30); do
     grep -q "listening on port" "$TMPDIR/lsp.log" 2>/dev/null && break
     sleep 1
 done
-LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+LSP_PUBKEY="${LSP_PUBKEY:-0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798}"
 
 # ---- Start 4 clients ----
 for i in 0 1 2 3; do
     stdbuf -oL $CLIENT_BIN --seckey "${CLIENT_SECKEYS[$i]}" \
+        --participant-id $((i + 1)) \
         --host 127.0.0.1 --port "$LSP_PORT" --network signet \
         --lsp-pubkey "$LSP_PUBKEY" --daemon \
         --db "$TMPDIR/client_${i}.db" \
@@ -195,6 +205,17 @@ for i in $(seq 1 30); do
     sleep 1
 done
 echo "Bridge: connected"
+
+# ---- Load the SS bridge plugin on the persistent plugin CLN ----
+# cln_plugin.py exits if it can't reach the bridge, so start it AFTER the bridge
+# is listening. Pin the plugin's bridge port to $BRIDGE_PORT via CLN's -k keyword
+# form (the plugin default 9736 collides with cln-grpc). "Extra parameters must be
+# in object" if you pass the option positionally -- must use -k.
+SS_PLUGIN="${SS_PLUGIN:-$PROJECT_DIR/tools/cln_plugin.py}"
+$LCLI_PLUGIN plugin stop "$SS_PLUGIN" 2>/dev/null || true
+sleep 1
+$LCLI_PLUGIN -k plugin subcommand=start plugin="$SS_PLUGIN" superscalar-bridge-port="$BRIDGE_PORT" 2>/dev/null && echo "Plugin: started on $PLUGIN_CLN_DIR (bridge-port $BRIDGE_PORT)" || echo "Plugin: start non-zero (may already be loaded)"
+sleep 3
 
 # ---- Wire the plugin CLN to the bridge ----
 # The persistent plugin CLN must be configured to talk to our ephemeral

--- a/tools/test_bridge_regtest.sh
+++ b/tools/test_bridge_regtest.sh
@@ -147,6 +147,12 @@ mkfifo "$LSP_FIFO"
 sleep infinity > "$LSP_FIFO" &
 FIFO_HOLDER_PID=$!
 
+# Trustless model: an inbound HTLC must expire BEFORE the factory CLTV
+# (lsp_channels.c:849) with > factory_delta (~144) of headroom to unwind the DW
+# tree on-chain. The regtest auto-CLTV is only current+35 -- too short for a
+# standard final_cltv_delta -- so pin the factory to a production-like lifetime
+# (matching --active-blocks 500 below). The CLTV safety check itself is unchanged.
+FACTORY_CLTV=$(( $($BCLI getblockcount) + 500 ))
 stdbuf -oL $LSP_BIN \
     --daemon \
     --cli \
@@ -160,6 +166,7 @@ stdbuf -oL $LSP_BIN \
     --rpcpassword rpcpass \
     --amount 100000 \
     --active-blocks 500 \
+    --cltv-timeout "$FACTORY_CLTV" \
     < "$LSP_FIFO" > "$TMPDIR/lsp.log" 2>&1 &
 LSP_PID=$!
 PIDS+=("$LSP_PID")

--- a/tools/test_bridge_regtest.sh
+++ b/tools/test_bridge_regtest.sh
@@ -65,6 +65,9 @@ cleanup() {
     # Stop bitcoind
     $BCLI stop 2>/dev/null || true
 
+    # Preserve logs for diagnosis before removing temp dir
+    cp "$TMPDIR/bridge.log" /tmp/bridge_regtest_last_bridge.log 2>/dev/null || true
+    cp "$TMPDIR/lsp.log" /tmp/bridge_regtest_last_lsp.log 2>/dev/null || true
     # Remove temp dir
     rm -rf "$TMPDIR"
     echo "=== Cleanup complete ==="
@@ -444,7 +447,10 @@ for attempt in $(seq 1 30); do
 done
 
 lightning-cli --network=regtest --lightning-dir="$CLN2_DIR" connect "$CLN_ID" 127.0.0.1 9738
-lightning-cli --network=regtest --lightning-dir="$CLN2_DIR" fundchannel "$CLN_ID" 500000
+# push_msat gives CLN1 (the bridge's CLN) return liquidity so the SS->external
+# OUTBOUND leg (Step 13) can route. Without it, after a small inbound the bridge
+# side sits below the 1% channel reserve and can't pay out.
+lightning-cli --network=regtest --lightning-dir="$CLN2_DIR" fundchannel -k id="$CLN_ID" amount=500000 push_msat=100000000
 
 # Mine blocks and wait for channel to reach NORMAL state
 echo "Mining blocks and waiting for channel to become NORMAL..."
@@ -532,6 +538,42 @@ except:
         echo "=== FAIL: Payment did not complete ==="
         echo "Result: $RESULT"
         FAIL=1
+    fi
+fi
+
+# --- Step 13: Outbound — SS client 0 pays a CLN2 invoice via the bridge ---
+# Proves the "sending" direction (SS -> non-bLIP-56 CLN2). After the inbound
+# payment, CLN1(bridge) holds outbound liquidity toward CLN2, so this can route.
+if [ "$FAIL" -eq 0 ]; then
+    echo ""
+    echo "--- Step 13: Outbound payment (SS client 0 -> CLN2 via bridge) ---"
+    OUT_LABEL="ss-out-$$"
+    OUT_INV=$(lightning-cli --network=regtest --lightning-dir="$CLN2_DIR" invoice 400000 "$OUT_LABEL" "SS client -> CLN2" 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('bolt11',''))" 2>/dev/null)
+    if [ -z "$OUT_INV" ]; then
+        echo "=== FAIL: could not create CLN2 invoice for outbound ==="
+        FAIL=1
+    else
+        echo "CLN2 invoice: ${OUT_INV:0:40}..."
+        echo "pay_external 0 $OUT_INV" > "$LSP_FIFO"
+        OUT_PAID="false"
+        for attempt in $(seq 1 60); do
+            OUT_PAID=$(lightning-cli --network=regtest --lightning-dir="$CLN2_DIR" listinvoices "$OUT_LABEL" 2>/dev/null | python3 -c "
+import json, sys
+try:
+    invs = json.load(sys.stdin).get('invoices', [])
+    print('true' if invs and invs[0].get('status') == 'paid' else 'false')
+except:
+    print('false')
+" 2>/dev/null)
+            [ "$OUT_PAID" = "true" ] && break
+            sleep 1
+        done
+        if [ "$OUT_PAID" = "true" ]; then
+            echo "=== PASS: CLN Bridge Outbound Payment (CLN2 invoice paid) ==="
+        else
+            echo "=== FAIL: outbound payment did not settle (CLN2 invoice not paid) ==="
+            FAIL=1
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Problem
Real Lightning payments routed from an external (non-bLIP-56) node through the CLN bridge into a SuperScalar client **fail**: the client daemon receives `MSG_FUNDING_REORG` (0x78), treats it as an "unexpected" message, desyncs the wire stream, and disconnect→"reconnecting from persisted state"→re-hit **livelocks** — so the inbound payment never completes.

## Root cause
The client daemon message loop (`tools/superscalar_client.c`) receives via raw `wire_recv` + a `switch` that handles PING/PONG but has **no case** for the async/unsolicited notifications `MSG_FUNDING_REORG` or `MSG_CEREMONY_ABORT` (0x79). The correct handling *already existed* in `wire_recv_handle_ping()` (the ceremony recv path) but was never shared with the daemon loop. The LSP legitimately emits `MSG_FUNDING_REORG` from its routine R5 reorg-revalidate (freeze/unfreeze on funding-confirmation state), so any client in daemon mode hits this whenever that fires — e.g. during the normal funding-confirmation transient in the bridge E2E.

## Fix
Extract the FUNDING_REORG + CEREMONY_ABORT handling into a shared `client_handle_async_msg()` (`src/client.c`, declared in `client.h`) and call it from **both** `wire_recv_handle_ping` and the daemon dispatch `default:` (before "unexpected"). Both paths now mirror the LSP freeze state / log the advisory identically; genuinely-unknown messages still log "unexpected" (non-fatal).

## Testing
- New regression test `test_client_handle_async_msg` — asserts the helper claims `MSG_FUNDING_REORG` + `MSG_CEREMONY_ABORT` and declines a non-async message.
- Full unit suite: **1517/1517 passed** (the `client.c` refactor is regression-free).
- Discovered by the regtest CLN-bridge E2E (`tools/test_bridge_regtest.sh`) inbound-payment livelock; a bridge re-run validates the end-to-end inbound path.

## Files
`src/client.c`, `include/superscalar/client.h`, `tools/superscalar_client.c`, `tests/test_reconnect.c`, `tests/test_main.c`
