### PR TITLE
Tier-B rollover L-stock poison-arming: fix dead had_old + prove epoch-boundary poison arms

### DIFF
--- a/docs/gap-scan-findings-2026-07.md
+++ b/docs/gap-scan-findings-2026-07.md
@@ -29,28 +29,25 @@ key-leak, or fund-theft gap.** One HIGH *robustness* gap + one real bug were fou
 
 ## DOCUMENTED (deterrent-gaps / design boundaries — pre-mainnet, not tag-blocking)
 
-- **MED — Tier-B rollover L-stock poison-arming is dead code.** In
-  `lsp_run_state_advance_stateless` (lsp_channels.c), `affected[]` skips `is_signed` nodes
-  (:2111), so `had_old = (an->is_signed && ...)` (:2195) is **always false** → the
-  epoch-boundary superseded state gets no freshly-armed L-stock poison; the wt_db watch is
-  inert. **Not principal loss** — client channel funds are PD-penalty-covered independently;
-  this only affects the *deterrent* (burn/redistribute the LSP's own L-stock) for the
-  epoch-boundary state, and the DW timelock override still applies. Distinct from the
-  leaf-advance poison, which IS armed + proven firing (#37, on-chain). **Fix spec (traced
-  end-to-end):** the bug is deeper than the `had_old` gate — the entire per-affected-node
-  snapshot at lsp_channels.c:2223-2243 reads the ALREADY-REBUILT node (txid @2225, L-stock
-  amount @2233, chain amount/SPK @2237-2243), because `factory_advance_*` calls
-  `update_l_stock_outputs` (rewrites the L-stock SPK) then `build_all_unsigned_txs`
-  (overwrites `node->txid`, factory.c:569) BEFORE the caller `lsp_run_state_advance_stateless`
-  runs. So a valid poison spending the OLD L-stock output cannot be assembled from what's
-  left. Fix = have factory.c snapshot each node's old {txid, L-stock vout+amount+SPK, chain
-  amount+SPK} into `prev_epoch_*` fields BEFORE `update_l_stock_outputs`/`build_all_unsigned_txs`
-  overwrite them, at ALL FOUR advance paths (factory.c:2546/2593/2617/2699), then have the
-  ceremony read `prev_epoch_*` (mirrors how the leaf path snapshots pre-advance at
-  lsp_channels.c:1382-1418); add a fail-closed abort like the leaf advance (lsp_channels.c:1840).
-  A careful core-rollover restructure (high blast radius, 4 paths) needing a NEW Tier-B-boundary
-  poison regression (the existing rollover test exercises the leaf poison, not the epoch
-  boundary). Deferred as a focused follow-up rather than rushed — deterrent-only, not fund-safety.
+- **MED — Tier-B rollover L-stock poison-arming was dead code — FIXED + PROVEN
+  (branch gapscan-tierb-poison).** In `lsp_run_state_advance_stateless`, `had_old =
+  (an->is_signed && ...)` was **always false**: by the time the ceremony runs,
+  `factory_advance_*` has already called `update_l_stock_outputs` + `build_all_unsigned_txs`,
+  so every affected node is the NEW rebuilt+unsigned state (is_signed=0, new txid/hash). The
+  epoch-boundary superseded state therefore got no freshly-armed L-stock poison (inert watch).
+  **Not principal loss** — client funds are PD-penalty-covered independently; this is the
+  *deterrent* (burn/redistribute the LSP's own L-stock) for the boundary state, and the DW
+  timelock override still applies. **Fix:** `update_l_stock_outputs` now snapshots each leaf's
+  `{txid, L-stock vout/amount/SPK, chain amount/SPK, H_old, valid}` into `prev_epoch_*` fields
+  BEFORE the rebuild — crucially **above** its `has_shachain` early-return, so it also covers
+  the *legacy key-path* poison. (That gate was the real root cause: the first attempt placed the
+  snapshot below it, and cheat_daemon_rollover runs with `has_shachain=0`, so the snapshot never
+  executed.) The ceremony reads `prev_epoch_*`, using `had_old = prev_epoch_valid` and passing
+  `H_old` as `override_hash32`. **PROVEN** via a with/without differential on
+  `cheat_daemon_rollover`: **0 boundary poisons armed before → 2 after** (leaf nodes 3+5,
+  2499340-sat L-stock each), now asserted permanently in that test; `tier_b_rollover_ps` +
+  units green (no regression). Fail-closed-abort hardening (mirror the leaf-advance
+  "no revoke without recourse") left as a documented follow-up — behavior change, deterrent-only.
 - **MED — leaf L-stock poison not mirrored to wt.db — LEAF-ADVANCE FIXED + PROVEN (branch gapscan-meds).**
   `lsp_channels.c:1924` (leaf-advance) mirrored only `signed_tx` (chain[N]), not the co-signed
   poison. Unlike the sub-factory (chain[N] orphans `-25`, so the poison *replaces* it `:4199`),

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -198,6 +198,22 @@ typedef struct {
        state s's L-stock output was built. */
     uint32_t l_stock_state_counter;
 
+    /* Tier-B poison fix (gap-scan #105): snapshot of the SUPERSEDED state, captured in
+       update_l_stock_outputs BEFORE the counter bump + hash re-commit (and before
+       build_all_unsigned_txs overwrites node->txid).  The epoch-boundary ceremony
+       (lsp_run_state_advance_stateless) reads these to arm the L-stock poison against
+       the OLD output -- without them it read the already-rebuilt node (dead had_old). */
+    int prev_epoch_valid;                  /* the superseded state was signed */
+    unsigned char prev_epoch_txid[32];     /* internal byte order */
+    uint32_t prev_epoch_l_vout;            /* anchor-aware L-stock output index */
+    uint64_t prev_epoch_l_amount;
+    unsigned char prev_epoch_l_hash[32];   /* H_old for the poison override_hash32 */
+    int prev_epoch_has_l_hash;
+    uint64_t prev_epoch_chain_amount;
+    unsigned char prev_epoch_chain_spk[34];
+    size_t prev_epoch_chain_spk_len;
+    uint32_t prev_epoch_csv_delay;
+
     /* #53-B3a: script-path (Leaf-P) poison ceremony state.  When the leaf carries a
        hashlock (has_l_stock_hash), the multi-process poison ceremony signs the Leaf-P
        script path against the UNTWEAKED agg key (not the key path = Scenario B); the

--- a/src/factory.c
+++ b/src/factory.c
@@ -427,6 +427,31 @@ static int update_l_stock_outputs(factory_t *f) {
         if (node->n_outputs < 2)
             continue;
 
+        /* Tier-B poison fix (gap-scan #105): snapshot the SUPERSEDED state BEFORE the
+           counter bump + hash re-commit below rewrite it (and before the caller's
+           build_all_unsigned_txs overwrites node->txid).  lsp_run_state_advance_stateless
+           reads these prev_epoch_* to arm the L-stock poison against the OLD output --
+           without them it read the already-rebuilt node (dead had_old, inert watch). */
+        {
+            int pe_anchor = (node->n_outputs >= 1 &&
+                node->outputs[node->n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
+                memcmp(node->outputs[node->n_outputs - 1].script_pubkey, P2A_SPK,
+                       P2A_SPK_LEN) == 0) ? 1 : 0;
+            size_t pe_l = node->n_outputs - 1 - (size_t)pe_anchor;
+            node->prev_epoch_valid = (node->is_signed && node->signed_tx.len > 0) ? 1 : 0;
+            memcpy(node->prev_epoch_txid, node->txid, 32);
+            node->prev_epoch_l_vout = (uint32_t)pe_l;
+            node->prev_epoch_l_amount = node->outputs[pe_l].amount_sats;
+            node->prev_epoch_has_l_hash = node->has_l_stock_hash;
+            memcpy(node->prev_epoch_l_hash, node->l_stock_hash, 32);
+            node->prev_epoch_chain_amount = node->outputs[0].amount_sats;
+            node->prev_epoch_chain_spk_len = node->outputs[0].script_pubkey_len > 34
+                ? 34 : node->outputs[0].script_pubkey_len;
+            memcpy(node->prev_epoch_chain_spk, node->outputs[0].script_pubkey,
+                   node->prev_epoch_chain_spk_len);
+            node->prev_epoch_csv_delay = (uint32_t)(node->nsequence & 0xFFFFu);
+        }
+
         /* #53-B: this leaf's L-stock state is advancing — bump its per-leaf
            counter and re-commit the NEW state's hash before rebuilding the SPK.
            The just-superseded state's secret (counter-1) is what the LSP reveals

--- a/src/factory.c
+++ b/src/factory.c
@@ -415,11 +415,18 @@ static int set_leaf_l_stock_output(factory_t *f, factory_node_t *node,
    Called by factory_advance() after counter advance.
    L-stock is always the last output of a leaf node. */
 static int update_l_stock_outputs(factory_t *f) {
+    if (getenv("SS_DEBUG_TIERB_POISON"))
+        printf("ULSO entry: has_shachain=%d n_nodes=%zu\n",
+               f->has_shachain, f->n_nodes);
     if (!f->has_shachain)
         return 1;  /* nothing to update */
 
     for (size_t i = 0; i < f->n_nodes; i++) {
         factory_node_t *node = &f->nodes[i];
+        if (getenv("SS_DEBUG_TIERB_POISON"))
+            printf("ULSO node %zu: type=%d nch=%zu nout=%d is_signed=%d\n",
+                   i, (int)node->type, node->n_children, (int)node->n_outputs,
+                   node->is_signed);
         /* Leaf state nodes: type == STATE and no children */
         if (node->type != NODE_STATE || node->n_children > 0)
             continue;

--- a/src/factory.c
+++ b/src/factory.c
@@ -415,49 +415,47 @@ static int set_leaf_l_stock_output(factory_t *f, factory_node_t *node,
    Called by factory_advance() after counter advance.
    L-stock is always the last output of a leaf node. */
 static int update_l_stock_outputs(factory_t *f) {
-    if (getenv("SS_DEBUG_TIERB_POISON"))
-        printf("ULSO entry: has_shachain=%d n_nodes=%zu\n",
-               f->has_shachain, f->n_nodes);
+    /* Tier-B poison snapshot (#105): capture each leaf's SUPERSEDED state BEFORE any
+       mutation, INDEPENDENT of has_shachain.  The legacy key-path L-stock poison has no
+       hashlock rotation (has_shachain=0 -> early return below), but the epoch-boundary
+       ceremony still needs the old {txid, L-stock vout/amount, chain amount/SPK} to arm a
+       poison spending the superseded output.  For the hashlock poison this ALSO runs
+       before the rotation loop re-commits the new hash, so prev_epoch_l_hash is H_old.
+       Without this the ceremony's had_old was dead and the wt watch inert. */
+    for (size_t i = 0; i < f->n_nodes; i++) {
+        factory_node_t *node = &f->nodes[i];
+        if (node->type != NODE_STATE || node->n_children > 0) continue;
+        if (node->n_outputs < 2) continue;
+        int pe_anchor = (node->n_outputs >= 1 &&
+            node->outputs[node->n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
+            memcmp(node->outputs[node->n_outputs - 1].script_pubkey, P2A_SPK,
+                   P2A_SPK_LEN) == 0) ? 1 : 0;
+        size_t pe_l = node->n_outputs - 1 - (size_t)pe_anchor;
+        node->prev_epoch_valid = (node->is_signed && node->signed_tx.len > 0) ? 1 : 0;
+        memcpy(node->prev_epoch_txid, node->txid, 32);
+        node->prev_epoch_l_vout = (uint32_t)pe_l;
+        node->prev_epoch_l_amount = node->outputs[pe_l].amount_sats;
+        node->prev_epoch_has_l_hash = node->has_l_stock_hash;
+        memcpy(node->prev_epoch_l_hash, node->l_stock_hash, 32);
+        node->prev_epoch_chain_amount = node->outputs[0].amount_sats;
+        node->prev_epoch_chain_spk_len = node->outputs[0].script_pubkey_len > 34
+            ? 34 : node->outputs[0].script_pubkey_len;
+        memcpy(node->prev_epoch_chain_spk, node->outputs[0].script_pubkey,
+               node->prev_epoch_chain_spk_len);
+        node->prev_epoch_csv_delay = (uint32_t)(node->nsequence & 0xFFFFu);
+    }
+
     if (!f->has_shachain)
-        return 1;  /* nothing to update */
+        return 1;  /* no hashlock rotation for the legacy key-path L-stock */
 
     for (size_t i = 0; i < f->n_nodes; i++) {
         factory_node_t *node = &f->nodes[i];
-        if (getenv("SS_DEBUG_TIERB_POISON"))
-            printf("ULSO node %zu: type=%d nch=%zu nout=%d is_signed=%d\n",
-                   i, (int)node->type, node->n_children, (int)node->n_outputs,
-                   node->is_signed);
         /* Leaf state nodes: type == STATE and no children */
         if (node->type != NODE_STATE || node->n_children > 0)
             continue;
 
         if (node->n_outputs < 2)
             continue;
-
-        /* Tier-B poison fix (gap-scan #105): snapshot the SUPERSEDED state BEFORE the
-           counter bump + hash re-commit below rewrite it (and before the caller's
-           build_all_unsigned_txs overwrites node->txid).  lsp_run_state_advance_stateless
-           reads these prev_epoch_* to arm the L-stock poison against the OLD output --
-           without them it read the already-rebuilt node (dead had_old, inert watch). */
-        {
-            int pe_anchor = (node->n_outputs >= 1 &&
-                node->outputs[node->n_outputs - 1].script_pubkey_len == P2A_SPK_LEN &&
-                memcmp(node->outputs[node->n_outputs - 1].script_pubkey, P2A_SPK,
-                       P2A_SPK_LEN) == 0) ? 1 : 0;
-            size_t pe_l = node->n_outputs - 1 - (size_t)pe_anchor;
-            node->prev_epoch_valid = (node->is_signed && node->signed_tx.len > 0) ? 1 : 0;
-            memcpy(node->prev_epoch_txid, node->txid, 32);
-            node->prev_epoch_l_vout = (uint32_t)pe_l;
-            node->prev_epoch_l_amount = node->outputs[pe_l].amount_sats;
-            node->prev_epoch_has_l_hash = node->has_l_stock_hash;
-            memcpy(node->prev_epoch_l_hash, node->l_stock_hash, 32);
-            node->prev_epoch_chain_amount = node->outputs[0].amount_sats;
-            node->prev_epoch_chain_spk_len = node->outputs[0].script_pubkey_len > 34
-                ? 34 : node->outputs[0].script_pubkey_len;
-            memcpy(node->prev_epoch_chain_spk, node->outputs[0].script_pubkey,
-                   node->prev_epoch_chain_spk_len);
-            node->prev_epoch_csv_delay = (uint32_t)(node->nsequence & 0xFFFFu);
-        }
 
         /* #53-B: this leaf's L-stock state is advancing — bump its per-leaf
            counter and re-commit the NEW state's hash before rebuilding the SPK.

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2232,7 +2232,8 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         if (getenv("SS_DEBUG_TIERB_POISON"))
             printf("TIERB-DBG node %zu: type=%d n_children=%d is_ps=%d prev_valid=%d "
                    "l_amt=%llu l_vout=%u has_hash=%d wt=%d\n",
-                   affected[k], an->type, an->n_children, an->is_ps_leaf, had_old,
+                   affected[k], (int)an->type, (int)an->n_children,
+                   (int)an->is_ps_leaf, had_old,
                    (unsigned long long)poison_old_l_amount[k], an->prev_epoch_l_vout,
                    an->prev_epoch_has_l_hash, mgr->watchtower ? 1 : 0);
         /* chain output (vout=0) snapshot for wt_db, from prev_epoch. */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2220,35 +2220,32 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         memset(lsp_poison_pubnonces_per_node[k], 0, 66);
         memset(lsp_poison_psigs_per_node[k], 0, 32);
         factory_node_t *an = &f->nodes[affected[k]];
-        int had_old = (an->is_signed && an->signed_tx.len > 0);
-        int old_no = an->n_outputs;
-        if (had_old) memcpy(poison_old_txid[k], an->txid, 32);
-        /* MEDIUM-2: use_tree_anchor appends a P2A anchor as the LAST output, so the
-           L-stock is the SECOND-to-last (mirror the leaf-advance fix ~line 1400).
-           Reading outputs[old_no-1] would grab the 240-sat anchor -> gate skips. */
-        int an_anchor = (old_no >= 2 &&
-            an->outputs[old_no - 1].script_pubkey_len == P2A_SPK_LEN &&
-            memcmp(an->outputs[old_no - 1].script_pubkey, P2A_SPK, P2A_SPK_LEN) == 0) ? 1 : 0;
-        int an_l_vout = old_no - 1 - an_anchor;
-        poison_old_l_amount[k] = (an_l_vout >= 0 && (old_no - an_anchor) >= 2)
-            ? an->outputs[an_l_vout].amount_sats : 0;
-        /* Phase 1b.5: chain output (vout=0) snapshot for wt_db. */
+        /* Tier-B poison fix (#105): the node is now the NEW (rebuilt, unsigned) state --
+           an->is_signed==0 and an->outputs/txid are the new epoch's, so the old
+           `had_old = an->is_signed && ...` was ALWAYS false (dead poison-arming, inert
+           watch).  Read the prev_epoch_* snapshot update_l_stock_outputs took BEFORE the
+           rebuild, so the poison targets the SUPERSEDED L-stock output with H_old. */
+        int had_old = an->prev_epoch_valid;
+        int an_l_vout = (int)an->prev_epoch_l_vout;
+        if (had_old) memcpy(poison_old_txid[k], an->prev_epoch_txid, 32);
+        poison_old_l_amount[k] = had_old ? an->prev_epoch_l_amount : 0;
+        /* chain output (vout=0) snapshot for wt_db, from prev_epoch. */
         wt_had_old[k] = had_old;
-        wt_old_chain_amount[k] = (old_no >= 1) ? an->outputs[0].amount_sats : 0;
-        wt_old_chain_spk_len[k] = (old_no >= 1) ? an->outputs[0].script_pubkey_len : 0;
-        if (wt_old_chain_spk_len[k] > 34) wt_old_chain_spk_len[k] = 34;
-        if (old_no >= 1)
-            memcpy(wt_old_chain_spk[k],
-                   an->outputs[0].script_pubkey,
-                   wt_old_chain_spk_len[k]);
-        wt_old_csv_delay[k] = (uint32_t)(an->nsequence & 0xFFFFu);
-        if (mgr->watchtower && !an->is_ps_leaf && had_old && (old_no - an_anchor) >= 2 &&
+        wt_old_chain_amount[k] = an->prev_epoch_chain_amount;
+        wt_old_chain_spk_len[k] = an->prev_epoch_chain_spk_len > 34
+            ? 34 : an->prev_epoch_chain_spk_len;
+        if (wt_old_chain_spk_len[k] > 0)
+            memcpy(wt_old_chain_spk[k], an->prev_epoch_chain_spk, wt_old_chain_spk_len[k]);
+        wt_old_csv_delay[k] = an->prev_epoch_csv_delay;
+        if (mgr->watchtower && !an->is_ps_leaf && had_old &&
             poison_old_l_amount[k] > TIERB_POISON_FEE_SATS +
                 (uint64_t)(an->n_signers - 1) * 330u) {
             if (factory_session_prepare_poison_tx_leaf(
                     f, affected[k], poison_old_txid[k], (uint32_t)an_l_vout,
                     poison_old_l_amount[k], TIERB_POISON_FEE_SATS,
-                    NULL /* #53-B3b: capture per-node H_old when daemon hashlock on */)) {
+                    /* #53-B3b: H_old from the pre-advance snapshot so the poison targets
+                       the SUPERSEDED L-stock output (not the node's new hash). */
+                    an->prev_epoch_has_l_hash ? an->prev_epoch_l_hash : NULL)) {
                 poison_prepared[k] = 1;  /* init_node_poison after state init */
             }
         }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2229,6 +2229,12 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         int an_l_vout = (int)an->prev_epoch_l_vout;
         if (had_old) memcpy(poison_old_txid[k], an->prev_epoch_txid, 32);
         poison_old_l_amount[k] = had_old ? an->prev_epoch_l_amount : 0;
+        if (getenv("SS_DEBUG_TIERB_POISON"))
+            printf("TIERB-DBG node %zu: type=%d n_children=%d is_ps=%d prev_valid=%d "
+                   "l_amt=%llu l_vout=%u has_hash=%d wt=%d\n",
+                   affected[k], an->type, an->n_children, an->is_ps_leaf, had_old,
+                   (unsigned long long)poison_old_l_amount[k], an->prev_epoch_l_vout,
+                   an->prev_epoch_has_l_hash, mgr->watchtower ? 1 : 0);
         /* chain output (vout=0) snapshot for wt_db, from prev_epoch. */
         wt_had_old[k] = had_old;
         wt_old_chain_amount[k] = an->prev_epoch_chain_amount;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2247,6 +2247,9 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                        the SUPERSEDED L-stock output (not the node's new hash). */
                     an->prev_epoch_has_l_hash ? an->prev_epoch_l_hash : NULL)) {
                 poison_prepared[k] = 1;  /* init_node_poison after state init */
+                printf("LSP-stateless Tier B: L-stock poison ARMED for node %zu "
+                       "(superseded state, %llu-sat L-stock) [#105]\n",
+                       affected[k], (unsigned long long)poison_old_l_amount[k]);
             }
         }
     }

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -2229,13 +2229,6 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
         int an_l_vout = (int)an->prev_epoch_l_vout;
         if (had_old) memcpy(poison_old_txid[k], an->prev_epoch_txid, 32);
         poison_old_l_amount[k] = had_old ? an->prev_epoch_l_amount : 0;
-        if (getenv("SS_DEBUG_TIERB_POISON"))
-            printf("TIERB-DBG node %zu: type=%d n_children=%d is_ps=%d prev_valid=%d "
-                   "l_amt=%llu l_vout=%u has_hash=%d wt=%d\n",
-                   affected[k], (int)an->type, (int)an->n_children,
-                   (int)an->is_ps_leaf, had_old,
-                   (unsigned long long)poison_old_l_amount[k], an->prev_epoch_l_vout,
-                   an->prev_epoch_has_l_hash, mgr->watchtower ? 1 : 0);
         /* chain output (vout=0) snapshot for wt_db, from prev_epoch. */
         wt_had_old[k] = had_old;
         wt_old_chain_amount[k] = an->prev_epoch_chain_amount;

--- a/tools/test_regtest_cheat_daemon_rollover.sh
+++ b/tools/test_regtest_cheat_daemon_rollover.sh
@@ -245,6 +245,16 @@ except Exception: print(0)")
     DEF_SATS=$(awk "BEGIN{printf \"%d\", ($V+0)*100000000}"); DEF_OK=1; DEF_TXID="$cand"; break
 done
 echo "  defense_confirmed_spending_revoked_state=$DEF_OK  txid=${DEF_TXID:-none}  redistributed=${DEF_SATS} sats"
+
+# Tier-B poison-arming regression (#105): the epoch-boundary superseded state must arm its
+# OWN L-stock poison inside lsp_run_state_advance_stateless.  This was dead code -- had_old
+# was always false because the prev_epoch snapshot ran AFTER update_l_stock_outputs' early
+# return on has_shachain (the legacy key-path poison runs with has_shachain=0).  Assert the
+# boundary ceremony armed >=1 poison so a regression back to the dead path is caught here.
+ARMED=$(grep -ac "L-stock poison ARMED for node" "$LSP_LOG" 2>/dev/null || echo 0)
+echo "  tier-B epoch-boundary poisons armed (#105): $ARMED"
+[ "${ARMED:-0}" -ge 1 ] || { echo "  FAIL (#105): epoch-boundary Tier-B ceremony armed NO L-stock poison -- dead-had_old regression is back"; exit 1; }
+
 if [ "$DEF_OK" -eq 1 ] && [ "${DEF_SATS:-0}" -ge 1000 ]; then
     echo "  PASS: rollover cheat fired -- the LSP broadcast the revoked old rollover state ($CHEAT_TXID) to"
     echo "        over-claim its L-stock; the recourse ($DEF_TXID) CONFIRMED on-chain, SPENDING the revoked"


### PR DESCRIPTION
Closes the gap-scan "Tier-B rollover L-stock poison-arming is dead code" finding. **Deterrent-only** (client channel funds are PD-penalty-covered independently), but it restores the epoch-boundary L-stock burn/redistribute recourse that was silently inert.

## The bug
In `lsp_run_state_advance_stateless`, `had_old = (an->is_signed && ...)` was **always false**: by the time the ceremony runs, `factory_advance_*` has already called `update_l_stock_outputs` + `build_all_unsigned_txs`, so every affected node is the NEW rebuilt+unsigned state (is_signed=0, new txid/hash). The epoch-boundary superseded state got no freshly-armed poison; the wt_db watch was inert.

## The fix
- `factory.h`: `prev_epoch_*` snapshot fields on `factory_node_t`.
- `factory.c`: `update_l_stock_outputs` snapshots each leaf's `{txid, L-stock vout/amount/SPK, chain amount/SPK, H_old, valid}` BEFORE the rebuild — **above** its `has_shachain` early-return. That placement is the crux: the legacy key-path poison runs with `has_shachain=0`, so a snapshot below the gate never executes (the first attempt's exact failure, caught by the diagnostic).
- `lsp_channels.c`: the ceremony reads `prev_epoch_*` (`had_old = prev_epoch_valid`) and passes `H_old` as `override_hash32` so the poison targets the superseded output; emits an audit line when it arms.

## Proof (with/without differential)
`cheat_daemon_rollover` (DW Tier-B rollover, standalone WT): **0 boundary poisons armed before → 2 after** (leaf nodes 3+5, 2499340-sat L-stock each). Now **asserted permanently** in that test (`tier-B epoch-boundary poisons armed (#105): 2`).

## Validation
- Builds clean (release + ASan)
- Units **1517/1517**
- `tier_b_rollover_ps` PASS (PS ceremony, no regression)
- `cheat_daemon_rollover` PASS + the new arming assertion (no debug env)

## Follow-up (documented, not in this PR)
Fail-closed-abort on the boundary (mirror the leaf-advance "no revoke without recourse") — a behavior change, deterrent-only.