### PR TITLE
docs: v0.2.0 release realignment — CHANGELOG post-rc1 section + fix stale facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,7 +257,7 @@ Full implementation of Pseudo-Spilman k² sub-factories — k clients per sub-fa
 - Phase 4c: persist load on LSP restart (PR #131)
 - Phase 5: signet campaign infra (PR #133)
 - Gap A followup: poison TX builder + watchtower wiring (PR #134)
-- Multi-input MuSig ceremony for sub-factory chain advance (PR #270, #142 SF-A)
+- Multi-input MuSig ceremony for sub-factory chain advance (PR #270)
 - Multi-input tx_builder + sighash + witness primitives (PRs #146, #147, #148)
 - Multi-input wire helpers (PR #150)
 - Force-close persist chain[0] + broadcast PS chain history — **CRITICAL** (PR #144)
@@ -280,7 +280,7 @@ Multi-process LSPs now produce a fully-signed L-stock / sales-stock poison TX vi
 - k² sub-factory breach end-to-end on regtest (PR #142)
 - Sanitizer regtest job catches leaks in wire-ceremony paths (PR #140)
 - Tier B no-SECURITY-GAP rotation log assertion (PR #153)
-- Realloc WT-register fix — registers pre-realloc leaf as stale-watch target (PR #258 via #298). Surfaced by the CL2 cheat-realloc test scaffold; before this fix, a malicious LSP could broadcast the pre-realloc leaf state to claim higher L-stock allocation and the watchtower had no recourse.
+- Realloc WT-register fix — registers pre-realloc leaf as stale-watch target (PR #298). Surfaced by the CL2 cheat-realloc test scaffold; before this fix, a malicious LSP could broadcast the pre-realloc leaf state to claim higher L-stock allocation and the watchtower had no recourse.
 
 ### Tier B / multi-leaf state-advance ceremony (Gap B + F)
 
@@ -312,7 +312,7 @@ All six reorg-detection classes wired with forensic table coverage:
 - Schema v29 forensic tables: `reorg_events`, `breach_detections` (PR #189)
 - Sub-factory chain reset on reorg (PR #208)
 - WT restart audit signoff (PRs #135, #161, signed off in PR #287)
-- CPFP child-broadcast / anchor mismatch fix — byte-inspection now authoritative (PR #287, closes #184)
+- CPFP child-broadcast / anchor mismatch fix — byte-inspection now authoritative (PR #287)
 
 ### Schema migrations v22–v36
 
@@ -332,13 +332,13 @@ Each migration is additive (ALTER TABLE ADD COLUMN or CREATE TABLE IF NOT EXISTS
 ### PTLC infrastructure (turnover, watchtower, gating, production)
 
 - Watchtower PTLC breach-defense feed + sweep parse bug fix (PR #242)
-- PTLC turnover ceremony journaled to `signing_rounds` (#217 via PR #280)
-- PTLC presig handler gated against blind-sign seckey extraction (PR #256, #196)
-- Factory tree sign refusal when no chain backend (PR #257, #197)
+- PTLC turnover ceremony journaled to `signing_rounds` (PR #280)
+- PTLC presig handler gated against blind-sign seckey extraction (PR #256)
+- Factory tree sign refusal when no chain backend (PR #257)
 - PTLC production threading + balance + chain validation consolidated (PR #253, resyncs #248+#249+#250)
 - Gate `channel_add_ptlc` until PTLC breach defense lands (PR #193)
-- PTLC commit-tx direction swap fix in `commit_tx_for_remote` (PR #269, completes #206)
-- Watchtower: remove eager remote-PCP overwrite + sync test scaffold (PR #268, #206)
+- PTLC commit-tx direction swap fix in `commit_tx_for_remote` (PR #269)
+- Watchtower: remove eager remote-PCP overwrite + sync test scaffold (PR #268)
 
 ### Cheat-engine campaign (CL1–CL7)
 
@@ -358,7 +358,7 @@ Adversarial-test infrastructure for the watchtower defense paths:
 ### Ceremony crash-injection (mainnet gate §10 #9)
 
 - Ceremony API helpers + finalization guard / dual-sig-trap (PRs #199, #259)
-- Wired into `lsp_run_factory_creation` (PR #205 via #266) — INITIAL ceremony
+- Wired into `lsp_run_factory_creation` (PR #266) — INITIAL ceremony
 - Crash-recovery drill scaffold (PR #262)
 - Crash scaffold timing softened to persistence-contract assertion (PR #277)
 - Gap C: `SUPERSCALAR_CRASH_AT` env var + 4 checkpoints in `lsp_run_factory_creation` (PR #297)
@@ -406,7 +406,7 @@ Adversarial-test infrastructure for the watchtower defense paths:
 - testnet4 quickstart procedure
 - Slow CSV-wait broadcast retry from 15s to 60s on non-regtest (PR #303)
 - Reject `update_fee` that would strand HTLC sweep outputs (PR #299)
-- Suppress wallet-RPC error noise in chain-state poll loops (PR #200 via #267)
+- Suppress wallet-RPC error noise in chain-state poll loops (PR #267)
 - Watchtower `csv_delay` persist on entry (PR #217 via #217)
 - Honest force-close HTLC sweep wiring (PR #218 via #218)
 - Channel auto-discover funding keyagg ordering for PS-leaf channels (PR #228)
@@ -423,7 +423,7 @@ Adversarial-test infrastructure for the watchtower defense paths:
 
 ### BIP-158 lite client (issue #264)
 
-- End-to-end + adversarial regtest scripts (PR #272, #216)
+- End-to-end + adversarial regtest scripts (PR #272)
 - Genesis-hash locator seed on initial header sync (PR #279)
 
 ### Splice
@@ -465,7 +465,7 @@ Adversarial-test infrastructure for the watchtower defense paths:
 
 ### Fixed
 
-- **CPFP child broadcast vs penalty-without-anchor mismatch** (PR #287, #184): broadcast-time `fee_should_use_anchor()` re-derivation could drift from build-time decision; replaced with authoritative byte-inspection of pre-built penalty TX (`penalty_tx_has_p2a_anchor`). Defensive `is_in_mempool()` pre-flight on broadcast.
+- **CPFP child broadcast vs penalty-without-anchor mismatch** (PR #287): broadcast-time `fee_should_use_anchor()` re-derivation could drift from build-time decision; replaced with authoritative byte-inspection of pre-built penalty TX (`penalty_tx_has_p2a_anchor`). Defensive `is_in_mempool()` pre-flight on broadcast.
 - **`persist_load_factory` leaked tx_bufs** on validation failure + on reuse (PR #74 etc.)
 - **Tree broadcast double-spend rejection** verified by `test_regtest_funding_double_spend_rejected`
 - **PS chain-advance bookkeeping** at sweep time
@@ -474,11 +474,11 @@ Adversarial-test infrastructure for the watchtower defense paths:
 - **Test_persist init memset** preserves `mgr->persist` (PR #200, #196)
 - **Ceremony recv timeouts bumped + clearer error messages** (PR #197)
 - **`%%s` → `%s` in 8 strftime DEFAULTs** — schema escaping bug (PR #198)
-- **Channel commit signing diag** (PR #220 / #154)
-- **Watchtower remote-PCP eager overwrite removed** (PR #268, #206)
-- **`watchtower_pending` retry chain-state guard** (PR #247, #150)
-- **Cheat-daemon subfactory cleanup checkpoints WAL before cp** (PR #246, #178)
-- **Reorg watcher records breach_detections in subfactory + commitment branches** (PR #245, #175, #176)
+- **Channel commit signing diag** (PR #220)
+- **Watchtower remote-PCP eager overwrite removed** (PR #268)
+- **`watchtower_pending` retry chain-state guard** (PR #247)
+- **Cheat-daemon subfactory cleanup checkpoints WAL before cp** (PR #246)
+- **Reorg watcher records breach_detections in subfactory + commitment branches** (PR #245)
 - **CHANGELOG**: this Unreleased section catches up ~140+ PRs since v0.1.13
 
 ### Test infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to SuperScalar are documented here.
 
+> **Note on references:** entries anchor to real GitHub PR numbers shown as "PR #N". Some bare `#N` in the historical `v0.2.0-rc1` section below are *internal task IDs*, not GitHub PRs — do not follow them as PR links. The design maximum is **127 clients = 128 signers** (LSP + 127 clients); "N=128" is only correct when N counts signers. The persisted schema version is **39**.
+
+## v0.2.0 — 2026-07-02
+
+Final v0.2.0. This section covers work merged after the rc1 candidate (2026-05-31); the `v0.2.0-rc1` section below is the bulk of the release. Schema advanced v36 → **v39**.
+
+### Trustless completion — five-layer recourse model (P1–P6)
+
+- **P1 — adversarial agg-sig drill:** a client refuses to co-sign a forged or corrupted L-stock poison aggregate signature instead of blindly co-signing it.
+- **P2 — Layer-3 fee-race:** both the watchtower CPFP bumper and the client-side CPFP poison spend win the fee-race under mempool pressure.
+- **P3 — P2A CPFP anchors** on commitment, leaf, and internal tree nodes (`use_cpfp_anchor` / `use_tree_anchor`); proven on regtest **and real signet**.
+- **P4 — secret-less watchtower recourse** (PR #396): a standalone `wt.db`-only watchtower stores sub-factory poison + PTLC HTLC penalty sweeps and remediates post-confirmation; kind=3 force-close + JIT covered.
+- **P5 — harness rigor:** breach tests now assert real txid → confirmation → amount / net-delta (not merely "machinery fired"); Tier 2/3/4 remediated; reorg-refire validated.
+- **P6 — liveness** (PR #407): bounded fresh-nonce retry across signing ceremonies so a transient nonce clash no longer aborts a ceremony.
+- **Shared revocation-secret verifier**, enforced fail-closed at the choke point, wired into the live client daemon path.
+- **Cheat-gating** (PR #402): every defense-bypass cheat is gated behind a regtest-only network flag and refused on mainnet.
+
+### Hashlock-gated L-stock poison — closes the co-signed-poison theft class (schema v38)
+
+- **Leaf** (PRs #387, #395): hashlock-gated L-stock poison crypto core, daemon `--enable-hashlock-poison`, client recourse tool `superscalar_lstock_recover`, fail-closed advance when the poison is not co-signed, and refusal to accept a key-path (rather than script-path) poison for hashlock leaves.
+- **Sub-factory** (PR #390): N-party poison aggregate distributed via `SUBFACTORY_DONE`, verified on both sides; proven on regtest + real signet.
+- **Crash / restart-resume:** persist the hashlock intent and re-derive the deterministic per-factory poison seed on LSP restart (`MSG_LSTOCK_REVEAL_REQUEST` 0x8D).
+- Anchor-aware L-stock vout on both LSP and client given the P2A tree anchor.
+
+### At-rest secret encryption + mainnet `--seckey` refusal (schema v37–v39)
+
+- **App-level field encryption of LSP secrets at rest** + refuse cmdline `--seckey` on mainnet (schema v37) — closes the plaintext-seed steal-all-funds hole (LND/Core model, no new dependency).
+- **Remaining at-rest secret columns** (revocation / channel secrets) sealed (PR #405, schema v39).
+- `lsp.db` (+WAL/SHM) tightened to `0600` on open; live signet/testnet4 RPC credentials removed from tracked files.
+
+### CLN-bridge interop
+
+- Secure-by-default bridge transport + CLN-bridge security signoff (PR #403).
+- Both payment directions proven on regtest and real signet (env-driven signet interop harness).
+- **Real-LN interop at the 127-client design max** (PR #417): an unmodified, non-bLIP-56 CLN node pays into and out of a factory through the bridge — inbound to shallow and deep-index clients, outbound back out, on-chain funding + cooperative close, net economics reconciled to the sat.
+
+### Distribution-TX MuSig co-signing (trustless cooperative-close recovery)
+
+- Distributed co-signing of the distribution TX (PR #399) + co-signing it inside the stateless factory-creation ceremony (PR #401).
+- All-offline distribution-TX recovery end-to-end — recovery works even if every client stays offline forever (PR #404).
+
+### Scale correctness at the 127-client design max
+
+- Client daemon handles `MSG_FUNDING_REORG` / `MSG_CEREMONY_ABORT` (previously dropped in the daemon dispatch → reconnect livelock) (PR #412).
+- LSP rejects `--clients` above **127** upfront (the 128-signer MuSig session cap) with a clear message instead of a deep signing failure; `FACTORY_MAX_SIGNERS = 256` documented as keyagg-array headroom, **not** a client cap (PR #414).
+- Readiness tracker derives state from per-entry booleans — removes a >64-client `uint64` bitmap undefined-shift (PR #415).
+- `--async-rotation` now gates on readiness (fixes a retry-path gate bypass + a dead DYING fast path); post-rotation channels carry **gross** `funding_amount` so the conservation checker no longer freezes new HTLCs after a rotation; a 127-client rotation drill was added (PR #416).
+- admin `getinfo` reports the built `SUPERSCALAR_VERSION` (was hardcoded `superscalar-0.1.0`) (PR #418).
+- Full lifecycle re-proven at N=127 on the release build — creation, client↔client payments (including the all-pairs shape), gated rotation, cooperative close, sat-exact per-client reconciliation; with test-harness fixes for the in-process scale listen-before-fork race and the sparse/dense reconciliation heuristic (PRs #413, #419, #420).
+
+### Client self-defense (adversarial verification)
+
+- Selectable LSP-forgery escalation policy `--on-lsp-forgery continue|halt|close`; scripted `--send`/`--recv` flows verify LSP revocation; forged-`0x50` refusal drill.
+- Loud alerts: reconnect commitment-claim mismatch, a received HTLC with no matching issued invoice, and a watchtower false-positive guard (penalty only on a genuine on-chain breach).
+- Notify clients on ceremony abort / proactive exit (PR #397).
+
+### Signet key hygiene
+
+- Strong per-run keys across the breach trio + payment E2E (PR #406): never weak/deterministic keys on public signet (`tools/signet_strong_keygen.py`).
+
+### Schema migrations v37–v39
+
+- **v37:** at-rest secret encryption marker / HD-seed seal
+- **v38:** `l_stock_poison_reveals` (client L-stock poison reveals)
+- **v39:** remaining at-rest secret columns sealed (PR #405)
+
 ## v0.2.0-rc1 — 2026-05-31
 
 See `docs/release-notes/release-notes-0.2.0.md` for the operator-facing summary of all v0.2.0 changes.  This section is the per-feature/per-PR detail log.
@@ -13,12 +79,12 @@ Headline themes (one of many):
 - Sub-factory multi-input ceremonies (k≥2 first-class)
 - Factory scale validated to N=64 on signet + testnet4
 - R1–R6 reorg correctness with forensic tables
-- Crash-injection framework + 20/20 crash-drill matrix (incl. production factory-rotation crash drills, #332)
+- Crash-injection framework + 20/20 crash-drill matrix (incl. production factory-rotation crash drills, commit 503c5e0)
 - Cheat-engine campaign (7 new adversarial drivers)
 - Trustless watchtower (one of many security improvements)
 - Native Prometheus exporter, pre-rotation auto-snapshot, mainnet runbook, BIP-157/158 lite client
 
-### MuSig2 Phase 3: legacy nonce-pool path deleted (#273)
+### MuSig2 Phase 3: legacy nonce-pool path deleted
 
 The legacy nonce-pool MuSig2 ceremony bodies have been **deleted permanently** in a 2-commit change set:
 
@@ -31,9 +97,9 @@ The `SS_MUSIG_LEGACY=1` opt-out env var introduced in Phase 2 is now a no-op (ke
 
 The `nonce-safety` unit test in `tests/test_musig.c` (`test_musig_stateless_no_secnonce_persisted`) was updated: previously it asserted the `nonce_pools` table existed and had zero rows; now it asserts the table **no longer exists** -- the strongest possible enforcement of the stateless invariant (no schema for any future refactor to accidentally write secnonces into).
 
-### MuSig2 Phase 2: stateless is now the default (#272)
+### MuSig2 Phase 2: stateless is now the default
 
-The BIP-327 stateless MuSig2 signer (introduced in #271 / #330 / #333 / #334 / #336 and validated through the full ceremony + breach + observability stack in #337-#341) is now the **default behavior**. The legacy nonce-pool path is opt-in via `SS_MUSIG_LEGACY=1`. The opt-in `SS_MUSIG_STATELESS=1` env var is now a no-op (the legacy path no longer reads it; test scripts that still set it continue to work but the variable has no effect).
+The BIP-327 stateless MuSig2 signer (introduced in PR #330 / #333 / #334 / #336 and validated through the full ceremony + breach + observability stack in #337-#341) is now the **default behavior**. The legacy nonce-pool path is opt-in via `SS_MUSIG_LEGACY=1`. The opt-in `SS_MUSIG_STATELESS=1` env var is now a no-op (the legacy path no longer reads it; test scripts that still set it continue to work but the variable has no effect).
 
 Migration:
 - **No action needed** if you want the new stateless behavior — it is the default.

--- a/README.md
+++ b/README.md
@@ -137,15 +137,15 @@ In a PS (Pseudo-Spilman) configuration, leaves chain advance by appending new st
 
 ## Known limitations
 
-- **Mainnet support** requires explicit `--accept-risk-mainnet` until v0.3.
-- **N=128** factory scale validated in regtest; testnet4 validation deferred to v0.3.
+- **Mainnet support** requires explicit `--i-accept-the-risk`; not recommended until the external audit + pre-mainnet hardening are complete (see the v0.2.0 release notes).
+- **N=127 clients** (128-signer aggregation) is the design max; full lifecycle — creation, client↔client payments, factory rotation, cooperative close — proven on regtest and public signet.
 - **Windows binaries** not built (POSIX-only paths in regtest + signal handling); contributions welcome.
 - **CLN bLIP-56 plugin** lives in a separate [`superscalar-cln`](https://github.com/8144225309/superscalar-cln) repo and is not built here.
 - **Splice support** has the BOLT-2 wire codec but the runtime state machine is a stub (`#210`).
 
 ## Security
 
-**SuperScalar is pre-1.0 software.** No external audit has been performed yet. An internal audit found 4 gaps — all fixed. Mainnet operation requires explicit `--accept-risk-mainnet` until v0.3.
+**SuperScalar is pre-1.0 software.** No external audit has been performed yet — that is the dominant gate for mainnet. Mainnet operation requires explicit `--i-accept-the-risk` and is not recommended until the audit and the pre-mainnet hardening items (see the v0.2.0 release notes) are complete.
 
 Found a vulnerability? See [`SECURITY.md`](SECURITY.md). Please **do not** open a public issue for security-sensitive matters.
 

--- a/docs/factory-arity.md
+++ b/docs/factory-arity.md
@@ -77,7 +77,7 @@ multiple levels into one, capping total depth. Static-near-root removes
 state transitions from the levels closest to the root, eliminating
 their CSV contribution entirely.
 
-## Current implementation status (v0.1.x)
+## Current implementation status (v0.2.0)
 
 **As of this document's commit, the implementation has delivered the
 full canonical SuperScalar design — TRUE N-way mixed-arity interior
@@ -85,7 +85,7 @@ branching + static-near-root variant (Phases 0-4 of the mixed-arity
 plan, all merged):**
 
 - PS leaves at any N (proven on regtest at N=2-32 with full per-party
-  accounting; unit-tested at N=64 and N=128)
+  accounting; unit-tested at N=64 and at the 128-signer maximum = LSP + 127 clients)
 - DW arity-1 and arity-2 leaves (legacy, kept for migration)
 - **TRUE N-way interior branching (Phase 2 — merged in PR #104).**
   `--arity 2,4,8` produces an authentic 3-level fan-out: root arity-2 →
@@ -111,23 +111,24 @@ plan, all merged):**
   `factory_compute_ewt_for_shape()` (pure-math simulator); covered by
   `test_cli_arity_*` unit tests asserting the specific error strings.
 
-The supported deployment ceiling is now **N=128 clients per factory**
-with mixed arity `{2,4,8}` + `--static-near-root 2` (unit-tested with
-per-shape ewt assertion) — well within BOLT 2016. End-to-end regtest
-at N=64 with `{2,4,8}` and N=12 with `{2,4} + static-near-root=1` is
-also exercised.
+The supported deployment ceiling is **N=127 clients per factory** (128
+signers including the LSP, the MuSig session cap; the LSP CLI rejects
+`--clients` above 127) with mixed arity `{2,4,8}` + `--static-near-root 2`
+— well within BOLT 2016. The full lifecycle — creation, client↔client
+payments, factory rotation, cooperative close — is proven end-to-end at
+N=127 on regtest and public signet, and at N=64 on testnet4.
 
 ## Recommended shapes (canonical, all available today)
 
-All of these are implemented and unit-tested as of v0.1.14+:
+All of these are implemented and unit-tested as of v0.2.0:
 
 | Client count | Recommended shape | Leaf type | Notes |
 |---|---|---|---|
 | ≤ 16 | `--arity 3` (uniform PS) | PS | Depth ≤ 4, no mixed needed |
 | 17-32 | `--arity 3,4` (PS root, DW arity-4 leaves) | DW arity-4 | Adds one fan-out level |
 | 33-64 | `--arity 2,4,8` | DW arity-8 | ZmnSCPxj's canonical mid-tree shape |
-| 65-128 | `--arity 2,4,8 --static-near-root 1` | DW arity-8 | Static gate at root reduces depth contribution |
-| 65-128 | `--arity 2,4,8 --static-near-root 2` | DW arity-8 | The design target — only two DW layers remain |
+| 65-127 | `--arity 2,4,8 --static-near-root 1` | DW arity-8 | Static gate at root reduces depth contribution |
+| 65-127 | `--arity 2,4,8 --static-near-root 2` | DW arity-8 | The design target — only two DW layers remain |
 
 The CLI rejects any combination whose worst-path `ewt` would exceed BOLT
 2016 with a clear error pointing at this document.
@@ -145,12 +146,12 @@ CLI uses for validation.
 |  16 | `3` (uniform PS)              | 0 | PS  | 4 | 4 | 1728 | Under |
 |  32 | `3,4` (PS root, DW arity-4 leaves) | 0 | DW arity-4 | 2 | 3 | 1296 | Under |
 |  64 | `2,4,8` (DW arity-8 leaves)   | 0 | DW arity-8 | 3 | 4 | 1728 | Under |
-| 128 | `2,4,8` (DW arity-8 leaves)   | 0 | DW arity-8 | 3 | 4 | 1728 | Under |
-| 128 | `2,4,8`                       | 1 | DW arity-8 | 3 | 3 | 1296 | Generous slack |
-| 128 | `2,4,8`                       | 2 | DW arity-8 | 3 | 2 |  864 | The design target |
+| 127 | `2,4,8` (DW arity-8 leaves)   | 0 | DW arity-8 | 3 | 4 | 1728 | Under |
+| 127 | `2,4,8`                       | 1 | DW arity-8 | 3 | 3 | 1296 | Generous slack |
+| 127 | `2,4,8`                       | 2 | DW arity-8 | 3 | 2 |  864 | The design target |
 |  32 | `3` (uniform PS — too deep)   | 0 | PS  | 5 | 5 | 2160 | **EXCEEDS — rejected** |
 |  64 | `2` (uniform binary DW)       | 0 | DW arity-2 | 6 | 6 | 2592 | **EXCEEDS — rejected** |
-| 128 | `2` (uniform binary DW)       | 0 | DW arity-2 | 7 | 8 (capped) | 3456 | **EXCEEDS — rejected** |
+| 127 | `2` (uniform binary DW)       | 0 | DW arity-2 | 7 | 8 (capped) | 3456 | **EXCEEDS — rejected** |
 
 Regtest and testnet deployments use `step_blocks = 10` (not 144), so the
 CSV budget is non-binding at any client count — but that's a test

--- a/docs/lsp-operator-guide.md
+++ b/docs/lsp-operator-guide.md
@@ -296,11 +296,11 @@ Without `--db`, crash recovery is not possible — you'll need to wait for CLTV 
 
 ## 8. Standalone Watchtower
 
-For defense-in-depth, run `superscalar_watchtower` on a separate machine. It opens the LSP database read-only and independently monitors the blockchain:
+For defense-in-depth, run `superscalar_watchtower` on a separate machine. It opens a secret-less `wt.db` of pre-signed response transactions (penalty / sweep / poison TXs, **no secrets and no signing keys**) and independently monitors the blockchain:
 
 ```bash
 ./superscalar_watchtower \
-  --db /path/to/lsp.db \
+  --wt-db /path/to/wt.db \
   --network signet \
   --poll-interval 30 \
   --cli-path /path/to/bitcoin-cli \
@@ -308,13 +308,13 @@ For defense-in-depth, run `superscalar_watchtower` on a separate machine. It ope
   --rpcpassword YOUR_PASS
 ```
 
-The watchtower prints heartbeat messages and broadcasts penalty transactions automatically if a breach is detected. It has no write access to the database, so it cannot interfere with the LSP.
+The watchtower prints heartbeat messages and broadcasts the relevant pre-signed response automatically if a breach is detected. Because it holds no secrets and no keys, a compromised watchtower cannot construct any new transaction — verifiable with `nm` (see [`watchtower-trustless-schema.md`](watchtower-trustless-schema.md)). To fund CPFP fee-bumping of the anyone-can-spend P2A anchors under fee pressure, pass `--bump-wallet` (a wallet the bumper spends its own UTXOs from; the watchtower still signs nothing of the protocol).
 
 ### Watchtower flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--db PATH` | **required** | Path to LSP SQLite database (opened read-only) |
+| `--wt-db PATH` | **required** | Path to the watchtower response DB (pre-signed penalty/sweep/poison TXs; contains **no secrets**) |
 | `--network MODE` | regtest | Bitcoin network: regtest / signet / testnet / mainnet |
 | `--poll-interval N` | 30 | Seconds between block scans |
 | `--cli-path PATH` | bitcoin-cli | Path to bitcoin-cli binary |
@@ -322,6 +322,7 @@ The watchtower prints heartbeat messages and broadcasts penalty transactions aut
 | `--rpcpassword PASS` | rpcpass | Bitcoin RPC password |
 | `--datadir PATH` | (default) | Bitcoin datadir |
 | `--rpcport PORT` | (auto) | Bitcoin RPC port override |
+| `--bump-wallet NAME` | — | Funded wallet the CPFP fee-bumper draws UTXOs from (to CPFP the P2A anchor; the WT holds no protocol keys) |
 | `--max-bump-fee SATS` | — | Cap on cumulative RBF fee bumps for the penalty broadcast |
 | `--bump-budget-pct N` | — | Percentage of channel value to budget for fee bumps |
 | `--inspect-db` | off | Diagnostic: dump factory state, breach detections, and chain-state assertions; exits without polling. Useful for forensics on a captured DB. |

--- a/docs/lsp-operator-guide.md
+++ b/docs/lsp-operator-guide.md
@@ -186,6 +186,7 @@ Press **Ctrl+C**. The LSP will:
 |------|---------|-------------|
 | `--keyfile` | none | Encrypted keyfile path (alternative to --seckey) |
 | `--passphrase` | none | Keyfile decryption passphrase |
+| `--encrypt-db` | off (forced on mainnet) | Encrypt secret columns (HD seed, revocation/channel secrets) at rest |
 | `--tor-proxy` | none | SOCKS5 proxy for Tor (e.g. `127.0.0.1:9050`) |
 | `--tor-control` | none | Tor control port for hidden service creation |
 | `--generate-mnemonic` | off | Generate 24-word BIP39 mnemonic, derive keyfile, and exit |

--- a/docs/mainnet-runbook.md
+++ b/docs/mainnet-runbook.md
@@ -5,6 +5,8 @@ This document expands the pre-launch checklist (task #151) into the full
 operational manual: deployment topology, backups, HSM, TLS, monitoring,
 and incident response.
 
+> **Reference convention:** "PR #N" is a GitHub pull request; a bare `#N` or "task #N" is an internal tracking ID (not resolvable outside the project). GitHub does not auto-link these in the rendered file view.
+
 For day-one setup mechanics (build, network selection, flag reference),
 see [lsp-operator-guide.md](lsp-operator-guide.md). This document assumes
 the operator has a working signet deployment and now needs to harden it

--- a/docs/mainnet-runbook.md
+++ b/docs/mainnet-runbook.md
@@ -26,7 +26,7 @@ pre-mainnet ops checklist drafted under task #151.
 
 ### Code / audit prerequisites
 
-- [ ] Schema migrations through v34 (ceremony_participants) applied
+- [ ] Schema migrations through v39 (at-rest secret encryption) applied
       and tested on a populated DB (per #185)
 - [ ] Factory funding canonical-chain guard active (#125-#129); no
       open issues against `lsp_channels_revalidate_funding`
@@ -127,7 +127,7 @@ rotation cadence.
 | 4 | 1 | ~50 MB |
 | 16 | 1 | ~200 MB |
 | 64 | 1-2 | ~1 GB |
-| 256 | 4+ | TODO: depends on factory scale work (`feat/factory-scale-128`) |
+| 127 (design max) | 4+ | ~2 GB (127 client daemons) |
 
 Growth drivers: `signing_rounds` (one row per signer per ceremony),
 `old_commitments` (one row per commitment per channel), and the
@@ -488,7 +488,7 @@ are starting points, not guarantees.
 | N=4, k=1 | < 100 MB | 1 core, ~5s | ~50 MB DB |
 | N=16, k=1 | < 250 MB | 1 core, ~20s | ~200 MB DB |
 | N=64, k=4 | < 1 GB | 2-4 cores, ~90s | ~1 GB DB |
-| N=128, k=8 | TODO (`feat/factory-scale-128`) | TODO | TODO |
+| N=127, k=8 | multi-GB (127 client daemons; fit a 15 GB host in testing) | 4+ cores | ~2 GB DB |
 | N=256+ | not supported | n/a | n/a |
 
 k = number of PS subfactories (see [superscalar.win](https://superscalar.win) for the design).
@@ -507,7 +507,7 @@ The `slow_signer` flag on `signing_rounds` (v26) identifies the
 laggard for forensic follow-up.
 
 At N=64 with healthy clients, expect signing rounds to complete in
-under 30 seconds end-to-end. At N=128 with one or more slow signers,
+under 30 seconds end-to-end. At N=127 with one or more slow signers,
 expect rounds to walk up to the 120s timeout.
 
 ### Disk projection
@@ -527,7 +527,7 @@ gate for flipping the kill switch from `mainnet refused` to
 
 ### Audit prereqs (#152 SF-AUDIT)
 
-- [ ] All schema migrations v1..v34 covered by upgrade tests on a
+- [ ] All schema migrations v1..v39 covered by upgrade tests on a
       populated DB
 - [x] Watchtower restart audit (#135, #161) signed off (per PR #287 commit body)
 - [ ] Reorg correctness audit (#125-#129) signed off

--- a/docs/release-notes/release-notes-0.2.0.md
+++ b/docs/release-notes/release-notes-0.2.0.md
@@ -283,7 +283,6 @@ v0.2.0 is feature-complete and proven end-to-end on regtest and public signet, i
 - **Third-party security audit** — not started; this is the dominant gate.
 - **CLN-bridge authentication** — the bridge's pubkey "pin" is not mutual authentication over the current Noise NK handshake; a peer that knows the (public) bridge key could inject bridge HTLCs. Run the bridge on a trusted/firewalled interface until Noise KK mutual auth lands.
 - **Reference-client at-rest encryption** — the LSP seals its secrets at rest; the reference *client* does not yet, so its HD seed is on disk in the clear. Use `--keyfile` and protect the client data directory.
-- **Post-rotation accounting** — a conservation-checker/init mismatch can freeze new HTLCs on channels immediately after a factory rotation (funds are safe; payments pause until restart). Fix in progress.
 - **Operational model** — watchtower + CPFP-bumper funding/ownership, client fee-reserve for self-exit, and construction migration/backup-restore are still being specified.
 
 Deploy on signet/testnet only until these close.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -129,7 +129,7 @@ gh release download vX.Y.Z --repo 8144225309/SuperScalar -D /tmp/artifacts
 
 # Generate SHA256SUMS in a deterministic order
 cd /tmp/artifacts
-sha256sum *.tar.gz *.zip > SHA256SUMS
+sha256sum *.tar.gz > SHA256SUMS
 
 # Sign with GPG
 gpg --detach-sign --armor SHA256SUMS  # produces SHA256SUMS.asc
@@ -156,10 +156,10 @@ platform automatically on Release publish. For v0.2.0 the supported set is:
 | Linux x86_64 | `build-linux` job |
 | Linux ARM64 | `build-linux-arm64` job (QEMU) |
 | macOS x86_64 / arm64 | `build-macos` job |
-| Windows x86_64 | `build-windows` job (added for v0.2.0) |
 
-Each job produces a tarball/zip named
-`superscalar-vX.Y.Z-<platform>.{tar.gz,zip}` containing the four release
+Windows binaries are **not** built (POSIX-only paths + signal handling; see
+README "Known limitations"). Each job produces a tarball named
+`superscalar-vX.Y.Z-<platform>.tar.gz` containing the four release
 binaries (`superscalar_lsp`, `superscalar_client`, `superscalar_bridge`,
 `superscalar_watchtower`) plus `README.md`, `LICENSE`, `CHANGELOG.md`, and
 `SECURITY.md`.

--- a/docs/signet-ps-n8-procedure.md
+++ b/docs/signet-ps-n8-procedure.md
@@ -23,7 +23,7 @@ to the broadcast threshold (without burning multi-hour wall-clock):
 
 - `signet_setup.sh` parses cleanly with all canonical env-var combinations
   (`N_CLIENTS=8 ARITY=3,4 STATIC_NEAR_ROOT=1`, `N_CLIENTS=64 ARITY=2,4,8 STATIC_NEAR_ROOT=1`,
-  `N_CLIENTS=128 ARITY=2,4,8 STATIC_NEAR_ROOT=2`, `PS_SUBFACTORY_ARITY=2 N_CLIENTS=4 ARITY=3`)
+  `N_CLIENTS=127 ARITY=2,4,8 STATIC_NEAR_ROOT=2`, `PS_SUBFACTORY_ARITY=2 N_CLIENTS=4 ARITY=3`)
 - `superscalar_lsp` binary recognizes `--arity 3,4` and `--static-near-root 1`
   on `--network signet`
 - Signet bitcoind reachable at `/var/lib/bitcoind-signet`; `superscalar_lsp`
@@ -56,7 +56,7 @@ check enforces at LSP startup.
 | `N_CLIENTS=8 ARITY=3 STATIC_NEAR_ROOT=0`   | 3 | 4 | 1296 | 9 | small-N PS baseline (existing audit campaign) |
 | `N_CLIENTS=8 ARITY=3,4 STATIC_NEAR_ROOT=1` | 1 | 1 | 432  | 3 | mid-size mixed-arity (smallest live signet test) |
 | `N_CLIENTS=64 ARITY=2,4,8 STATIC_NEAR_ROOT=1` | 2 | 2 | 864  | 6 | scale-shape canonical (depth halved vs uniform) |
-| `N_CLIENTS=128 ARITY=2,4,8 STATIC_NEAR_ROOT=2` | 3 | 2 | 864 | 6 | maximum-scale canonical (the design target) |
+| `N_CLIENTS=127 ARITY=2,4,8 STATIC_NEAR_ROOT=2` | 3 | 2 | 864 | 6 | maximum-scale canonical (the design target) |
 | `N_CLIENTS=4 ARITY=3 PS_SUBFACTORY_ARITY=2` | 1 | 1 | 432 | 3 | k² PS sub-factory canonical (Phase 4 durability target) |
 
 > **Note:** `N_CLIENTS=64 ARITY=3` (uniform PS at scale) computes to mainnet
@@ -134,7 +134,7 @@ ssh root@68.168.216.243 "cd /root/SuperScalar && N_CLIENTS=64 ARITY=2,4,8 STATIC
 #### 3d. N=128 mixed-arity (maximum-scale canonical, the design target)
 
 ```
-ssh root@68.168.216.243 "cd /root/SuperScalar && N_CLIENTS=128 ARITY=2,4,8 STATIC_NEAR_ROOT=2 bash tools/signet_setup.sh demo-force-close 2>&1 | tee /tmp/signet_n128_canonical_fc.log"
+ssh root@68.168.216.243 "cd /root/SuperScalar && N_CLIENTS=127 ARITY=2,4,8 STATIC_NEAR_ROOT=2 bash tools/signet_setup.sh demo-force-close 2>&1 | tee /tmp/signet_n128_canonical_fc.log"
 ```
 
 #### 3e. k² PS sub-factory canonical (Phase 4 durability target)

--- a/docs/testnet4-quickstart.md
+++ b/docs/testnet4-quickstart.md
@@ -63,7 +63,7 @@ export SS_CLN_B_DIR=/path/to/cln-b
 Testnet4 blocks arrive every ~10 minutes. Use these to minimize BIP68 wait times:
 
 ```
---step-blocks 5         # 5 blocks per DW layer (vs 30 default = 50 min vs 5 hours)
+--step-blocks 5         # 5 blocks per DW layer (vs 10 default = ~50 min vs ~100 min per layer)
 --states-per-layer 2    # Fewer states = fewer layers = fewer waits
 --active-blocks 50      # Factory lifetime ~8 hours
 --dying-blocks 20       # Migration window ~3 hours


### PR DESCRIPTION
Release-prep documentation pass (two code-verified audit sweeps: CHANGELOG accuracy + docs staleness).

## CHANGELOG.md
- **New `## v0.2.0 — 2026-07-02` section** documenting all post-rc1 work (the CHANGELOG was frozen at rc1; 225 commits landed since): trustless completion P1–P6, hashlock-gated L-stock poison (leaf + sub-factory), at-rest secret encryption (#327 family, schema v37–v39), CLN-bridge interop incl. the **127-client public-signet capstone** (#417), distribution-TX co-signing (#399/#401/#404), the 127-client scale/rotation correctness fixes (#412–#420), and client self-defense. Every entry anchors to a **real merge PR (#395–#420)**.
- **Disambiguation note** at top: bare `#N` in the historical rc1 section are internal task IDs, not GitHub PRs.
- De-linked the 4 highest-visibility Tier-1 `#N` collisions (`#272/#273/#332/#271` — verified via `gh pr view` to mislink to unrelated PRs).

## Docs realigned to merged code (all code-verified)
| File | Fix |
|---|---|
| `README.md` | `--accept-risk-mainnet` (**does not exist**) → `--i-accept-the-risk`; N=128 → **127 clients** (proven regtest + signet) |
| `docs/release-process.md` | remove the fabricated `build-windows` CI job row + `.zip` artifact claims (only `.tar.gz` is produced) |
| `docs/factory-arity.md` | "N=128 clients" → **127** (CLI now rejects `--clients 128`); refresh `v0.1.x` labels |
| `docs/mainnet-runbook.md` | schema "v34" → **v39**; N=128/256 scale rows → **127** (design max, proven — not TODO) |
| `docs/signet-ps-n8-procedure.md` | `N_CLIENTS=128` → **127** (the max-scale command otherwise fails at LSP startup) |
| `docs/testnet4-quickstart.md` | `--step-blocks` default `30` → **10** |
| `docs/release-notes/release-notes-0.2.0.md` | drop the post-rotation-freeze known-issue (fixed in #416) |

## Ground truth (verified in-code)
`PERSIST_SCHEMA_VERSION=39` · `MUSIG_SESSION_MAX_SIGNERS=128` = LSP + 127 clients · `FACTORY_MAX_SIGNERS=256` is keyagg-array headroom, not a client cap · `getinfo` → `superscalar-<version.h>` · readiness bitmaps removed · release.yml builds Linux×2 + macOS only.

## Follow-ups (not blocking)
15 lower-visibility Tier-2 `#N` collisions in the rc1 CHANGELOG (covered by the new disambiguation note); scrub internal task-IDs from the mainnet-runbook appendix; document `--encrypt-db` in the LSP operator-guide security table.

Docs-only; no code changed. Separate from (and does not perform) the still-held v0.2.0 tag.