### PR TITLE
WT F2: mirror leaf L-stock poison to wt_db (secret-less standalone WT fires chain[N] + poison)

### DIFF
--- a/docs/gap-scan-findings-2026-07.md
+++ b/docs/gap-scan-findings-2026-07.md
@@ -36,11 +36,21 @@ key-leak, or fund-theft gap.** One HIGH *robustness* gap + one real bug were fou
   inert. **Not principal loss** — client channel funds are PD-penalty-covered independently;
   this only affects the *deterrent* (burn/redistribute the LSP's own L-stock) for the
   epoch-boundary state, and the DW timelock override still applies. Distinct from the
-  leaf-advance poison, which IS armed + proven firing (#37, on-chain). **Fix approach**
-  (`docs/cl4-rollover-remediation-plan.md`): snapshot each affected node's old signed_tx +
-  txid BEFORE `build_all_unsigned_txs` (factory.c:569) overwrites them, and add a fail-closed
-  abort mirroring the in-epoch leaf advance (lsp_channels.c:1840). Non-trivial restructure;
-  do with a targeted Tier-B-boundary regression.
+  leaf-advance poison, which IS armed + proven firing (#37, on-chain). **Fix spec (traced
+  end-to-end):** the bug is deeper than the `had_old` gate — the entire per-affected-node
+  snapshot at lsp_channels.c:2223-2243 reads the ALREADY-REBUILT node (txid @2225, L-stock
+  amount @2233, chain amount/SPK @2237-2243), because `factory_advance_*` calls
+  `update_l_stock_outputs` (rewrites the L-stock SPK) then `build_all_unsigned_txs`
+  (overwrites `node->txid`, factory.c:569) BEFORE the caller `lsp_run_state_advance_stateless`
+  runs. So a valid poison spending the OLD L-stock output cannot be assembled from what's
+  left. Fix = have factory.c snapshot each node's old {txid, L-stock vout+amount+SPK, chain
+  amount+SPK} into `prev_epoch_*` fields BEFORE `update_l_stock_outputs`/`build_all_unsigned_txs`
+  overwrite them, at ALL FOUR advance paths (factory.c:2546/2593/2617/2699), then have the
+  ceremony read `prev_epoch_*` (mirrors how the leaf path snapshots pre-advance at
+  lsp_channels.c:1382-1418); add a fail-closed abort like the leaf advance (lsp_channels.c:1840).
+  A careful core-rollover restructure (high blast radius, 4 paths) needing a NEW Tier-B-boundary
+  poison regression (the existing rollover test exercises the leaf poison, not the epoch
+  boundary). Deferred as a focused follow-up rather than rushed — deterrent-only, not fund-safety.
 - **MED — leaf/factory-node L-stock poison not mirrored to wt.db.** `lsp_channels.c:1924/2715/3366`
   mirror only `signed_tx` (chain[N]) as the factory-node response, not the co-signed poison.
   **Deeper analysis (corrects an earlier "just mirror sub-factory" read):** unlike the

--- a/docs/gap-scan-findings-2026-07.md
+++ b/docs/gap-scan-findings-2026-07.md
@@ -51,20 +51,22 @@ key-leak, or fund-theft gap.** One HIGH *robustness* gap + one real bug were fou
   A careful core-rollover restructure (high blast radius, 4 paths) needing a NEW Tier-B-boundary
   poison regression (the existing rollover test exercises the leaf poison, not the epoch
   boundary). Deferred as a focused follow-up rather than rushed — deterrent-only, not fund-safety.
-- **MED — leaf/factory-node L-stock poison not mirrored to wt.db.** `lsp_channels.c:1924/2715/3366`
-  mirror only `signed_tx` (chain[N]) as the factory-node response, not the co-signed poison.
-  **Deeper analysis (corrects an earlier "just mirror sub-factory" read):** unlike the
-  sub-factory — where chain[N] orphans `-25` once the breach confirms, so the poison *replaces*
-  it (`:4199`) — the **leaf's chain[N] is a VALID post-confirmation response**: it spends
-  `old_leaf_txid` directly and re-asserts the client channel balances (≥90% value, proven by
-  `test_regtest_cheat_daemon_leaf.sh`). So the client's **primary fund-recourse already works
-  standalone** via chain[N]; the L-stock poison is a *secondary deterrent* (redistribute the
-  LSP's over-claimed L-stock) that spends a DIFFERENT vout of `old_leaf_txid`. **Fix approach:**
-  register a SECOND wt_db watch for the poison (same parent `old_leaf_txid`, response =
-  `node->poison_signed_tx`, `response_txid = node->poison_txid`; the leaf node carries all three,
-  factory.h:177-182) — NOT a swap. The hydrating WT fires all rows sharing a parent txid, so
-  both chain[N] and the poison broadcast on breach (different vouts, no conflict). Needs a
-  standalone-WT-fires-leaf-poison regression to prove. Not fund-safety (chain[N] covers balances).
+- **MED — leaf L-stock poison not mirrored to wt.db — LEAF-ADVANCE FIXED + PROVEN (branch gapscan-meds).**
+  `lsp_channels.c:1924` (leaf-advance) mirrored only `signed_tx` (chain[N]), not the co-signed
+  poison. Unlike the sub-factory (chain[N] orphans `-25`, so the poison *replaces* it `:4199`),
+  the leaf's chain[N] is a VALID post-confirmation response that re-asserts client balances
+  (≥90%), so the poison is a *secondary deterrent* spending a DIFFERENT vout of `old_leaf_txid`.
+  **Fix (proven):** register the poison as a SECOND wt_db factory-node watch on the same parent
+  (leaf node carries `poison_signed_tx`/`poison_is_signed`/`poison_txid`, factory.h:177-182);
+  `wt_watches` has an AUTOINCREMENT PK and the hydrating WT fires every row sharing a parent, so
+  both broadcast. VALIDATED e2e: `test_regtest_cheat_daemon_leaf.sh` asserts the secret-less
+  standalone WT confirms BOTH chain[N] AND the poison (2 responses from wt.db alone). CAVEAT: the
+  cheat tests read BUILD_DIR from `$1` (default ASan `build/`) — validate with `build-release`
+  as `$1` or rebuild `build/`, else you test a stale binary (feedback_cheat_test_build_dir).
+  **Realloc variant (:3366) REVERTED — code-ready follow-up:** identical pattern, but no suite
+  test has BOTH `--wt-db` AND a prepared realloc poison (cheat_realloc has the poison, no
+  `--wt-db`; watchtower_trustless has `--wt-db`, no realloc poison), so it can't be e2e-validated
+  now. Follow-up: add `--wt-db` + standalone WT to cheat_realloc, then re-apply the 2nd-watch mirror.
 - **LOW — WT completeness nuances.** (F4) force-close kind=3 is armed reactively (on a peer's
   BOLT ERROR), so a *pre-suppressed* LSP leaves no kind=3 row — pre-emptive arming would close
   it. (F5) `fee_bump_*` metadata is inert in every wt_db row; the WT only CPFPs if the

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3415,30 +3415,6 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                         "realloc node %zu\n", node_idx);
             }
         }
