### PR TITLE
fix(readiness): derive readiness from per-entry state (removes 64-client bitmap UB)

### DIFF
--- a/include/superscalar/readiness.h
+++ b/include/superscalar/readiness.h
@@ -16,12 +16,17 @@ typedef struct {
     int      ready_for;      /* QUEUE_REQ_* type acknowledged */
 } readiness_entry_t;
 
+/* Readiness is tracked ONLY in the per-entry booleans below.  There is
+ * deliberately no summary bitmap: n_clients can reach FACTORY_MAX_SIGNERS
+ * (256), a uint64_t bitmap made every shift for client_idx >= 64 undefined
+ * behaviour (x86 shift-wrap aliased bit i to bit i%64, so at 127 clients
+ * readiness_all_ready could report true with 63 clients still not ready),
+ * and the entries are the source of truth anyway — every query derives
+ * from them directly. */
 typedef struct {
     readiness_entry_t clients[FACTORY_MAX_SIGNERS];
     size_t   n_clients;
     uint32_t factory_id;
-    uint64_t ready_bitmap;      /* bit i = connected AND ready */
-    uint64_t connected_bitmap;  /* bit i = connected */
     persist_t *db;              /* may be NULL */
 } readiness_tracker_t;
 
@@ -46,10 +51,10 @@ void readiness_touch(readiness_tracker_t *rt, uint32_t client_idx);
 /* True when all n_clients are connected AND ready. */
 int readiness_all_ready(const readiness_tracker_t *rt);
 
-/* Count of ready clients (popcount of ready_bitmap). */
+/* Count of ready clients. */
 size_t readiness_count_ready(const readiness_tracker_t *rt);
 
-/* Count of connected clients (popcount of connected_bitmap). */
+/* Count of connected clients. */
 size_t readiness_count_connected(const readiness_tracker_t *rt);
 
 /* Fill out[] with indices of clients that are NOT ready. Returns count. */

--- a/src/readiness.c
+++ b/src/readiness.c
@@ -2,13 +2,6 @@
 #include <stdio.h>
 #include <string.h>
 
