### PR TITLE
hardening: close the 6 non-blocking findings from the v0.2.0 release review

### DIFF
--- a/include/superscalar/channel.h
+++ b/include/superscalar/channel.h
@@ -287,9 +287,10 @@ int channel_get_remote_pcp(const channel_t *ch, uint64_t commitment_num,
 /* Revocation-verification standard (shared by LSP and client): verify a revealed
    per-commitment secret matches the per-commitment point the peer committed to
    (secret*G == committed_PCP), using channel_get_remote_pcp (which consults the
-   durable DB record). Returns 1 if valid, 0 if demonstrably wrong. NOTE: in the
-   current phase this still returns 1 when no committed point can be found at all
-   (legacy accept-on-trust); that branch flips to fail-closed in a later phase. */
+   durable DB record). Returns 1 if valid, 0 if demonstrably wrong. FAIL-CLOSED:
+   if no committed point can be retrieved anywhere (durable DB included) this
+   returns 0 -- a revocation that cannot be checked is never trusted (storing it
+   would arm a broken penalty). */
 int channel_verify_revocation_secret(const channel_t *ch, uint64_t commitment_num,
                                      const unsigned char *secret32);
 

--- a/include/superscalar/client.h
+++ b/include/superscalar/client.h
@@ -94,7 +94,8 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
                                size_t n_participants,
                                const wire_msg_t *initial_msg,
                                uint32_t current_height,
