### PR TITLE
Gap-scan regression tests: anchor-fix guard + tree-verify efficacy (both proven)

### DIFF
--- a/src/lsp.c
+++ b/src/lsp.c
@@ -870,6 +870,24 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
         fprintf(stderr, "LSP-stateless: dist co-sign incomplete -- FACTORY_READY "
                 "omits the signed distribution TX (offline-recovery degraded)\n");
 
+    /* Gap-scan efficacy cheat (mainnet-inert): simulate a malicious/buggy LSP shipping
+       an INVALID tree.  The LSP's own Phase-B factory_verify_all (above) already passed,
+       so this is a genuinely bad FACTORY_READY the honest path would never emit.  Proves
+       the client's own factory_verify_all REFUSES it (the HIGH gap-scan fix -- without
+       that fix the client would accept an unverifiable tree and be unable to self-exit).
+       Gated by superscalar_cheat_allowed() (regtest-only) + the env knob. */
+    if (superscalar_cheat_allowed() && getenv("SS_CHEAT_BAD_TREE_SIG")) {
+        for (size_t ni = 0; ni < f->n_nodes; ni++) {
+            factory_node_t *bn = &f->nodes[ni];
+            if (bn->parent_index < 0) continue;                    /* skip root */
+            if (!bn->is_signed || bn->signed_tx.len < 70) continue;
+            bn->signed_tx.data[bn->signed_tx.len - 68] ^= 0x01;    /* corrupt the 64-byte agg sig */
+            fprintf(stderr, "SS_CHEAT_BAD_TREE_SIG: corrupted node %zu aggregate sig in "
+                            "FACTORY_READY (client MUST refuse)\n", ni);
+            break;
+        }
+    }
+
     {
         cJSON *ready = wire_build_factory_ready(f);
         for (size_t i = 0; i < lsp->n_clients; i++) {

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6765,6 +6765,17 @@ int test_factory_anchor_lstock_advance(void) {
     size_t m = leaf->n_outputs;
     TEST_ASSERT(m >= 3, "leaf still has >=3 outputs after advance");
 
+    printf("  DBG anchor_lstock: n=%zu m=%zu ctr %llu->%llu | anchor[m-1] len=%u spk=%02x%02x%02x%02x"
+           " | lstock[m-2] spk=%02x%02x%02x%02x changed=%d\n",
+           n, m, (unsigned long long)counter_before,
+           (unsigned long long)leaf->l_stock_state_counter,
+           (unsigned)leaf->outputs[m-1].script_pubkey_len,
+           leaf->outputs[m-1].script_pubkey[0], leaf->outputs[m-1].script_pubkey[1],
+           leaf->outputs[m-1].script_pubkey[2], leaf->outputs[m-1].script_pubkey[3],
+           leaf->outputs[m-2].script_pubkey[0], leaf->outputs[m-2].script_pubkey[1],
+           leaf->outputs[m-2].script_pubkey[2], leaf->outputs[m-2].script_pubkey[3],
+           memcmp(leaf->outputs[m-2].script_pubkey, lstock_spk_before, 34) != 0);
+
     /* (a) The anchor (last output) STAYS the canonical P2A anchor -- the bug
        overwrote its 4-byte SPK with 34 bytes of L-stock SPK (len frozen at 4). */
     TEST_ASSERT(leaf->outputs[m-1].script_pubkey_len == P2A_SPK_LEN,

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6719,6 +6719,74 @@ int test_regtest_lstock_poison_ceremony(void) {
     return 1;
 }
 
+/* Anchor-fix regression (gap-scan 2026-07): a leaf advance with use_tree_anchor +
+   hashlock must rebuild the REAL L-stock output (second-to-last), NOT the P2A anchor
+   (last).  Guards the #98-class off-by-one in update_l_stock_for_leaf (factory.c) +
+   update_l_stock_outputs -- the bug wrote the L-stock SPK into outputs[n_outputs-1]
+   (the 240-sat P2A anchor), corrupting the CPFP anchor AND freezing the L-stock
+   hashlock (never rebuilt while l_stock_state_counter bumped).  It was symmetric
+   (LSP+client advance in lockstep) so invisible to conservation/poison-fires tests;
+   this asserts the observable invariant directly. */
+int test_factory_anchor_lstock_advance(void) {
+    secp256k1_context *ctx = test_ctx();
+    secp256k1_keypair kps[3];
+    factory_t *f = calloc(1, sizeof(factory_t));
+    TEST_ASSERT(f, "alloc factory");
+
+    uint8_t arities[1] = {2};
+    TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 3, arities, 1, 5000000),
+                "setup n3 {2}");
+    f->use_tree_anchor = 1;   /* #56 P2A CPFP anchors (production default) */
+    unsigned char seed[32];
+    for (int i = 0; i < 32; i++) seed[i] = (unsigned char)(0x5A ^ i);
+    factory_set_shachain_seed(f, seed);
+    TEST_ASSERT(factory_enable_hashlock_poison(f), "enable hashlock poison");
+    TEST_ASSERT(factory_build_tree(f), "build tree");
+    TEST_ASSERT(factory_sign_all(f), "sign all");
+
+    factory_node_t *leaf = &f->nodes[f->leaf_node_indices[0]];
+    size_t n = leaf->n_outputs;
+    TEST_ASSERT(n >= 3, "anchored+hashlock leaf has >=3 outputs (chan + L-stock + anchor)");
+
+    /* Precondition: the anchor must be the LAST output, else the bug is unreachable
+       and this test would be vacuous. */
+    TEST_ASSERT(leaf->outputs[n-1].script_pubkey_len == P2A_SPK_LEN &&
+                memcmp(leaf->outputs[n-1].script_pubkey, P2A_SPK, P2A_SPK_LEN) == 0,
+                "leaf last output IS the P2A anchor (precondition)");
+    TEST_ASSERT(leaf->has_l_stock_hash, "leaf has an L-stock hashlock to advance");
+
+    unsigned char lstock_spk_before[34];
+    memcpy(lstock_spk_before, leaf->outputs[n-2].script_pubkey, 34);
+    uint64_t counter_before = leaf->l_stock_state_counter;
+
+    /* Advance -> update_l_stock_for_leaf/_outputs rebuilds the L-stock hashlock. */
+    TEST_ASSERT(factory_advance_leaf(f, 0), "advance leaf 0");
+    leaf = &f->nodes[f->leaf_node_indices[0]];  /* re-fetch (nodes may move) */
+    size_t m = leaf->n_outputs;
+    TEST_ASSERT(m >= 3, "leaf still has >=3 outputs after advance");
+
+    /* (a) The anchor (last output) STAYS the canonical P2A anchor -- the bug
+       overwrote its 4-byte SPK with 34 bytes of L-stock SPK (len frozen at 4). */
+    TEST_ASSERT(leaf->outputs[m-1].script_pubkey_len == P2A_SPK_LEN,
+                "anchor SPK len stayed 4 after advance");
+    TEST_ASSERT(memcmp(leaf->outputs[m-1].script_pubkey, P2A_SPK, P2A_SPK_LEN) == 0,
+                "anchor SPK stayed canonical (51 02 4e 73), NOT overwritten by L-stock");
+    TEST_ASSERT(leaf->outputs[m-1].amount_sats == ANCHOR_OUTPUT_AMOUNT,
+                "anchor amount stayed 240 sats");
+
+    /* (b) The real L-stock (second-to-last) ADVANCED: counter bumped + SPK re-committed
+       to the new hashlock.  Without the fix it was frozen (the write hit the anchor). */
+    TEST_ASSERT(leaf->l_stock_state_counter == counter_before + 1,
+                "l_stock_state_counter bumped by the advance");
+    TEST_ASSERT(memcmp(leaf->outputs[m-2].script_pubkey, lstock_spk_before, 34) != 0,
+                "real L-stock SPK advanced (hashlock re-committed to new state)");
+
+    factory_free(f);
+    secp256k1_context_destroy(ctx);
+    free(f);
+    return 1;
+}
+
 /* #53-B3b CONSENSUS PROOF (old-hash targeting): after a leaf advances to H_new, a
    poison built for the SUPERSEDED state (override_hash32 = H_old) must spend the OLD
    state's output validly — even though the node's current hash is now H_new.  This is

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -6765,17 +6765,6 @@ int test_factory_anchor_lstock_advance(void) {
     size_t m = leaf->n_outputs;
     TEST_ASSERT(m >= 3, "leaf still has >=3 outputs after advance");
 
-    printf("  DBG anchor_lstock: n=%zu m=%zu ctr %llu->%llu | anchor[m-1] len=%u spk=%02x%02x%02x%02x"
-           " | lstock[m-2] spk=%02x%02x%02x%02x changed=%d\n",
-           n, m, (unsigned long long)counter_before,
-           (unsigned long long)leaf->l_stock_state_counter,
-           (unsigned)leaf->outputs[m-1].script_pubkey_len,
-           leaf->outputs[m-1].script_pubkey[0], leaf->outputs[m-1].script_pubkey[1],
-           leaf->outputs[m-1].script_pubkey[2], leaf->outputs[m-1].script_pubkey[3],
-           leaf->outputs[m-2].script_pubkey[0], leaf->outputs[m-2].script_pubkey[1],
-           leaf->outputs[m-2].script_pubkey[2], leaf->outputs[m-2].script_pubkey[3],
-           memcmp(leaf->outputs[m-2].script_pubkey, lstock_spk_before, 34) != 0);
-
     /* (a) The anchor (last output) STAYS the canonical P2A anchor -- the bug
        overwrote its 4-byte SPK with 34 bytes of L-stock SPK (len frozen at 4). */
     TEST_ASSERT(leaf->outputs[m-1].script_pubkey_len == P2A_SPK_LEN,

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1042,6 +1042,7 @@ extern int test_regtest_burn_tx(void);
 extern int test_regtest_lstock_hashlock_poison(void);
 extern int test_regtest_lstock_poison_ceremony(void);
 extern int test_regtest_lstock_poison_old_state(void);
+extern int test_factory_anchor_lstock_advance(void);  /* anchor-fix regression (gap-scan) */
 
 extern int test_channel_key_derivation(void);
 extern int test_channel_commitment_tx(void);
@@ -3932,6 +3933,7 @@ static void run_regtest_tests(void) {
     RUN_TEST(test_regtest_lstock_hashlock_poison);
     RUN_TEST(test_regtest_lstock_poison_ceremony);
     RUN_TEST(test_regtest_lstock_poison_old_state);
+    RUN_TEST(test_factory_anchor_lstock_advance);  /* anchor-fix regression (gap-scan) */
     RUN_TEST(test_regtest_channel_unilateral);
     RUN_TEST(test_regtest_channel_penalty);
     RUN_TEST(test_regtest_htlc_success);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -3009,6 +3009,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_factory_l_stock_with_burn_path);
     RUN_TEST(test_factory_burn_tx_construction);
     RUN_TEST(test_factory_advance_with_shachain);
+    RUN_TEST(test_factory_anchor_lstock_advance);  /* anchor-fix regression (gap-scan) */
 
     printf("\n=== Channel (Poon-Dryja) ===\n");
     RUN_TEST(test_channel_key_derivation);
@@ -3933,7 +3934,6 @@ static void run_regtest_tests(void) {
     RUN_TEST(test_regtest_lstock_hashlock_poison);
     RUN_TEST(test_regtest_lstock_poison_ceremony);
     RUN_TEST(test_regtest_lstock_poison_old_state);
-    RUN_TEST(test_factory_anchor_lstock_advance);  /* anchor-fix regression (gap-scan) */
     RUN_TEST(test_regtest_channel_unilateral);
     RUN_TEST(test_regtest_channel_penalty);
     RUN_TEST(test_regtest_htlc_success);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -5430,6 +5430,25 @@ int test_persist_secret_columns_sealed(void) {
         TEST_ASSERT(persist_load_anchor_key(&db, gak), "load anchor key");
         TEST_ASSERT(memcmp(gak, ak, 32) == 0, "anchor key round-trip");
     }
+
+    /* G3 (gap-scan): local_pcs.secret (per-commitment secret) -- seal-on-write ->
+       sealed on disk -> accessor round-trip. */
+    {
+        unsigned char lp[32]; for (int i = 0; i < 32; i++) lp[i] = (unsigned char)(0xA0 + i);
+        TEST_ASSERT(persist_save_local_pcs(&db, 4, 6, lp), "save local_pcs");
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(db.db,
+            "SELECT secret FROM local_pcs WHERE channel_id=4 AND commit_num=6;",
+            -1, &st, NULL) == SQLITE_OK, "prep lp");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "lp row");
+        const char *v = (const char *)sqlite3_column_text(st, 0);
+        TEST_ASSERT(v && strncmp(v, "ssenc1:", 7) == 0, "local_pcs.secret sealed on write");
+        sqlite3_finalize(st);
+        unsigned char lpgot[8][32]; size_t lpn = 0; memset(lpgot, 0, sizeof lpgot);
+        TEST_ASSERT(persist_load_local_pcs(&db, 4, lpgot, 8, &lpn), "load local_pcs");
+        TEST_ASSERT(memcmp(lpgot[6], lp, 32) == 0, "local_pcs round-trip");
+    }
+
     persist_close(&db);
     unlink(path);
 
@@ -5481,6 +5500,16 @@ int test_persist_secret_columns_sealed(void) {
         snprintf(dins, sizeof dins,
             "INSERT INTO departed_clients(factory_id,client_idx,extracted_key) VALUES(22,1,'%s');", dmh);
         TEST_ASSERT(sqlite3_exec(kdb.db, dins, NULL, NULL, NULL) == SQLITE_OK, "insert departed plaintext");
+    }
+
+    /* G3 (gap-scan): a legacy plaintext local_pcs.secret to migrate (rowid+text path). */
+    unsigned char lpm[32]; for (int i = 0; i < 32; i++) lpm[i] = (unsigned char)(0x80 + i);
+    {
+        char lph[65]; hex_encode(lpm, 32, lph);
+        char lpins[200];
+        snprintf(lpins, sizeof lpins,
+            "INSERT INTO local_pcs(channel_id,commit_num,secret) VALUES(9,2,'%s');", lph);
+        TEST_ASSERT(sqlite3_exec(kdb.db, lpins, NULL, NULL, NULL) == SQLITE_OK, "insert local_pcs plaintext");
     }
     persist_close(&kdb);
 
@@ -5537,6 +5566,20 @@ int test_persist_secret_columns_sealed(void) {
         int dep[8] = {0}; unsigned char gk[8][32];
         TEST_ASSERT(persist_load_departed_clients(&kdb2, 22, dep, gk, 8) >= 1, "load departed migrated");
         TEST_ASSERT(dep[1] && memcmp(gk[1], dm, 32) == 0, "departed migrated round-trip");
+    }
+    /* G3 (gap-scan): legacy plaintext local_pcs sealed by migration + round-trip */
+    {
+        sqlite3_stmt *st = NULL;
+        TEST_ASSERT(sqlite3_prepare_v2(kdb2.db,
+            "SELECT secret FROM local_pcs WHERE channel_id=9 AND commit_num=2;",
+            -1, &st, NULL) == SQLITE_OK, "prep lp-mig");
+        TEST_ASSERT(sqlite3_step(st) == SQLITE_ROW, "lp-mig row");
+        const char *v = (const char *)sqlite3_column_text(st, 0);
+        TEST_ASSERT(v && strncmp(v, "ssenc1:", 7) == 0, "local_pcs sealed by migration");
+        sqlite3_finalize(st);
+        unsigned char lpg[8][32]; size_t lpc = 0; memset(lpg, 0, sizeof lpg);
+        TEST_ASSERT(persist_load_local_pcs(&kdb2, 9, lpg, 8, &lpc), "load migrated local_pcs");
+        TEST_ASSERT(memcmp(lpg[2], lpm, 32) == 0, "migrated local_pcs round-trip");
     }
     persist_close(&kdb2);
     unlink(path2);

--- a/tools/regtest_full_regression_v020.sh
+++ b/tools/regtest_full_regression_v020.sh
@@ -21,6 +21,9 @@ RUNNERS=(
     test_regtest_tier_b_rollover_ps.sh
     test_regtest_cheat_daemon_subfactory.sh
 
+    # Gap-scan efficacy: client refuses a malicious LSP's invalid factory tree
+    test_regtest_bad_tree_verify.sh
+
     # Sub-factory + Tier B (additional)
     test_regtest_subfactory_chain_advance_multi.sh
     test_regtest_k2_subfactory_breach.sh

--- a/tools/test_regtest_bad_tree_verify.sh
+++ b/tools/test_regtest_bad_tree_verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# test_regtest_bad_tree_verify.sh — gap-scan EFFICACY test: a client REFUSES a
+# malicious/buggy LSP that ships an INVALID factory tree in FACTORY_READY.
+#
+# The HIGH gap-scan fix made the client call factory_verify_all on the tree it
+# receives (client_apply_factory_ready) and REFUSE on failure.  SAFETY (valid trees
+# are not refused) is proven by every green creation test; this proves EFFICACY:
+# with SS_CHEAT_BAD_TREE_SIG the LSP corrupts one node's aggregate signature AFTER its
+# own Phase-B verify, so it ships a genuinely bad tree that the honest path never
+# emits -- the client MUST refuse (without the fix it would accept an unverifiable
+# tree and later be unable to self-exit = frozen funds).
+#
+# PASS: LSP logs "SS_CHEAT_BAD_TREE_SIG: corrupted node" AND >=1 client logs
+#       "REFUSING factory" / "tree failed signature verification".
+set -uo pipefail
+BUILD_DIR="${1:-/root/SuperScalar/build-release}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"; CLIENT_BIN="$BUILD_DIR/superscalar_client"
+N_CLIENTS="${N_CLIENTS:-4}"; LSP_PORT=29983
+FUNDING_SATS=100000
+LSP_SECKEY="0000000000000000000000000000000000000000000000000000000000000001"
+CLIENT_SECKEYS=(
+    "0000000000000000000000000000000000000000000000000000000000000002"
+    "0000000000000000000000000000000000000000000000000000000000000003"
+    "0000000000000000000000000000000000000000000000000000000000000004"
+    "0000000000000000000000000000000000000000000000000000000000000005"
+)
+LSP_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+[ -f "$REGTEST_CONF" ] || REGTEST_CONF="$HOME/bitcoin-regtest/bitcoin.conf"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+TMPDIR=$(mktemp -d /tmp/ss-bad-tree.XXXXXX)
+LSP_DB="$TMPDIR/lsp.db"; LSP_LOG="$TMPDIR/lsp.log"
+MINER_WALLET="ss_cheat_leaf_miner"; PIDS=(); MINE_PID=""
+cleanup(){ [ -n "$MINE_PID" ] && kill -9 "$MINE_PID" 2>/dev/null||true; for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null||true; done; cp "$LSP_LOG" /tmp/bad_tree_lsp.log 2>/dev/null||true; for i in $(seq 0 $((N_CLIENTS-1))); do cp "$TMPDIR/client_${i}.log" "/tmp/bad_tree_client_${i}.log" 2>/dev/null||true; done; rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+green(){ printf '\033[32m%s\033[0m\n' "$*"; }; red(){ printf '\033[31m%s\033[0m\n' "$*"; }; fail(){ red "FAIL: $*"; exit 1; }
+$BCLI -named createwallet wallet_name=$MINER_WALLET load_on_startup=false 2>/dev/null || $BCLI loadwallet $MINER_WALLET 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet=$MINER_WALLET -named getnewaddress address_type=bech32m); $BCLI generatetoaddress 101 "$MINE_ADDR" >/dev/null
+
+echo "=== BAD-TREE efficacy drill (gap-scan): client must REFUSE an invalid factory tree ==="
+SS_CHEAT_BAD_TREE_SIG=1 "$LSP_BIN" --network regtest --port $LSP_PORT --clients $N_CLIENTS --arity 3 \
+    --amount $FUNDING_SATS --fee-rate 1000 --confirm-timeout 600 \
+    --active-blocks 6 --dying-blocks 4 --step-blocks 1 --states-per-layer 2 \
+    --seckey "$LSP_SECKEY" --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} \
+    --wallet $MINER_WALLET --db "$LSP_DB" --demo --lsp-balance-pct 50 \
+    > "$LSP_LOG" 2>&1 &
+LSP_PID=$!; PIDS+=($LSP_PID)
+for i in $(seq 1 60); do sleep 1; grep -q "listening on port $LSP_PORT" "$LSP_LOG" 2>/dev/null && break; kill -0 $LSP_PID 2>/dev/null || { tail -20 "$LSP_LOG"; fail "LSP exited before listening"; }; done
+for i in $(seq 0 $((N_CLIENTS - 1))); do
+    "$CLIENT_BIN" --network regtest --host 127.0.0.1 --port $LSP_PORT --seckey "${CLIENT_SECKEYS[$i]}" \
+        --fee-rate 1000 --lsp-pubkey "$LSP_PUBKEY" --participant-id $((i + 1)) --daemon \
+        --rpcuser ${RPCUSER:-rpcuser} --rpcpassword ${RPCPASSWORD:-rpcpass} --wallet $MINER_WALLET \
+        --db "$TMPDIR/client_${i}.db" > "$TMPDIR/client_${i}.log" 2>&1 &
+    PIDS+=($!); sleep 0.5
+done
+( while kill -0 $LSP_PID 2>/dev/null; do $BCLI generatetoaddress 1 "$MINE_ADDR" >/dev/null 2>&1; sleep 2; done ) & MINE_PID=$!
+
+echo "--- Waiting for a client to receive + REFUSE the corrupted FACTORY_READY (timeout 260s) ---"
+REFUSED=0
+for i in $(seq 1 130); do
+    sleep 2
+    if grep -rqiE "REFUSING factory|tree failed signature verification|tree aggregate signatures INVALID" "$TMPDIR"/client_*.log 2>/dev/null; then
+        REFUSED=1; echo "  client refused after ~$((i*2))s"; break
+    fi
+done
+kill -9 $MINE_PID 2>/dev/null || true; MINE_PID=""
+
+echo "=== assertions ==="
+grep -q "SS_CHEAT_BAD_TREE_SIG: corrupted node" "$LSP_LOG" || fail "LSP did not arm the bad-tree cheat (corruption not logged)"
+green "  OK: LSP corrupted a tree node aggregate sig in FACTORY_READY"
+[ "$REFUSED" = 1 ] || { echo "  --- client log tails ---"; for i in $(seq 0 $((N_CLIENTS-1))); do echo "  client $i:"; tail -6 "$TMPDIR/client_${i}.log" 2>/dev/null; done; fail "no client REFUSED the invalid tree -- the HIGH factory_verify_all fix did not fire"; }
+NREF=$(grep -rliE "REFUSING factory|tree failed signature verification|tree aggregate signatures INVALID" "$TMPDIR"/client_*.log 2>/dev/null | wc -l)
+green "  OK: $NREF/$N_CLIENTS clients REFUSED the invalid factory tree (client-side factory_verify_all fired)"
+green "PASS: malicious-LSP bad tree -> client refuses (efficacy proven, not just safety)"
+exit 0

--- a/tools/test_regtest_watchtower_trustless.sh
+++ b/tools/test_regtest_watchtower_trustless.sh
@@ -39,6 +39,10 @@
 set -uo pipefail
 
 BUILD_DIR="${1:-/root/SuperScalar/build-release}"
+# Robust sqlite reads: the LSP holds wt.db/lsp.db during the probe phases, so a plain
+# read intermittently hits "database is locked" (a flake that failed Phase D as a false
+# "no active rows"). Wait for the transient writer lock instead of failing immediately.
+sq() { sqlite3 -cmd "PRAGMA busy_timeout=20000;" "$@"; }
 LSP_BIN="$BUILD_DIR/superscalar_lsp"
 CLIENT_BIN="$BUILD_DIR/superscalar_client"
 WT_BIN="$BUILD_DIR/superscalar_watchtower"
@@ -209,25 +213,25 @@ sleep 2
 # ---------------------------------------------------------------------------
 echo
 echo "--- Phase D: assert wt.db content + trustless invariant ---"
-N_WATCHES=$(sqlite3 "$WT_DB" "SELECT count(*) FROM wt_watches WHERE superseded_at IS NULL;" 2>/dev/null || echo "?")
-N_RESPONSES=$(sqlite3 "$WT_DB" "SELECT count(*) FROM wt_responses;" 2>/dev/null || echo "?")
+N_WATCHES=$(sq "$WT_DB" "SELECT count(*) FROM wt_watches WHERE superseded_at IS NULL;" 2>/dev/null || echo "?")
+N_RESPONSES=$(sq "$WT_DB" "SELECT count(*) FROM wt_responses;" 2>/dev/null || echo "?")
 echo "  wt_watches (active)  : $N_WATCHES  (want >= 1)"
 echo "  wt_responses         : $N_RESPONSES  (want >= 1)"
 if [ "$N_WATCHES" = "?" ] || [ "$N_WATCHES" -lt 1 ]; then
     echo "FAIL: A — no active rows in wt_watches"
-    sqlite3 "$WT_DB" ".tables" 2>&1
+    sq "$WT_DB" ".tables" 2>&1
     exit 1
 fi
 echo "  ✓ A. wt_watches populated"
 
 # Trustless invariant: no secret-like columns in any wt_ table.
-SECRET_HITS=$(sqlite3 "$WT_DB" \
+SECRET_HITS=$(sq "$WT_DB" \
     "SELECT sql FROM sqlite_master WHERE type='table' AND name LIKE 'wt_%';" 2>/dev/null \
     | grep -iE "secret|seckey|private|revocation_secret" | wc -l)
 echo "  secret-like columns  : $SECRET_HITS  (want 0)"
 if [ "$SECRET_HITS" -gt 0 ]; then
     echo "FAIL: B — wt.db schema contains secret-like columns:"
-    sqlite3 "$WT_DB" \
+    sq "$WT_DB" \
         "SELECT sql FROM sqlite_master WHERE type='table' AND name LIKE 'wt_%';" \
         | grep -iE "secret|seckey|private|revocation_secret"
     exit 1
@@ -238,14 +242,14 @@ echo "  ✓ B. trustless invariant holds — no secret columns in wt.db"
 # known revocation_secret from lsp.db (defense-in-depth byte-level check).
 # We do this by extracting all revocation_secret BLOBs from lsp.db, then
 # scanning wt.db's BLOBs for any byte match.
-LSP_SECRETS=$(sqlite3 "$LSP_DB" \
+LSP_SECRETS=$(sq "$LSP_DB" \
     "SELECT hex(revocation_secret) FROM channels WHERE revocation_secret IS NOT NULL UNION SELECT hex(revocation_secret) FROM ceremony_participants WHERE revocation_secret IS NOT NULL;" \
     2>/dev/null | grep -v "^$" | sort -u)
 if [ -n "$LSP_SECRETS" ]; then
     LEAK_COUNT=0
     for secret_hex in $LSP_SECRETS; do
         # Search every BLOB column in every wt_ table for this byte sequence.
-        if sqlite3 "$WT_DB" \
+        if sq "$WT_DB" \
             "SELECT 1 FROM wt_watches WHERE instr(hex(parent_txid), '$secret_hex') > 0 OR instr(hex(parent_spk), '$secret_hex') > 0 LIMIT 1;" \
             2>/dev/null | grep -q 1; then
             LEAK_COUNT=$((LEAK_COUNT + 1))


### PR DESCRIPTION
Closes the two test gaps in the gap-scan fixes (a fix without a regression, a defense without an efficacy test) that I flagged as "not actually done."

## #99 — anchor-fix regression (unit, DIFFERENTIAL-proven)
`test_factory_anchor_lstock_advance`: builds a use_tree_anchor + hashlock factory, advances a leaf, asserts the P2A anchor stays canonical (51 02 4e 73, len 4, 240 sats) AND the real L-stock advanced. Guards the #98-class off-by-one in `update_l_stock_for_leaf`/`update_l_stock_outputs` (PR #434) that the campaign missed because the bug is symmetric (invisible to conservation/poison tests).

**Differential proof:** WITH the fix -> anchor `51024e73`, L-stock `changed=1` (pass). WITHOUT -> anchor `51201e4b` (the L-stock SPK prefix, corrupted), L-stock `changed=0` (frozen) -> FAILs. The test catches the exact bug. Units: 1517/1517.

## #100 — tree-verify EFFICACY (regtest, e2e-proven)
`SS_CHEAT_BAD_TREE_SIG` (lsp.c, gated by `superscalar_cheat_allowed()`, mainnet-inert) corrupts a node's aggregate sig AFTER the LSP's own Phase-B verify, shipping a genuinely invalid tree. `test_regtest_bad_tree_verify.sh` asserts the LSP armed it AND clients refuse.

**Result:** LSP corrupted the tree · **4/4 clients REFUSED** (client-side `factory_verify_all` fired). Proves the HIGH gap-scan fix's efficacy (refuses invalid trees) — safety (valid not refused) was already proven. Added to the v0.2.0 regression gate.

## Note
Both surfaced real process issues caught by rigor, now in memory: the cheat tests take BUILD_DIR from positional `$1` (default ASan `build/`), and a mis-placed RUN_TEST silently kept the unit test out of `--unit` (caught by the 1516-vs-1517 count).