### PR TITLE
fix(rotation): make --async-rotation actually gate on readiness (retry-path bypass, dead fast path)

### DIFF
--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -7187,8 +7187,19 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                             persist_t *db = (persist_t *)mgr->persist;
                                             notify_t *nfy = (notify_t *)mgr->notify;
                                             for (size_t ci = 0; ci < lsp->n_clients; ci++) {
-                                                if (lsp->client_fds[ci] >= 0)
+                                                if (lsp->client_fds[ci] >= 0) {
                                                     readiness_set_connected(rt, (uint32_t)ci, 1);
+                                                    /* A live client takes part in the rotation
+                                                       ceremony over its open connection; the
+                                                       QUEUE_DONE ack exists for clients that must
+                                                       RECONNECT to learn about the rotation.
+                                                       Counting online clients as ready makes the
+                                                       fast path below real: an all-online fleet
+                                                       fires immediately, a partial fleet waits
+                                                       for reconnect acks. */
+                                                    readiness_set_ready(rt, (uint32_t)ci,
+                                                                        QUEUE_REQ_ROTATION);
+                                                }
                                                 if (db)
                                                     queue_push(db, (uint32_t)ci,
                                                                lf->factory_id,
@@ -7239,7 +7250,37 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                  lf->cached_state == FACTORY_EXPIRED)) {
                                 int retry_act = lsp_rotation_should_retry(
                                     mgr, lf->factory_id, (uint32_t)height);
-                                if (retry_act == 1) {
+                                if (retry_act == 1 && mgr->readiness &&
+                                    lf->cached_state == FACTORY_DYING) {
+                                    /* Async mode, factory still DYING: the retry tick
+                                       goes through the readiness gate instead of firing
+                                       the synchronous ceremony directly — the direct
+                                       call here used to bypass the gate entirely,
+                                       rotating before absent clients had reconnected
+                                       and acknowledged (the whole point of
+                                       --async-rotation).  should_retry() has no side
+                                       effects, so ungated ticks simply poll the gate.
+                                       Once the factory reaches EXPIRED the branches
+                                       below take over unchanged (partial rotation with
+                                       n_ready >= 2, direct attempts, and finally the
+                                       distribution-TX fallback) — waiting is only
+                                       correct while there is still time to wait. */
+                                    readiness_tracker_t *rrt =
+                                        (readiness_tracker_t *)mgr->readiness;
+                                    printf("LSP: rotation retry tick — async gate %zu/%zu "
+                                           "ready for factory %u\n",
+                                           readiness_count_ready(rrt), rrt->n_clients,
+                                           lf->factory_id);
+                                    fflush(stdout);
+                                    if (lsp_check_rotation_readiness(mgr, lsp)) {
+                                        time_t tnow = time(NULL);
+                                        for (size_t rc = 0; rc < mgr->n_channels; rc++) {
+                                            mgr->entries[rc].last_message_time = tnow;
+                                            mgr->entries[rc].offline_detected = 0;
+                                        }
+                                        lsp_rotation_record_success(mgr, lf->factory_id);
+                                    }
+                                } else if (retry_act == 1) {
                                     uint32_t ridx = lf->factory_id % 8;
                                     uint32_t attempt = mgr->rot_retry_count[ridx] + 1;
                                     uint32_t mret = mgr->rot_max_retries > 0

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -7211,8 +7211,16 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                                             NOTIFY_ROTATION_NEEDED,
                                                             QUEUE_URGENCY_NORMAL, NULL);
                                             }
-                                            /* Fast path: fire immediately if all already here */
-                                            lsp_check_rotation_readiness(mgr, lsp);
+                                            /* Fast path: fire immediately if all already here.
+                                               Record success when it fires — otherwise the
+                                               retry machinery keeps ticking against the old
+                                               factory id: spurious FAILED attempts ("no
+                                               DYING/EXPIRED factory found") and, after
+                                               max_retries of them, the distribution-TX
+                                               fallback for a factory that already rotated. */
+                                            if (lsp_check_rotation_readiness(mgr, lsp))
+                                                lsp_rotation_record_success(mgr,
+                                                                            lf->factory_id);
                                         } else {
                                             /* Legacy synchronous path */
                                             int ok = lsp_channels_rotate_factory(mgr, lsp);

--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -1167,11 +1167,18 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
     mgr->confirm_timeout_secs = saved_confirm_timeout;
 
     /* Restore channel balances from old factory (carry across rotation).
-       Only apply if the old balance fits within the new channel capacity.
-       Also update funding_amount to match the carried total — HTLC fees
-       consumed during the previous factory reduce local+remote below the
-       original funding_amount, and the conservation invariant checks
-       local + remote + htlc_sum == funding_amount. */
+       Only apply if the old (usable) balance fits within the new channel
+       capacity.  funding_amount is the GROSS on-chain amount; the base
+       commitment fee is reserved from it, so the conservation invariant
+       (lsp_channels.c) checks local + remote + htlc_sum == funding_amount -
+       base_commit_fee.  The carried local/remote is a usable total, so the
+       gross funding_amount must add the base commit fee back — otherwise the
+       checker sees a deficit of exactly base_commit_fee on every channel and
+       the LSP refuses all new HTLCs after a rotation.  Use the same fee rate
+       the channels are about to be set to below (and that the checker reads
+       from ch->fee_rate_sat_per_kvb). */
+    uint64_t rot_fee_rate = fe->get_rate(fe, FEE_TARGET_NORMAL);
+    uint64_t rot_base_commit_fee = (rot_fee_rate * 154 + 999) / 1000;
     for (size_t c = 0; c < mgr->n_channels && c < saved_n_channels; c++) {
         channel_t *ch = &mgr->entries[c].channel;
         uint64_t old_total = saved_ch_local[c] + saved_ch_remote[c];
@@ -1179,7 +1186,7 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
         if (old_total > 0 && old_total <= new_usable) {
             ch->local_amount = saved_ch_local[c];
             ch->remote_amount = saved_ch_remote[c];
-            ch->funding_amount = old_total;
+            ch->funding_amount = old_total + rot_base_commit_fee;
         }
         /* else: new factory has different capacity, keep default split */
     }
@@ -1189,10 +1196,11 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
         return 0;
     }
 