-                               const channel_t *ch);
+                               const channel_t *ch,
+                               int repropose_depth);
 
 /* Reconnect to LSP using persisted state from SQLite.
    Loads factory + channel from DB, sends MSG_RECONNECT, receives

--- a/src/channel.c
+++ b/src/channel.c
@@ -589,11 +589,11 @@ int channel_get_remote_pcp(const channel_t *ch, uint64_t commitment_num,
    channel_get_remote_pcp, which now consults the durable DB record, so a
    legitimate revocation can always be checked.
 
-   PHASE 1 (this commit) preserves the historical behavior of accepting when no
-   committed point can be found anywhere (returns 1) so this is a pure,
-   behavior-neutral relocation + durability upgrade. PHASE 2 flips that branch to
-   fail-closed (return 0) once the choke-point + tests prove no legitimate
-   revocation lands without a retrievable point. */
+   FAIL-CLOSED: if no committed point can be found anywhere (durable DB included),
+   this returns 0 -- a revocation that cannot be checked against a committed point
+   is never trusted (storing it would arm a broken penalty). Durable-PCP
+   persistence guarantees a legitimate revocation always has a retrievable point,
+   so a miss means a protocol desync or an attack. */
 int channel_verify_revocation_secret(const channel_t *ch, uint64_t commitment_num,
                                      const unsigned char *secret32) {
     if (!ch || !secret32) return 0;

--- a/src/client.c
+++ b/src/client.c
@@ -531,6 +531,12 @@ int client_fulfill_payment(int fd, channel_t *ch,
 
 /* --- Cooperative close ceremony (extracted for reuse) --- */
 
+/* MEDIUM-1: cap on LSP-driven re-PROPOSE recursion depth. The LSP is untrusted;
+   without a cap a malicious/looping LSP that streams CLOSE_PROPOSE could exhaust
+   the client's stack. On exceed, the client aborts the coop close and can still
+   exit via --force-close. */
+#define MAX_CLOSE_REPROPOSE 16
+
 int client_do_close_ceremony(int fd, secp256k1_context *ctx,
                                const secp256k1_keypair *keypair,
                                const secp256k1_pubkey *my_pubkey,
@@ -538,7 +544,8 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
                                size_t n_participants,
                                const wire_msg_t *initial_msg,
                                uint32_t current_height,
-                               const channel_t *ch) {
+                               const channel_t *ch,
+                               int repropose_depth) {
     wire_msg_t msg;
     int got_propose = 0;
 
@@ -856,10 +863,18 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
         return 0;
     }
     if (done_msg.msg_type == MSG_CLOSE_PROPOSE) {
+        if (repropose_depth + 1 > MAX_CLOSE_REPROPOSE) {
+            fprintf(stderr, "Client: LSP exceeded %d cooperative-close re-proposes -- "
+                    "aborting coop close (use --force-close to exit)\n", MAX_CLOSE_REPROPOSE);
+            cJSON_Delete(done_msg.json);
+            tx_buf_free(&close_unsigned);
+            return 0;
+        }
         fprintf(stderr, "Client: LSP re-proposing cooperative close -- retrying with a fresh nonce\n");
         tx_buf_free(&close_unsigned);
         int _r = client_do_close_ceremony(fd, ctx, keypair, my_pubkey, factory,
-                                           n_participants, &done_msg, current_height, ch);
+                                           n_participants, &done_msg, current_height, ch,
+                                           repropose_depth + 1);
         cJSON_Delete(done_msg.json);
         return _r;
     }
@@ -2836,7 +2851,7 @@ int client_run_with_channels(secp256k1_context *ctx,
     /* === Cooperative Close Ceremony === */
     if (!client_do_close_ceremony(fd, ctx, keypair, &my_pubkey,
                                     factory, n_participants, NULL, 0,
-                                    NULL)) {
+                                    NULL, 0)) {
         goto fail;
     }
 

--- a/src/client_reconnect.c
+++ b/src/client_reconnect.c
@@ -464,7 +464,7 @@ int client_run_reconnect(secp256k1_context *ctx,
         /* Run close ceremony */
         int close_ok = client_do_close_ceremony(fd, ctx, keypair, &my_pubkey,
                                                   factory, n_participants,
-                                                  NULL, 0, &channel);
+                                                  NULL, 0, &channel, 0);
         factory_free(factory); free(factory);
         wire_close(fd);
         return close_ok;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2195,8 +2195,15 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         int had_old = (an->is_signed && an->signed_tx.len > 0);
         int old_no = an->n_outputs;
         if (had_old) memcpy(poison_old_txid[k], an->txid, 32);
-        poison_old_l_amount[k] = (old_no >= 2)
-            ? an->outputs[old_no - 1].amount_sats : 0;
+        /* MEDIUM-2: use_tree_anchor appends a P2A anchor as the LAST output, so the
+           L-stock is the SECOND-to-last (mirror the leaf-advance fix ~line 1400).
+           Reading outputs[old_no-1] would grab the 240-sat anchor -> gate skips. */
+        int an_anchor = (old_no >= 2 &&
+            an->outputs[old_no - 1].script_pubkey_len == P2A_SPK_LEN &&
+            memcmp(an->outputs[old_no - 1].script_pubkey, P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
+        int an_l_vout = old_no - 1 - an_anchor;
+        poison_old_l_amount[k] = (an_l_vout >= 0 && (old_no - an_anchor) >= 2)
+            ? an->outputs[an_l_vout].amount_sats : 0;
         /* Phase 1b.5: chain output (vout=0) snapshot for wt_db. */
         wt_had_old[k] = had_old;
         wt_old_chain_amount[k] = (old_no >= 1) ? an->outputs[0].amount_sats : 0;
@@ -2207,11 +2214,11 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                    an->outputs[0].script_pubkey,
                    wt_old_chain_spk_len[k]);
         wt_old_csv_delay[k] = (uint32_t)(an->nsequence & 0xFFFFu);
-        if (mgr->watchtower && !an->is_ps_leaf && had_old && old_no >= 2 &&
+        if (mgr->watchtower && !an->is_ps_leaf && had_old && (old_no - an_anchor) >= 2 &&
             poison_old_l_amount[k] > TIERB_POISON_FEE_SATS +
                 (uint64_t)(an->n_signers - 1) * 330u) {
             if (factory_session_prepare_poison_tx_leaf(
-                    f, affected[k], poison_old_txid[k], (uint32_t)(old_no - 1),
+                    f, affected[k], poison_old_txid[k], (uint32_t)an_l_vout,
                     poison_old_l_amount[k], TIERB_POISON_FEE_SATS,
                     NULL /* #53-B3b: capture per-node H_old when daemon hashlock on */)) {
                 poison_prepared[k] = 1;  /* init_node_poison after state init */
@@ -2968,8 +2975,17 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     unsigned char realloc_old_leaf_txid[32];
     memcpy(realloc_old_leaf_txid, node->txid, 32);
     int realloc_old_n_outputs = node->n_outputs;
-    uint64_t realloc_old_l_amount = (realloc_old_n_outputs >= 2)
-        ? node->outputs[realloc_old_n_outputs - 1].amount_sats : 0;
+    /* MEDIUM-2: use_tree_anchor appends a P2A anchor as the LAST output, so the
+       L-stock is the SECOND-to-last (mirror the leaf-advance fix ~line 1400).
+       Reading outputs[n-1] would grab the 240-sat anchor -> poison gate skips. */
+    int realloc_anchor = (realloc_old_n_outputs >= 2 &&
+        node->outputs[realloc_old_n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
+        memcmp(node->outputs[realloc_old_n_outputs - 1].script_pubkey,
+               P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
+    int realloc_l_vout = realloc_old_n_outputs - 1 - realloc_anchor;
+    uint64_t realloc_old_l_amount = (realloc_l_vout >= 0 &&
+        (realloc_old_n_outputs - realloc_anchor) >= 2)
+        ? node->outputs[realloc_l_vout].amount_sats : 0;
     int realloc_had_signed = (node->is_signed && node->signed_tx.len > 0);
     /* SF-WT-TRUSTLESS Phase 1b.5b (#248): snapshot OLD chain output for
      * wt_db register at the bottom of this function.  Same pattern as
@@ -2989,12 +3005,13 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
 
     const uint64_t REALLOC_POISON_FEE_SATS = 1000;
     int realloc_poison_prepared = 0;
-    if (mgr->watchtower && realloc_had_signed && realloc_old_n_outputs >= 2 &&
+    if (mgr->watchtower && realloc_had_signed &&
+        (realloc_old_n_outputs - realloc_anchor) >= 2 &&
         realloc_old_l_amount > REALLOC_POISON_FEE_SATS +
                                (uint64_t)(node->n_signers - 1) * 330u) {
         if (factory_session_prepare_poison_tx_leaf(
                 f, node_idx,
-                realloc_old_leaf_txid, (uint32_t)(realloc_old_n_outputs - 1),
+                realloc_old_leaf_txid, (uint32_t)realloc_l_vout,
                 realloc_old_l_amount, REALLOC_POISON_FEE_SATS,
                 /* #53-B3b: this path prepares BEFORE the advance, so the node's
                    current hash IS H_old — NULL is already correct here. */

--- a/src/musig.c
+++ b/src/musig.c
@@ -277,6 +277,11 @@ void musig_session_init(
     memset(session, 0, sizeof(*session));
     memcpy(&session->cache, &keyagg->cache, sizeof(secp256k1_musig_keyagg_cache));
     memcpy(&session->agg_pubkey, &keyagg->agg_pubkey, sizeof(secp256k1_xonly_pubkey));
+    /* Defense-in-depth: pubnonces[]/partial_sigs[] are [MUSIG_SESSION_MAX_SIGNERS].
+       Clamp so a caller that passes more than the max can never drive an OOB read
+       in the finalize loop (design max is 128 = LSP + 127 clients). */
+    if (n_signers > MUSIG_SESSION_MAX_SIGNERS)
+        n_signers = MUSIG_SESSION_MAX_SIGNERS;
     session->n_signers = n_signers;
 }
 

--- a/src/persist_crypto.c
+++ b/src/persist_crypto.c
@@ -411,6 +411,14 @@ int persist_apply_encryption(persist_t *p) {
         free(tok);
     }
     if (own_txn) { if (ok) ok = persist_commit(p); else persist_rollback(p); }
+    /* #327b LOW-4: on FIRST encryption (no prior verify token) the in-place seal
+       UPDATEs leave the previous plaintext secret pages in SQLite's freelist,
+       carvable from the raw file. VACUUM (outside any txn, after commit) reclaims
+       them. Fires once per DB at first-seal; already-tokened steady-state opens
+       skip it. Fresh encrypted DBs never wrote plaintext, so this is a cheap
+       no-op for them. Best-effort: a VACUUM failure does not fail the open. */
+    if (ok && own_txn && !have_token)
+        sqlite3_exec(p->db, "VACUUM;", NULL, NULL, NULL);
     if (ok) fprintf(stderr, "persist: at-rest field encryption active (%zu secret columns %s).\n",
                     N_SECRET_COLS, have_token ? "verified" : "sealed");
     return ok;

--- a/src/watchtower.c
+++ b/src/watchtower.c
@@ -876,8 +876,12 @@ void watchtower_watch_revoked_commitment(watchtower_t *wt, channel_t *ch,
                         unsigned char pp33[33];
                         pp33[0] = 0x02;
                         memcpy(pp33 + 1, wp_p->payment_hash, 32);
-                        secp256k1_ec_pubkey_parse(ch->ctx,
-                            &ch->ptlcs[0].payment_point, pp33, 33);
+                        if (!secp256k1_ec_pubkey_parse(ch->ctx,
+                                &ch->ptlcs[0].payment_point, pp33, 33)) {
+                            fprintf(stderr, "watchtower: PTLC mirror skipped -- "
+                                "invalid payment_point for output %zu\n", p);
+                            continue;
+                        }
                     }
                     tx_buf_t psweep;
                     tx_buf_init(&psweep, 512);

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1494,7 +1494,7 @@ handle_message:
         case MSG_CLOSE_PROPOSE:
             printf("Client %u: received CLOSE_PROPOSE in daemon mode\n", my_index);
             client_do_close_ceremony(fd, ctx, keypair, &my_pubkey,
-                                      factory, n_participants, &msg, 0, ch);
+                                      factory, n_participants, &msg, 0, ch, 0);
             cJSON_Delete(msg.json);
             return 2;  /* close already handled */
 


### PR DESCRIPTION
Post-review hardening for the v0.2.0 release. Closes the 6 non-blocking findings from the independent rc1->final diff review (4 subsystem reviewers + main-thread verification). No theft / fund-loss / key-leak was found anywhere; these are 2 fail-safe MEDIUMs + 4 LOWs.

- **MEDIUM-1 (#80)** bound the coop-close re-PROPOSE recursion (untrusted-LSP stack exhaustion -> self-DoS). Cap 16, falls back to `--force-close`.
- **MEDIUM-2 (#81)** L-stock poison vout tree-anchor-aware in the Tier-B state-advance + realloc paths (was reading the P2A anchor instead of the L-stock on anchored shapes -> fail-safe skip). Mirrors the leaf-advance fix.
- **LOW-3 (#82)** correct the stale fail-open comment on `channel_verify_revocation_secret` (code is fail-closed).
- **LOW-4 (#83)** `VACUUM` after the first at-rest seal-migration (reclaims plaintext pages on a DB upgraded from an unencrypted binary).
- **LOW-5 (#84)** clamp `musig` `n_signers` to `MUSIG_SESSION_MAX_SIGNERS`.
- **LOW-6 (#85)** check the ignored `pubkey_parse` return in the watchtower PTLC mirror.

Deferred to the mainnet audit: AEAD AAD binding (#86).

Verification: build green (all 4 binaries compiled clean); unit suite + full regression + crash matrix running on the VPS, plus CI on this PR. The v0.2.0 tag is gated on all green.