### PR TITLE
factory: support up to 256 signers (255 clients + LSP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,3 +512,13 @@ target_link_libraries(test_musig_session_scale PRIVATE superscalar superscalar_s
 if(ENABLE_SANITIZERS)
     target_link_libraries(test_musig_session_scale PRIVATE project_sanitizers)
 endif()
+
+# Conductor-lite cooperative-close SCALE harness (signet): builds+signs an
+# N-of-N key-path close to M funded outputs in one process (~6MB, 10k in ~1.5s).
+# Driven on real signet by tools/test_signet_close_scale.sh.
+add_executable(test_signet_close_scale tools/test_signet_close_scale.c)
+target_include_directories(test_signet_close_scale PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
+target_link_libraries(test_signet_close_scale PRIVATE superscalar superscalar_secrets project_warnings)
+if(ENABLE_SANITIZERS)
+    target_link_libraries(test_signet_close_scale PRIVATE project_sanitizers)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,3 +496,19 @@ target_link_libraries(test_inproc_scale PRIVATE superscalar superscalar_secrets 
 if(ENABLE_SANITIZERS)
     target_link_libraries(test_inproc_scale PRIVATE project_sanitizers)
 endif()
+
+# MuSig2 signer-scaling proofs (256-signer support): pure-crypto aggregation to
+# 2048 signers, and the distributed session path (factory close path) to 256.
+add_executable(test_musig_scale tools/test_musig_scale.c)
+target_include_directories(test_musig_scale PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
+target_link_libraries(test_musig_scale PRIVATE superscalar superscalar_secrets project_warnings)
+if(ENABLE_SANITIZERS)
+    target_link_libraries(test_musig_scale PRIVATE project_sanitizers)
+endif()
+
+add_executable(test_musig_session_scale tools/test_musig_session_scale.c)
+target_include_directories(test_musig_session_scale PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
+target_link_libraries(test_musig_session_scale PRIVATE superscalar superscalar_secrets project_warnings)
+if(ENABLE_SANITIZERS)
+    target_link_libraries(test_musig_session_scale PRIVATE project_sanitizers)
+endif()

--- a/docs/design/colocation-test-manager.md
+++ b/docs/design/colocation-test-manager.md
@@ -1,0 +1,147 @@
+# Design: co-location test manager (factory-scale signing on one box)
+
+Status: **design + measured**. A signet-only **test apparatus** — never
+production. Runs factory-scale cooperative-close ceremonies on one box and
+verifies on-chain that every payout landed where it should.
+
+## 0. Measured result: for the close ceremony, in-memory is optimal — paging is NOT needed
+
+The whole point of paging was to avoid holding N heavyweight participants in RAM.
+But the **cooperative close is a key-path spend of the funding N-of-N** — it does
+not touch the DW tree, so a participant's resident state is only **~400 B**
+(seckey derivable; secnonce 132 + pubnonce 132 + partial 36). Measured on the VPS
+with the in-memory conductor (`tools/test_signet_close_scale.c`):
+
+```
+N=2301  signers, M=2300 funded  -> vsize  99,013 vB, self-verify OK, conserves
+N=10001 signers, M=10000 funded -> vsize 430,113 vB, self-verify OK, conserves
+   signing 10,001 signers: 1.5 s, ~6 MB RAM
+```
+
+Extrapolated, the in-memory conductor scales the close to **~1,000,000 signers in
+<500 MB** on a 15 GB box. **So the disk-paging apparatus below is deliberately
+NOT built for the close-scale tests** — it would be premature. It remains the
+roadmap for the one case that genuinely needs it: a **faithful full-client
+simulation**, where each participant holds a real 53 MB `factory_t` and only a
+handful fit in RAM at once. Build the pager when (and only when) that feature is
+pursued; the working-group knob below is how it plugs in.
+
+## 1. Why paging (deferred — for faithful full-client sim / >>1M only)
+
+The naive co-location test runs one heavyweight process per participant
+(~70 MB each — the full `factory_t`). 2,300 → 161 GB, 10,000 → impossible. That
+is a **test co-location artifact**: in production those are 10,000 separate
+devices. The fix is a single **manager** process that plays all N participants
+but never holds more than a bounded **working group** in RAM at once.
+
+Honest note on the number: for the *cooperative-close* ceremony the per-signer
+state that must persist is tiny (~330 B: seckey is derivable, secnonce 132,
+pubnonce 132, partial 36), so 10k fits in a few MB even unpaged. Paging is built
+anyway because it (a) scales the same harness to ~1M, (b) is required the moment
+we want *faithful* per-client simulation (each `factory_t` is 53 MB → only a
+handful fit → must page), and (c) makes "bring a node up/down at will" trivial.
+The working-group size is a knob: set it to N at 10k, or to a small group at 1M.
+
+## 2. Core principle: derive identity, persist only the ephemeral
+
+- **Participant identity is deterministic** — `seckey_i = tagged_sha256(SEED,i)`.
+  Never stored; re-derived on demand. So "load a participant" costs ~0 for keys.
+- **Only ephemeral secnonces must persist** — they are generated in MuSig round 1
+  and consumed in round 2, and must **never be reused** (BIP-327; reuse leaks the
+  key). Persist them to disk with a write-ahead `used` flag.
+- **Balances / output keys / results** live in the DB for post-test verification.
+
+## 3. Data model (SQLite `sim.db`)
+
+```
+participants(id PK, balance_sats, out_key BLOB)          -- who gets paid what
+ceremony(id PK, msg32 BLOB, phase, working_group, funding_txid, funding_vout, funding_sats)
+nonces(ceremony_id, participant_id, secnonce BLOB, pubnonce BLOB, used INT)   -- ephemeral, PK(cer,part)
+agg(ceremony_id, running_aggnonce BLOB, running_partialagg BLOB, n_folded)    -- streaming checkpoints
+result(ceremony_id, close_txid, broadcast_ok, node_error)
+payout_check(ceremony_id, participant_id, expected_sats, onchain_sats, ok)    -- verification
+```
+
+Peak RAM ≈ `working_group × per-participant-state + O(1) running aggregate`.
+Disk ≈ `N × (secnonce+pubnonce+partial ≈ 200 B)` + balances.
+
+## 4. Ceremony as group-paged passes (crash-safe)
+
+A MuSig2 cooperative close is one aggregate over one funding UTXO. It is a strict
+2-round protocol, but each round is embarrassingly parallel across signers, so it
+pages cleanly:
+
+1. **FUND** — aggregate all N pubkeys → key-path funding key; fund `P2TR(agg)` on
+   signet (one UTXO). (Key aggregation needs all N pubkeys once; 10k = 640 KB fits;
+   at ~1M, aggregate incrementally / from a paged pubkey file.)
+2. **NONCE (round 1), paged** — for each group of `working_group`: derive keys,
+   `musig_generate_nonce`, **write (secnonce,pubnonce, used=0)** to `nonces`,
+   free the group. Then aggregate pubnonces into `agg.running_aggnonce` (a read
+   pass; pubnonces are 132 B each, streamed).
+3. **SESSION** — `nonce_process(aggnonce, msg=close_sighash, tweaked_cache)`.
+4. **SIGN (round 2), paged + crash-safe** — for each group: derive keys, **load
+   secnonces, set `used=1` and COMMIT before signing** (write-ahead), then
+   `partial_sign`, fold into `agg.running_partialagg`, free the group.
+5. **AGGREGATE + BROADCAST** — finalize the 64-byte sig, attach witness,
+   `sendrawtransaction`, record `result`.
+
+**Crash-safety (the only genuinely hard part):** if the manager dies after
+`used=1` for any nonce, those nonces are **burned** — on restart the ceremony
+**aborts round 2 and restarts round 1 with fresh nonces** (never resumes a used
+secnonce). A crash can only *lose* a nonce, never reuse one. This mirrors the
+project's stateless-signer discipline; the DB just makes it durable and auditable.
+
+Streaming aggregation note: `secp256k1_musig_nonce_agg` / `partial_sig_agg` take
+arrays, but both are point/scalar sums — foldable incrementally (sum the R1,R2
+points; sum the partial scalars mod n). At 10k the arrays fit (1.3 MB / 360 KB)
+so we can call the library directly; incremental folding is the ~1M path.
+
+## 5. Bring participants up / down at will
+
+There are **no processes or sockets** — a "node" is a DB row + derivable keys.
+"Up" = load its row into the working group; "down" = flush + free. The manager
+just streams groups. This is what replaces the daemon-per-client model and
+eliminates the reconnect storms / races entirely.
+
+## 6. Post-test verification ("everything went where it should")
+
+After the close confirms:
+- **Per-payout reconciliation** — for each funded participant, find its output in
+  the close tx by `out_key`/spk and assert `onchain_sats == expected balance`;
+  write `payout_check`. Assert `Σ outputs + fee == funding`.
+- **Conservation + count** — assert output count == funded (minus dust-folded).
+- **Sweep-home** — since every key is deterministic from SEED, sweep all funded
+  outputs (and any LSP output / the funding on the rejected run) back to the home
+  wallet; assert the sweep confirms. No sats stranded.
+
+## 7. The two target runs (single-tx, via this manager)
+
+1. **~99 KB valid** — `signers=2300 funded=2300` → ~99 KB close → **broadcasts +
+   confirms on real signet** → verify all ~2,300 payouts → sweep home. The
+   "largest cooperative close that lands on-chain" exhibit.
+2. **~430 KB oversized** — `signers=10000 funded=10000` → manager builds + signs
+   (paged) → broadcast → **signet rejects (`tx-size`/non-standard)** → record the
+   exact error, pinning the ceiling → sweep the funding back.
+
+`working_group` set to fit the box (e.g., 1,000). Both runs stay under ~100 MB.
+
+## 8. Build plan
+
+- **Step 0 (done):** `tools/test_signet_close_scale.c` — the in-memory ceremony
+  *core* (derive → aggregate → build M-output close → `musig_sign_taproot` →
+  self-verify → serialize), proving the tx/signing path on the reused, tested
+  builders. It currently holds all N in RAM (fine ≤ ~50k).
+- **Step 1:** wrap the core in the SQLite pager (derive-on-demand, disk secnonces,
+  group passes, write-ahead `used`), driven by `working_group`.
+- **Step 2:** the signet orchestration wrapper (`.sh`): fund `P2TR(agg)`, find the
+  vout, call the manager, broadcast, then run the verification + sweep passes.
+- **Step 3:** run #1 (99 KB, confirms) and #2 (430 KB, rejected); capture exhibits.
+
+## 9. Non-goals / limits
+
+- Test harness only — not a production signing path (production is distributed).
+- Does **not** exercise the wire/reconnect protocol (that stays on the ≤127
+  multi-process harness). It validates **crypto + tx construction + on-chain
+  behavior at scale**, with full fund-flow verification.
+- Multi-tx cooperative close (payouts beyond one standard tx) is a separate
+  feature — see `docs/design/multi-tx-cooperative-close.md`.

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -19,15 +19,22 @@
  * 8 × tx_output_t to 16 × tx_output_t; at 506 nodes (max PS factory at
  * N=128) that's ~50KB extra per factory_t — acceptable. */
 #define FACTORY_MAX_OUTPUTS 16
-/* FACTORY_MAX_SIGNERS = size of the keyagg/pubkey ARRAYS, not the signing
- * cap.  Bumped 128 to 256 by the #303 fix only so the all_pubkeys array in
- * lsp.c cannot overrun when misconfigured with 129 signers (release build's
- * stack canary caught that overrun).  The actual signing limit is
- * MUSIG_SESSION_MAX_SIGNERS (128) = the LSP + up to 127 clients; more than
- * 128 signers is NOT signable, so N=255 is NOT a supported configuration
- * and the LSP CLI rejects --clients above 127. */
+/* FACTORY_MAX_SIGNERS = size of the keyagg/pubkey ARRAYS and the upper bound
+ * on the MuSig2 signing group (LSP + clients).  The signing limit is
+ * MUSIG_SESSION_MAX_SIGNERS, now also 256 (LSP + up to 255 clients).  The old
+ * comment here claimed >128 signers was "NOT signable"; that was overly
+ * conservative — MuSig2/Schnorr aggregate + sign + verify cleanly to 2048
+ * signers, and the distributed session path is valgrind-clean at 256 (see
+ * tools/test_musig_scale.c, tools/test_musig_session_scale.c).  NOTE: running
+ * 255 client daemons is memory-heavy (~70 MB RSS each); a large-factory
+ * deployment is RAM-bound, and shrinking factory_t (dynamic leaf_layers) is a
+ * worthwhile follow-up. */
 #define FACTORY_MAX_SIGNERS 256
-#define FACTORY_MAX_LEAVES  128
+/* FACTORY_MAX_LEAVES: one channel (leaf) per client, so this bounds the client
+ * count.  Raised 128 -> 256 to support up to 255-client factories.  Cost:
+ * leaf_layers[FACTORY_MAX_LEAVES] is embedded in factory_t, so this enlarges
+ * factory_t for all factories (dynamic sizing is the future optimization). */
+#define FACTORY_MAX_LEAVES  256
 
 #define NSEQUENCE_DISABLE_BIP68 0xFFFFFFFFu
 

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -8,7 +8,7 @@
 #include "persist_wt.h"
 #include <secp256k1.h>
 
-#define LSP_MAX_CLIENTS 128
+#define LSP_MAX_CLIENTS 256
 
 typedef struct {
     secp256k1_context *ctx;

--- a/include/superscalar/musig.h
+++ b/include/superscalar/musig.h
@@ -61,7 +61,13 @@ typedef struct {
 } musig_nonce_pool_t;
 
 /* --- Signing session (one per transaction being signed) --- */
-#define MUSIG_SESSION_MAX_SIGNERS 128  /* the factory signing group is the LSP + up to 127 clients = 128 signers; a 128th client would be the 129th signer, which is out of design (the LSP is one of the 128) */
+#define MUSIG_SESSION_MAX_SIGNERS 256  /* max signers in one MuSig2 signing
+   session = LSP + up to 255 clients.  Raised 128 -> 256: MuSig2/Schnorr has no
+   such limit (verified by aggregating + signing + BIP-340-verifying up to 2048
+   signers), and the distributed session path (set_pubnonce/finalize/partial/agg)
+   is valgrind-clean at 256 with clean rejection past it.  See the standalone
+   proofs tools/test_musig_scale.c and tools/test_musig_session_scale.c.
+   secp256k1's aggregation takes size_t; this fixed array is the only cap. */
 
 typedef struct {
     secp256k1_musig_pubnonce pubnonces[MUSIG_SESSION_MAX_SIGNERS];

--- a/src/tx_builder.c
+++ b/src/tx_builder.c
@@ -250,9 +250,17 @@ int compute_taproot_sighash(
     unsigned char sha_sequences[32];
     sha256(seq_le, 4, sha_sequences);
 
-    /* outputs hash: skip output_count varint at offset 46 */
+    /* outputs hash: skip the output_count varint at offset 46.  The varint is
+       1 byte for < 253 outputs, but 3 bytes (0xfd + u16) for 253..65535 and
+       5 bytes (0xfe + u32) beyond — a large cooperative close (>=253 clients)
+       has a multi-byte count, and assuming 1 byte here mis-hashes the outputs
+       and yields an invalid key-path signature. Decode the varint length. */
     size_t out_start = 46;
-    out_start++; /* 1-byte varint for count < 253 */
+    unsigned char cnt_tag = unsigned_tx[out_start];
+    if (cnt_tag < 0xfd)       out_start += 1;
+    else if (cnt_tag == 0xfd) out_start += 3;
+    else if (cnt_tag == 0xfe) out_start += 5;
+    else                      out_start += 9;
     size_t outputs_data_len = tx_len - 4 - out_start;
     unsigned char sha_outputs[32];
     sha256(unsigned_tx + out_start, outputs_data_len, sha_outputs);

--- a/tools/test_musig_scale.c
+++ b/tools/test_musig_scale.c
@@ -1,0 +1,65 @@
+/* Standalone MuSig2 scaling test: does the crypto have a hard limit at 256?
+   Aggregates N pubkeys, does the full nonce->partial->aggregate MuSig2 flow via
+   the project's dynamic (size_t/calloc) wrappers, and BIP-340 verifies the
+   resulting 64-byte Schnorr sig against the aggregate x-only key.
+   If it PASSES at 512/1024/2048, Schnorr/MuSig2 has no 256 limit -> our factory's
+   256 failure is an implementation cap (the fixed session array / wire), not crypto. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <secp256k1.h>
+#include <secp256k1_extrakeys.h>
+#include <secp256k1_schnorrsig.h>
+#include <secp256k1_musig.h>
+#include "superscalar/musig.h"
+
+static void seckey_from_i(unsigned char sk[32], unsigned int i) {
+    memset(sk, 0, 32);
+    sk[0] = 0x01;                     /* keep well inside curve order, nonzero */
+    sk[28] = (unsigned char)(i >> 24);
+    sk[29] = (unsigned char)(i >> 16);
+    sk[30] = (unsigned char)(i >> 8);
+    sk[31] = (unsigned char)(i) ;
+    sk[31] = (unsigned char)(sk[31] | 0x01); /* ensure nonzero even for i=0 */
+}
+
+static int test_n(secp256k1_context *ctx, size_t n) {
+    int rc = 0;
+    secp256k1_keypair *kps = calloc(n, sizeof(secp256k1_keypair));
+    secp256k1_pubkey  *pks = calloc(n, sizeof(secp256k1_pubkey));
+    if (!kps || !pks) { printf("N=%zu: ALLOC FAIL\n", n); goto done; }
+
+    for (size_t i = 0; i < n; i++) {
+        unsigned char sk[32];
+        seckey_from_i(sk, (unsigned)(i + 1));
+        if (!secp256k1_keypair_create(ctx, &kps[i], sk)) { printf("N=%zu: keypair %zu FAIL\n", n, i); goto done; }
+        if (!secp256k1_keypair_pub(ctx, &pks[i], &kps[i])) { printf("N=%zu: pub %zu FAIL\n", n, i); goto done; }
+    }
+
+    musig_keyagg_t ka;
+    if (!musig_aggregate_keys(ctx, &ka, pks, n)) { printf("N=%4zu: KEYAGG FAIL\n", n); goto done; }
+
+    unsigned char msg[32]; memset(msg, 0x42, 32);
+    unsigned char sig[64];
+    if (!musig_sign_all_local(ctx, sig, msg, kps, n, &ka)) { printf("N=%4zu: SIGN FAIL\n", n); goto done; }
+
+    int ok = secp256k1_schnorrsig_verify(ctx, sig, msg, 32, &ka.agg_pubkey);
+    printf("N=%4zu signers:  keyagg=OK  sign=OK  BIP340-verify=%s\n", n, ok ? "PASS" : "FAIL");
+    rc = ok;
+done:
+    free(kps); free(pks);
+    return rc;
+}
+
+int main(void) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    size_t sizes[] = { 2, 128, 160, 255, 256, 257, 384, 512, 1024, 2048 };
+    int all = 1;
+    printf("=== MuSig2 aggregation scaling (pure crypto, dynamic path) ===\n");
+    for (size_t i = 0; i < sizeof(sizes)/sizeof(sizes[0]); i++)
+        all &= test_n(ctx, sizes[i]);
+    printf("\n%s\n", all ? "ALL PASS: MuSig2/Schnorr has NO hard limit at 256 (verifies to 2048 signers)"
+                          : "SOME FAILED: a real limit exists at the failing N");
+    secp256k1_context_destroy(ctx);
+    return all ? 0 : 1;
+}

--- a/tools/test_musig_session_scale.c
+++ b/tools/test_musig_session_scale.c
@@ -1,0 +1,94 @@
+/* Distributed MuSig2 SESSION-flow scaling test — replicates the factory's exact
+   cooperative-close signing path (fixed-array session + taproot tweak + per-signer
+   partial-sig verify + aggregate), in isolation (no wire, no thrash).
+   If the session path fails at 256 while pure crypto passes, the limiter is our
+   fixed-array session cap. Per-partial verify pinpoints a bad signer if any. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <secp256k1.h>
+#include <secp256k1_extrakeys.h>
+#include <secp256k1_schnorrsig.h>
+#include <secp256k1_musig.h>
+#include "superscalar/musig.h"
+
+static void seckey_from_i(unsigned char sk[32], unsigned int i) {
+    memset(sk, 0, 32);
+    sk[0] = 0x01;
+    sk[28] = (unsigned char)(i >> 24); sk[29] = (unsigned char)(i >> 16);
+    sk[30] = (unsigned char)(i >> 8);  sk[31] = (unsigned char)(i | 0x01);
+}
+
+static int test_session_n(secp256k1_context *ctx, size_t n) {
+    int rc = 0, bad_partial = -1;
+    secp256k1_keypair *kps = calloc(n, sizeof(secp256k1_keypair));
+    secp256k1_pubkey  *pks = calloc(n, sizeof(secp256k1_pubkey));
+    secp256k1_musig_secnonce *sns = calloc(n, sizeof(secp256k1_musig_secnonce));
+    secp256k1_musig_pubnonce *pns = calloc(n, sizeof(secp256k1_musig_pubnonce));
+    secp256k1_musig_partial_sig *psigs = calloc(n, sizeof(secp256k1_musig_partial_sig));
+    musig_signing_session_t *session = calloc(1, sizeof(musig_signing_session_t));
+    if (!kps||!pks||!sns||!pns||!psigs||!session) { printf("N=%zu: ALLOC FAIL\n", n); goto done; }
+
+    for (size_t i = 0; i < n; i++) {
+        unsigned char sk[32]; seckey_from_i(sk, (unsigned)(i + 1));
+        if (!secp256k1_keypair_create(ctx, &kps[i], sk)) { printf("N=%zu kp %zu FAIL\n",n,i); goto done; }
+        secp256k1_keypair_pub(ctx, &pks[i], &kps[i]);
+    }
+    musig_keyagg_t ka;
+    if (!musig_aggregate_keys(ctx, &ka, pks, n)) { printf("N=%4zu SESSION: keyagg FAIL\n", n); goto done; }
+
+    musig_session_init(session, &ka, n);
+    unsigned char msg[32]; memset(msg, 0x37, 32);
+
+    /* each signer generates a nonce and hands its pubnonce to the session (fixed array) */
+    int set_ok = 1;
+    for (size_t i = 0; i < n; i++) {
+        unsigned char sk[32];
+        if (!secp256k1_keypair_sec(ctx, sk, &kps[i])) { goto done; }
+        if (!musig_generate_nonce(ctx, &sns[i], &pns[i], sk, &pks[i], &ka.cache)) { printf("N=%zu nonce %zu FAIL\n",n,i); goto done; }
+        if (!musig_session_set_pubnonce(session, i, &pns[i])) { set_ok = 0; printf("N=%4zu SESSION: set_pubnonce REJECTED at signer %zu (cap)\n", n, i); break; }
+    }
+    if (!set_ok) goto done;
+
+    if (!musig_session_finalize_nonces(ctx, session, msg, NULL /*keypath*/, NULL)) { printf("N=%4zu SESSION: finalize_nonces FAIL\n", n); goto done; }
+
+    /* each signer partial-signs; verify EACH partial against the session */
+    for (size_t i = 0; i < n; i++) {
+        if (!musig_create_partial_sig(ctx, &psigs[i], &sns[i], &kps[i], session)) { printf("N=%zu partial %zu FAIL\n",n,i); goto done; }
+        if (!musig_verify_partial_sig(ctx, &psigs[i], &pns[i], &pks[i], session) && bad_partial < 0) bad_partial = (int)i;
+    }
+
+    unsigned char sig[64];
+    if (!musig_aggregate_partial_sigs(ctx, sig, session, psigs, n)) { printf("N=%4zu SESSION: partial_sig_agg FAIL\n", n); goto done; }
+
+    /* verify aggregate vs the TAPROOT-TWEAKED aggregate key (keypath, merkle_root NULL) */
+    unsigned char xser[32]; secp256k1_xonly_pubkey_serialize(ctx, xser, &ka.agg_pubkey);
+    unsigned char tweak[32]; secp256k1_tagged_sha256(ctx, tweak, (const unsigned char*)"TapTweak", 8, xser, 32);
+    secp256k1_musig_keyagg_cache cc = ka.cache; secp256k1_pubkey tpk;
+    secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tpk, &cc, tweak);
+    secp256k1_xonly_pubkey txo; secp256k1_xonly_pubkey_from_pubkey(ctx, &txo, NULL, &tpk);
+    int ok = secp256k1_schnorrsig_verify(ctx, sig, msg, 32, &txo);
+
+    printf("N=%4zu SESSION: set=OK finalize=OK partials=%s agg=OK BIP340-verify=%s\n",
+           n, bad_partial < 0 ? "all-valid" : "BAD", ok ? "PASS" : "FAIL");
+    if (bad_partial >= 0) printf("        (first invalid partial sig at signer %d)\n", bad_partial);
+    rc = ok && (bad_partial < 0);
+done:
+    free(kps); free(pks); free(sns); free(pns); free(psigs); free(session);
+    return rc;
+}
+
+int main(void) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    size_t sizes[] = { 128, 255, 256, 257, 300, 512 };
+    printf("=== MuSig2 DISTRIBUTED SESSION flow (factory close path) ===\n");
+    printf("(MUSIG_SESSION_MAX_SIGNERS = %d)\n", MUSIG_SESSION_MAX_SIGNERS);
+    int all_upto256 = 1;
+    for (size_t i = 0; i < sizeof(sizes)/sizeof(sizes[0]); i++) {
+        int r = test_session_n(ctx, sizes[i]);
+        if (sizes[i] <= 256) all_upto256 &= r;
+    }
+    printf("\nSession path %s at N<=256\n", all_upto256 ? "PASSES" : "FAILS");
+    secp256k1_context_destroy(ctx);
+    return 0;
+}

--- a/tools/test_signet_close_scale.c
+++ b/tools/test_signet_close_scale.c
@@ -1,0 +1,252 @@
+/* test_signet_close_scale.c — conductor-lite cooperative-close SCALE harness.
+ *
+ * The cooperative close is a KEY-PATH spend of the factory funding output (the
+ * N-of-N MuSig2 aggregate) to one output per funded client.  It never touches
+ * the DW tree, so this harness needs no factory_t (no 53 MB/client), no daemons
+ * and no tree ceremony: it simulates all N signers in one process, holding only
+ * N keypairs + the running MuSig aggregate (~6 MB even at N=10,000, seconds).
+ *
+ * It exercises the REAL close-signing path (musig_sign_taproot -> the same
+ * dynamic musig_sign_all_local proven to 2048 signers) and the REAL tx builder
+ * (build_unsigned_tx / compute_taproot_sighash / finalize_signed_tx), then
+ * self-verifies the aggregate before anything is broadcast.
+ *
+ * Purpose: prove close-tx construction + N-of-N aggregate signing + on-chain
+ * size at scale, and pin the standardness ceiling with a real node error.
+ *   Run 1 (~2,300 funded): ~99 KB close that lands on signet.
+ *   Run 2 (~10,000 funded): ~430 KB close that our code builds + signs and the
+ *          network rejects (tx-size / non-standard).
+ *
+ * Signet RPC orchestration (fund the address, find the vout, broadcast) is done
+ * by the wrapper test_signet_close_scale.sh; this tool is pure crypto+tx and is
+ * deterministic from SEED, so funds are always recoverable.
+ *
+ * Modes:
+ *   test_signet_close_scale addr  <N> <SEED>
+ *       -> prints the funding output x-only key (hex); wrapper funds rawtr(hex).
+ *   test_signet_close_scale close <N> <M> <SEED> <FUND_TXID> <VOUT> <AMOUNT_SATS> <OUTFILE> [FEE_RATE]
+ *       -> builds+signs+self-verifies the close paying M funded clients; writes
+ *          the signed tx hex to OUTFILE; prints signer/output counts, serialized
+ *          size, weight, vsize and the standardness verdict.
+ */
+#include "superscalar/musig.h"
+#include "superscalar/tx_builder.h"
+#include <secp256k1.h>
+#include <secp256k1_extrakeys.h>
+#include <secp256k1_schnorrsig.h>
+#include <secp256k1_musig.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void hex_encode(const unsigned char *data, size_t len, char *out);
+extern int  hex_decode(const char *hex, unsigned char *out, size_t out_len);
+extern void reverse_bytes(unsigned char *data, size_t len);
+
+#define DUST_LIMIT      546
+#define STD_MAX_VSIZE   100000   /* MAX_STANDARD_TX_WEIGHT / 4 */
+
+/* Deterministic STRONG per-signer seckey (no weak keys on public signet):
+   tagged_sha256("SSCloseScale", "SEED:i:bump") until a valid scalar. */
+static int derive_seckey(const secp256k1_context *ctx, const char *seed,
+                         size_t i, unsigned char sk[32]) {
+    char buf[160];
+    for (uint32_t bump = 0; bump < 1024; bump++) {
+        int n = snprintf(buf, sizeof buf, "%s:%zu:%u", seed, i, bump);
+        secp256k1_tagged_sha256(ctx, sk, (const unsigned char *)"SSCloseScale", 12,
+                                (const unsigned char *)buf, (size_t)n);
+        if (secp256k1_ec_seckey_verify(ctx, sk)) return 1;
+    }
+    return 0;
+}
+
+/* Aggregate N deterministic pubkeys; also return keypairs (caller frees). */
+static int build_signers(const secp256k1_context *ctx, const char *seed, size_t N,
+                         secp256k1_keypair **kps_out, secp256k1_pubkey **pks_out,
+                         musig_keyagg_t *ka_out) {
+    secp256k1_keypair *kps = calloc(N, sizeof(*kps));
+    secp256k1_pubkey  *pks = calloc(N, sizeof(*pks));
+    if (!kps || !pks) { free(kps); free(pks); return 0; }
+    for (size_t i = 0; i < N; i++) {
+        unsigned char sk[32];
+        if (!derive_seckey(ctx, seed, i, sk) ||
+            !secp256k1_keypair_create(ctx, &kps[i], sk) ||
+            !secp256k1_keypair_pub(ctx, &pks[i], &kps[i])) {
+            free(kps); free(pks); return 0;
+        }
+    }
+    if (!musig_aggregate_keys(ctx, ka_out, pks, N)) { free(kps); free(pks); return 0; }
+    *kps_out = kps; *pks_out = pks;
+    return 1;
+}
+
+/* BIP-341 key-path output key = internal(agg) tweaked by TapTweak(agg) (no script tree). */
+static int funding_output_key(const secp256k1_context *ctx, const musig_keyagg_t *ka,
+                              secp256k1_xonly_pubkey *out_key) {
+    unsigned char xser[32], tweak[32];
+    if (!secp256k1_xonly_pubkey_serialize(ctx, xser, &ka->agg_pubkey)) return 0;
+    secp256k1_tagged_sha256(ctx, tweak, (const unsigned char *)"TapTweak", 8, xser, 32);
+    secp256k1_musig_keyagg_cache cc = ka->cache;
+    secp256k1_pubkey tpk;
+    if (!secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tpk, &cc, tweak)) return 0;
+    return secp256k1_xonly_pubkey_from_pubkey(ctx, out_key, NULL, &tpk);
+}
+
+int main(int argc, char **argv) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    if (argc >= 4 && !strcmp(argv[1], "addr")) {
+        size_t N = strtoull(argv[2], NULL, 10);
+        const char *seed = argv[3];
+        secp256k1_keypair *kps; secp256k1_pubkey *pks; musig_keyagg_t ka;
+        if (!build_signers(ctx, seed, N, &kps, &pks, &ka)) { fprintf(stderr, "signer setup failed\n"); return 1; }
+        secp256k1_xonly_pubkey ok; if (!funding_output_key(ctx, &ka, &ok)) { fprintf(stderr, "tweak failed\n"); return 1; }
+        unsigned char ser[32]; secp256k1_xonly_pubkey_serialize(ctx, ser, &ok);
+        char hex[65]; hex_encode(ser, 32, hex); hex[64] = 0;
+        printf("%s\n", hex);   /* wrapper: bitcoin-cli deriveaddresses "rawtr(<hex>)" */
+        free(kps); free(pks);
+        return 0;
+    }
+
+    if (argc >= 9 && !strcmp(argv[1], "close")) {
+        size_t N = strtoull(argv[2], NULL, 10);
+        size_t M = strtoull(argv[3], NULL, 10);           /* funded clients */
+        const char *seed = argv[4];
+        const char *txid_hex = argv[5];
+        uint32_t vout = (uint32_t)strtoul(argv[6], NULL, 10);
+        uint64_t amount = strtoull(argv[7], NULL, 10);    /* funding UTXO value */
+        const char *outfile = argv[8];
+        uint64_t fee_rate = (argc >= 10) ? strtoull(argv[9], NULL, 10) : 1;  /* sat/vB */
+
+        if (M + 1 > N) { fprintf(stderr, "need funded M(%zu)+LSP <= N(%zu)\n", M, N); return 1; }
+
+        secp256k1_keypair *kps; secp256k1_pubkey *pks; musig_keyagg_t ka;
+        if (!build_signers(ctx, seed, N, &kps, &pks, &ka)) { fprintf(stderr, "signer setup failed\n"); return 1; }
+
+        secp256k1_xonly_pubkey fund_key;
+        if (!funding_output_key(ctx, &ka, &fund_key)) { fprintf(stderr, "tweak failed\n"); return 1; }
+        unsigned char funding_spk[34]; build_p2tr_script_pubkey(funding_spk, &fund_key);
+
+        /* Close outputs: [0] = LSP (signer 0), [1..M] = funded clients (signers 1..M).
+           Each funded client is paid to rawtr(its own x-only key) — recoverable from SEED.
+           Empty channels (signers M+1..N-1) get nothing — the real dust-fold behavior. */
+        tx_output_t *outs = calloc(M + 1, sizeof(tx_output_t));
+        if (!outs) { fprintf(stderr, "oom outputs\n"); return 1; }
+        size_t n_out = 1;
+        uint64_t client_sum = 0;
+        for (size_t i = 1; i <= M; i++) {
+            uint64_t amt = 700 + (uint64_t)(i % 600);   /* 700..1299 sats, all > dust, varied */
+            secp256k1_xonly_pubkey xo; secp256k1_keypair_xonly_pub(ctx, &xo, NULL, &kps[i]);
+            build_p2tr_script_pubkey(outs[n_out].script_pubkey, &xo);
+            outs[n_out].script_pubkey_len = 34;
+            outs[n_out].amount_sats = amt;
+            client_sum += amt;
+            n_out++;
+        }
+        /* fee from an estimate of the final vsize (key-path: witness ~ negligible weight) */
+        uint64_t est_vsize = 11 /*version+locktime+counts*/ + 58 /*p2tr input*/ + (uint64_t)n_out * 43;
+        uint64_t fee = est_vsize * fee_rate;
+        if (amount < client_sum + fee + DUST_LIMIT) {
+            fprintf(stderr, "funding %llu too small for %zu clients (need >= %llu + fee %llu + LSP dust)\n",
+                    (unsigned long long)amount, M, (unsigned long long)client_sum, (unsigned long long)fee);
+            return 1;
+        }
+        secp256k1_xonly_pubkey lsp_xo; secp256k1_keypair_xonly_pub(ctx, &lsp_xo, NULL, &kps[0]);
+        build_p2tr_script_pubkey(outs[0].script_pubkey, &lsp_xo);
+        outs[0].script_pubkey_len = 34;
+        outs[0].amount_sats = amount - client_sum - fee;
+
+        /* Build, sighash, N-of-N sign (key-path, no script tree), self-verify. */
+        unsigned char txid_le[32];
+        if (hex_decode(txid_hex, txid_le, 32) != 32) { fprintf(stderr, "bad txid\n"); return 1; }
+        reverse_bytes(txid_le, 32);
+
+        tx_buf_t utx; tx_buf_init(&utx, 1u << 20);
+        if (!build_unsigned_tx(&utx, NULL, txid_le, vout, 0xFFFFFFFDu, outs, n_out)) { fprintf(stderr, "build_unsigned_tx fail\n"); return 1; }
+        unsigned char sighash[32];
+        if (!compute_taproot_sighash(sighash, utx.data, utx.len, 0, funding_spk, 34, amount, 0xFFFFFFFDu)) { fprintf(stderr, "sighash fail\n"); return 1; }
+        unsigned char sig[64];
+        if (!musig_sign_taproot(ctx, sig, sighash, kps, N, &ka, NULL)) { fprintf(stderr, "musig_sign_taproot fail\n"); return 1; }
+        if (!secp256k1_schnorrsig_verify(ctx, sig, sighash, 32, &fund_key)) {
+            fprintf(stderr, "SELF-VERIFY FAILED — not writing tx\n"); return 1;
+        }
+        tx_buf_t stx; tx_buf_init(&stx, 1u << 20);
+        if (!finalize_signed_tx(&stx, utx.data, utx.len, sig)) { fprintf(stderr, "finalize fail\n"); return 1; }
+
+        uint64_t weight = (uint64_t)utx.len * 4 + (stx.len - utx.len);  /* non-witness*4 + witness */
+        uint64_t vsize  = (weight + 3) / 4;
+
+        FILE *f = fopen(outfile, "w");
+        if (!f) { fprintf(stderr, "cannot write %s\n", outfile); return 1; }
+        char *hx = malloc(stx.len * 2 + 1); hex_encode(stx.data, stx.len, hx); hx[stx.len * 2] = 0;
+        fputs(hx, f); fclose(f);
+
+        printf("close-scale: signers=%zu funded=%zu outputs=%zu\n", N, M, n_out);
+        printf("  in=%llu client_sum=%llu fee=%llu(@%llu sat/vB) lsp=%llu conserves=%s\n",
+               (unsigned long long)amount, (unsigned long long)client_sum, (unsigned long long)fee,
+               (unsigned long long)fee_rate, (unsigned long long)outs[0].amount_sats,
+               (amount == outs[0].amount_sats + client_sum + fee) ? "yes" : "NO");
+        printf("  serialized=%zu B  weight=%llu wu  vsize=%llu vB  self_verify=OK\n",
+               stx.len, (unsigned long long)weight, (unsigned long long)vsize);
+        printf("  standardness(<=%d vB): %s\n", STD_MAX_VSIZE,
+               vsize <= STD_MAX_VSIZE ? "WITHIN — expect relay" : "OVER — expect tx-size rejection");
+        printf("  hex written to %s\n", outfile);
+        free(hx); free(outs); free(kps); free(pks);
+        return 0;
+    }
+
+    if (argc >= 9 && !strcmp(argv[1], "sweep")) {
+        /* Spend the N-of-N funding UTXO to a single dest scriptPubKey (recover funds,
+           e.g. after RUN 2's oversized close is rejected). N-of-N key-path signed. */
+        size_t N = strtoull(argv[2], NULL, 10);
+        const char *seed = argv[3];
+        const char *txid_hex = argv[4];
+        uint32_t vout = (uint32_t)strtoul(argv[5], NULL, 10);
+        uint64_t amount = strtoull(argv[6], NULL, 10);
+        const char *dest_spk_hex = argv[7];
+        const char *outfile = argv[8];
+        uint64_t fee_rate = (argc >= 10) ? strtoull(argv[9], NULL, 10) : 1;
+
+        secp256k1_keypair *kps; secp256k1_pubkey *pks; musig_keyagg_t ka;
+        if (!build_signers(ctx, seed, N, &kps, &pks, &ka)) { fprintf(stderr, "signer setup failed\n"); return 1; }
+        secp256k1_xonly_pubkey fund_key;
+        if (!funding_output_key(ctx, &ka, &fund_key)) { fprintf(stderr, "tweak failed\n"); return 1; }
+        unsigned char funding_spk[34]; build_p2tr_script_pubkey(funding_spk, &fund_key);
+
+        tx_output_t o; memset(&o, 0, sizeof o);
+        if (hex_decode(dest_spk_hex, o.script_pubkey, 34) < 1) { fprintf(stderr, "bad dest spk\n"); return 1; }
+        o.script_pubkey_len = (strlen(dest_spk_hex) / 2);
+        uint64_t fee = (uint64_t)(11 + 58 + 43) * fee_rate;
+        if (amount <= fee + DUST_LIMIT) { fprintf(stderr, "amount too small for fee\n"); return 1; }
+        o.amount_sats = amount - fee;
+
+        unsigned char txid_le[32];
+        if (hex_decode(txid_hex, txid_le, 32) != 32) { fprintf(stderr, "bad txid\n"); return 1; }
+        reverse_bytes(txid_le, 32);
+        tx_buf_t utx; tx_buf_init(&utx, 4096);
+        if (!build_unsigned_tx(&utx, NULL, txid_le, vout, 0xFFFFFFFDu, &o, 1)) { fprintf(stderr, "build fail\n"); return 1; }
+        unsigned char sighash[32];
+        if (!compute_taproot_sighash(sighash, utx.data, utx.len, 0, funding_spk, 34, amount, 0xFFFFFFFDu)) { fprintf(stderr, "sighash fail\n"); return 1; }
+        unsigned char sig[64];
+        if (!musig_sign_taproot(ctx, sig, sighash, kps, N, &ka, NULL)) { fprintf(stderr, "sign fail\n"); return 1; }
+        if (!secp256k1_schnorrsig_verify(ctx, sig, sighash, 32, &fund_key)) { fprintf(stderr, "SELF-VERIFY FAILED\n"); return 1; }
+        tx_buf_t stx; tx_buf_init(&stx, 4096);
+        if (!finalize_signed_tx(&stx, utx.data, utx.len, sig)) { fprintf(stderr, "finalize fail\n"); return 1; }
+        FILE *f = fopen(outfile, "w");
+        if (!f) { fprintf(stderr, "cannot write %s\n", outfile); return 1; }
+        char *hx = malloc(stx.len * 2 + 1); hex_encode(stx.data, stx.len, hx); hx[stx.len * 2] = 0;
+        fputs(hx, f); fclose(f);
+        printf("sweep: signers=%zu in=%llu out=%llu fee=%llu self_verify=OK -> %s\n",
+               N, (unsigned long long)amount, (unsigned long long)o.amount_sats, (unsigned long long)fee, outfile);
+        free(hx); free(kps); free(pks);
+        return 0;
+    }
+
+    fprintf(stderr,
+        "usage:\n"
+        "  %s addr  <N> <SEED>\n"
+        "  %s close <N> <M_FUNDED> <SEED> <FUND_TXID> <VOUT> <AMOUNT_SATS> <OUTFILE> [FEE_RATE]\n"
+        "  %s sweep <N> <SEED> <FUND_TXID> <VOUT> <AMOUNT_SATS> <DEST_SPK_HEX> <OUTFILE> [FEE_RATE]\n",
+        argv[0], argv[0], argv[0]);
+    return 1;
+}

--- a/tools/test_signet_close_scale.sh
+++ b/tools/test_signet_close_scale.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# test_signet_close_scale.sh — drive test_signet_close_scale on REAL signet.
+#
+# Funds a P2TR(N-of-N aggregate) from the home wallet, cooperatively closes it to
+# M funded clients in ONE tx, broadcasts, verifies on-chain, and recovers funds.
+#   RUN 1 (~99 KB):  N=2301 M=2300  -> expect the close to CONFIRM.
+#   RUN 2 (~430 KB): N=10001 M=10000 -> expect broadcast REJECTION (tx-size),
+#                    then sweep the intact funding back home.
+#
+# Env: N M SEED FUNDING_SATS FEE_RATE(1) EXPECT(confirm|reject) BIN WALLET
+set -uo pipefail
+CONF="${SIGNET_CONF:-/var/lib/bitcoind-signet/bitcoin.conf}"
+CLI="bitcoin-cli -signet -conf=$CONF"
+WALLET="${WALLET:-ss_sig_n127}"
+WCLI="$CLI -rpcwallet=$WALLET"
+BIN="${BIN:-/root/SuperScalar-lsppay/build-lsppay/test_signet_close_scale}"
+N="${N:?}"; M="${M:?}"; SEED="${SEED:?}"; FUNDING_SATS="${FUNDING_SATS:?}"
+FEE_RATE="${FEE_RATE:-1}"; EXPECT="${EXPECT:-confirm}"
+TAG="closescale_${SEED}"
+info(){ printf '\033[36m[close-scale]\033[0m %s\n' "$*"; }
+ok(){ printf '\033[32m%s\033[0m\n' "$*"; }
+bad(){ printf '\033[31m%s\033[0m\n' "$*"; }
+
+# 1. funding address = rawtr(agg output key)
+OUTKEY=$("$BIN" addr "$N" "$SEED"); [ ${#OUTKEY} -eq 64 ] || { bad "addr failed"; exit 1; }
+FUND_ADDR=$($CLI deriveaddresses "rawtr($OUTKEY)" | python3 -c 'import sys,json;print(json.load(sys.stdin)[0])')
+info "N=$N M=$M funding addr=$FUND_ADDR outkey=$OUTKEY"
+
+# 2. fund it + wait 1 conf
+BTC=$(python3 -c "print(f'{$FUNDING_SATS/1e8:.8f}')")
+FUND_TXID=$($WCLI -named sendtoaddress address="$FUND_ADDR" amount="$BTC" fee_rate="$FEE_RATE")
+info "funded: $FUND_TXID ($BTC BTC) — waiting for 1 conf (signet ~10min)..."
+for i in $(seq 1 120); do
+  c=$($WCLI gettransaction "$FUND_TXID" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("confirmations",0))' 2>/dev/null || echo 0)
+  [ "${c:-0}" -ge 1 ] && break; sleep 30
+done
+[ "${c:-0}" -ge 1 ] || { bad "funding not confirmed"; exit 1; }
+# 3. find the vout paying our address
+VOUT=$($CLI getrawtransaction "$FUND_TXID" 1 | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+for v in d['vout']:
+    if v['scriptPubKey'].get('address')=='$FUND_ADDR': print(v['n']); break
+")
+info "confirmed; funding vout=$VOUT"
+
+# 4. build + sign the close
+"$BIN" close "$N" "$M" "$SEED" "$FUND_TXID" "$VOUT" "$FUNDING_SATS" /tmp/${TAG}_close.hex "$FEE_RATE" || { bad "close build failed"; exit 1; }
+
+# 5. broadcast
+info "broadcasting close ($(wc -c < /tmp/${TAG}_close.hex) hex chars)..."
+set +e
+CLOSE_TXID=$($CLI sendrawtransaction "$(cat /tmp/${TAG}_close.hex)" 2>/tmp/${TAG}_err.txt)
+RC=$?
+set -e
+if [ "$EXPECT" = confirm ]; then
+  [ $RC -eq 0 ] || { bad "UNEXPECTED broadcast failure:"; cat /tmp/${TAG}_err.txt; exit 1; }
+  ok "CLOSE BROADCAST: $CLOSE_TXID"
+  info "verifying on-chain (nout==M+1, conservation)..."
+  $CLI getrawtransaction "$CLOSE_TXID" 1 | python3 -c "
+import sys,json
+d=json.load(sys.stdin); nout=len(d['vout']); outs=round(sum(v['value'] for v in d['vout'])*1e8)
+exp=$M+1
+print(f'  nout={nout} (expect {exp})  out_sum={outs}  funding={$FUNDING_SATS}  fee={$FUNDING_SATS-outs}')
+print('  VERIFY: '+('PASS' if nout==exp and outs<$FUNDING_SATS else 'FAIL'))
+"
+  ok "RUN 1 exhibit: largest cooperative close landed on signet ($CLOSE_TXID)"
+  info "NOTE: $M client outputs are at deterministic rawtr(SEED,i) addrs — recoverable via a batched consolidation (follow-up)."
+else
+  if [ $RC -eq 0 ]; then bad "UNEXPECTED: oversized tx was ACCEPTED ($CLOSE_TXID)?!"; else
+    ok "RUN 2 ceiling pinned — signet REJECTED the ~430KB close as expected:"; cat /tmp/${TAG}_err.txt; fi
+  # sweep the intact funding back home (N-of-N -> home)
+  DEST_SPK=$($WCLI getaddressinfo "$($WCLI getnewaddress ${TAG}_sweep bech32m)" | python3 -c 'import sys,json;print(json.load(sys.stdin)["scriptPubKey"])')
+  "$BIN" sweep "$N" "$SEED" "$FUND_TXID" "$VOUT" "$FUNDING_SATS" "$DEST_SPK" /tmp/${TAG}_sweep.hex "$FEE_RATE" || { bad "sweep build failed"; exit 1; }
+  SWEEP_TXID=$($CLI sendrawtransaction "$(cat /tmp/${TAG}_sweep.hex)") || { bad "sweep broadcast failed"; exit 1; }
+  ok "funding swept home: $SWEEP_TXID"
+fi

--- a/tools/test_signet_close_scale.sh
+++ b/tools/test_signet_close_scale.sh
@@ -23,7 +23,8 @@ bad(){ printf '\033[31m%s\033[0m\n' "$*"; }
 
 # 1. funding address = rawtr(agg output key)
 OUTKEY=$("$BIN" addr "$N" "$SEED"); [ ${#OUTKEY} -eq 64 ] || { bad "addr failed"; exit 1; }
-FUND_ADDR=$($CLI deriveaddresses "rawtr($OUTKEY)" | python3 -c 'import sys,json;print(json.load(sys.stdin)[0])')
+DESC=$($CLI getdescriptorinfo "rawtr($OUTKEY)" | python3 -c 'import sys,json;print(json.load(sys.stdin)["descriptor"])')
+FUND_ADDR=$($CLI deriveaddresses "$DESC" | python3 -c 'import sys,json;print(json.load(sys.stdin)[0])')
 info "N=$N M=$M funding addr=$FUND_ADDR outkey=$OUTKEY"
 
 # 2. fund it + wait 1 conf
@@ -50,7 +51,7 @@ info "confirmed; funding vout=$VOUT"
 # 5. broadcast
 info "broadcasting close ($(wc -c < /tmp/${TAG}_close.hex) hex chars)..."
 set +e
-CLOSE_TXID=$($CLI sendrawtransaction "$(cat /tmp/${TAG}_close.hex)" 2>/tmp/${TAG}_err.txt)
+CLOSE_TXID=$(cat /tmp/${TAG}_close.hex | $CLI -stdin sendrawtransaction 2>/tmp/${TAG}_err.txt)
 RC=$?
 set -e
 if [ "$EXPECT" = confirm ]; then
@@ -72,6 +73,6 @@ else
   # sweep the intact funding back home (N-of-N -> home)
   DEST_SPK=$($WCLI getaddressinfo "$($WCLI getnewaddress ${TAG}_sweep bech32m)" | python3 -c 'import sys,json;print(json.load(sys.stdin)["scriptPubKey"])')
   "$BIN" sweep "$N" "$SEED" "$FUND_TXID" "$VOUT" "$FUNDING_SATS" "$DEST_SPK" /tmp/${TAG}_sweep.hex "$FEE_RATE" || { bad "sweep build failed"; exit 1; }
-  SWEEP_TXID=$($CLI sendrawtransaction "$(cat /tmp/${TAG}_sweep.hex)") || { bad "sweep broadcast failed"; exit 1; }
+  SWEEP_TXID=$(cat /tmp/${TAG}_sweep.hex | $CLI -stdin sendrawtransaction) || { bad "sweep broadcast failed"; exit 1; }
   ok "funding swept home: $SWEEP_TXID"
 fi


### PR DESCRIPTION
## What
Raises the factory signing group from **128 to 256 signers** (LSP + up to 255 clients) by widening three fixed-array caps, and adds two scaling proofs built via CMake.

```
MUSIG_SESSION_MAX_SIGNERS  128 -> 256   (musig.h)  — the signing-session array
LSP_MAX_CLIENTS            128 -> 256   (lsp.h)    — LSP client/connection arrays
FACTORY_MAX_LEAVES         128 -> 256   (factory.h)— one channel/leaf per client
```

## Why it is safe
`factory.h` previously declared *"more than 128 signers is NOT signable, N=255 is NOT a supported configuration."* That was overly conservative — **MuSig2/Schnorr have no such limit**, and this PR proves it against the exact library and wrappers we ship:

- **`tools/test_musig_scale.c`** — pure MuSig2 aggregate → sign → BIP-340-verify at **N = 2, 128, 160, 255, 256, 257, 384, 512, 1024, 2048**. **ALL PASS.** (A Schnorr sig is one 64-byte `(R,s)` regardless of signer count; on-chain a 256-signer close is byte-identical to a 2-signer one.)
- **`tools/test_musig_session_scale.c`** — the **distributed session path the cooperative close actually uses** (`session_init` → `set_pubnonce` ×N → `finalize_nonces` w/ taproot tweak → per-signer `partial_sign` + **verify** → `partial_sig_agg`). **PASSES at 256**, and **cleanly rejects** 257+ at the bounds check (no memory corruption).
- **valgrind memcheck:** `ERROR SUMMARY: 0 errors` on the session path at 256.

`secp256k1`'s aggregation takes `size_t` — the only limit was our fixed arrays.

## Verified on regtest
A **256-signer factory births** (255-channel MuSig2 creation ceremony), **onboards all 255 clients at zero balance**, and **funds all 255 over Lightning** (255/255 seeded). The convergence gate marshals all 255 for the close.

## Honest caveat (memory, not crypto)
Running 255 client daemons is memory-heavy (~70 MB RSS each ≈ 18 GB), so a large-factory *deployment* is RAM-bound — the crypto and code are ready, the box needs the RAM. `FACTORY_MAX_LEAVES` is embedded in `factory_t` (`leaf_layers[]`), so this bump enlarges `factory_t` for all factories; **making `leaf_layers` dynamic is a worthwhile follow-up** to remove the memory cost for small factories and to run 255 clients within a smaller footprint.