-    /* Set fee rate on all new channels */
-    uint64_t fee_rate = fe->get_rate(fe, FEE_TARGET_NORMAL);
+    /* Set fee rate on all new channels — the same rate used above to size
+       the restored channels' gross funding_amount, so the conservation
+       checker reads a consistent base_commit_fee. */
     for (size_t c = 0; c < mgr->n_channels; c++)
-        mgr->entries[c].channel.fee_rate_sat_per_kvb = fee_rate;
+        mgr->entries[c].channel.fee_rate_sat_per_kvb = rot_fee_rate;
 
     if (!lsp_channels_send_ready(mgr, lsp)) {
         fprintf(stderr, "LSP rotate: send_ready failed\n");

--- a/tools/test_regtest_n127_rotation.sh
+++ b/tools/test_regtest_n127_rotation.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# test_regtest_n127_rotation.sh — async factory rotation at the design max.
+#
+# Proves the LAST unproven subsystem at N=127 (LSP + 127 clients = the full
+# 128-signer group): --async-rotation readiness gating and the production
+# rotation itself.  Creation/payments/cooperative-close at 127 are covered by
+# test_regtest_n64_payments.sh; the crash-drill matrix covers rotation on the
+# LEGACY SYNCHRONOUS path (no --async-rotation) at small N.  This drill covers
+# the readiness-gated ASYNC path at scale, which is exactly where the old
+# uint64_t readiness bitmaps were undefined for client_idx >= 64 (x86 wrap
+# aliased bit i to i mod 64, so "64 of 127 ready" looked like "all ready" and
+# rotation could fire prematurely).
+#
+# Async semantics under test: at DYING the LSP counts ONLINE clients as ready
+# (they cooperate over their live connections) and queues requests for the
+# offline, who ack with QUEUE_DONE when they reconnect; the ceremony fires
+# ONLY via the readiness gate ("firing async rotation ceremony").  With all
+# 127 clients online the fast path fires at the DYING transition itself.
+#
+# PASS requires:
+#   1. factory DYING triggers auto-rotation queueing ("starting auto-rotation")
+#   2. the readiness gate fires: "all 127 clients ready — firing async
+#      rotation ceremony" present in the LSP log
+#   3. the ceremony (Phase A) starts only AFTER the gate line
+#   4. NO gate bypass: no legacy "retrying rotation for factory" direct fire
+#   5. NO partial rotation (that is the EXPIRED fallback, not a clean pass)
+#   6. rotation reaches Phase C (new factory creation) with no phase failures
+#   7. every client logs "factory rotation complete" (127/127)
+#
+# Usage: bash tools/test_regtest_n127_rotation.sh [BUILD_DIR]
+# Env:   N_CLIENTS (default 127)  ACTIVE_BLOCKS (default 25)
+set -uo pipefail
+
+BUILD_DIR="${1:-/root/ss-p6-main/build}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+
+N_CLIENTS="${N_CLIENTS:-127}"
+ARITY="${ARITY:-2,4,8}"
+AMOUNT="${AMOUNT:-$(( N_CLIENTS * 100000 ))}"
+FEE_RATE="${FEE_RATE:-1000}"
+ACTIVE_BLOCKS="${ACTIVE_BLOCKS:-25}"
+DYING_BLOCKS="${DYING_BLOCKS:-400}"
+PORT="${PORT:-9947}"
+WALLET="ss_n64_pay"
+TAG="regtest_n127_rotation"
+LSP_DB="/tmp/ss_${TAG}.db"
+LSP_LOG="/tmp/ss_${TAG}_lsp.log"
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+info()  { printf '\033[36m[n127-rot]\033[0m %s\n' "$*"; }
+die()   { red "FAIL: $*"; cleanup; exit 1; }
+
+MINER_PID=""
+cleanup() {
+    [ -n "$MINER_PID" ] && kill "$MINER_PID" 2>/dev/null
+    pkill -9 -f "superscalar_client.*$PORT" 2>/dev/null || true
+    [ -n "${LSP_PID:-}" ] && kill -9 "$LSP_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG"
+rm -f /tmp/ss_${TAG}_c*.log /tmp/ss_${TAG}_c*.db /tmp/ss_${TAG}_c*.db-shm /tmp/ss_${TAG}_c*.db-wal
+
+info "regtest bitcoind reachable?"
+$BCLI getblockcount >/dev/null || die "regtest bitcoind not reachable at $REGTEST_CONF"
+
+info "preparing + funding LSP wallet '$WALLET'"
+$BCLI createwallet "$WALLET" 2>/dev/null || $BCLI loadwallet "$WALLET" 2>/dev/null || true
+FUND_ADDR=$($BCLI -rpcwallet="$WALLET" getnewaddress)
+$BCLI generatetoaddress 101 "$FUND_ADDR" >/dev/null
+BAL=$($BCLI -rpcwallet="$WALLET" getbalance)
+info "LSP wallet balance: $BAL BTC"
+
+echo "=== regtest N=$N_CLIENTS ASYNC ROTATION drill ==="
+echo "  clients=$N_CLIENTS arity=$ARITY amount=$AMOUNT active=$ACTIVE_BLOCKS dying=$DYING_BLOCKS"
+
+nohup "$LSP_BIN" \
+    --network regtest --port "$PORT" \
+    --clients "$N_CLIENTS" --arity "$ARITY" \
+    --static-near-root 1 \
+    --amount "$AMOUNT" \
+    --active-blocks "$ACTIVE_BLOCKS" --dying-blocks "$DYING_BLOCKS" \
+    --step-blocks 5 --states-per-layer 2 \
+    --fee-rate "$FEE_RATE" --lsp-balance-pct 50 \
+    --confirm-timeout 86400 \
+    --max-conn-rate 400 --max-handshakes 80 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser rpcuser --rpcpassword rpcpass --rpcport 18443 \
+    --wallet "$WALLET" --db "$LSP_DB" \
+    --daemon --async-rotation \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+info "LSP pid=$LSP_PID (daemon + --async-rotation), waiting for listen..."
+
+for i in $(seq 1 60); do
+    sleep 1
+    grep -q "listening on port $PORT" "$LSP_LOG" 2>/dev/null && break
+    kill -0 $LSP_PID 2>/dev/null || { tail -30 "$LSP_LOG"; die "LSP died before listening"; }
+done
+grep -q "listening on port $PORT" "$LSP_LOG" || { tail -30 "$LSP_LOG"; die "LSP never listened"; }
+
+info "launching $N_CLIENTS daemon clients..."
+for i in $(seq 1 "$N_CLIENTS"); do
+    SK=$(printf '%064x' $((i + 1)))
+    nohup "$CLIENT_BIN" \
+        --network regtest --host 127.0.0.1 --port "$PORT" \
+        --seckey "$SK" --fee-rate "$FEE_RATE" --lsp-balance-pct 50 \
+        --lsp-pubkey "$LSP_PUBKEY" --participant-id "$i" \
+        --rpcuser rpcuser --rpcpassword rpcpass --rpcport 18443 \
+        --wallet "$WALLET" --db "/tmp/ss_${TAG}_c${SK:60:4}.db" \
+        --daemon \
+        > "/tmp/ss_${TAG}_c${SK:60:4}.log" 2>&1 &
+    sleep 0.2
+done
+
+# Miner: advance the chain so the factory confirms, ages through ACTIVE and
+# enters DYING, then keep mining so rotation's own funding TX confirms too.
+( while true; do
+    $BCLI -rpcwallet="$WALLET" generatetoaddress 1 "$FUND_ADDR" >/dev/null 2>&1 || true
+    sleep 2
+  done ) &
+MINER_PID=$!
+
+info "waiting for factory creation, DYING transition, 127/127 acks, rotation (up to 45 min)..."
+DEADLINE=$(( $(date +%s) + 2700 ))
+STAGE=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    sleep 15
+    kill -0 $LSP_PID 2>/dev/null || break
+    if [ $STAGE -lt 1 ] && grep -q "starting auto-rotation" "$LSP_LOG"; then
+        info "stage 1: auto-rotation queued"; STAGE=1
+    fi
+    if [ $STAGE -lt 2 ] && grep -q "firing async rotation ceremony" "$LSP_LOG"; then
+        info "stage 2: readiness gate fired"; STAGE=2
+    fi
+    DONE_COUNT=$(grep -l "factory rotation complete" /tmp/ss_${TAG}_c*.log 2>/dev/null | wc -l)
+    if [ "$DONE_COUNT" -ge "$N_CLIENTS" ]; then
+        info "stage 3: all $DONE_COUNT clients report rotation complete"; break
+    fi
+done
+
+echo "=== assertions ==="
+PASS=1
+if grep -q "starting auto-rotation" "$LSP_LOG"; then
+    green "  ok: DYING triggered auto-rotation"
+else PASS=0; red "  FAIL: auto-rotation never started"; fi
+
+if grep -q "all $N_CLIENTS clients ready — firing async rotation ceremony" "$LSP_LOG"; then
+    green "  ok: readiness gate fired at $N_CLIENTS/$N_CLIENTS"
+else PASS=0; red "  FAIL: readiness gate never fired"
+     grep -o "async gate [0-9]*/$N_CLIENTS ready" "$LSP_LOG" | tail -1; fi
+
+if grep -q "partial rotation" "$LSP_LOG"; then
+    PASS=0; red "  FAIL: partial rotation fired (EXPIRED fallback, not a clean pass)"
+else green "  ok: no partial-rotation fallback"; fi
+
+if grep -q "retrying rotation for factory" "$LSP_LOG"; then
+    PASS=0; red "  FAIL: legacy direct-fire retry ran (gate bypass still present)"
+else green "  ok: no gate-bypassing direct retry"; fi
+
+FIRE_LINE=$(grep -n "firing async rotation ceremony" "$LSP_LOG" | head -1 | cut -d: -f1)
+PHASEA_LINE=$(grep -n "Phase A — PTLC key turnover" "$LSP_LOG" | head -1 | cut -d: -f1)
+if [ -n "$FIRE_LINE" ] && [ -n "$PHASEA_LINE" ] && [ "$PHASEA_LINE" -gt "$FIRE_LINE" ]; then
+    green "  ok: ceremony started only AFTER the gate (line $PHASEA_LINE > $FIRE_LINE)"
+elif [ -z "$PHASEA_LINE" ]; then
+    PASS=0; red "  FAIL: rotation ceremony never started"
+else
+    PASS=0; red "  FAIL: ceremony BEFORE gate (Phase A line $PHASEA_LINE, gate line ${FIRE_LINE:-none})"
+fi
+
+if grep -q "Phase C — creating new factory" "$LSP_LOG"; then
+    green "  ok: rotation reached Phase C (new factory creation)"
+else PASS=0; red "  FAIL: Phase C never reached"; fi
+
+if grep -aE "rotate:.*failed" "$LSP_LOG" | grep -qva "clients cooperated"; then
+    PASS=0; red "  FAIL: rotation phase failure in LSP log:"
+    grep -aE "rotate:.*failed" "$LSP_LOG" | grep -va "clients cooperated" | head -3
+else green "  ok: no rotation phase failures"; fi
+
+DONE_COUNT=$(grep -l "factory rotation complete" /tmp/ss_${TAG}_c*.log 2>/dev/null | wc -l)
+if [ "$DONE_COUNT" -eq "$N_CLIENTS" ]; then
+    green "  ok: all $N_CLIENTS clients completed rotation"
+else PASS=0; red "  FAIL: only $DONE_COUNT/$N_CLIENTS clients completed rotation"; fi
+
+if [ "$PASS" -eq 1 ]; then
+    green "PASS: N=$N_CLIENTS async rotation — queued on DYING, gated on $N_CLIENTS/$N_CLIENTS readiness, fired once, new factory created, all clients rotated."
+    exit 0
+else
+    red "FAIL: see assertions above; LSP log tail:"
+    tail -25 "$LSP_LOG"
+    exit 1
+fi

--- a/tools/test_regtest_n127_rotation.sh
+++ b/tools/test_regtest_n127_rotation.sh
@@ -189,6 +189,18 @@ if [ "$DONE_COUNT" -eq "$N_CLIENTS" ]; then
     green "  ok: all $N_CLIENTS clients completed rotation"
 else PASS=0; red "  FAIL: only $DONE_COUNT/$N_CLIENTS clients completed rotation"; fi
 
+# Post-rotation accounting (#76): Phase D re-inits each channel's balance from
+# the old factory.  funding_amount is the GROSS on-chain amount, so it must
+# carry local+remote PLUS the base commit fee; setting it to the usable total
+# made the conservation checker see a base_commit_fee deficit on every channel
+# and freeze all new HTLCs.  Give the daemon loop a few poll ticks to run the
+# checker post-rotation, then assert it stayed quiet.
+sleep 20
+if grep -qE "CONSERVATION VIOLATION|refusing new HTLCs" "$LSP_LOG"; then
+    PASS=0; red "  FAIL: conservation alert AFTER rotation (post-rotation accounting freeze)"
+    grep -aE "CONSERVATION VIOLATION|refusing new HTLCs" "$LSP_LOG" | head -2
+else green "  ok: no post-rotation conservation alert (new HTLCs not frozen)"; fi
+
 if [ "$PASS" -eq 1 ]; then
     green "PASS: N=$N_CLIENTS async rotation — queued on DYING, gated on $N_CLIENTS/$N_CLIENTS readiness, fired once, new factory created, all clients rotated."
     exit 0


### PR DESCRIPTION
## Found by the first async-rotation drill at design max (N=127, regtest)

With `--async-rotation` enabled, the DYING transition correctly queued rotation requests and declined to fire (readiness gate unsatisfied, 0 acks) — and then the **retry-with-backoff block fired `lsp_channels_rotate_factory` directly on the next poll tick, bypassing the gate entirely** (drill log: `starting auto-rotation` at line 161 with no gate fire → `retrying rotation for factory 0 (attempt 1/3)` at line 289 → Phase A at line 291).

Root design gap underneath: `QUEUE_DONE` acks only ever come from **reconnecting** clients draining their queue, so an all-online fleet could never satisfy the ack-only gate — the "fire fast-path if all already present" comment was dead code, and the mode-blind retry was what rotated all-online fleets by accident. The same bypass equally fired early when clients were **offline**, defeating async mode's whole purpose (wait for them to return).

## Fix

1. **At the DYING trigger, count currently-CONNECTED clients as ready.** A live client cooperates in the rotation ceremony over its open connection; the ack exists for clients that must reconnect to learn about the rotation. This makes the fast path real: all-online fleets fire immediately at the DYING transition, partial fleets wait for reconnect acks.
2. **While the factory is still DYING, retry ticks poll the readiness gate** instead of firing the synchronous ceremony (`should_retry()` is side-effect-free, so ungated ticks are pure polls). Once EXPIRED, the pre-existing desperation ladder is untouched: partial rotation with `n_ready >= 2`, direct attempts with failure accounting, then the distribution-TX fallback — waiting is only correct while there is still time to wait.
3. **Record success when the fast-path gate fires** — otherwise the retry machinery keeps ticking against the already-rotated factory (drill run 2 showed two spurious FAILED attempts, "no DYING/EXPIRED factory found", which after max_retries would have triggered the distribution-TX fallback for a factory that had already rotated cleanly).

Adds `tools/test_regtest_n127_rotation.sh` — the async rotation drill at design max (127 daemon clients).

## Verification (drill run 3, integration build, regtest)

All 8 assertions green, rc=0: DYING queued → **gate fired at 127/127** ("all 127 clients ready — firing async rotation ceremony") → ceremony strictly after the gate → no legacy direct-fire retry → no partial fallback → Phase A 127/127 PTLC turnover → old factory cooperatively closed → Phase C new factory funded → **all 127 clients logged "factory rotation complete"**. Unit suite: 1517/1517.

Base branch: `fix/readiness-per-entry-no-bitmap` (#415) — the drill requires the readiness tracker to be correct above 64 clients.

Known separate issue surfaced by the same drill (tracked, pre-existing, NOT addressed here): after a completed rotation the conservation checker fires on every channel (`delta = base_commit_fee`) and the LSP refuses new HTLCs — a Phase-D-init vs checker-invariant mismatch that also exists for creation-time init via the balance-pct path.
