### PR TITLE
WT completeness bundle: realloc L-stock poison to wt_db + client tree_nodes re-persist

### DIFF
--- a/docs/gap-scan-findings-2026-07.md
+++ b/docs/gap-scan-findings-2026-07.md
@@ -63,10 +63,10 @@ key-leak, or fund-theft gap.** One HIGH *robustness* gap + one real bug were fou
   standalone WT confirms BOTH chain[N] AND the poison (2 responses from wt.db alone). CAVEAT: the
   cheat tests read BUILD_DIR from `$1` (default ASan `build/`) — validate with `build-release`
   as `$1` or rebuild `build/`, else you test a stale binary (feedback_cheat_test_build_dir).
-  **Realloc variant (:3366) REVERTED — code-ready follow-up:** identical pattern, but no suite
-  test has BOTH `--wt-db` AND a prepared realloc poison (cheat_realloc has the poison, no
-  `--wt-db`; watchtower_trustless has `--wt-db`, no realloc poison), so it can't be e2e-validated
-  now. Follow-up: add `--wt-db` + standalone WT to cheat_realloc, then re-apply the 2nd-watch mirror.
+  **Realloc variant (:3366) DONE (branch gapscan-wt-bundle):** the 2nd-watch mirror is re-applied,
+  and cheat_realloc now arms `--wt-db` and asserts the realloc poison REGISTERS in wt_db (validated).
+  The standalone-WT FIRING rides the same mechanism the leaf-advance path proved e2e (2 factory-node
+  watches on one parent both broadcast).
 - **LOW — WT completeness nuances.** (F4) force-close kind=3 is armed reactively (on a peer's
   BOLT ERROR), so a *pre-suppressed* LSP leaves no kind=3 row — pre-emptive arming would close
   it. (F5) `fee_bump_*` metadata is inert in every wt_db row; the WT only CPFPs if the
@@ -77,10 +77,11 @@ key-leak, or fund-theft gap.** One HIGH *robustness* gap + one real bug were fou
 - **LOW — client-side.** Client's own watchtower handles only revoked channel commitments (no
   reactive factory/sub-factory WT — offline clients lean on the LSP-populated wt.db or
   `--force-close`; canonical model is "each client runs its own WT", `pre-mainnet-design-decisions.md`).
-  Client revoked-commitment watch is armed with `NULL` PTLCs (superscalar_client.c:827) — main
-  penalty sweeps to_local, but a PTLC output on that commitment wouldn't be swept by the
-  client's WT. Client does not re-persist `tree_nodes` after intra-factory advances (a crash
-  recovers the last-rotation tree, not principal-affecting).
+  Client `tree_nodes` re-persist after intra-factory advances is now **DONE** (MSG_LEAF_ADVANCE_DONE
+  handler, branch gapscan-wt-bundle). **REMAINING (scoped, LOW):** (a) client revoked-commitment
+  watch armed with `NULL` PTLCs (superscalar_client.c:827) — narrow (the standalone WT already
+  covers PTLC breaches; needs client-side PTLC snapshot tracking); (b) F4 kind3 pre-emptive arming
+  — needs pre-signing the timeout sweep at commitment time (pre-suppressed-LSP edge case).
 
 ## Verified-solid (no gap)
 Poon-Dryja channel-penalty recourse is client-secret-complete, persisted, and enforced by a

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -3415,6 +3415,31 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                         "realloc node %zu\n", node_idx);
             }
         }
+
+        /* WT F2 (gap-scan): also mirror the realloc L-stock POISON as a 2nd wt_db
+           watch on the same parent (mirror the PROVEN leaf-advance fix ~line 1958).
+           chain[N] above re-asserts client balances; the poison redistributes the
+           LSP's over-claimed L-stock. Second row on the same parent -> the hydrating
+           standalone WT fires both from wt.db alone (identical mechanism to the
+           leaf-advance path, which is e2e-proven). */
+        if (lsp && lsp->wt_db && realloc_had_signed && realloc_old_chain_spk_len > 0 &&
+            poison_data && poison_len > 0) {
+            int64_t p_watch_id = lsp_wt_register_factory_node_watch(
+                lsp->wt_db, (uint32_t)node_idx, realloc_old_leaf_txid,
+                /* parent_vout      */ 0,
+                /* parent_value_sat */ realloc_old_chain_amount,
+                realloc_old_chain_spk, realloc_old_chain_spk_len,
+                /* csv_delay        */ realloc_old_csv_delay,
+                poison_data, poison_len, node->poison_txid,
+                /* fee_bump_budget  */ 0,
+                /* fee_bump_dline   */ 0);
+            if (p_watch_id > 0)
+                printf("LSP-WT-TRUSTLESS: registered realloc POISON watch_id=%lld "
+                       "for node %zu\n", (long long)p_watch_id, node_idx);
+            else
+                fprintf(stderr, "LSP-WT-TRUSTLESS: WARN — wt_db POISON register "
+                        "failed for realloc node %zu\n", node_idx);
+        }
     }
 
     /* Step 12: Update channel amounts in lsp_channel_entry_t.

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -2031,9 +2031,16 @@ handle_message:
             /* LSP confirms leaf advance — the signed tx is now finalized.
                Client's factory already has the correct unsigned tx from PROPOSE. */
             int leaf_side;
