### PR TITLE
Signet scale-harness: payment-script-driven per-client reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Robustness fixes surfaced while proving the live 127-client cooperative close on
 
 - **Patient LSP demo event-loop:** the demo/test-path event loop (`lsp_channels_run_event_loop` — used by `--demo` and the harnesses, *not* the production hot path) no longer treats a single 30-second `poll()` lull as fatal. A bounded total patience budget (`SS_EVENT_LOOP_WAIT_SEC`, default 300s) is what lets a 127-party create → pay → close complete under load instead of dying before the first payment fires.
 - **Mainnet `step_blocks` floor:** reject `step_blocks < 144` on mainnet (`cli_validate_mainnet_step_floor`, +5 unit tests); non-mainnet networks keep small values for fast tests.
-- **Signet scale-harness (`test_signet_scale_payments.sh`):** funding scales with N (`AMOUNT` defaults to `N_CLIENTS * 100_000`; the old fixed 2.75M under-funded large N below the 5000-sat channel reserve, so scripted sends never fired), a client-launch `STAGGER` knob, and the close-wait now keys on the *confirmed* close marker with an override-able `CLOSE_WAIT_SEC` budget (the old fixed 3600s printed a false TIMEOUT on a close that in fact succeeded).
+- **Signet scale-test harness hardened:** funding-by-N, a confirmed-close wait (`CLOSE_WAIT_SEC`), and payment-script-driven per-client reconciliation (robust regardless of mover/idle ratio).
 
 ### Gap-scan hardening wave (defense-in-depth; no theft/key-leak/fund-loss gap)
 

--- a/tools/test_signet_scale_payments.sh
+++ b/tools/test_signet_scale_payments.sh
@@ -297,7 +297,7 @@ if [ "$CLOSE_PARTIES" -ge "$N_CLIENTS" ]; then note_ok "all $N_CLIENTS clients j
 if [ -n "$CLOSE_TXID" ]; then
     RECON=$(python3 - "$CLOSE_TXID" "$REGTEST_CONF" "$LSP_LOG" "$N_CLIENTS" <<'PYEOF'
 import sys, json, subprocess, re
-from collections import Counter
+from collections import Counter, defaultdict
 txid, conf, lsplog, ncli = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
 r = subprocess.run(["bitcoin-cli","-signet","-conf="+conf,"getrawtransaction",txid,"1"],
                    capture_output=True, text=True)
@@ -309,24 +309,32 @@ txt = open(lsplog, errors="replace").read()
 i = txt.rfind("Close outputs:")
 block = txt[i:] if i >= 0 else ""
 lsp_amts = [int(m) for m in re.findall(r"LSP:\s+(\d+) sats", block)]
-cli_amts = [int(m) for m in re.findall(r"Client \d+:\s+(\d+) sats", block)]
+cli_map = {int(n): int(a) for n, a in re.findall(r"Client (\d+):\s+(\d+) sats", block)}
+cli_amts = [cli_map[k] for k in sorted(cli_map)]
 ledger = sorted(lsp_amts + cli_amts)
 errs = []
 if len(cli_amts) != ncli:
     errs.append("client-lines %d!=%d" % (len(cli_amts), ncli))
 if ledger != onchain:
     errs.append("ledger!=onchain(sum %d vs %d, n %d vs %d)" % (sum(ledger), sum(onchain), len(ledger), len(onchain)))
-base, base_n = Counter(cli_amts).most_common(1)[0] if cli_amts else (0, 0)
-# The idle baseline must dominate: a per-client skim (varying many clients'
-# balances individually) would destroy the shared baseline. Most clients are
-# idle, so >= half sharing one exact value proves no per-client drift.
-if cli_amts and base_n < (ncli // 2):
-    errs.append("baseline-not-dominant(%d/%d at mode %d - possible per-client skim)" % (base_n, ncli, base))
-surplus = sum(a - base for a in cli_amts if a > base)
-deficit = sum(base - a for a in cli_amts if a < base)
+# Per-client reconciliation, robust to any mover/idle mix. Each client's IMPLIED
+# initial baseline = final - net payment delta (parsed from the real routed-HTLC
+# and demo payment flows). All clients were funded to the same baseline, so these
+# must be uniform (allow one remainder leaf); a per-client skim breaks uniformity.
+# (Supersedes an earlier mode-of-all-balances check that false-failed when movers
+# outnumbered idle clients, e.g. N=8 with 3 payments -> 6 movers.)
+delta = defaultdict(int)
+for snd, rcv, amt in re.findall(r"(?:forwarded|Payment complete): client (\d+) -> client (\d+) \((\d+) sats\)", txt):
+    delta[int(snd)] -= int(amt); delta[int(rcv)] += int(amt)
+implied = {k: cli_map[k] - delta.get(k, 0) for k in cli_map}
+base, base_n = Counter(implied.values()).most_common(1)[0] if implied else (0, 0)
+if implied and base_n < max(1, len(implied) - 1):
+    off = {k: implied[k] for k in implied if implied[k] != base}
+    errs.append("implied-baseline-not-uniform(%d/%d at %d; off=%s - possible per-client skim)" % (base_n, len(implied), base, off))
+movers = sum(1 for k in delta if delta.get(k, 0) != 0)
 print(("OK" if not errs else "FAIL") +
-      " clients=%d at_baseline=%d/%d baseline=%d movers=%d exact_ledger_match=%s ledger_sum=%d onchain_sum=%d info_surplus=%d info_deficit=%d" %
-      (len(cli_amts), base_n, ncli, base, len(cli_amts) - base_n, ledger == onchain, sum(ledger), sum(onchain), surplus, deficit) +
+      " clients=%d movers=%d implied_baseline=%d uniform=%d/%d exact_ledger_match=%s ledger_sum=%d onchain_sum=%d" %
+      (len(cli_amts), movers, base, base_n, len(implied), ledger == onchain, sum(ledger), sum(onchain)) +
       ("" if not errs else " :: " + "; ".join(errs)))
 PYEOF
 )


### PR DESCRIPTION
## What

Fixes the signet scale-harness per-client reconciliation, which false-FAILed on a **mathematically correct** cooperative close.

**Before:** baseline = statistical *mode of all client balances*, FAIL if fewer than `ncli//2` share it. This breaks whenever movers outnumber idle clients — e.g. N=8 with 3 payments → 6 movers, 2 idle — producing a scary `possible per-client skim` on a perfect close.

**After:** each client's implied initial baseline = `final − net_payment_delta` (delta parsed from the real routed-HTLC + demo flows). All clients were funded to one baseline, so these must be uniform (one remainder leaf allowed). Robust to any mover/idle ratio, and **stronger** — it catches a genuine multi-client skim regardless of shape.

## Validation (no new signet runs)

Ran the fixed logic against real on-chain closes:
- `8373457332eb…` (N=8, the run that FAILED): now **OK** — implied_baseline 39815, uniform 8/8, `exact_ledger_match=True`.
- `65ac21f5…` (N=4, all-movers, previously passed): still **OK** — implied_baseline 33113, uniform 4/4.

Embedded Python syntax-checked.

## Scope

**Test-harness + CHANGELOG only — no product/binary change.** The close being reconciled (`8373457332eb`) was already correct (hand-verified all 8 client outputs to the satoshi); this fixes the *checker*, not the protocol. Also trims the over-detailed harness CHANGELOG bullet from #441.
