### PR TITLE
hardening: anchor x realloc bug fixes (#98) + client #81 poison mirror + dist-TX signed (#90)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -2902,19 +2902,27 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
     unsigned char pre_old_leaf_txid_r[32];
     memcpy(pre_old_leaf_txid_r, pre_leaf_r->txid, 32);
     int pre_old_n_outputs_r = pre_leaf_r->n_outputs;
-    uint64_t pre_old_l_amount_r = (pre_old_n_outputs_r >= 2)
-                                  ? pre_leaf_r->outputs[pre_old_n_outputs_r - 1].amount_sats
+    /* #81 mirror: use_tree_anchor makes the L-stock the SECOND-to-last output (the
+       240-sat P2A anchor is last). Read the real L-stock, not the anchor. */
+    int pre_anchor_r = (pre_old_n_outputs_r >= 2 &&
+        pre_leaf_r->outputs[pre_old_n_outputs_r - 1].script_pubkey_len == P2A_SPK_LEN &&
+        memcmp(pre_leaf_r->outputs[pre_old_n_outputs_r - 1].script_pubkey,
+               P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
+    int pre_l_vout_r = pre_old_n_outputs_r - 1 - pre_anchor_r;
+    uint64_t pre_old_l_amount_r = (pre_l_vout_r >= 0 &&
+                                   (pre_old_n_outputs_r - pre_anchor_r) >= 2)
+                                  ? pre_leaf_r->outputs[pre_l_vout_r].amount_sats
                                   : 0;
     int pre_had_signed_r = (pre_leaf_r->is_signed && pre_leaf_r->signed_tx.len > 0);
 
     const uint64_t REALLOC_POISON_FEE_SATS = 1000;
     int realloc_poison_prepared = 0;
-    if (wire_poison_offered && pre_had_signed_r && pre_old_n_outputs_r >= 2 &&
+    if (wire_poison_offered && pre_had_signed_r && (pre_old_n_outputs_r - pre_anchor_r) >= 2 &&
         pre_old_l_amount_r > REALLOC_POISON_FEE_SATS +
                              (uint64_t)(pre_leaf_r->n_signers - 1) * 330u) {
         if (factory_session_prepare_poison_tx_leaf(
                 factory, pre_node_idx_r,
-                pre_old_leaf_txid_r, (uint32_t)(pre_old_n_outputs_r - 1),
+                pre_old_leaf_txid_r, (uint32_t)pre_l_vout_r,
                 pre_old_l_amount_r, REALLOC_POISON_FEE_SATS,
                 NULL /* #53-B3b: client mirrors LSP; daemon hashlock off -> key-path */)) {
             realloc_poison_prepared = 1;

--- a/src/factory.c
+++ b/src/factory.c
@@ -2348,11 +2348,21 @@ int factory_set_leaf_amounts(factory_t *f, int leaf_side,
     size_t node_idx = f->leaf_node_indices[leaf_side];
     factory_node_t *node = &f->nodes[node_idx];
 
-    if (n_amounts != node->n_outputs) return 0;
+    /* #98: use_tree_anchor appends a fixed 240-sat P2A anchor as the LAST leaf
+       output; it is NOT part of the reallocatable channel/L-stock amounts. Callers
+       pass amounts for the non-anchor outputs only, so exclude the anchor from the
+       count + conservation and leave it untouched. */
+    int has_anchor = (node->n_outputs >= 1 &&
+        node->outputs[node->n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
+        memcmp(node->outputs[node->n_outputs - 1].script_pubkey,
+               P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
+    size_t n_realloc = node->n_outputs - (size_t)has_anchor;
 
-    /* Compute current output total */
+    if (n_amounts != n_realloc) return 0;
+
+    /* Compute current reallocatable (non-anchor) total */
     uint64_t current_total = 0;
-    for (size_t i = 0; i < node->n_outputs; i++)
+    for (size_t i = 0; i < n_realloc; i++)
         current_total += node->outputs[i].amount_sats;
 
     /* Validate new amounts sum = current total (conservation of funds) */
@@ -2363,7 +2373,7 @@ int factory_set_leaf_amounts(factory_t *f, int leaf_side,
     }
     if (new_total != current_total) return 0;
 
-    /* Update amounts */
+    /* Update amounts (anchor output, if present, is left untouched) */
     for (size_t i = 0; i < n_amounts; i++)
         node->outputs[i].amount_sats = amounts[i];
 

--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -1029,14 +1029,20 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
         lf_new->is_initialized = 1;
         lf_new->is_funded = 1;
         lf_new->cached_state = FACTORY_ACTIVE;
-        /* Copy signed distribution TX from ceremony (if available) */
+        /* #90: copy the SIGNED distribution TX from the ceremony. Previously this
+           copied dist_UNSIGNED_tx, which is unrelayable -> the LSP-side auto-broadcast
+           at EXPIRED (lsp_channels.c) silently failed. Require dist_tx_ready==2
+           (signed); if only the unsigned exists, leave distribution_tx empty (skip
+           auto-broadcast) rather than broadcast an invalid tx. Offline clients still
+           hold their own co-signed copy (wire.c ships dist_signed_tx), so fund safety
+           is unaffected either way. */
         tx_buf_init(&lf_new->distribution_tx, 256);
-        if (lsp->factory.dist_tx_ready && lsp->factory.dist_unsigned_tx.len > 0) {
+        if (lsp->factory.dist_tx_ready == 2 && lsp->factory.dist_signed_tx.len > 0) {
             tx_buf_free(&lf_new->distribution_tx);
-            tx_buf_init(&lf_new->distribution_tx, lsp->factory.dist_unsigned_tx.len);
-            memcpy(lf_new->distribution_tx.data, lsp->factory.dist_unsigned_tx.data,
-                   lsp->factory.dist_unsigned_tx.len);
-            lf_new->distribution_tx.len = lsp->factory.dist_unsigned_tx.len;
+            tx_buf_init(&lf_new->distribution_tx, lsp->factory.dist_signed_tx.len);
+            memcpy(lf_new->distribution_tx.data, lsp->factory.dist_signed_tx.data,
+                   lsp->factory.dist_signed_tx.len);
+            lf_new->distribution_tx.len = lsp->factory.dist_signed_tx.len;
         }
         lad->n_factories++;
     } else {

--- a/tools/superscalar_lsp_post_daemon_tests.inc
+++ b/tools/superscalar_lsp_post_daemon_tests.inc
@@ -1135,7 +1135,10 @@
             /* Verify amounts updated (read from leaf node outputs) */
             if (realloc_pass) {
                 uint64_t post_total = 0;
-                for (size_t k = 0; k < leaf_node->n_outputs; k++)
+                /* #98: match orig_total's k<3 (the reallocatable channel+L-stock
+                   outputs) -- exclude the trailing P2A tree anchor (fixed 240 sats,
+                   present before + after the realloc, not part of the redistribution). */
+                for (size_t k = 0; k < 3 && k < leaf_node->n_outputs; k++)
                     post_total += leaf_node->outputs[k].amount_sats;
                 if (post_total != orig_total) {
                     printf("  FAIL: total funding changed "

--- a/tools/test_regtest_cheat_realloc.sh
+++ b/tools/test_regtest_cheat_realloc.sh
@@ -229,6 +229,11 @@ except Exception: print("0 0 0")')
     echo "  defense confirmed on-chain; $PNUM P2TR output(s), smallest ${PMIN:-0} sats, total ${PTOT:-0} sats"
     [ "${PNUM:-0}" -ge 1 ] || { echo "  FAIL: defense has no P2TR redistribution output"; exit 1; }
     [ "${PMIN:-0}" -ge 330 ] || { echo "  FAIL: a per-client output ${PMIN} sats <= dust — redistribution shorted a client"; exit 1; }
+    # #91 anchor-vout regression guard (proves #81/#98): the poison MUST redistribute
+    # the REAL L-stock (thousands of sats), never the 240-sat P2A tree anchor. A
+    # regression in the anchor-vout handling would collapse the total toward ~240.
+    [ "${PTOT:-0}" -gt 5000 ] || { echo "  FAIL (#81/#98 anchor-vout regression): poison total ${PTOT} sats collapsed toward the 240-sat P2A anchor — read the anchor, not the L-stock"; exit 1; }
+    echo "  #91 anchor guard OK: poison total ${PTOT} sats >> 240 (P2A anchor) — targeted the real L-stock"
     A2=$(pen_recovers_most "$PEN_TXID"); echo "  A-2 recovery ratio: $A2 (OK=outputs>=90% of swept inputs)"
     case "$A2" in LOW*) echo "  FAIL: penalty recovers <90% of swept value ($A2) — value leaked/burned to fee"; exit 1;; esac
     echo "  PASS: WT detected breach (FACTORY BREACH x$BREACH_DETECTED) + CONFIRMED redistribution $PEN_TXID ($PNUM outs, min ${PMIN}, total ${PTOT} sats) — outcome verified per-client"


### PR DESCRIPTION
Adversarial-hardening campaign checkpoint (Tier-1 + first real bugs). Everything here is validated green; NOT a release (tag stays held).

**Two real bugs found by the #91 anchor-poison campaign** (running cheat_realloc with tree anchors ON, never exercised since anchors landed 06-24 -- neither is fund-losing):
- **#98** `factory_set_leaf_amounts` required n_amounts == n_outputs, but the P2A tree anchor makes that off-by-one -> realloc/buy-liquidity was BROKEN with anchors on. Now anchor-aware (count + conserve over non-anchor outputs; preserve the 240 anchor).
- **client #81 mirror** -- the client's realloc poison read the 240 anchor instead of the L-stock (the instance my #81 LSP fix missed). Now anchor-aware.

**#90** LSP dist-TX auto-broadcast now uses the SIGNED tx (was the unrelayable unsigned buffer at rotation).

**Tests:** cheat_realloc conservation check made anchor-consistent; explicit #91 anchor-vout regression guard added (poison total >> 240 = real L-stock).

**Validation:** build clean; cheat_realloc GREEN with anchors on -- WT redistributes the real 65,374-sat L-stock on-chain (not 240). Full unit + regression + crash matrix running on the VPS + CI on this PR.