-
-        /* WT F2 (gap-scan): also mirror the realloc L-stock POISON as a 2nd wt_db
-           watch on the same parent (mirror the leaf-advance fix ~line 1950). chain[N]
-           above re-asserts client balances; the poison redistributes the LSP's
-           over-claimed L-stock. Second row on the same parent -> the hydrating
-           standalone WT fires both from wt.db alone. */
-        if (lsp && lsp->wt_db && realloc_had_signed && realloc_old_chain_spk_len > 0 &&
-            poison_data && poison_len > 0) {
-            int64_t p_watch_id = lsp_wt_register_factory_node_watch(
-                lsp->wt_db, (uint32_t)node_idx, realloc_old_leaf_txid,
-                /* parent_vout      */ 0,
-                /* parent_value_sat */ realloc_old_chain_amount,
-                realloc_old_chain_spk, realloc_old_chain_spk_len,
-                /* csv_delay        */ realloc_old_csv_delay,
-                poison_data, poison_len, node->poison_txid,
-                /* fee_bump_budget  */ 0,
-                /* fee_bump_dline   */ 0);
-            if (p_watch_id > 0)
-                printf("LSP-WT-TRUSTLESS: registered realloc POISON watch_id=%lld "
-                       "for node %zu\n", (long long)p_watch_id, node_idx);
-            else
-                fprintf(stderr, "LSP-WT-TRUSTLESS: WARN — wt_db POISON register "
-                        "failed for realloc node %zu\n", node_idx);
-        }
     }
 
     /* Step 12: Update channel amounts in lsp_channel_entry_t.

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1947,6 +1947,34 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             }
         }
 
+        /* WT F2 (gap-scan): also register the co-signed L-stock POISON as a SECOND
+           wt_db watch on the same breach parent (old_leaf_txid). Unlike the
+           sub-factory (where chain[N] orphans -25 so the poison REPLACES it), the
+           leaf's chain[N] above is a VALID post-confirmation response that re-asserts
+           client balances; the poison is a SECONDARY deterrent spending a DIFFERENT
+           vout of old_leaf_txid (the LSP's over-claimed L-stock). wt_watches has an
+           AUTOINCREMENT PK (no unique-parent constraint) and the hydrating standalone
+           WT fires every row sharing a parent txid, so both broadcast on breach. */
+        if (lsp && lsp->wt_db && had_old_signed && old_chain_spk_len > 0 &&
+            poison_data && poison_len > 0) {
+            int64_t p_watch_id = lsp_wt_register_factory_node_watch(
+                lsp->wt_db, (uint32_t)node_idx, old_leaf_txid,
+                /* parent_vout      */ 0,
+                /* parent_value_sat */ old_chain_amount,
+                old_chain_spk, old_chain_spk_len,
+                /* csv_delay        */ old_csv_delay,
+                poison_data, poison_len, node->poison_txid,
+                /* fee_bump_budget  */ 0,
+                /* fee_bump_dline   */ 0);
+            if (p_watch_id > 0)
+                printf("LSP-WT-TRUSTLESS: registered leaf-advance POISON "
+                       "watch_id=%lld for node %d\n",
+                       (long long)p_watch_id, (int)node_idx);
+            else
+                fprintf(stderr, "LSP-WT-TRUSTLESS: WARN — wt_db POISON register "
+                        "failed for leaf-advance node %d\n", (int)node_idx);
+        }
+
         /* Snapshot poison bytes for Step 11 persist before reset frees them. */
         if (poison_data && poison_len > 0) {
             poison_snapshot = malloc(poison_len);

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3415,6 +3415,30 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                         "realloc node %zu\n", node_idx);
             }
         }
