### PR TITLE
docs: reconcile PTLC gate comments with shipped state

### DIFF
--- a/include/superscalar/ptlc_commit.h
+++ b/include/superscalar/ptlc_commit.h
@@ -5,10 +5,19 @@
 #include "peer_mgr.h"
 #include <secp256k1.h>
 
-/* PTLC safety gate (task #104).
-   Default: disabled.  Tests that create real PTLCs (amount>0 or point!=NULL)
-   must call ptlc_safety_set_enabled(1) at start.  Production never sets
-   this until the Phase 0 audit (task #103) + breach-defense PR lands. */
+/* PTLC payment-kind flag (formerly the task 104 safety gate).
+   HTLC and PTLC are peer payment kinds; both constructors are always compiled
+   in.  Which kind a payment uses is a per-payment/per-factory SELECTOR
+   (default HTLC) once issue #192 P0 lands; retire this flag then.
+   Library default is 0, but the LSP/client binaries set it enabled at startup
+   (SF-W-PTLC 174, after the Phase 0 audit, task 103, and the breach-defense
+   feed, PR #242, landed).  Enabled is a no-op in practice: nothing in
+   production ORIGINATES a real PTLC today (origination is test-only), so all
+   production payments are HTLCs.
+   SAFETY (load-bearing rule): do not originate a real PTLC (amount>0 or
+   point!=NULL) on a real-value factory until force-close success/timeout
+   resolution is wired (issue #192 P2); the resolution builders currently have
+   no callers, so such an output would be unswept at unilateral close. */
 void ptlc_safety_set_enabled(int enabled);
 int  ptlc_safety_is_enabled(void);
 

--- a/src/ptlc_commit.c
+++ b/src/ptlc_commit.c
@@ -16,22 +16,33 @@
 /* Minimum capacity for PTLC array growth */
 #define PTLC_INIT_CAP 8
 
-/* PTLC safety gate (task #104).
+/* PTLC payment-kind flag (formerly the task 104 safety gate).
 
-   PTLC machinery (channel ops, wire protocol, watchtower sweep loop, ptlcs
-   persistence table) is built — but the breach-defense feed is incomplete:
-   nothing populates watchtower_entry_t.ptlc_outputs, so the sweep loop at
-   watchtower.c:947 is unreachable.  Until the Phase 0 audit (task #103)
-   confirms the full threat surface and the breach-defense PRs land, refuse
-   any production attempt to create a real PTLC output.
+   State as shipped (verified 2026-07-13, post PR #242): the PTLC machinery is
+   built AND breach-defended.  The watchtower rebuilds revoked commitments with
+   their PTLC outputs and sweeps them via channel_build_ptlc_penalty_tx (wired
+   and tested, including the standalone-WT PTLC sweep).  The old note here that
+   "nothing populates ptlc_outputs / the sweep loop is unreachable" is obsolete.
 
-   Today's call surface is benign — ptlc_commit_add_and_sign + the
-   meaningful overload of channel_add_ptlc are only invoked from tests.
-   This gate is defense in depth against future refactors accidentally
-   wiring a production callsite.
+   What remains open (tracked in issue #192): production ORIGINATION
+   (ptlc_commit_add_and_sign + the meaningful overload of channel_add_ptlc are
+   only invoked from tests), real-PTLC receive handling (the dispatch below
+   stores 0-amount placeholders for presig storage only), and force-close
+   success/timeout resolution (channel_build_ptlc_success_tx and
+   channel_build_ptlc_timeout_tx have no callers yet).
 
-   Tests opt in by setting ptlc_safety_set_enabled(1) at start of the test
-   that needs to exercise real PTLCs. */
+   Posture: HTLC and PTLC are peer payment kinds, both always compiled in;
+   selection is per-payment/per-factory (default HTLC) once the #192 P0
+   selector lands, and this flag retires then.  The LSP/client binaries set it
+   enabled at startup (SF-W-PTLC 174); that is a no-op in practice because
+   nothing originates a real PTLC.
+
+   SAFETY (load-bearing rule): do not originate a real PTLC (amount>0 or
+   point!=NULL) on a real-value factory until #192 P2 wires force-close
+   resolution; such an output would be unswept at unilateral close.
+
+   Unit tests that exercise real PTLCs without the binaries still opt in by
+   calling ptlc_safety_set_enabled(1) at test start. */
 static int g_ptlc_safety_enabled = 0;
 
 void ptlc_safety_set_enabled(int enabled) {


### PR DESCRIPTION
## Why

The `ptlc_commit.h` / `ptlc_commit.c` safety-gate comments still describe the pre-#242 world: "Default: disabled" and "the breach-defense feed is incomplete ... the sweep loop at watchtower.c:947 is unreachable." Both are false as shipped — the LSP/client binaries enable the flag at startup (SF-W-PTLC 174), and since PR #242 the watchtower rebuilds revoked commitments **with their PTLC outputs** and sweeps them via `channel_build_ptlc_penalty_tx` (wired + tested, including the standalone-WT PTLC sweep). This stale text is exactly what misled the Delving implementation-report discussion about PTLC state.

## What

Comment-only rewrite of both blocks to the verified, reconciled state:

- **Posture:** HTLC and PTLC are peer payment kinds, both always compiled in; which kind a payment uses becomes a per-payment/per-factory **selector** (default HTLC) when #192 P0 lands — the legacy flag retires then.
- **Verified done:** watchtower breach-defense for PTLC outputs (post-#242).
- **Verified still open** (tracked in #192): production origination (`ptlc_commit_add_and_sign` is test-only), real-PTLC receive (dispatch stores 0-amount presig placeholders only), force-close success/timeout resolution (`channel_build_ptlc_success_tx` / `_timeout_tx` have no callers).
- **Load-bearing safety rule stated where the ops live:** never originate a real PTLC on a real-value factory until #192 P2 wires force-close resolution — such an output would be unswept at unilateral close.

No behavior change. Companion to the #192 tracker-body refresh.