-            if (wire_parse_leaf_advance_done(msg.json, &leaf_side))
+            if (wire_parse_leaf_advance_done(msg.json, &leaf_side)) {
                 printf("Client %u: leaf %d advance confirmed by LSP\n",
                        my_index, leaf_side);
+                /* WT bundle (gap-scan LOW): re-persist the advanced tree so a crash
+                   recovers the CURRENT leaf state, not the last-rotation snapshot.
+                   The factory already holds the advanced tx from the PROPOSE ceremony. */
+                if (cbd && cbd->db && !persist_save_tree_nodes(cbd->db, factory, 0))
+                    fprintf(stderr, "Client %u: WARN — tree_nodes re-persist after "
+                            "leaf advance failed\n", my_index);
+            }
             cJSON_Delete(msg.json);
             break;
         }

--- a/tools/test_regtest_cheat_realloc.sh
+++ b/tools/test_regtest_cheat_realloc.sh
@@ -36,6 +36,7 @@ BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
 
 TMPDIR=$(mktemp -d /tmp/ss-cheat-realloc.XXXXXX)
 LSP_DB="$TMPDIR/lsp.db"
+WT_DB="$TMPDIR/wt.db"
 LSP_LOG="$TMPDIR/lsp.log"
 
 PIDS=()
@@ -47,6 +48,7 @@ cleanup() {
     for pid in "${PIDS[@]:-}"; do kill -9 "$pid" 2>/dev/null || true; done
     cp "$LSP_LOG" /tmp/cheat_realloc_last_lsp.log 2>/dev/null || true
     cp "$LSP_DB"  /tmp/cheat_realloc_last_lsp.db  2>/dev/null || true
+    cp "$WT_DB"   /tmp/cheat_realloc_last_wt.db   2>/dev/null || true
     for i in $(seq 0 $((N_CLIENTS - 1))); do
         cp "$TMPDIR/client_${i}.log" "/tmp/cheat_realloc_last_client_${i}.log" 2>/dev/null || true
     done
@@ -111,6 +113,7 @@ ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.8 \
     --rpcpassword ${RPCPASSWORD:-rpcpass} \
     --wallet ss_cheat_leaf_miner \
     --db "$LSP_DB" \
+    --wt-db "$WT_DB" \
     --demo --test-realloc --cheat-realloc \
     --lsp-balance-pct 50 \
     > "$LSP_LOG" 2>&1 &
@@ -236,6 +239,12 @@ except Exception: print("0 0 0")')
     echo "  #91 anchor guard OK: poison total ${PTOT} sats >> 240 (P2A anchor) — targeted the real L-stock"
     A2=$(pen_recovers_most "$PEN_TXID"); echo "  A-2 recovery ratio: $A2 (OK=outputs>=90% of swept inputs)"
     case "$A2" in LOW*) echo "  FAIL: penalty recovers <90% of swept value ($A2) — value leaked/burned to fee"; exit 1;; esac
+    # WT F2 (gap-scan): with --wt-db armed, the realloc L-stock poison must ALSO mirror
+    # to wt_db as a 2nd factory-node watch so a standalone WT can fire it (same proven
+    # mechanism as the leaf-advance path). Assert the mirror registered.
+    grep -q "registered realloc POISON" "$LSP_LOG" || { echo "  FAIL: WT F2 — realloc poison NOT mirrored to wt_db (registration missing)"; exit 1; }
+    WTN=$(sqlite3 "$WT_DB" "PRAGMA busy_timeout=10000; SELECT count(*) FROM wt_watches;" 2>/dev/null || echo 0)
+    echo "  WT F2 OK: realloc poison mirrored to wt_db (${WTN} total watches — chain[N] + poison)"
     echo "  PASS: WT detected breach (FACTORY BREACH x$BREACH_DETECTED) + CONFIRMED redistribution $PEN_TXID ($PNUM outs, min ${PMIN}, total ${PTOT} sats) — outcome verified per-client"
     grep -E "FACTORY BREACH|L-stock burn|response_tx|watchtower registered OLD" "$LSP_LOG" | head -10
     exit 0


### PR DESCRIPTION
Bounded completeness follow-ups from the gap-scan (docs/gap-scan-findings-2026-07.md). None are fund-safety; all defense-in-depth / crash-recovery.

## Done + validated
- **WT F2 realloc** — re-applies the realloc L-stock poison as a 2nd wt_db factory-node watch (`lsp_channels.c:3366`), completing the WT F2 story (leaf-advance shipped in #435). `cheat_realloc` now arms `--wt-db` and asserts the mirror REGISTERS in wt_db; the standalone-WT FIRING rides the same mechanism the leaf-advance path proved e2e. Validated green (register + the existing 65374-sat redistribution).
- **Client tree_nodes re-persist** — the client persisted tree_nodes only at init + full rotation, not after intra-factory leaf advances (a crash recovered the last-rotation tree). Added to `MSG_LEAF_ADVANCE_DONE`. Not principal-affecting; crash-recovery robustness. Validated: units 1517/1517, wire_leaf_advance PASS (legacy + stateless), builds clean.

## Scoped (LOW, documented, not in this PR)
- **F4 kind3 pre-emptive arming** — needs pre-signing the timeout sweep at commitment time (pre-suppressed-LSP edge case).
- **Client PTLC arm** (`superscalar_client.c:827` NULL PTLCs) — narrow; the standalone WT already covers PTLC breaches; needs client-side PTLC snapshot tracking.