+
+        /* WT F2 (gap-scan): also mirror the realloc L-stock POISON as a 2nd wt_db
+           watch on the same parent (mirror the leaf-advance fix ~line 1950). chain[N]
+           above re-asserts client balances; the poison redistributes the LSP's
+           over-claimed L-stock. Second row on the same parent -> the hydrating
+           standalone WT fires both from wt.db alone. */
+        if (lsp && lsp->wt_db && realloc_had_signed && realloc_old_chain_spk_len > 0 &&
+            poison_data && poison_len > 0) {
+            int64_t p_watch_id = lsp_wt_register_factory_node_watch(
+                lsp->wt_db, (uint32_t)node_idx, realloc_old_leaf_txid,
+                /* parent_vout      */ 0,
+                /* parent_value_sat */ realloc_old_chain_amount,
+                realloc_old_chain_spk, realloc_old_chain_spk_len,
+                /* csv_delay        */ realloc_old_csv_delay,
+                poison_data, poison_len, node->poison_txid,
+                /* fee_bump_budget  */ 0,
+                /* fee_bump_dline   */ 0);
+            if (p_watch_id > 0)
+                printf("LSP-WT-TRUSTLESS: registered realloc POISON watch_id=%lld "
+                       "for node %zu\n", (long long)p_watch_id, node_idx);
+            else
+                fprintf(stderr, "LSP-WT-TRUSTLESS: WARN — wt_db POISON register "
+                        "failed for realloc node %zu\n", node_idx);
+        }
     }
 
     /* Step 12: Update channel amounts in lsp_channel_entry_t.

--- a/tools/test_regtest_cheat_daemon_leaf.sh
+++ b/tools/test_regtest_cheat_daemon_leaf.sh
@@ -303,6 +303,19 @@ if [ "$WT_FIRED" -eq 1 ]; then
     [ "${PSATS:-0}" -ge 1000 ] || { echo "  FAIL: WT response output ${PSATS} sats <= dust — not a real recapture"; exit 1; }
     A2=$(pen_recovers_most "$PEN_TXID"); echo "  A-2 recovery ratio: $A2 (OK=outputs>=90% of swept inputs)"
     case "$A2" in LOW*) echo "  FAIL: WT response recovers <90% of swept value ($A2) — value leaked/burned"; exit 1;; esac
+    # WT F2 (gap-scan): the standalone WT must now fire BOTH chain[N] (re-assert client
+    # balances) AND the co-signed L-stock POISON (redistribute the LSP over-claim) from
+    # wt.db ALONE. Pre-fix only chain[N] was mirrored, so the "+ poison" in this test's
+    # header was aspirational. Assert >=2 DISTINCT WT-broadcast responses confirm on-chain
+    # (the delta from the historical single response is precisely the mirrored poison).
+    F2_RESP=$(grep -aiE "broadcast" "$WT_LOG" 2>/dev/null | grep -aoiE "[0-9a-f]{64}" | sort -u)
+    F2_NCONF=0
+    for tx in $F2_RESP; do
+        $BCLI getrawtransaction "$tx" true 2>/dev/null | grep -q '"confirmations"' && F2_NCONF=$((F2_NCONF+1))
+    done
+    echo "  WT F2: $F2_NCONF distinct WT responses confirmed on-chain (want >=2: chain[N] + L-stock poison)"
+    [ "${F2_NCONF:-0}" -ge 2 ] || { echo "  FAIL: WT F2 — standalone WT fired <2 confirmed responses; the leaf L-stock poison did not fire from wt.db (secret-less)"; exit 1; }
+    echo "  WT F2 PASS: standalone WT fired chain[N] + L-stock poison ($F2_NCONF confirmed) from wt.db alone"
     # Tier-4 reorg-robustness (opt-in: SS_REORG_REFIRE=1, #95-b): orphan the WT's
     # leaf-poison/response block and verify it RE-confirms. The standalone WT (WT_PID)
     # is still polling — watchtower_on_reorg re-arms + Core returns the tx to mempool —


### PR DESCRIPTION
Follow-up to the gap-scan (#434) closing the tractable, e2e-provable half of the WT-F2 MED.

## Fixed + PROVEN
The leaf-advance factory-node mirror (`lsp_channels.c:1924`) registered only chain[N] as the trustless wt_db response. Unlike the sub-factory (where chain[N] orphans -25 so the poison replaces it), the leaf chain[N] is a valid post-confirmation response that re-asserts client balances — so the L-stock poison is a **secondary deterrent** (redistributes the LSP over-claim, spends a different vout of `old_leaf_txid`). Now registered as a **second** wt_db watch on the same parent (leaf node carries `poison_signed_tx`/`poison_is_signed`/`poison_txid`; `wt_watches` has an AUTOINCREMENT PK and the hydrating WT fires every row sharing a parent).

**Validated e2e:** `test_regtest_cheat_daemon_leaf.sh` now asserts the secret-less standalone WT confirms **BOTH** chain[N] AND the L-stock poison — 2 responses on-chain from `wt.db` alone (was 1). Regression 18/19 on the correctly-rebuilt binary (the 1 fail is the known `watchtower_trustless` db-lock/OOM flake, confirmed unrelated — my code logged 0 times there).

## Not fund-safety
The client's principal is covered by chain[N] regardless; this extends the "run your own WT" story to the L-stock deterrent leg.

## Deferred follow-ups (documented in `docs/gap-scan-findings-2026-07.md`)
- **Realloc variant** (`:3366`): identical pattern, but no suite test has both `--wt-db` and a prepared realloc poison — reverted rather than ship unvalidated. Follow-up: add `--wt-db` + standalone WT to `cheat_realloc`, then re-apply the trivial mirror.
- **Tier-B poison-arming dead code**: a deterrent-only core-rollover snapshot restructure across 4 advance paths — full end-to-end fix spec in the findings doc.

## Note
The cheat tests read BUILD_DIR from positional `$1` (default ASan `build/`), NOT env — validate with `build-release` as `$1` or rebuild `build/`, else a stale binary silently no-ops the fix (this caused a wrong-binary false-negative mid-review).