-/* popcount for uint64_t */
-static size_t popcount64(uint64_t x) {
-    size_t count = 0;
-    while (x) { count += x & 1; x >>= 1; }
-    return count;
-}
-
 void readiness_init(readiness_tracker_t *rt, uint32_t factory_id,
                     size_t n_clients, persist_t *db) {
     if (!rt) return;
@@ -26,14 +19,11 @@ void readiness_set_connected(readiness_tracker_t *rt, uint32_t client_idx,
     if (!rt || client_idx >= rt->n_clients) return;
     rt->clients[client_idx].is_connected = connected;
     if (connected) {
-        rt->connected_bitmap |= (1ULL << client_idx);
         rt->clients[client_idx].last_seen = time(NULL);
     } else {
-        rt->connected_bitmap &= ~(1ULL << client_idx);
         /* Disconnecting also clears ready */
         rt->clients[client_idx].is_ready = 0;
         rt->clients[client_idx].ready_for = 0;
-        rt->ready_bitmap &= ~(1ULL << client_idx);
     }
 }
 
@@ -45,7 +35,6 @@ void readiness_set_ready(readiness_tracker_t *rt, uint32_t client_idx,
     rt->clients[client_idx].is_ready = 1;
     rt->clients[client_idx].ready_for = ready_for;
     rt->clients[client_idx].last_seen = time(NULL);
-    rt->ready_bitmap |= (1ULL << client_idx);
 }
 
 void readiness_clear(readiness_tracker_t *rt, uint32_t client_idx) {
@@ -53,8 +42,6 @@ void readiness_clear(readiness_tracker_t *rt, uint32_t client_idx) {
     rt->clients[client_idx].is_connected = 0;
     rt->clients[client_idx].is_ready = 0;
     rt->clients[client_idx].ready_for = 0;
-    rt->connected_bitmap &= ~(1ULL << client_idx);
-    rt->ready_bitmap &= ~(1ULL << client_idx);
 }
 
 void readiness_touch(readiness_tracker_t *rt, uint32_t client_idx) {
@@ -64,19 +51,29 @@ void readiness_touch(readiness_tracker_t *rt, uint32_t client_idx) {
 
 int readiness_all_ready(const readiness_tracker_t *rt) {
     if (!rt || rt->n_clients == 0) return 0;
-    uint64_t full_mask = (rt->n_clients >= 64) ?
-                         0xFFFFFFFFFFFFFFFFULL : ((1ULL << rt->n_clients) - 1);
-    return (rt->ready_bitmap & full_mask) == full_mask;
+    for (size_t i = 0; i < rt->n_clients; i++) {
+        if (!rt->clients[i].is_ready)
+            return 0;
+    }
+    return 1;
 }
 
 size_t readiness_count_ready(const readiness_tracker_t *rt) {
     if (!rt) return 0;
-    return popcount64(rt->ready_bitmap);
+    size_t count = 0;
+    for (size_t i = 0; i < rt->n_clients; i++)
+        if (rt->clients[i].is_ready)
+            count++;
+    return count;
 }
 
 size_t readiness_count_connected(const readiness_tracker_t *rt) {
     if (!rt) return 0;
-    return popcount64(rt->connected_bitmap);
+    size_t count = 0;
+    for (size_t i = 0; i < rt->n_clients; i++)
+        if (rt->clients[i].is_connected)
+            count++;
+    return count;
 }
 
 size_t readiness_get_missing(const readiness_tracker_t *rt,
@@ -84,7 +81,7 @@ size_t readiness_get_missing(const readiness_tracker_t *rt,
     if (!rt || !out || max == 0) return 0;
     size_t count = 0;
     for (uint32_t i = 0; i < rt->n_clients && count < max; i++) {
-        if (!(rt->ready_bitmap & (1ULL << i)))
+        if (!rt->clients[i].is_ready)
             out[count++] = i;
     }
     return count;
@@ -134,9 +131,6 @@ int readiness_load(readiness_tracker_t *rt) {
     if (sqlite3_prepare_v2(rt->db->db, sql, -1, &stmt, NULL) != SQLITE_OK)
         return 0;
     sqlite3_bind_int(stmt, 1, (int)rt->factory_id);
-    /* Clear bitmaps before loading */
-    rt->ready_bitmap = 0;
-    rt->connected_bitmap = 0;
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         uint32_t idx = (uint32_t)sqlite3_column_int(stmt, 0);
         if (idx >= rt->n_clients) continue;
@@ -145,10 +139,6 @@ int readiness_load(readiness_tracker_t *rt) {
         e->is_ready = sqlite3_column_int(stmt, 2);
         e->last_seen = (time_t)sqlite3_column_int64(stmt, 3);
         e->ready_for = sqlite3_column_int(stmt, 4);
-        if (e->is_connected)
-            rt->connected_bitmap |= (1ULL << idx);
-        if (e->is_ready)
-            rt->ready_bitmap |= (1ULL << idx);
     }
     sqlite3_finalize(stmt);
     return 1;
@@ -162,6 +152,4 @@ void readiness_reset(readiness_tracker_t *rt) {
         rt->clients[i].ready_for = 0;
         rt->clients[i].last_seen = 0;
     }
-    rt->ready_bitmap = 0;
-    rt->connected_bitmap = 0;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1980,6 +1980,7 @@ extern int test_readiness_persist_roundtrip(void);
 extern int test_readiness_urgency_levels(void);
 extern int test_readiness_get_missing(void);
 extern int test_readiness_reset(void);
+extern int test_readiness_beyond_64(void);
 
 /* Async Signing: Rotation Readiness (lsp_check_rotation_readiness) */
 extern int test_rotation_readiness_null(void);
@@ -3892,6 +3893,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_readiness_urgency_levels);
     RUN_TEST(test_readiness_get_missing);
     RUN_TEST(test_readiness_reset);
+    RUN_TEST(test_readiness_beyond_64);
 
     printf("\n=== Async Signing: Rotation Readiness ===\n");
     RUN_TEST(test_rotation_readiness_null);

--- a/tests/test_readiness.c
+++ b/tests/test_readiness.c
@@ -15,8 +15,8 @@ int test_readiness_init(void) {
     readiness_init(&rt, 42, 4, NULL);
     TEST_ASSERT(rt.factory_id == 42, "factory_id");
     TEST_ASSERT(rt.n_clients == 4, "n_clients");
-    TEST_ASSERT(rt.ready_bitmap == 0, "ready_bitmap zeroed");
-    TEST_ASSERT(rt.connected_bitmap == 0, "connected_bitmap zeroed");
+    TEST_ASSERT(readiness_count_ready(&rt) == 0, "no one ready");
+    TEST_ASSERT(readiness_count_connected(&rt) == 0, "no one connected");
     TEST_ASSERT(rt.db == NULL, "db NULL");
     for (size_t i = 0; i < 4; i++) {
         TEST_ASSERT(rt.clients[i].client_idx == (uint32_t)i, "client_idx");
@@ -30,10 +30,12 @@ int test_readiness_set_connected(void) {
     readiness_tracker_t rt;
     readiness_init(&rt, 1, 4, NULL);
     readiness_set_connected(&rt, 2, 1);
-    TEST_ASSERT(rt.connected_bitmap == (1ULL <<2), "bit 2 set");
+    TEST_ASSERT(readiness_count_connected(&rt) == 1, "one connected");
     TEST_ASSERT(rt.clients[2].is_connected == 1, "entry connected");
     readiness_set_connected(&rt, 0, 1);
-    TEST_ASSERT(rt.connected_bitmap == ((1ULL <<2) | (1ULL <<0)), "bits 0,2 set");
+    TEST_ASSERT(readiness_count_connected(&rt) == 2, "two connected");
+    TEST_ASSERT(rt.clients[0].is_connected == 1 && rt.clients[1].is_connected == 0,
+                "exactly clients 0 and 2");
     return 1;
 }
 
@@ -42,11 +44,12 @@ int test_readiness_set_ready(void) {
     readiness_init(&rt, 1, 4, NULL);
     /* Not connected — ready should be rejected */
     readiness_set_ready(&rt, 1, QUEUE_REQ_ROTATION);
-    TEST_ASSERT(rt.ready_bitmap == 0, "not ready without connection");
+    TEST_ASSERT(readiness_count_ready(&rt) == 0, "not ready without connection");
     /* Connect then set ready */
     readiness_set_connected(&rt, 1, 1);
     readiness_set_ready(&rt, 1, QUEUE_REQ_ROTATION);
-    TEST_ASSERT(rt.ready_bitmap == (1ULL <<1), "bit 1 ready");
+    TEST_ASSERT(readiness_count_ready(&rt) == 1, "client 1 ready");
+    TEST_ASSERT(rt.clients[1].is_ready == 1, "entry ready");
     TEST_ASSERT(rt.clients[1].ready_for == QUEUE_REQ_ROTATION, "ready_for type");
     return 1;
 }
@@ -80,10 +83,10 @@ int test_readiness_clear(void) {
     readiness_init(&rt, 1, 4, NULL);
     readiness_set_connected(&rt, 2, 1);
     readiness_set_ready(&rt, 2, QUEUE_REQ_ROTATION);
-    TEST_ASSERT(rt.ready_bitmap == (1ULL <<2), "ready before clear");
+    TEST_ASSERT(readiness_count_ready(&rt) == 1, "ready before clear");
     readiness_clear(&rt, 2);
-    TEST_ASSERT(rt.ready_bitmap == 0, "ready cleared");
-    TEST_ASSERT(rt.connected_bitmap == 0, "connected cleared");
+    TEST_ASSERT(readiness_count_ready(&rt) == 0, "ready cleared");
+    TEST_ASSERT(readiness_count_connected(&rt) == 0, "connected cleared");
     TEST_ASSERT(rt.clients[2].is_connected == 0, "entry disconnected");
     TEST_ASSERT(rt.clients[2].is_ready == 0, "entry not ready");
     return 1;
@@ -111,9 +114,8 @@ int test_readiness_persist_roundtrip(void) {
     TEST_ASSERT(rt2.clients[0].ready_for == QUEUE_REQ_ROTATION, "client 0 ready_for");
     TEST_ASSERT(rt2.clients[2].is_connected == 1, "client 2 connected");
     TEST_ASSERT(rt2.clients[2].is_ready == 0, "client 2 not ready");
-    TEST_ASSERT(rt2.ready_bitmap == (1ULL <<0), "ready bitmap restored");
-    TEST_ASSERT(rt2.connected_bitmap == ((1ULL <<0) | (1ULL <<2)),
-                "connected bitmap restored");
+    TEST_ASSERT(readiness_count_ready(&rt2) == 1, "ready count restored");
+    TEST_ASSERT(readiness_count_connected(&rt2) == 2, "connected count restored");
     persist_close(&db);
     return 1;
 }
@@ -166,8 +168,61 @@ int test_readiness_reset(void) {
     }
     TEST_ASSERT(readiness_all_ready(&rt) == 1, "all ready before reset");
     readiness_reset(&rt);
-    TEST_ASSERT(rt.ready_bitmap == 0, "ready zeroed");
-    TEST_ASSERT(rt.connected_bitmap == 0, "connected zeroed");
+    TEST_ASSERT(readiness_count_ready(&rt) == 0, "ready zeroed");
+    TEST_ASSERT(readiness_count_connected(&rt) == 0, "connected zeroed");
     TEST_ASSERT(readiness_all_ready(&rt) == 0, "not ready after reset");
+    return 1;
+}
+
+/* Regression for the >64-client undefined behaviour: the tracker used two
+ * uint64_t bitmaps with 1ULL << client_idx while n_clients can reach
+ * FACTORY_MAX_SIGNERS (256).  On x86 the shift wrapped (idx mod 64), so at
+ * 127 clients marking only clients 0..63 ready aliased to "all bits set"
+ * and readiness_all_ready returned TRUE with 63 clients still missing —
+ * i.e. an async rotation could fire prematurely.  State is now derived
+ * from the per-entry booleans, which are correct at any supported N. */
+int test_readiness_beyond_64(void) {
+    readiness_tracker_t rt;
+    readiness_init(&rt, 9, 127, NULL);
+    TEST_ASSERT(rt.n_clients == 127, "127 clients tracked");
+
+    /* Exactly the aliasing trap: first 64 ready, 63 NOT ready. */
+    for (uint32_t i = 0; i < 64; i++) {
+        readiness_set_connected(&rt, i, 1);
+        readiness_set_ready(&rt, i, QUEUE_REQ_ROTATION);
+    }
+    TEST_ASSERT(readiness_count_ready(&rt) == 64, "64 ready");
+    TEST_ASSERT(readiness_all_ready(&rt) == 0,
+                "NOT all ready with 63 clients missing (old bitmap said yes)");
+
+    /* High-index state must be tracked individually, not aliased mod 64. */
+    readiness_set_connected(&rt, 100, 1);
+    readiness_set_ready(&rt, 100, QUEUE_REQ_ROTATION);
+    TEST_ASSERT(readiness_count_ready(&rt) == 65, "client 100 counted once");
+    TEST_ASSERT(rt.clients[100].is_ready == 1, "entry 100 ready");
+    TEST_ASSERT(rt.clients[36].is_ready == 1 && rt.clients[36].client_idx == 36,
+                "client 36 (100 mod 64) unaffected by client 100");
+    readiness_clear(&rt, 100);
+    TEST_ASSERT(readiness_count_ready(&rt) == 64, "clear(100) removes only 100");
+    TEST_ASSERT(rt.clients[36].is_ready == 1, "client 36 survives clear(100)");
+
+    /* Fill everyone, then poke the boundary and top indices. */
+    for (uint32_t i = 64; i < 127; i++) {
+        readiness_set_connected(&rt, i, 1);
+        readiness_set_ready(&rt, i, QUEUE_REQ_ROTATION);
+    }
+    TEST_ASSERT(readiness_count_ready(&rt) == 127, "all 127 ready");
+    TEST_ASSERT(readiness_all_ready(&rt) == 1, "all ready at 127");
+
+    readiness_set_connected(&rt, 126, 0);
+    TEST_ASSERT(readiness_all_ready(&rt) == 0, "top index disconnect noticed");
+    TEST_ASSERT(readiness_count_ready(&rt) == 126, "126 ready");
+    uint32_t missing[4];
+    size_t n = readiness_get_missing(&rt, missing, 4);
+    TEST_ASSERT(n == 1 && missing[0] == 126, "missing is exactly client 126");
+
+    readiness_set_connected(&rt, 126, 1);
+    readiness_set_ready(&rt, 126, QUEUE_REQ_ROTATION);
+    TEST_ASSERT(readiness_all_ready(&rt) == 1, "all ready again");
     return 1;
 }


### PR DESCRIPTION
## Problem (pre-release audit HIGH, adversarially re-verified)

`readiness_tracker_t` kept `ready_bitmap` / `connected_bitmap` as `uint64_t` while `n_clients` caps at `FACTORY_MAX_SIGNERS` (256), so every `1ULL << client_idx` for `idx >= 64` was **undefined behaviour** — and it is reachable in production: `--async-rotation` allocates the tracker, the factory-DYING auto-rotate path initializes it for up to `LSP_MAX_CLIENTS` clients, and `lsp_rotation.c` gates rotation on `readiness_all_ready()`.

Concrete consequence (x86 shift-wrap, bit `i` aliases bit `i mod 64`): at 127 clients, marking only clients 0–63 ready makes `all_ready()` report **true with 63 clients still missing** — an async rotation can fire prematurely. `get_missing()` and the counts likewise confuse aliased index pairs (e.g. client 100 vs client 36). The module even had an explicit `n_clients >= 64` branch, so >64 was clearly intended to be supported.

## Fix — remove the bitmaps rather than widen them

Considered widening to `uint64_t[4]`, rejected: it keeps two sources of truth in sync, adds mask arithmetic at every touch point, and the array size silently depends on `FACTORY_MAX_SIGNERS/64`.

The per-entry booleans (`clients[i].is_connected` / `.is_ready`) were already maintained on every code path, bounds-checked, and correct at any supported N — the bitmaps were a redundant cache of them. So: **delete the bitmaps and derive** `all_ready` / `count_ready` / `count_connected` / `get_missing` from the entries. No shift arithmetic remains (UB impossible at any N), the dual-source-of-truth hazard is gone for good, and the tracker scales with `FACTORY_MAX_SIGNERS` by construction. These are rotation-coordination paths — a bounded 256-entry scan is not measurable there. Net diff is negative.

No caller changes: production code (`lsp_channels.c`, `lsp_rotation.c`) only ever used the API; the only direct bitmap readers were unit tests asserting internals, now rewritten to assert observable behaviour.

## Tests

- Existing readiness tests converted from bitmap-internal asserts to API asserts.
- New `test_readiness_beyond_64` (127 clients): 64-of-127 ready must NOT be all-ready (the old code returned true here on x86); client 100 must not alias client 36; clearing client 126 reports exactly client 126 missing.
- Full unit suite on the VPS worktree: **1517/1517 passed**.

Follow-up (tracked): a 127-client `--async-rotation` rotation drill on regtest to prove rotation at design max end-to-end — the last unproven subsystem at N=127 (creation/payments/close re-proven on this RC 2026-07-02).
