### PR TITLE
test(scale): listen before forking clients + raise per-IP rate limit in the in-proc scale harness

### DIFF
--- a/tools/test_inproc_scale.c
+++ b/tools/test_inproc_scale.c
@@ -23,6 +23,7 @@
  */
 
 #include "superscalar/lsp.h"
+#include "superscalar/wire.h"
 #include "superscalar/lsp_channels.h"
 #include "superscalar/client.h"
 #include "superscalar/factory.h"
@@ -71,8 +72,8 @@ int main(int argc, char **argv) {
         return 2;
     }
     int N = atoi(argv[1]);
-    if (N < 1 || N > 255) {
-        fprintf(stderr, "N_CLIENTS must be 1..255 (got %d)\n", N);
+    if (N < 1 || N > 127) {
+        fprintf(stderr, "N_CLIENTS must be 1..127 (LSP + N clients <= 128-signer MuSig cap; got %d)\n", N);
         return 2;
     }
     size_t n_signers = (size_t)N + 1; /* LSP + N clients */
@@ -134,6 +135,20 @@ int main(int argc, char **argv) {
         free(lsp); return 1;
     }
     factory_set_arity(&lsp->factory, FACTORY_ARITY_PS);
+
+    /* Bind+listen NOW, before forking: lsp_accept_clients creates the listen
+     * socket lazily (lsp.c), and child 0 (usleep 0) can win the race to
+     * connect on a loaded box -- ECONNREFUSED, ceremony hangs at N-1 clients
+     * (proven by strace).  Also raise the per-IP connection rate limit: all N
+     * clients connect from 127.0.0.1 and the production default (10/min, from
+     * the #325 real-network hardening, which postdates the June N=127 proof)
+     * rejects an all-localhost N>10 harness.  Production defaults untouched. */
+    lsp->listen_fd = wire_listen(NULL, port);
+    if (lsp->listen_fd < 0) {
+        fprintf(stderr, "[scale] pre-listen on port %d failed\n", port);
+        return 1;
+    }
+    rate_limiter_init(&lsp->rate_limiter, 1000000, 60, 1000000);
 
     /* Fork N client children (the listen socket already exists). */
     pid_t *child = calloc((size_t)N, sizeof(pid_t));


### PR DESCRIPTION
## Problem

`test_inproc_scale` hung deterministically at every `N >= 3` (while `N = 2` passed) on the VPS, on a clean `origin/main` checkout — the max-scale proof was no longer re-runnable.

`strace` gave the ground truth: the **first-forked client got `ECONNREFUSED` on 127.0.0.1:PORT while later clients connected fine** — i.e. nothing was listening yet when client 0 arrived.

Root cause: the harness comment says the listen socket exists before the fork loop, but `lsp_init` leaves `listen_fd = -1` and `lsp_accept_clients` creates the socket lazily — **after** all N clients are forked. Client 0 has zero connect stagger (`usleep(0 * 40000)`), so on a loaded box it beats the parent to the port, dies, and the LSP then waits for N clients forever. (June runs passed because the box was idle and the parent won the race; CI still passes for the same reason.)

Second latent issue: the per-IP connection rate limit (10/min default, added by the real-network hardening **after** the June N=127 proof) rejects any all-localhost run at `N > 10`.

## Fix (test-only; production paths untouched)

- Bind + listen explicitly **before** the fork loop (makes the existing comment true).
- Raise the harness LSP's per-IP rate limit (all N clients legitimately share 127.0.0.1).
- Cap `N_CLIENTS` at **127**: the signing group is the LSP + N clients and the MuSig session caps at 128 signers, so `N >= 128` was never signable — and `N` in 129..255 could write `leaf_layers[]` past its 128-entry bound before `factory_build_tree` validates.

## Verification (on the v0.2.0 RC, `d87e11e`, clean worktree, Release build)

- `test_inproc_scale 3 / 4`: PASS (previously deterministic timeout)
- `test_inproc_scale 127`: PASS (~30 s) — full 128-signer wire ceremony, all 127 channels `CHANNEL_READY`, all children exit 0
- `test_inproc_scale 128`: clean reject with the new message
- Follow-on: `test_regtest_n64_payments.sh` `N_CLIENTS=127 PAYMENTS=8` FULL PASS in ~9 min — 8 scripted client-to-client payment flows settled on every leg, cooperative close `f30ad821...` confirmed (1 in / 128 out), conservation exact (`12694268 = 12700000 - 5732` fee), 127/127 clients joined the close, per-client reconciliation matched LSP ledger and chain to the sat.
