### PR TITLE
fix(lsp): reject --clients above 127 upfront (128-signer MuSig session cap)

### DIFF
--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -19,11 +19,13 @@
  * 8 × tx_output_t to 16 × tx_output_t; at 506 nodes (max PS factory at
  * N=128) that's ~50KB extra per factory_t — acceptable. */
 #define FACTORY_MAX_OUTPUTS 16
-/* FACTORY_MAX_SIGNERS = max participants in a MuSig2 group = 1 LSP + up to
- * N clients.  Was 128 (= LSP + 127 clients).  Bumped to 256 in #303 fix
- * because N=128 clients + LSP = 129 signers overflowed the previous cap by
- * exactly one pubkey slot — release build's stack canary caught the overrun
- * on the all_pubkeys array in lsp.c:275.  256 gives headroom up to N=255. */
+/* FACTORY_MAX_SIGNERS = size of the keyagg/pubkey ARRAYS, not the signing
+ * cap.  Bumped 128 to 256 by the #303 fix only so the all_pubkeys array in
+ * lsp.c cannot overrun when misconfigured with 129 signers (release build's
+ * stack canary caught that overrun).  The actual signing limit is
+ * MUSIG_SESSION_MAX_SIGNERS (128) = the LSP + up to 127 clients; more than
+ * 128 signers is NOT signable, so N=255 is NOT a supported configuration
+ * and the LSP CLI rejects --clients above 127. */
 #define FACTORY_MAX_SIGNERS 256
 #define FACTORY_MAX_LEAVES  128
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2450,8 +2450,15 @@ int main(int argc, char *argv[]) {
     uint32_t dying_blocks = (dying_blocks_arg > 0) ? (uint32_t)dying_blocks_arg
                             : (is_regtest ? 10 : 432);
 
-    if (n_clients < 1 || n_clients > LSP_MAX_CLIENTS) {
-        fprintf(stderr, "Error: --clients must be 1..%d\n", LSP_MAX_CLIENTS);
+    /* The factory signing group is the LSP plus every client, and a MuSig
+       session holds at most MUSIG_SESSION_MAX_SIGNERS (128) signers, so the
+       supported maximum is 127 clients.  Reject the 129th signer here with a
+       clear message instead of failing deep inside the root signing ceremony
+       (set_pubnonce rejects slot 128 and finalize_nonces never completes). */
+    if (n_clients < 1 || n_clients + 1 > MUSIG_SESSION_MAX_SIGNERS) {
+        fprintf(stderr, "Error: --clients must be 1..%d "
+                "(the LSP co-signs every factory: clients + 1 <= %d-signer MuSig cap)\n",
+                MUSIG_SESSION_MAX_SIGNERS - 1, MUSIG_SESSION_MAX_SIGNERS);
         return 1;
     }
     /* In uniform mode (no comma list) the leaf semantics are 1, 2, or 3;


### PR DESCRIPTION
## Problem

The LSP CLI accepts `--clients 128`, but that means **129 signers** (the LSP co-signs every factory), which exceeds `MUSIG_SESSION_MAX_SIGNERS` (128). The run then fails deep inside the root signing ceremony — `set_pubnonce` rejects slot 128 and `finalize_nonces` never completes — with no hint that the client count was the problem. (Pre-release audit finding: scale cluster, "129 signers unsignable".)

The factory participant guards can't catch it either: they check `config.max_signers` = `FACTORY_MAX_SIGNERS` (256), which is keyagg-**array** headroom from the earlier `all_pubkeys` overrun fix, not signing capability. Its comment even advertised "headroom up to N=255", which was never signable.

## Fix

- Validate at the CLI: `--clients` must satisfy `clients + 1 <= MUSIG_SESSION_MAX_SIGNERS`, with an error message stating the real limit (1..127) and why.
- Correct the `FACTORY_MAX_SIGNERS` comment to say what 256 actually is (array headroom, not capacity) and what the real signing cap is.

No behavior change for any supported configuration (1..127 clients). The design max itself is unchanged and freshly re-proven: N=127 full lifecycle with client-to-client payments + cooperative close passed on this RC (see the in-proc scale harness PR).

## Verification

- `superscalar_lsp --clients 128 --network regtest ...` → clean upfront reject with the new message
- `superscalar_lsp --clients 127 --network regtest ...` → passes the cap check (proceeds to later validation as before)
- Build + verification output posted in a PR comment (built on the VPS worktree).
