### PR TITLE
Gap-scan hardening: client factory-tree verification + L-stock advance anchor fix + at-rest/mainnet guards

### DIFF
--- a/docs/gap-scan-findings-2026-07.md
+++ b/docs/gap-scan-findings-2026-07.md
@@ -42,12 +42,19 @@ key-leak, or fund-theft gap.** One HIGH *robustness* gap + one real bug were fou
   abort mirroring the in-epoch leaf advance (lsp_channels.c:1840). Non-trivial restructure;
   do with a targeted Tier-B-boundary regression.
 - **MED — leaf/factory-node L-stock poison not mirrored to wt.db.** `lsp_channels.c:1924/2715/3366`
-  mirror only `signed_tx` (chain[N]) as the factory-node response, not the co-signed poison
-  (contrast sub-factory, which stores the poison). A standalone WT re-asserts client channel
-  balances (chain[N], ≥90% value proven) but does not fire the leaf L-stock poison — that leg
-  is client-driven by design (`superscalar_lstock_recover`, #62) or in-memory-WT only. **Fix
-  approach:** mirror the co-signed leaf poison into wt_db as the response (symmetry with
-  sub-factory) so the "run your own WT" story covers the L-stock leg.
+  mirror only `signed_tx` (chain[N]) as the factory-node response, not the co-signed poison.
+  **Deeper analysis (corrects an earlier "just mirror sub-factory" read):** unlike the
+  sub-factory — where chain[N] orphans `-25` once the breach confirms, so the poison *replaces*
+  it (`:4199`) — the **leaf's chain[N] is a VALID post-confirmation response**: it spends
+  `old_leaf_txid` directly and re-asserts the client channel balances (≥90% value, proven by
+  `test_regtest_cheat_daemon_leaf.sh`). So the client's **primary fund-recourse already works
+  standalone** via chain[N]; the L-stock poison is a *secondary deterrent* (redistribute the
+  LSP's over-claimed L-stock) that spends a DIFFERENT vout of `old_leaf_txid`. **Fix approach:**
+  register a SECOND wt_db watch for the poison (same parent `old_leaf_txid`, response =
+  `node->poison_signed_tx`, `response_txid = node->poison_txid`; the leaf node carries all three,
+  factory.h:177-182) — NOT a swap. The hydrating WT fires all rows sharing a parent txid, so
+  both chain[N] and the poison broadcast on breach (different vouts, no conflict). Needs a
+  standalone-WT-fires-leaf-poison regression to prove. Not fund-safety (chain[N] covers balances).
 - **LOW — WT completeness nuances.** (F4) force-close kind=3 is armed reactively (on a peer's
   BOLT ERROR), so a *pre-suppressed* LSP leaves no kind=3 row — pre-emptive arming would close
   it. (F5) `fee_bump_*` metadata is inert in every wt_db row; the WT only CPFPs if the

--- a/docs/gap-scan-findings-2026-07.md
+++ b/docs/gap-scan-findings-2026-07.md
@@ -1,0 +1,72 @@
+# Gap-scan audit findings — 2026-07 (pre-v0.2.0-tag)
+
+A four-lens adversarial audit (fund-safety, watchtower completeness, mainnet-safety,
+recent-PR correctness) of `main`. Every finding below was **verified against the code**
+by the orchestrator, not taken on an agent's word. Headline: **no direct-theft,
+key-leak, or fund-theft gap.** One HIGH *robustness* gap + one real bug were found and
+**fixed**; the rest are MED/LOW deterrent-gaps and design boundaries, recorded here.
+
+## FIXED (this pass)
+
+- **HIGH — client never verified the LSP factory tree signatures.** `client_apply_factory_ready`
+  set `is_signed=1` with no check; `factory_verify_all` (secret-free) was never called
+  client-side. A buggy/malicious LSP could ship an invalid tree → client uses the channel,
+  then can't self-exit (force-close rejected on-chain) = **frozen funds** (freeze/ransom, not
+  theft — N-of-N frozen for the LSP too). **Fix:** client now calls `factory_verify_all` and
+  refuses on failure (client.c). Validated: passes on 319 valid factories, regression 19/19,
+  INVALID marker absent → no false-positive.
+- **BUG — L-stock advance siblings not anchor-aware.** `update_l_stock_for_leaf` (factory.c:2488)
+  and `update_l_stock_outputs` (:435) wrote the L-stock SPK into `outputs[n_outputs-1]` = the
+  P2A anchor when `use_tree_anchor` is on (same #98 off-by-one). Corrupted the CPFP anchor +
+  froze the L-stock hashlock on advance. **Fix:** anchor-aware index in both.
+- **G3 (MED) — `local_pcs` per-commitment secrets plaintext at rest.** A channel-security
+  secret mis-grouped with the v0.3 payment-privacy deferral. **Fix:** sealed (writer/reader +
+  SECRET_COLS, auto-migrates).
+- **G1/G2/G5 (LOW) — mainnet guard gaps.** Broadened the LSP env-refusal to `SUPERSCALAR_CRASH`
+  prefix (catches `_ALLOW`); mirrored the env-refusal in the client (was args-only); added an
+  unknown-`--network` allowlist (an unrecognized network defaulted to the mainnet RPC port
+  while exact-`"mainnet"` guards did not fire).
+
+## DOCUMENTED (deterrent-gaps / design boundaries — pre-mainnet, not tag-blocking)
+
+- **MED — Tier-B rollover L-stock poison-arming is dead code.** In
+  `lsp_run_state_advance_stateless` (lsp_channels.c), `affected[]` skips `is_signed` nodes
+  (:2111), so `had_old = (an->is_signed && ...)` (:2195) is **always false** → the
+  epoch-boundary superseded state gets no freshly-armed L-stock poison; the wt_db watch is
+  inert. **Not principal loss** — client channel funds are PD-penalty-covered independently;
+  this only affects the *deterrent* (burn/redistribute the LSP's own L-stock) for the
+  epoch-boundary state, and the DW timelock override still applies. Distinct from the
+  leaf-advance poison, which IS armed + proven firing (#37, on-chain). **Fix approach**
+  (`docs/cl4-rollover-remediation-plan.md`): snapshot each affected node's old signed_tx +
+  txid BEFORE `build_all_unsigned_txs` (factory.c:569) overwrites them, and add a fail-closed
+  abort mirroring the in-epoch leaf advance (lsp_channels.c:1840). Non-trivial restructure;
+  do with a targeted Tier-B-boundary regression.
+- **MED — leaf/factory-node L-stock poison not mirrored to wt.db.** `lsp_channels.c:1924/2715/3366`
+  mirror only `signed_tx` (chain[N]) as the factory-node response, not the co-signed poison
+  (contrast sub-factory, which stores the poison). A standalone WT re-asserts client channel
+  balances (chain[N], ≥90% value proven) but does not fire the leaf L-stock poison — that leg
+  is client-driven by design (`superscalar_lstock_recover`, #62) or in-memory-WT only. **Fix
+  approach:** mirror the co-signed leaf poison into wt_db as the response (symmetry with
+  sub-factory) so the "run your own WT" story covers the L-stock leg.
+- **LOW — WT completeness nuances.** (F4) force-close kind=3 is armed reactively (on a peer's
+  BOLT ERROR), so a *pre-suppressed* LSP leaves no kind=3 row — pre-emptive arming would close
+  it. (F5) `fee_bump_*` metadata is inert in every wt_db row; the WT only CPFPs if the
+  pre-signed response happens to carry a P2A anchor (baked at registration), so a penalty
+  signed in a low-fee window can't be bumped later (relates to #52). (F6) the HTLC-sweep mirror
+  is nested under `wt->db` presence while to_local/PTLC mirrors are not — inconsistent coupling,
+  never hit in production (always both DBs).
+- **LOW — client-side.** Client's own watchtower handles only revoked channel commitments (no
+  reactive factory/sub-factory WT — offline clients lean on the LSP-populated wt.db or
+  `--force-close`; canonical model is "each client runs its own WT", `pre-mainnet-design-decisions.md`).
+  Client revoked-commitment watch is armed with `NULL` PTLCs (superscalar_client.c:827) — main
+  penalty sweeps to_local, but a PTLC output on that commitment wouldn't be swept by the
+  client's WT. Client does not re-persist `tree_nodes` after intra-factory advances (a crash
+  recovers the last-rotation tree, not principal-affecting).
+
+## Verified-solid (no gap)
+Poon-Dryja channel-penalty recourse is client-secret-complete, persisted, and enforced by a
+client-controlled watchtower the LSP cannot suppress. Cheat gate is fail-safe (only `"regtest"`
+enables; all 11 theft-cheats inert on mainnet). All custody secrets sealed; `--seckey` refused
+on mainnet; no MuSig secnonce persisted. Standalone WT is genuinely secret-less. Reconnect
+untrusted-claim refusal, revocation-secret handling, and poison/distribution verify-before-trust
+are fail-closed.

--- a/src/client.c
+++ b/src/client.c
@@ -932,6 +932,20 @@ static int client_apply_factory_ready(factory_t *f, const cJSON *json) {
     if (count > 0)
         printf("Client: applied %d signed tree nodes from FACTORY_READY\n", count);
 
+    /* GAP-SCAN (fund-safety) FIX: verify the LSP-supplied tree aggregate signatures
+       before trusting them. The client's unilateral self-exit (factory_recovery)
+       broadcasts exactly these bytes root-down; an unverified INVALID tree would be
+       rejected on-chain, freezing the client's funds under a buggy or malicious LSP
+       (the documented "self-exit always available" invariant transitively assumes
+       tree-sig validity, which was never checked client-side). factory_verify_all is
+       secret-free -- it recomputes each node sighash and schnorr-verifies against
+       node->tweaked_pubkey (data the client already holds). Refuse on failure. */
+    if (count > 0 && !factory_verify_all(f)) {
+        fprintf(stderr, "Client: FACTORY_READY tree aggregate signatures INVALID "
+                        "-- REFUSING factory (would be unrecoverable via self-exit)\n");
+        return -1;
+    }
+
     /* Parse signed distribution TX if present */
     cJSON *dist_hex_j = cJSON_GetObjectItem(json, "distribution_tx_hex");
     if (dist_hex_j && cJSON_IsString(dist_hex_j)) {

--- a/src/client.c
+++ b/src/client.c
@@ -1348,8 +1348,15 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
         if (msg.json) cJSON_Delete(msg.json);
         free(secnonces); free(nonce_entries); return 0;
     }
-    client_apply_factory_ready(factory_out, msg.json);
-    cJSON_Delete(msg.json);
+    {
+        int fr_apply = client_apply_factory_ready(factory_out, msg.json);
+        cJSON_Delete(msg.json);
+        if (fr_apply < 0) {   /* tree aggregate sigs invalid -- refuse (fund-safety) */
+            fprintf(stderr, "Client: refusing rotation -- LSP factory tree failed "
+                            "signature verification\n");
+            free(secnonces); free(nonce_entries); return 0;
+        }
+    }
 
     /* Basepoint exchange: receive LSP's basepoints */
     secp256k1_pubkey rot_lsp_pay_bp, rot_lsp_delay_bp, rot_lsp_revoc_bp;
@@ -2349,8 +2356,13 @@ int client_run_with_channels(secp256k1_context *ctx,
                 goto fail;
             }
             if (msg.msg_type == MSG_FACTORY_READY) {
-                client_apply_factory_ready(factory, msg.json);
+                int fr_apply = client_apply_factory_ready(factory, msg.json);
                 cJSON_Delete(msg.json);
+                if (fr_apply < 0) {   /* tree aggregate sigs invalid -- refuse */
+                    fprintf(stderr, "Client: refusing factory -- tree failed "
+                                    "signature verification\n");
+                    goto fail;
+                }
                 created = 1;
                 break;
             } else if (msg.msg_type == MSG_FACTORY_PROPOSE_INTENT &&
@@ -2625,8 +2637,15 @@ int client_run_with_channels(secp256k1_context *ctx,
             if (msg.json) cJSON_Delete(msg.json);
             goto fail;
         }
-        client_apply_factory_ready(factory, msg.json);
-        cJSON_Delete(msg.json);
+        {
+            int fr_apply = client_apply_factory_ready(factory, msg.json);
+            cJSON_Delete(msg.json);
+            if (fr_apply < 0) {   /* tree aggregate sigs invalid -- refuse */
+                fprintf(stderr, "Client: refusing factory -- tree failed "
+                                "signature verification\n");
+                goto fail;
+            }
+        }
     }
 
     /* Log expected distribution amount.  The distribution TX is a fallback

--- a/src/factory.c
+++ b/src/factory.c
@@ -432,7 +432,14 @@ static int update_l_stock_outputs(factory_t *f) {
            The just-superseded state's secret (counter-1) is what the LSP reveals
            to this leaf's clients for recourse against the old state. */
         node->l_stock_state_counter++;
-        if (!set_leaf_l_stock_output(f, node, node->outputs[node->n_outputs - 1].script_pubkey))
+        /* #98-sibling fix: L-stock is the last NON-ANCHOR output (see
+           update_l_stock_for_leaf); outputs[n_outputs-1] is the P2A anchor when
+           use_tree_anchor is on. */
+        int ls_has_anchor = (node->n_outputs >= 1 &&
+            node->outputs[node->n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
+            memcmp(node->outputs[node->n_outputs - 1].script_pubkey, P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
+        size_t ls_idx = node->n_outputs - 1 - (size_t)ls_has_anchor;
+        if (!set_leaf_l_stock_output(f, node, node->outputs[ls_idx].script_pubkey))
             return 0;
     }
     return 1;
@@ -2485,7 +2492,18 @@ static int update_l_stock_for_leaf(factory_t *f, size_t node_idx) {
     /* #53-B: per-leaf advance — bump this leaf's L-stock state index so the new
        state commits a fresh hash (the old state's secret becomes revealable). */
     node->l_stock_state_counter++;
-    return set_leaf_l_stock_output(f, node, node->outputs[node->n_outputs - 1].script_pubkey);
+    /* #98-sibling fix: the L-stock is the last NON-ANCHOR output. With
+       use_tree_anchor on (production default), outputs[n_outputs-1] is the P2A
+       anchor -- writing the L-stock SPK there would corrupt the anchor (len stays
+       4 -> unspendable CPFP) AND freeze the real L-stock's hashlock (never rebuilt
+       on advance while l_stock_state_counter bumps). Target the pre-anchor index. */
+    {
+        int ls_has_anchor = (node->n_outputs >= 1 &&
+            node->outputs[node->n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
+            memcmp(node->outputs[node->n_outputs - 1].script_pubkey, P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
+        size_t ls_idx = node->n_outputs - 1 - (size_t)ls_has_anchor;
+        return set_leaf_l_stock_output(f, node, node->outputs[ls_idx].script_pubkey);
+    }
 }
 
 int factory_advance_leaf(factory_t *f, int leaf_side) {

--- a/src/persist.c
+++ b/src/persist.c
@@ -2885,10 +2885,14 @@ int persist_save_local_pcs(persist_t *p, uint32_t channel_id,
 
     sqlite3_bind_int(stmt, 1, (int)channel_id);
     sqlite3_bind_int64(stmt, 2, (sqlite3_int64)commit_num);
-    sqlite3_bind_text(stmt, 3, secret_hex, -1, SQLITE_TRANSIENT);
+    char *lp_sealed = persist_seal_text(p, secret_hex);   /* G3: seal at rest */
+    memset(secret_hex, 0, sizeof secret_hex);
+    if (!lp_sealed) { sqlite3_finalize(stmt); return 0; }
+    sqlite3_bind_text(stmt, 3, lp_sealed, -1, SQLITE_TRANSIENT);
 
     int ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
+    memset(lp_sealed, 0, strlen(lp_sealed)); free(lp_sealed);
     return ok;
 }
 
@@ -2910,11 +2914,14 @@ int persist_load_local_pcs(persist_t *p, uint32_t channel_id,
     size_t count = 0;
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         uint64_t commit_num = (uint64_t)sqlite3_column_int64(stmt, 0);
-        const char *hex = (const char *)sqlite3_column_text(stmt, 1);
-        if (!hex || commit_num >= max) continue;
+        const char *stored = (const char *)sqlite3_column_text(stmt, 1);
+        if (!stored || commit_num >= max) continue;
 
+        char *hex = NULL;                                  /* G3: open at rest */
+        if (!persist_open_text(p, stored, &hex) || !hex) continue;
         if (hex_decode(hex, secrets_out[commit_num], 32) == 32)
             count++;
+        memset(hex, 0, strlen(hex)); free(hex);
     }
 
     sqlite3_finalize(stmt);

--- a/src/persist_crypto.c
+++ b/src/persist_crypto.c
@@ -231,7 +231,7 @@ static const secret_col_t SECRET_COLS[] = {
        open, so adding a column here auto-seals it on the next startup with no
        schema/enc-version bump.
        v0.3 (payment-privacy tier): preimage / payment_secret / stateless_nonce
-       across htlcs/ptlcs/ln_invoices/local_pcs. */
+       across htlcs/ptlcs/ln_invoices. */
     { "revocation_secrets",         "rowid",      "secret",                  0 },
     { "factory_revocation_secrets", "rowid",      "secret",                  0 },
     { "channel_basepoints",         "channel_id", "local_payment_secret",    0 },
@@ -253,6 +253,11 @@ static const secret_col_t SECRET_COLS[] = {
        PK), so the migrate id is `rowid`. */
     { "departed_clients",           "rowid",      "extracted_key",           0 },
     { "watchtower_keys",            "rowid",      "key_hex",                 0 },
+    /* G3 (gap-scan): per-commitment secrets are a CHANNEL-security secret (were
+       mis-grouped with the payment-privacy tier). Seal them -- combined with the
+       already-sealed basepoint secrets they derive revocation keys. Composite PK
+       (channel_id,commit_num) -> migrate id = rowid. Writer/reader in persist.c. */
+    { "local_pcs",                  "rowid",      "secret",                  0 },
 };
 static const size_t N_SECRET_COLS = sizeof(SECRET_COLS) / sizeof(SECRET_COLS[0]);
 

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -2705,6 +2705,16 @@ int main(int argc, char *argv[]) {
     /* #9 cheat-gate: defense-bypass cheats inert unless regtest; refuse all
        test/cheat scaffolding flags on mainnet (footgun guard). */
     superscalar_set_cheat_gate(strcmp(network, "regtest") == 0);
+    /* G5 (gap-scan): reject unknown network strings -- an unrecognized --network
+       silently defaults to the mainnet RPC port while the exact-"mainnet" guards
+       would not fire. Allowlist the known chains. */
+    if (strcmp(network, "regtest") != 0 && strcmp(network, "testnet") != 0 &&
+        strcmp(network, "testnet4") != 0 && strcmp(network, "signet") != 0 &&
+        strcmp(network, "mainnet") != 0 && strcmp(network, "bitcoin") != 0) {
+        fprintf(stderr, "Error: unknown --network '%s' (expected regtest|testnet|"
+                "testnet4|signet|mainnet).\n", network);
+        return 1;
+    }
     if (strcmp(network, "mainnet") == 0) {
         for (int ci = 1; ci < argc; ci++) {
             if (strncmp(argv[ci], "--cheat-", 8) == 0 ||
@@ -2712,6 +2722,21 @@ int main(int argc, char *argv[]) {
                 fprintf(stderr, "Error: %s is test/cheat scaffolding and is "
                         "refused on mainnet.\n", argv[ci]);
                 return 1;
+            }
+        }
+        /* G2 (gap-scan): mirror the LSP -- also refuse cheat/kill/crash ENV vars on
+           mainnet (SS_CHEAT_* are gate-inert, but SUPERSCALAR_CRASH* -> abort() is
+           env-driven; fail LOUD rather than silently accept a crash knob). */
+        {
+            extern char **environ;
+            for (char **e = environ; e && *e; e++) {
+                if (strncmp(*e, "SS_CHEAT", 8) == 0 ||
+                    strncmp(*e, "SS_KILL", 7) == 0 ||
+                    strncmp(*e, "SUPERSCALAR_CRASH", 17) == 0) {
+                    fprintf(stderr, "Error: test/cheat env var (%.40s) is refused "
+                            "on mainnet.\n", *e);
+                    return 1;
+                }
             }
         }
     }

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2381,6 +2381,16 @@ int main(int argc, char *argv[]) {
     /* #9: refuse ALL test/cheat scaffolding flags on mainnet (footgun guard on
        top of --i-accept-the-risk). Detection cheats are self-harming and
        defense-bypass cheats are theft; neither belongs on a mainnet node. */
+    /* G5 (gap-scan): reject unknown network strings -- an unrecognized --network
+       silently defaults to the mainnet RPC port (chain_backend_rpc.c) while the
+       exact-"mainnet" guards would NOT fire. Allowlist the known chains. */
+    if (strcmp(network, "regtest") != 0 && strcmp(network, "testnet") != 0 &&
+        strcmp(network, "testnet4") != 0 && strcmp(network, "signet") != 0 &&
+        strcmp(network, "mainnet") != 0 && strcmp(network, "bitcoin") != 0) {
+        fprintf(stderr, "Error: unknown --network '%s' (expected regtest|testnet|"
+                "testnet4|signet|mainnet).\n", network);
+        return 1;
+    }
     if (strcmp(network, "mainnet") == 0) {
         for (int ci = 1; ci < argc; ci++) {
             if (strncmp(argv[ci], "--cheat-", 8) == 0 ||
@@ -2399,7 +2409,9 @@ int main(int argc, char *argv[]) {
             for (char **e = environ; e && *e; e++) {
                 if (strncmp(*e, "SS_CHEAT", 8) == 0 ||
                     strncmp(*e, "SS_KILL", 7) == 0 ||
-                    strncmp(*e, "SUPERSCALAR_CRASH_AT", 20) == 0) {
+                    /* G1 (gap-scan): prefix, not exact, so SUPERSCALAR_CRASH_ALLOW
+                       (gates peer-sent MSG_FORCE_OUT/MSG_ROTATE) is caught too. */
+                    strncmp(*e, "SUPERSCALAR_CRASH", 17) == 0) {
                     fprintf(stderr, "Error: test/cheat env var (%.40s) is refused "
                             "on mainnet.\n", *e);
                     return 1;


### PR DESCRIPTION
Four-lens adversarial gap-scan of `main` (fund-safety, watchtower completeness, mainnet-safety, recent-PR correctness). Every finding verified against the code before acting. **No direct-theft/key-leak/fund-theft gap.** This PR lands the clean, validated fixes; deterrent/completeness follow-ups are documented in `docs/gap-scan-findings-2026-07.md`.

## Fixed
- **HIGH (fund-safety robustness) — client now verifies the LSP factory tree signatures.** `client_apply_factory_ready` accepted the tree with `is_signed=1` and no check; `factory_verify_all` (secret-free) was never called client-side. A buggy/malicious LSP could ship an invalid tree → client uses the channel, then cannot self-exit (force-close rejected on-chain) = frozen funds (freeze/ransom, not theft). Client now calls `factory_verify_all` and refuses on failure at all 3 callers. Enforces the documented "unilateral self-exit always available" invariant.
- **BUG — L-stock advance not anchor-aware.** `update_l_stock_for_leaf`/`update_l_stock_outputs` wrote the L-stock SPK into `outputs[n_outputs-1]` = the P2A anchor when `use_tree_anchor` is on (same class as #98). Corrupted the CPFP anchor + froze the L-stock hashlock on advance. Fixed with the anchor-aware index.
- **G3 (MED) — seal `local_pcs`.** Per-commitment secrets (a channel-security secret, mis-grouped with the v0.3 payment-privacy deferral) now sealed at rest (writer/reader + SECRET_COLS, auto-migrates).
- **G1/G2/G5 (LOW) — mainnet guards.** LSP env-refusal broadened to `SUPERSCALAR_CRASH` prefix (catches `_ALLOW`); client mirrors the env-refusal (was args-only); unknown `--network` rejected (was defaulting to the mainnet RPC port with guards silent).

## Validation
Build clean; units 1516/1516; regression 19/19; crash matrix 20/20 (base). Client-side tree-verify passes on 319 valid factories with zero false-positive refusals.

## Documented follow-ups (not tag-blocking; deterrent/completeness, not fund-safety)
See `docs/gap-scan-findings-2026-07.md`: Tier-B rollover poison-arming dead code (`had_old` always false — a snapshot-before-rebuild restructure); leaf L-stock poison as a second wt_db watch (the leaf chain[N] already re-asserts client balances standalone); plus WT force-close/fee-bump nuances and client-side LOWs.