### PR TITLE
factory: one process handles 1000+ clients with real LN payments (O(N log N) memory) — proven on signet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,3 +522,9 @@ target_link_libraries(test_signet_close_scale PRIVATE superscalar superscalar_se
 if(ENABLE_SANITIZERS)
     target_link_libraries(test_signet_close_scale PRIVATE project_sanitizers)
 endif()
+
+# In-process single-process factory lifecycle manager (scale on a small box):
+# one factory_t (build_tree + sign_all + cooperative_close), no daemons.
+add_executable(test_inproc_factory_lifecycle tools/test_inproc_factory_lifecycle.c)
+target_include_directories(test_inproc_factory_lifecycle PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
+target_link_libraries(test_inproc_factory_lifecycle PRIVATE superscalar superscalar_secrets project_warnings)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,4 +527,5 @@ endif()
 # one factory_t (build_tree + sign_all + cooperative_close), no daemons.
 add_executable(test_inproc_factory_lifecycle tools/test_inproc_factory_lifecycle.c)
 target_include_directories(test_inproc_factory_lifecycle PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
+target_include_directories(test_inproc_factory_lifecycle PRIVATE ${cjson_SOURCE_DIR})
 target_link_libraries(test_inproc_factory_lifecycle PRIVATE superscalar superscalar_secrets project_warnings)

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -121,8 +121,13 @@ typedef enum {
 typedef struct {
     factory_node_type_t type;
 
-    /* Signers for this node's N-of-N */
-    uint32_t signer_indices[FACTORY_MAX_SIGNERS];
+    /* Signers for this node's N-of-N.  Dynamic: allocated in factory_build_tree
+       to n_signers (this node's SUBTREE signer count), not the global max.  This
+       is a local->global mapping (slot j in [0,n_signers) -> global participant
+       signer_indices[j]) so every per-node/per-session array can be subtree-sized,
+       keeping the whole tree O(N log N) rather than O(N^2).  Also lets the root
+       node (n_signers == N+1) exceed the old fixed FACTORY_MAX_SIGNERS cap. */
+    uint32_t *signer_indices;
     size_t n_signers;
     musig_keyagg_t keyagg;
 
@@ -162,9 +167,11 @@ typedef struct {
     unsigned char merkle_root[32];
     int output_parity;        /* parity of tweaked output key */
 
-    /* Split-round signing state */
+    /* Split-round signing state.  partial_sigs is dynamic (sized to n_signers in
+       factory_build_tree) — subtree-sized, and lets the root node exceed the old
+       fixed FACTORY_MAX_SIGNERS cap. */
     musig_signing_session_t signing_session;
-    secp256k1_musig_partial_sig partial_sigs[FACTORY_MAX_SIGNERS];
+    secp256k1_musig_partial_sig *partial_sigs;
     int partial_sigs_received;
 
     /* Wire-ceremony poison TX state — second MuSig session per node so a
@@ -177,7 +184,7 @@ typedef struct {
        broadcast the poison TX on breach detection.  Closes the SECURITY
        GAP documented in docs/poison-tx.md. */
     musig_signing_session_t poison_signing_session;
-    secp256k1_musig_partial_sig poison_partial_sigs[FACTORY_MAX_SIGNERS];
+    secp256k1_musig_partial_sig *poison_partial_sigs;  /* dynamic, sized to n_signers */
     int poison_partial_sigs_received;
     unsigned char poison_sighash[32];
     tx_buf_t poison_unsigned_tx;
@@ -316,9 +323,11 @@ typedef struct {
 typedef struct {
     secp256k1_context *ctx;
 
-    /* Participants: 0 = LSP, 1..N = clients */
-    secp256k1_keypair keypairs[FACTORY_MAX_SIGNERS];
-    secp256k1_pubkey pubkeys[FACTORY_MAX_SIGNERS];
+    /* Participants: 0 = LSP, 1..N = clients.  Dynamic (calloc'd in factory_init
+       to config.max_signers) so a single-process factory can exceed the old fixed
+       FACTORY_MAX_SIGNERS (256) cap.  These are O(N), one copy per factory. */
+    secp256k1_keypair *keypairs;
+    secp256k1_pubkey *pubkeys;
     size_t n_participants;
 
     /* Flat node array */
@@ -388,10 +397,14 @@ typedef struct {
     int *node_l_stock_hash_valid;               /* dynamic, sized to config.max_nodes */
     int has_node_l_stock_hashes;
 
-    /* Per-leaf DW layers (for independent leaf advance) */
-    dw_layer_t leaf_layers[FACTORY_MAX_LEAVES];
+    /* Per-leaf DW layers (for independent leaf advance).  Dynamic (calloc'd in
+       factory_init to config.max_leaves) — PS uses one leaf per client, so a
+       fixed [FACTORY_MAX_LEAVES]=256 capped the factory at 255 clients and (worse)
+       factory_set_arity's dw_layer_init loop silently overran it into adjacent
+       fields for N>=256.  Freed in factory_free, deep-copied in detach. */
+    dw_layer_t *leaf_layers;
     int n_leaf_nodes;              /* number of leaf state nodes */
-    size_t leaf_node_indices[FACTORY_MAX_LEAVES];
+    size_t *leaf_node_indices;
 
     int per_leaf_enabled;          /* activated after first leaf advance */
     factory_arity_t leaf_arity;    /* FACTORY_ARITY_2 (default) or FACTORY_ARITY_1 */
@@ -450,7 +463,7 @@ typedef struct {
     /* Placement + Economics */
     placement_mode_t placement_mode;  /* client ordering strategy */
     economic_mode_t  economic_mode;   /* fee distribution model */
-    participant_profile_t profiles[FACTORY_MAX_SIGNERS];
+    participant_profile_t *profiles;  /* dynamic, sized to config.max_signers */
 
     /* Runtime config (Mainnet Gap #6) — stored limits for this factory */
     factory_config_t config;
@@ -467,7 +480,7 @@ typedef struct {
        nodes[0].keyagg (no taptree), message = dist_sighash.  Mirrors the per-node
        session helpers but targets the funding output instead of a tree node. */
     musig_signing_session_t dist_signing_session;
-    secp256k1_musig_partial_sig dist_partial_sigs[FACTORY_MAX_SIGNERS];
+    secp256k1_musig_partial_sig *dist_partial_sigs;  /* dynamic, sized to config.max_signers */
     int dist_partial_sigs_received;
     tx_buf_t dist_signed_tx;       /* fully-signed distribution TX (dist_tx_ready==2) */
 } factory_t;

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -485,6 +485,14 @@ typedef struct {
     tx_buf_t dist_signed_tx;       /* fully-signed distribution TX (dist_tx_ready==2) */
 } factory_t;
 
+/* Allocate the dynamic arrays (participants / per-leaf / per-node) at config
+   defaults for a factory_t that was built BY HAND — calloc'd or stack-zeroed and
+   then field-poked — instead of going through factory_init*().  Many tests and
+   recovery paths do that; before these arrays became dynamic they were inline, so
+   a zeroed struct was immediately usable.  NULL-safe and idempotent: passing NULL
+   or an already-initialized factory is a no-op.  Returns 1 on success. */
+int factory_alloc_default_arrays(factory_t *f);
+
 int factory_init(factory_t *f, secp256k1_context *ctx,
                   const secp256k1_keypair *keypairs, size_t n_participants,
                   uint16_t step_blocks, uint32_t states_per_layer);

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -322,7 +322,12 @@ typedef struct {
     size_t n_participants;
 
     /* Flat node array */
-    factory_node_t nodes[FACTORY_MAX_NODES];
+    factory_node_t *nodes;   /* dynamic: calloc'd in factory_init to config.max_nodes,
+                                grown in factory_build_tree to the actual node count.
+                                Was inline nodes[FACTORY_MAX_NODES]; made dynamic so a
+                                single-process factory can exceed the 512-node cap
+                                (a 255-client PS factory needs ~1018 nodes) without
+                                bloating every factory_t. */
     size_t n_nodes;
 
     /* Funding UTXO */
@@ -379,8 +384,8 @@ typedef struct {
        node_l_stock_hashes[idx] (the shipped H) instead of deriving, so the client
        builds the SAME 2-leaf L-stock SPK as the LSP (else the leaf-state tx bytes
        diverge and the MuSig co-sign fails). */
-    unsigned char node_l_stock_hashes[FACTORY_MAX_NODES][32];
-    int node_l_stock_hash_valid[FACTORY_MAX_NODES];
+    unsigned char (*node_l_stock_hashes)[32];  /* dynamic, sized to config.max_nodes */
+    int *node_l_stock_hash_valid;               /* dynamic, sized to config.max_nodes */
     int has_node_l_stock_hashes;
 
     /* Per-leaf DW layers (for independent leaf advance) */

--- a/include/superscalar/musig.h
+++ b/include/superscalar/musig.h
@@ -70,7 +70,11 @@ typedef struct {
    secp256k1's aggregation takes size_t; this fixed array is the only cap. */
 
 typedef struct {
-    secp256k1_musig_pubnonce pubnonces[MUSIG_SESSION_MAX_SIGNERS];
+    secp256k1_musig_pubnonce *pubnonces; /* dynamic: allocated in musig_session_init
+                                            to n_signers (subtree size), not the global
+                                            max — keeps a large factory's tree O(N log N)
+                                            instead of O(N^2).  Free with musig_session_free. */
+    size_t pubnonces_cap;                /* allocated capacity of pubnonces[] */
     secp256k1_musig_aggnonce aggnonce;
     secp256k1_musig_session session;
     secp256k1_musig_keyagg_cache cache;  /* working copy, potentially tweaked */
@@ -80,6 +84,10 @@ typedef struct {
     int nonces_collected;                /* count of pubnonces received */
     int session_ready;                   /* nonce_process completed */
 } musig_signing_session_t;
+
+/* Free the dynamic pubnonces of a session (idempotent; safe on a zero-inited
+   or already-freed session).  Does not touch the enclosing struct otherwise. */
+void musig_session_free(musig_signing_session_t *session);
 
 /* --- Nonce pool functions --- */
 

--- a/include/superscalar/musig.h
+++ b/include/superscalar/musig.h
@@ -69,12 +69,21 @@ typedef struct {
    proofs tools/test_musig_scale.c and tools/test_musig_session_scale.c.
    secp256k1's aggregation takes size_t; this fixed array is the only cap. */
 
+#define MUSIG_SESSION_SMALL 8  /* sessions with <= this many signers use the inline
+                                  buffer: no heap, safe on uninitialized stack
+                                  sessions, no free needed (channel 2-of-2 etc.).
+                                  Larger sessions (big factory subtree nodes) are
+                                  heap-allocated to n_signers and MUST be released
+                                  with musig_session_free — factory_free does. */
+
 typedef struct {
-    secp256k1_musig_pubnonce *pubnonces; /* dynamic: allocated in musig_session_init
-                                            to n_signers (subtree size), not the global
-                                            max — keeps a large factory's tree O(N log N)
-                                            instead of O(N^2).  Free with musig_session_free. */
-    size_t pubnonces_cap;                /* allocated capacity of pubnonces[] */
+    secp256k1_musig_pubnonce *pubnonces; /* points at pubnonces_small when
+                                            n_signers <= MUSIG_SESSION_SMALL, else a
+                                            heap array sized to n_signers (subtree
+                                            size, not the global max — keeps a large
+                                            factory's tree O(N log N), not O(N^2)). */
+    size_t pubnonces_cap;                /* usable capacity of pubnonces[] */
+    secp256k1_musig_pubnonce pubnonces_small[MUSIG_SESSION_SMALL];
     secp256k1_musig_aggnonce aggnonce;
     secp256k1_musig_session session;
     secp256k1_musig_keyagg_cache cache;  /* working copy, potentially tweaked */

--- a/src/factory.c
+++ b/src/factory.c
@@ -394,7 +394,7 @@ static int apply_l_stock_hashlock(factory_t *f, factory_node_t *node) {
 
 void factory_set_node_l_stock_hash(factory_t *f, size_t node_idx,
                                    const unsigned char *h32) {
-    if (!f || node_idx >= FACTORY_MAX_NODES || !h32) return;
+    if (!f || node_idx >= f->config.max_nodes || !h32) return;
     memcpy(f->node_l_stock_hashes[node_idx], h32, 32);
     f->node_l_stock_hash_valid[node_idx] = 1;
     f->has_node_l_stock_hashes = 1;
@@ -755,6 +755,12 @@ int factory_init_with_config(factory_t *f, secp256k1_context *ctx,
        sub-factories — preserves all historical PS test behavior).
        Override with factory_set_ps_subfactory_arity() before build. */
     f->ps_subfactory_arity = 1;
+
+    /* Dynamic node arrays (were inline [FACTORY_MAX_NODES]).  Allocate to the
+       config cap; factory_build_tree grows them if the tree needs more nodes. */
+    f->nodes                  = calloc(f->config.max_nodes, sizeof(factory_node_t));
+    f->node_l_stock_hashes    = calloc(f->config.max_nodes, 32);
+    f->node_l_stock_hash_valid= calloc(f->config.max_nodes, sizeof(int));
     return 1;
 }
 
@@ -797,6 +803,12 @@ void factory_init_from_pubkeys(factory_t *f, secp256k1_context *ctx,
        sub-factories — preserves all historical PS test behavior).
        Override with factory_set_ps_subfactory_arity() before build. */
     f->ps_subfactory_arity = 1;
+
+    /* Dynamic node arrays (were inline [FACTORY_MAX_NODES]).  Allocate to the
+       config cap; factory_build_tree grows them if the tree needs more nodes. */
+    f->nodes                  = calloc(f->config.max_nodes, sizeof(factory_node_t));
+    f->node_l_stock_hashes    = calloc(f->config.max_nodes, 32);
+    f->node_l_stock_hash_valid= calloc(f->config.max_nodes, sizeof(int));
 }
 
 void factory_set_arity(factory_t *f, factory_arity_t arity) {
@@ -1791,7 +1803,24 @@ int factory_build_tree(factory_t *f) {
     int n_dw_layers = dw_n_layers_for(tree_depth, f->static_threshold_depth);
     int total_nodes_ub = 2 * (2 * n_leaves - 1);  /* kickoff+state per logical node */
 
-    if (total_nodes_ub > (int)f->config.max_nodes) return 0;
+    /* Grow the dynamic node arrays if this tree needs more than the current cap
+       (a 255-client PS factory needs ~1018 nodes vs the 512 default). */
+    if (total_nodes_ub > (int)f->config.max_nodes) {
+        size_t nn = (size_t)total_nodes_ub, old = f->config.max_nodes;
+        factory_node_t *gn = realloc(f->nodes, nn * sizeof(factory_node_t));
+        if (!gn) return 0;
+        f->nodes = gn;
+        unsigned char (*gh)[32] = realloc(f->node_l_stock_hashes, nn * 32);
+        if (!gh) return 0;
+        f->node_l_stock_hashes = gh;
+        int *gv = realloc(f->node_l_stock_hash_valid, nn * sizeof(int));
+        if (!gv) return 0;
+        f->node_l_stock_hash_valid = gv;
+        memset(f->nodes + old, 0, (nn - old) * sizeof(factory_node_t));
+        memset(f->node_l_stock_hashes + old, 0, (nn - old) * 32);
+        memset(f->node_l_stock_hash_valid + old, 0, (nn - old) * sizeof(int));
+        f->config.max_nodes = (uint32_t)nn;
+    }
     if (n_leaves > (int)f->config.max_leaves) return 0;
     if (n_dw_layers > DW_MAX_LAYERS) return 0;
 
@@ -4839,6 +4868,11 @@ void factory_free(factory_t *f) {
     tx_buf_free(&f->dist_signed_tx);   /* #54 G1 */
     /* Zero node count so a second factory_free is a no-op (idempotent). */
     f->n_nodes = 0;
+    /* Free the dynamic node arrays (were inline).  NULL after free so a second
+       factory_free / a detached copy is a no-op (free(NULL) is safe). */
+    free(f->nodes);                    f->nodes = NULL;
+    free(f->node_l_stock_hashes);      f->node_l_stock_hashes = NULL;
+    free(f->node_l_stock_hash_valid);  f->node_l_stock_hash_valid = NULL;
 }
 
 uint64_t factory_derive_scid(const factory_t *f, int leaf_index, uint32_t output_index) {
@@ -4847,6 +4881,23 @@ uint64_t factory_derive_scid(const factory_t *f, int leaf_index, uint32_t output
 }
 
 void factory_detach_txbufs(factory_t *f) {
+    /* This is called right after a factory_t struct copy (e.g. a ladder entry
+       ← lsp->factory).  The dynamic node arrays were shallow-shared by that
+       copy; give this copy its OWN arrays so (a) factory_free is independent
+       (no double-free) and (b) the txbuf-zeroing below touches only this copy,
+       not the original.  This reproduces the pre-dynamic inline-array copy
+       semantics (per-node txbuf POINTERS stay shared, then get zeroed below). */
+    if (f->nodes && f->config.max_nodes > 0) {
+        size_t mn = f->config.max_nodes;
+        factory_node_t *n2 = malloc(mn * sizeof(factory_node_t));
+        if (n2) { memcpy(n2, f->nodes, mn * sizeof(factory_node_t)); f->nodes = n2; }
+        unsigned char (*h2)[32] = malloc(mn * 32);
+        if (h2 && f->node_l_stock_hashes) { memcpy(h2, f->node_l_stock_hashes, mn * 32); f->node_l_stock_hashes = h2; }
+        else if (h2) { memset(h2, 0, mn * 32); f->node_l_stock_hashes = h2; }
+        int *v2 = malloc(mn * sizeof(int));
+        if (v2 && f->node_l_stock_hash_valid) { memcpy(v2, f->node_l_stock_hash_valid, mn * sizeof(int)); f->node_l_stock_hash_valid = v2; }
+        else if (v2) { memset(v2, 0, mn * sizeof(int)); f->node_l_stock_hash_valid = v2; }
+    }
     for (size_t i = 0; i < f->n_nodes; i++) {
         memset(&f->nodes[i].unsigned_tx, 0, sizeof(tx_buf_t));
         memset(&f->nodes[i].signed_tx, 0, sizeof(tx_buf_t));

--- a/src/factory.c
+++ b/src/factory.c
@@ -727,6 +727,32 @@ void factory_config_default(factory_config_t *cfg) {
     cfg->dust_limit_sats = 546;
 }
 
+int factory_alloc_default_arrays(factory_t *f) {
+    if (!f) return 0;
+    if (f->config.max_signers == 0) factory_config_default(&f->config);
+    if (!f->keypairs)
+        f->keypairs = calloc(f->config.max_signers, sizeof(secp256k1_keypair));
+    if (!f->pubkeys)
+        f->pubkeys = calloc(f->config.max_signers, sizeof(secp256k1_pubkey));
+    if (!f->profiles)
+        f->profiles = calloc(f->config.max_signers, sizeof(participant_profile_t));
+    if (!f->dist_partial_sigs)
+        f->dist_partial_sigs = calloc(f->config.max_signers, sizeof(secp256k1_musig_partial_sig));
+    if (!f->leaf_layers)
+        f->leaf_layers = calloc(f->config.max_leaves, sizeof(dw_layer_t));
+    if (!f->leaf_node_indices)
+        f->leaf_node_indices = calloc(f->config.max_leaves, sizeof(size_t));
+    if (!f->nodes)
+        f->nodes = calloc(f->config.max_nodes, sizeof(factory_node_t));
+    if (!f->node_l_stock_hashes)
+        f->node_l_stock_hashes = calloc(f->config.max_nodes, 32);
+    if (!f->node_l_stock_hash_valid)
+        f->node_l_stock_hash_valid = calloc(f->config.max_nodes, sizeof(int));
+    return f->keypairs && f->pubkeys && f->profiles && f->dist_partial_sigs &&
+           f->leaf_layers && f->leaf_node_indices && f->nodes &&
+           f->node_l_stock_hashes && f->node_l_stock_hash_valid;
+}
+
 int factory_init_with_config(factory_t *f, secp256k1_context *ctx,
                               const secp256k1_keypair *keypairs, size_t n_participants,
                               uint16_t step_blocks, uint32_t states_per_layer,
@@ -1964,6 +1990,7 @@ int factory_sessions_init(factory_t *f) {
     for (size_t i = 0; i < f->n_nodes; i++) {
         factory_node_t *node = &f->nodes[i];
         if (!node->is_built) return 0;
+        musig_session_free(&node->signing_session);   /* re-init of a live session: release first */
         musig_session_init(&node->signing_session, &node->keyagg, node->n_signers);
         node->partial_sigs_received = 0;
     }
@@ -2101,6 +2128,7 @@ int factory_sessions_init_path(factory_t *f, int leaf_node_idx) {
     for (size_t i = 0; i < n; i++) {
         factory_node_t *node = &f->nodes[path[i]];
         if (!node->is_built) return 0;
+        musig_session_free(&node->signing_session);   /* re-init of a live session: release first */
         musig_session_init(&node->signing_session, &node->keyagg, node->n_signers);
         node->partial_sigs_received = 0;
     }
@@ -3207,6 +3235,7 @@ int factory_session_init_node_input(factory_t *f, size_t node_idx, size_t input_
                 node_idx, input_idx);
         return 0;
     }
+    musig_session_free(&node->input_signing_sessions[input_idx]);   /* re-init: release first */
     musig_session_init(&node->input_signing_sessions[input_idx],
                         &node->input_keyaggs[input_idx],
                         node->input_n_signers[input_idx]);
@@ -3447,6 +3476,7 @@ int factory_session_init_node_poison(factory_t *f, size_t node_idx) {
     /* The poison TX is signed against the SAME keyagg as the state TX
        (LSP + leaf signers, N-of-N MuSig).  The SIGHASH differs (poison
        TX bytes vs new state TX bytes) and the NONCES MUST be fresh. */
+    musig_session_free(&node->poison_signing_session);   /* re-init: release first */
     musig_session_init(&node->poison_signing_session, &node->keyagg,
                         node->n_signers);
     node->poison_partial_sigs_received = 0;
@@ -4431,6 +4461,7 @@ int factory_session_init_dist(factory_t *f) {
     if (f->dist_tx_ready < 1 || f->dist_unsigned_tx.len == 0) return 0;
     if (!f->nodes[0].is_built) return 0;
     /* Same aggregate key as kickoff_root (factory_build_distribution_tx). */
+    musig_session_free(&f->dist_signing_session);   /* re-init: release first */
     musig_session_init(&f->dist_signing_session, &f->nodes[0].keyagg,
                        f->n_participants);
     f->dist_partial_sigs_received = 0;

--- a/src/factory.c
+++ b/src/factory.c
@@ -168,6 +168,16 @@ static int add_node(
 
     node->type = type;
     node->n_signers = n_signers;
+    /* Per-node signer arrays are subtree-sized (n_signers), not the global max —
+       this is what makes the whole tree O(N log N) in memory and lets the root
+       node (n_signers == N+1) exceed the old fixed FACTORY_MAX_SIGNERS cap.
+       Freed in factory_free (the node is already counted in n_nodes, so a
+       mid-init error return still gets these reclaimed). */
+    node->signer_indices      = calloc(n_signers, sizeof(uint32_t));
+    node->partial_sigs        = calloc(n_signers, sizeof(secp256k1_musig_partial_sig));
+    node->poison_partial_sigs = calloc(n_signers, sizeof(secp256k1_musig_partial_sig));
+    if (!node->signer_indices || !node->partial_sigs || !node->poison_partial_sigs)
+        return -1;
     memcpy(node->signer_indices, signer_indices, n_signers * sizeof(uint32_t));
     node->parent_index = parent_index;
     node->parent_vout = parent_vout;
@@ -178,8 +188,11 @@ static int add_node(
     tx_buf_init(&node->unsigned_tx, 256);
     tx_buf_init(&node->signed_tx, 512);
 
-    /* Aggregate keys and compute tweaked pubkey + spending SPK */
-    secp256k1_pubkey pks[FACTORY_MAX_SIGNERS];
+    /* Aggregate keys and compute tweaked pubkey + spending SPK.  Heap scratch
+       sized to n_signers (was a pks[FACTORY_MAX_SIGNERS] stack array, which would
+       overflow the stack for the root node at N>255).  Freed on every return. */
+    secp256k1_pubkey *pks = malloc(n_signers * sizeof(secp256k1_pubkey));
+    if (!pks) return -1;
     for (size_t i = 0; i < n_signers; i++)
         pks[i] = f->pubkeys[signer_indices[i]];
 
@@ -187,23 +200,24 @@ static int add_node(
         /* Build CLTV timeout script leaf using LSP pubkey (index 0) */
         secp256k1_xonly_pubkey lsp_xonly;
         if (!secp256k1_xonly_pubkey_from_pubkey(f->ctx, &lsp_xonly, NULL, &f->pubkeys[0]))
-            return -1;
+            { free(pks); return -1; }
 
         if (!tapscript_build_cltv_timeout(&node->timeout_leaf, node_cltv,
                                           &lsp_xonly, f->ctx))
-            return -1;
+            { free(pks); return -1; }
         tapscript_merkle_root(node->merkle_root, &node->timeout_leaf, 1);
 
         /* Tweak internal key with merkle root */
         if (!build_musig_p2tr_spk(f->ctx, node->spending_spk, &node->tweaked_pubkey,
                                    &node->output_parity, &node->keyagg, pks, n_signers,
                                    node->merkle_root))
-            return -1;
+            { free(pks); return -1; }
     } else {
         if (!build_musig_p2tr_spk(f->ctx, node->spending_spk, &node->tweaked_pubkey,
                                    NULL, &node->keyagg, pks, n_signers, NULL))
-            return -1;
+            { free(pks); return -1; }
     }
+    free(pks);
 
     node->spending_spk_len = 34;
 
@@ -733,6 +747,23 @@ int factory_init_with_config(factory_t *f, secp256k1_context *ctx,
     if (n_participants > f->config.max_signers)
         return 0;
 
+    /* Factory-level participant arrays sized to the config cap (were fixed
+       [FACTORY_MAX_SIGNERS]).  O(N), one copy per factory — this is what lets the
+       manager exceed 256 signers.  Freed in factory_free, deep-copied in
+       factory_detach_txbufs. */
+    f->keypairs          = calloc(f->config.max_signers, sizeof(secp256k1_keypair));
+    f->pubkeys           = calloc(f->config.max_signers, sizeof(secp256k1_pubkey));
+    f->profiles          = calloc(f->config.max_signers, sizeof(participant_profile_t));
+    f->dist_partial_sigs = calloc(f->config.max_signers, sizeof(secp256k1_musig_partial_sig));
+    /* Per-leaf arrays sized to config.max_leaves (were fixed [FACTORY_MAX_LEAVES]).
+       Allocated here — BEFORE the dw_layer_init loop below — because PS makes one
+       leaf per client and the loop indexes up to n_leaves. */
+    f->leaf_layers       = calloc(f->config.max_leaves, sizeof(dw_layer_t));
+    f->leaf_node_indices = calloc(f->config.max_leaves, sizeof(size_t));
+    if (!f->keypairs || !f->pubkeys || !f->profiles || !f->dist_partial_sigs ||
+        !f->leaf_layers || !f->leaf_node_indices)
+        return 0;
+
     for (size_t i = 0; i < n_participants; i++) {
         f->keypairs[i] = keypairs[i];
         if (!secp256k1_keypair_pub(ctx, &f->pubkeys[i], &keypairs[i]))
@@ -781,6 +812,15 @@ void factory_init_from_pubkeys(factory_t *f, secp256k1_context *ctx,
     f->states_per_layer = states_per_layer;
     f->fee_per_tx = 200;  /* 1 sat/vB floor for ~200 vB tx; overridden by factory_build_tree */
     factory_config_default(&f->config);
+
+    /* Factory-level arrays sized to the config cap (were fixed
+       [FACTORY_MAX_SIGNERS]).  keypairs stays zeroed here (pubkey-only path). */
+    f->keypairs          = calloc(f->config.max_signers, sizeof(secp256k1_keypair));
+    f->pubkeys           = calloc(f->config.max_signers, sizeof(secp256k1_pubkey));
+    f->profiles          = calloc(f->config.max_signers, sizeof(participant_profile_t));
+    f->dist_partial_sigs = calloc(f->config.max_signers, sizeof(secp256k1_musig_partial_sig));
+    f->leaf_layers       = calloc(f->config.max_leaves, sizeof(dw_layer_t));
+    f->leaf_node_indices = calloc(f->config.max_leaves, sizeof(size_t));
 
     for (size_t i = 0; i < n_participants; i++)
         f->pubkeys[i] = pubkeys[i];
@@ -1316,7 +1356,7 @@ static int setup_ps_leaf_with_subfactories(
         if (end_client > n_leaf_clients) end_client = n_leaf_clients;
         size_t n_in_sub = end_client - start_client;
 
-        uint32_t sub_signers[FACTORY_MAX_SIGNERS];
+        uint32_t sub_signers[n_in_sub + 1];   /* subtree-sized, not the global max */
         sub_signers[0] = 0;
         for (size_t ci = 0; ci < n_in_sub; ci++)
             sub_signers[ci + 1] = leaf_client_indices[start_client + ci];
@@ -1506,8 +1546,11 @@ static int build_subtree(
 ) {
     if (n_clients == 0) return 0;
 
-    /* Build signer set: {0 (LSP)} ∪ all client_indices in this subtree */
-    uint32_t signers[FACTORY_MAX_SIGNERS];
+    /* Build signer set: {0 (LSP)} ∪ all client_indices in this subtree.
+       VLA sized to this subtree's signer count (n_clients+1), not the global
+       max — the root's set is N+1, which the old fixed [FACTORY_MAX_SIGNERS]
+       stack array overflowed at N>255. */
+    uint32_t signers[n_clients + 1];
     size_t n_signers = 0;
     signers[n_signers++] = 0;  /* LSP always signs */
     for (size_t i = 0; i < n_clients; i++)
@@ -1698,8 +1741,9 @@ static int build_subtree(
                 return 0;
         }
 
-        /* Record leaf index */
-        if (*leaf_counter >= FACTORY_MAX_LEAVES) return 0;
+        /* Record leaf index (bound is the dynamic config cap, not the old
+           compile-time FACTORY_MAX_LEAVES — leaf_node_indices is sized to it). */
+        if (*leaf_counter >= (int)f->config.max_leaves) return 0;
         f->leaf_node_indices[*leaf_counter] = (size_t)st_idx;
         (*leaf_counter)++;
     } else {
@@ -1839,8 +1883,9 @@ int factory_build_tree(factory_t *f) {
         return 0;
     }
 
-    /* Build client index array [1, 2, ..., n_clients] */
-    uint32_t clients[FACTORY_MAX_SIGNERS];
+    /* Build client index array [1, 2, ..., n_clients].  VLA sized to n_clients
+       (was fixed [FACTORY_MAX_SIGNERS], which capped the factory at 255 clients). */
+    uint32_t clients[n_clients ? n_clients : 1];
     for (size_t i = 0; i < n_clients; i++)
         clients[i] = (uint32_t)(i + 1);
 
@@ -3301,8 +3346,15 @@ void factory_session_reset_poison(factory_t *f, size_t node_idx) {
     node->poison_partial_sigs_received = 0;
     node->poison_is_signed = 0;
     /* secp256k1_musig structures are POD-style; zeroing is safe. */
+    /* poison_signing_session.pubnonces is dynamic — free before zeroing the
+       struct so the reset does not leak the old allocation. */
+    musig_session_free(&node->poison_signing_session);
     memset(&node->poison_signing_session, 0, sizeof(node->poison_signing_session));
-    memset(node->poison_partial_sigs, 0, sizeof(node->poison_partial_sigs));
+    /* poison_partial_sigs is now a heap pointer (sized to n_signers), so
+       sizeof() would only zero the pointer.  Zero the actual array. */
+    if (node->poison_partial_sigs)
+        memset(node->poison_partial_sigs, 0,
+               node->n_signers * sizeof(secp256k1_musig_partial_sig));
     /* #53-B3a script-path ceremony state */
     node->poison_is_scriptpath = 0;
     node->poison_has_agg_sig = 0;
@@ -4849,9 +4901,23 @@ void factory_free(factory_t *f) {
            (tx_buf_free is a no-op on zero-init). */
         tx_buf_free(&f->nodes[i].poison_unsigned_tx);
         tx_buf_free(&f->nodes[i].poison_signed_tx);
+        /* Free the two per-node signing sessions' dynamic pubnonces[] (sized to
+           node->n_signers in musig_session_init).  musig_session_free is a no-op
+           on a zero-inited/never-signed node (pubnonces == NULL). */
+        musig_session_free(&f->nodes[i].signing_session);
+        musig_session_free(&f->nodes[i].poison_signing_session);
+        /* Subtree-sized per-node signer arrays (allocated in add_node). */
+        free(f->nodes[i].signer_indices);      f->nodes[i].signer_indices = NULL;
+        free(f->nodes[i].partial_sigs);        f->nodes[i].partial_sigs = NULL;
+        free(f->nodes[i].poison_partial_sigs); f->nodes[i].poison_partial_sigs = NULL;
         /* Multi-input chain advance per-input session arrays (#207).
            free() is a no-op on NULL, so safe even when the multi-input
-           path was never exercised on this node. */
+           path was never exercised on this node.  Each per-input session also
+           owns a dynamic pubnonces[]; free those before the array itself. */
+        if (f->nodes[i].input_signing_sessions) {
+            for (size_t s = 0; s < f->nodes[i].n_input_sessions; s++)
+                musig_session_free(&f->nodes[i].input_signing_sessions[s]);
+        }
         free(f->nodes[i].input_signing_sessions);
         f->nodes[i].input_signing_sessions = NULL;
         free(f->nodes[i].input_partial_sigs);
@@ -4868,11 +4934,21 @@ void factory_free(factory_t *f) {
     tx_buf_free(&f->dist_signed_tx);   /* #54 G1 */
     /* Zero node count so a second factory_free is a no-op (idempotent). */
     f->n_nodes = 0;
+    /* Factory-level distribution signing session's dynamic pubnonces. */
+    musig_session_free(&f->dist_signing_session);
     /* Free the dynamic node arrays (were inline).  NULL after free so a second
        factory_free / a detached copy is a no-op (free(NULL) is safe). */
     free(f->nodes);                    f->nodes = NULL;
     free(f->node_l_stock_hashes);      f->node_l_stock_hashes = NULL;
     free(f->node_l_stock_hash_valid);  f->node_l_stock_hash_valid = NULL;
+    /* Factory-level participant arrays (were fixed [FACTORY_MAX_SIGNERS]). */
+    free(f->keypairs);          f->keypairs = NULL;
+    free(f->pubkeys);           f->pubkeys = NULL;
+    free(f->profiles);          f->profiles = NULL;
+    free(f->dist_partial_sigs); f->dist_partial_sigs = NULL;
+    /* Per-leaf arrays (were fixed [FACTORY_MAX_LEAVES]). */
+    free(f->leaf_layers);       f->leaf_layers = NULL;
+    free(f->leaf_node_indices); f->leaf_node_indices = NULL;
 }
 
 uint64_t factory_derive_scid(const factory_t *f, int leaf_index, uint32_t output_index) {
@@ -4908,7 +4984,67 @@ void factory_detach_txbufs(factory_t *f) {
            lsp_cleanup, once via ladder_free) → double-free abort. */
         memset(&f->nodes[i].poison_unsigned_tx, 0, sizeof(tx_buf_t));
         memset(&f->nodes[i].poison_signed_tx, 0, sizeof(tx_buf_t));
+        /* The struct memcpy above aliased the two per-node sessions' dynamic
+           pubnonces[] pointers onto the original.  Sessions are transient signing
+           scratch (rebuilt by musig_session_init on the next sign), so detach the
+           COPY by nulling its pointers — the original keeps + frees them.  Same
+           shared-pointer / double-free logic as the txbufs zeroed above. */
+        f->nodes[i].signing_session.pubnonces = NULL;
+        f->nodes[i].signing_session.pubnonces_cap = 0;
+        f->nodes[i].poison_signing_session.pubnonces = NULL;
+        f->nodes[i].poison_signing_session.pubnonces_cap = 0;
+        /* The struct memcpy above also aliased the 3 subtree-sized signer arrays.
+           Unlike the sessions, these are read (signer_indices) and written
+           (partial_sigs) by factory_sign_node WITHOUT re-allocating, so the copy
+           needs its OWN — deep-copy rather than null.  Sized to this node's
+           n_signers, matching add_node. */
+        size_t ns = f->nodes[i].n_signers;
+        if (ns > 0) {
+            uint32_t *si = malloc(ns * sizeof(uint32_t));
+            if (si && f->nodes[i].signer_indices)
+                memcpy(si, f->nodes[i].signer_indices, ns * sizeof(uint32_t));
+            f->nodes[i].signer_indices = si;
+            secp256k1_musig_partial_sig *ps = malloc(ns * sizeof(*ps));
+            if (ps && f->nodes[i].partial_sigs)
+                memcpy(ps, f->nodes[i].partial_sigs, ns * sizeof(*ps));
+            f->nodes[i].partial_sigs = ps;
+            secp256k1_musig_partial_sig *pps = malloc(ns * sizeof(*pps));
+            if (pps && f->nodes[i].poison_partial_sigs)
+                memcpy(pps, f->nodes[i].poison_partial_sigs, ns * sizeof(*pps));
+            f->nodes[i].poison_partial_sigs = pps;
+        }
     }
     memset(&f->dist_unsigned_tx, 0, sizeof(tx_buf_t));
     memset(&f->dist_signed_tx, 0, sizeof(tx_buf_t));   /* #54 G1 */
+    /* The factory_t struct copy aliased the 4 dynamic factory-level arrays.
+       keypairs/pubkeys/profiles are structural (needed to sign the copy), so
+       deep-copy them; dist_partial_sigs is transient but copied too for
+       uniformity.  dist_signing_session.pubnonces is transient — null it. */
+    size_t ms = f->config.max_signers;
+    if (ms > 0) {
+        secp256k1_keypair *kp = malloc(ms * sizeof(*kp));
+        if (kp && f->keypairs) memcpy(kp, f->keypairs, ms * sizeof(*kp));
+        f->keypairs = kp;
+        secp256k1_pubkey *pk = malloc(ms * sizeof(*pk));
+        if (pk && f->pubkeys) memcpy(pk, f->pubkeys, ms * sizeof(*pk));
+        f->pubkeys = pk;
+        participant_profile_t *pr = malloc(ms * sizeof(*pr));
+        if (pr && f->profiles) memcpy(pr, f->profiles, ms * sizeof(*pr));
+        f->profiles = pr;
+        secp256k1_musig_partial_sig *dp = malloc(ms * sizeof(*dp));
+        if (dp && f->dist_partial_sigs) memcpy(dp, f->dist_partial_sigs, ms * sizeof(*dp));
+        f->dist_partial_sigs = dp;
+    }
+    f->dist_signing_session.pubnonces = NULL;
+    f->dist_signing_session.pubnonces_cap = 0;
+    /* Per-leaf arrays: structural DW state, deep-copy so the copy is independent. */
+    size_t ml = f->config.max_leaves;
+    if (ml > 0) {
+        dw_layer_t *ll = malloc(ml * sizeof(*ll));
+        if (ll && f->leaf_layers) memcpy(ll, f->leaf_layers, ml * sizeof(*ll));
+        f->leaf_layers = ll;
+        size_t *li = malloc(ml * sizeof(*li));
+        if (li && f->leaf_node_indices) memcpy(li, f->leaf_node_indices, ml * sizeof(*li));
+        f->leaf_node_indices = li;
+    }
 }

--- a/src/musig.c
+++ b/src/musig.c
@@ -274,23 +274,22 @@ void musig_session_init(
     const musig_keyagg_t *keyagg,
     size_t n_signers
 ) {
-    /* pubnonces is a dynamic array sized to n_signers (the subtree signer count for
-       a factory node), not the global max — this is what keeps a large factory's
-       tree O(N log N) instead of O(N^2).  Preserve+reuse any existing allocation
-       across a re-init (retry/rotation) so we neither leak nor free garbage.
-       CONTRACT: the session must be zero-inited before its FIRST musig_session_init
-       (factory nodes are calloc'd; standalone sessions must be {0}/memset). */
-    secp256k1_musig_pubnonce *pn = session->pubnonces;
-    size_t cap = session->pubnonces_cap;
+    /* NEVER reads the incoming struct (an uninitialized stack session is safe).
+       Small sessions (<= MUSIG_SESSION_SMALL signers: channel 2-of-2, adaptor,
+       most factory nodes) use the inline buffer — no heap, no free needed, the
+       exact pre-refactor behavior.  Large sessions (big subtree nodes) heap-
+       allocate to n_signers, which is what keeps the whole tree O(N log N);
+       their owners must musig_session_free (factory_free does), and any RE-init
+       of a live large session must free first (factory sign sites do). */
     memset(session, 0, sizeof(*session));
-    if (n_signers == 0) n_signers = 1;   /* never calloc(0) */
-    if (cap < n_signers) {
-        free(pn);
-        pn = calloc(n_signers, sizeof(secp256k1_musig_pubnonce));
-        cap = pn ? n_signers : 0;
+    if (n_signers == 0) n_signers = 1;
+    if (n_signers <= MUSIG_SESSION_SMALL) {
+        session->pubnonces = session->pubnonces_small;
+        session->pubnonces_cap = MUSIG_SESSION_SMALL;
+    } else {
+        session->pubnonces = calloc(n_signers, sizeof(secp256k1_musig_pubnonce));
+        session->pubnonces_cap = session->pubnonces ? n_signers : 0;
     }
-    session->pubnonces = pn;
-    session->pubnonces_cap = cap;
     memcpy(&session->cache, &keyagg->cache, sizeof(secp256k1_musig_keyagg_cache));
     memcpy(&session->agg_pubkey, &keyagg->agg_pubkey, sizeof(secp256k1_xonly_pubkey));
     session->n_signers = n_signers;
@@ -299,7 +298,8 @@ void musig_session_init(
 void musig_session_free(musig_signing_session_t *session)
 {
     if (!session) return;
-    free(session->pubnonces);
+    if (session->pubnonces && session->pubnonces != session->pubnonces_small)
+        free(session->pubnonces);
     session->pubnonces = NULL;
     session->pubnonces_cap = 0;
 }

--- a/src/musig.c
+++ b/src/musig.c
@@ -274,15 +274,34 @@ void musig_session_init(
     const musig_keyagg_t *keyagg,
     size_t n_signers
 ) {
+    /* pubnonces is a dynamic array sized to n_signers (the subtree signer count for
+       a factory node), not the global max — this is what keeps a large factory's
+       tree O(N log N) instead of O(N^2).  Preserve+reuse any existing allocation
+       across a re-init (retry/rotation) so we neither leak nor free garbage.
+       CONTRACT: the session must be zero-inited before its FIRST musig_session_init
+       (factory nodes are calloc'd; standalone sessions must be {0}/memset). */
+    secp256k1_musig_pubnonce *pn = session->pubnonces;
+    size_t cap = session->pubnonces_cap;
     memset(session, 0, sizeof(*session));
+    if (n_signers == 0) n_signers = 1;   /* never calloc(0) */
+    if (cap < n_signers) {
+        free(pn);
+        pn = calloc(n_signers, sizeof(secp256k1_musig_pubnonce));
+        cap = pn ? n_signers : 0;
+    }
+    session->pubnonces = pn;
+    session->pubnonces_cap = cap;
     memcpy(&session->cache, &keyagg->cache, sizeof(secp256k1_musig_keyagg_cache));
     memcpy(&session->agg_pubkey, &keyagg->agg_pubkey, sizeof(secp256k1_xonly_pubkey));
-    /* Defense-in-depth: pubnonces[]/partial_sigs[] are [MUSIG_SESSION_MAX_SIGNERS].
-       Clamp so a caller that passes more than the max can never drive an OOB read
-       in the finalize loop (design max is 128 = LSP + 127 clients). */
-    if (n_signers > MUSIG_SESSION_MAX_SIGNERS)
-        n_signers = MUSIG_SESSION_MAX_SIGNERS;
     session->n_signers = n_signers;
+}
+
+void musig_session_free(musig_signing_session_t *session)
+{
+    if (!session) return;
+    free(session->pubnonces);
+    session->pubnonces = NULL;
+    session->pubnonces_cap = 0;
 }
 
 int musig_session_set_pubnonce(
@@ -292,7 +311,7 @@ int musig_session_set_pubnonce(
 ) {
     if (signer_index >= session->n_signers)
         return 0;
-    if (signer_index >= MUSIG_SESSION_MAX_SIGNERS)
+    if (signer_index >= session->pubnonces_cap)
         return 0;
 
     memcpy(&session->pubnonces[signer_index], pubnonce,
@@ -311,13 +330,19 @@ int musig_session_finalize_nonces(
     if ((size_t)session->nonces_collected != session->n_signers)
         return 0;
 
-    /* Build pointer array for nonce aggregation */
-    const secp256k1_musig_pubnonce *ptrs[MUSIG_SESSION_MAX_SIGNERS];
+    /* Build pointer array for nonce aggregation (heap: n_signers can exceed the
+       old fixed 256 for a large in-process factory). */
+    const secp256k1_musig_pubnonce **ptrs =
+        malloc(session->n_signers * sizeof(*ptrs));
+    if (!ptrs) return 0;
     for (size_t i = 0; i < session->n_signers; i++)
         ptrs[i] = &session->pubnonces[i];
 
-    if (!secp256k1_musig_nonce_agg(ctx, &session->aggnonce, ptrs, session->n_signers))
+    if (!secp256k1_musig_nonce_agg(ctx, &session->aggnonce, ptrs, session->n_signers)) {
+        free(ptrs);
         return 0;
+    }
+    free(ptrs);
 
     /* Apply taproot tweak to a LOCAL copy of the cache.
        Do not modify session->cache in-place before nonce_process succeeds —
@@ -354,12 +379,17 @@ int musig_session_finalize_nonces_untweaked(
     if ((size_t)session->nonces_collected != session->n_signers)
         return 0;
 
-    const secp256k1_musig_pubnonce *ptrs[MUSIG_SESSION_MAX_SIGNERS];
+    const secp256k1_musig_pubnonce **ptrs =
+        malloc(session->n_signers * sizeof(*ptrs));
+    if (!ptrs) return 0;
     for (size_t i = 0; i < session->n_signers; i++)
         ptrs[i] = &session->pubnonces[i];
 
-    if (!secp256k1_musig_nonce_agg(ctx, &session->aggnonce, ptrs, session->n_signers))
+    if (!secp256k1_musig_nonce_agg(ctx, &session->aggnonce, ptrs, session->n_signers)) {
+        free(ptrs);
         return 0;
+    }
+    free(ptrs);
 
     memcpy(session->msg32, msg32, 32);
 
@@ -415,15 +445,17 @@ int musig_aggregate_partial_sigs(
     if (!session->session_ready)
         return 0;
 
-    const secp256k1_musig_partial_sig *ptrs[MUSIG_SESSION_MAX_SIGNERS];
-    if (n_sigs > MUSIG_SESSION_MAX_SIGNERS)
-        return 0;
+    const secp256k1_musig_partial_sig **ptrs =
+        malloc(n_sigs * sizeof(*ptrs));
+    if (!ptrs) return 0;
 
     for (size_t i = 0; i < n_sigs; i++)
         ptrs[i] = &partial_sigs[i];
 
-    return secp256k1_musig_partial_sig_agg(ctx, sig64_out, &session->session,
-                                            ptrs, n_sigs);
+    int ret = secp256k1_musig_partial_sig_agg(ctx, sig64_out, &session->session,
+                                              ptrs, n_sigs);
+    free(ptrs);
+    return ret;
 }
 
 /* --- Ad-hoc single nonce generation --- */

--- a/tests/test_adaptor.c
+++ b/tests/test_adaptor.c
@@ -399,6 +399,7 @@ int test_ptlc_factory_coop_close_after_turnover(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -582,6 +583,7 @@ int test_regtest_ptlc_turnover(void) {
 
     /* Init factory */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     for (int i = 0; i < 15; i++)

--- a/tests/test_channel.c
+++ b/tests/test_channel.c
@@ -854,6 +854,7 @@ int test_regtest_channel_unilateral(void) {
     /* Build factory tree, then advance to max state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);  /* step=1, states=4 */
 
@@ -2467,6 +2468,7 @@ int test_regtest_channel_coop_close(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 
@@ -2945,6 +2947,7 @@ int test_factory_advance_past_exhaustion(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, keypairs, 5, 10, 4);
 
@@ -3062,6 +3065,7 @@ int test_regtest_channel_penalty(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 
@@ -3695,6 +3699,7 @@ int test_regtest_penalty_with_htlcs(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -206,6 +206,8 @@ int test_lsp_channel_init(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32] = {0};
@@ -1829,6 +1831,8 @@ int test_fee_policy_balance_split(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32] = {0};
@@ -2000,6 +2004,8 @@ int test_fee_estimator_wiring(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 10, 4);
     unsigned char fake_txid[32], fake_spk[34];
@@ -2068,6 +2074,8 @@ int test_fee_estimator_null_fallback(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 10, 4);
     unsigned char fake_txid[32], fake_spk[34];
@@ -2554,6 +2562,8 @@ int test_regtest_lsp_restart_recovery(void) {
 
     /* Phase 6: Recover from SQLite */
     factory_t *rec_f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(rec_f);
+    factory_alloc_default_arrays(rec_f);
     if (!rec_f) return 0;
     lsp_channel_mgr_t rec_mgr;
 
@@ -2712,6 +2722,8 @@ int test_profit_settlement_calculation(void) {
 
     /* Build a minimal factory with profit-shared economics */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     f->economic_mode = ECON_PROFIT_SHARED;
@@ -2766,6 +2778,8 @@ int test_settlement_trigger_at_interval(void) {
     mgr.entries[1].channel.remote_amount = 50000;
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     f->n_participants = 3;
@@ -2806,6 +2820,8 @@ int test_on_close_includes_unsettled(void) {
     mgr.economic_mode = ECON_PROFIT_SHARED;
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) { free(mgr.entries); return 0; }
 
     f->economic_mode = ECON_PROFIT_SHARED;
@@ -3110,6 +3126,8 @@ int test_regtest_crash_double_recovery(void) {
 
     /* Recover #1 */
     factory_t *rec_f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(rec_f);
+    factory_alloc_default_arrays(rec_f);
     if (!rec_f) return 0;
     lsp_channel_mgr_t rec_mgr;
 
@@ -3190,6 +3208,8 @@ int test_regtest_crash_double_recovery(void) {
     /* Recover #2 */
     lsp_channel_mgr_t rec_mgr2;
     factory_t *rec_f2 = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(rec_f2);
+    factory_alloc_default_arrays(rec_f2);
     if (!rec_f2) return 0;
 
     memset(&rec_mgr2, 0, sizeof(rec_mgr2));
@@ -3742,6 +3762,8 @@ int test_fee_accumulation_and_settlement(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     f->economic_mode = ECON_PROFIT_SHARED;
@@ -3847,6 +3869,8 @@ int test_fee_levels_and_profit_split(void) {
             }
 
             factory_t *f = calloc(1, sizeof(factory_t));
+            factory_alloc_default_arrays(f);
+            factory_alloc_default_arrays(f);
             f->economic_mode = (economic_mode_t)configs[ci].econ;
             f->n_participants = 3;
             f->profiles[0].profit_share_bps = configs[ci].lsp_bps;
@@ -3989,6 +4013,8 @@ int test_cltv_delta_from_tree_depth(void) {
 
     /* Factory with step_blocks=6, states_per_layer=2, 5 participants */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     factory_init(f, ctx, kps, 5, 6, 2);
 
     uint32_t delta = lsp_compute_factory_cltv_delta(f);
@@ -4034,6 +4060,8 @@ int test_close_outputs_wallet_spk(void) {
     mgr.entries[1].channel.remote_amount = 2000;
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     f->funding_amount_sats = 5000 + 3000 + 4000 + 2000 + 500;  /* balances + fee */
@@ -4178,6 +4206,8 @@ int test_lsp_close_spk_derived(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32] = {0};
@@ -4448,6 +4478,8 @@ int test_client_ps_double_spend_defense_refuses(void) {
     memset(fake_fund_txid, 0x7A, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, N, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);

--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -148,6 +148,7 @@ static int run_coop_close_for_arity(regtest_t *rt,
     const size_t N = 5;  /* 1 LSP + 4 clients */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -809,6 +810,7 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
     const size_t N = 3;  /* 1 LSP + 2 clients (minimum for PS MuSig) */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -1059,7 +1061,9 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     const size_t N = 5;
     secp256k1_keypair kpsA[5], kpsB[5];
     factory_t *fA = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(fA);
     factory_t *fB = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(fB);
     if (!fA || !fB) { free(fA); free(fB); return 0; }
 
     unsigned char spkA[34], spkB[34];
@@ -1312,6 +1316,7 @@ static int run_full_tree_force_close_for_arity(regtest_t *rt,
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -1408,6 +1413,7 @@ static int run_k2_ps_subfactory_force_close(regtest_t *rt,
     const size_t N = 5;  /* 1 LSP + 4 clients */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -1664,6 +1670,7 @@ int test_regtest_k2_ps_subfactory_per_client_sweep(void) {
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
     secp256k1_pubkey pks[5];
     for (size_t i = 0; i < N; i++) {
@@ -2412,6 +2419,7 @@ int test_regtest_inversion_of_timeout_default(void) {
     const size_t N = 5;  /* LSP + 4 clients */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -2587,6 +2595,7 @@ int test_regtest_old_state_poisoning(void) {
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -2751,6 +2760,7 @@ int test_regtest_kickoff_paired_with_latest_state(void) {
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -2893,6 +2903,7 @@ int test_regtest_full_force_close_and_sweep_arity1(void) {
     const size_t N = 2;  /* LSP + 1 client (smallest arity-1 factory) */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -3151,6 +3162,7 @@ int test_regtest_full_force_close_and_sweep_arity2(void) {
     const size_t N = 5;  /* LSP + 4 clients → 2 arity-2 leaves */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -3411,6 +3423,7 @@ int test_regtest_full_force_close_and_sweep_arityPS(void) {
     const size_t N = 3;  /* LSP + 2 clients → 2 PS leaves */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -3663,6 +3676,7 @@ static int run_ps_chain_advance_sweep(regtest_t *rt,
     const size_t N = 3;  /* LSP + 2 clients -> 2 PS leaves of 1 client each */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -4122,6 +4136,7 @@ static int run_htlc_force_to_local_for_arity(regtest_t *rt,
     const size_t N = n_participants;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -4590,6 +4605,7 @@ static int run_htlc_breach_for_arity(regtest_t *rt,
     const size_t N = n_participants;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -5340,6 +5356,7 @@ int test_regtest_mixed_arity_2_4_8_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8}. */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);  /* step_blocks=4, states_per_layer=4 */
     /* Wider N-way state nodes are larger TXs than the binary builder's;
@@ -5983,6 +6000,7 @@ static int run_ps_full_lifecycle(regtest_t *rt,
     secp256k1_keypair kps[32];
     secp256k1_pubkey  pks[32];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -6428,6 +6446,7 @@ int test_regtest_ps_old_state_broadcast_fails_n8(void) {
     secp256k1_keypair kps[16];
     secp256k1_pubkey  pks[16];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -6653,6 +6672,7 @@ int test_regtest_nway_n64_arity_2_4_8_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8} */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* Wider N-way state nodes need more fee than default 200 sats to
@@ -6959,6 +6979,7 @@ int test_regtest_nway_n64_arity_2_4_8_static_threshold_1_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8} */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* Wider N-way state nodes need more fee than default 200 sats to
@@ -7273,6 +7294,7 @@ int test_regtest_nway_n64_dw_advance_resign_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8} */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* Wider N-way state nodes need more fee than default 200 sats to
@@ -7601,6 +7623,7 @@ int test_regtest_static_near_root_lifecycle(void) {
 
     /* Build factory: arity {2,4}, static_threshold=1 (root kickoff-only) */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* PR #104 bumped fee_per_tx to 1000 sats for N-way regtest mempool floor. */
@@ -7900,6 +7923,7 @@ int test_regtest_static_near_root_unilateral_exit(void) {
     TEST_ASSERT(fund_vout != UINT32_MAX, "find fund vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     f->fee_per_tx = 1000;

--- a/tests/test_economic_correctness.c
+++ b/tests/test_economic_correctness.c
@@ -137,6 +137,7 @@ static int run_factory_aware_baseline(secp256k1_context *ctx, regtest_t *rt,
 
     /* Build factory tree (arity-specific). */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, N, 2, 4);
     factory_set_arity(f, arity);
@@ -533,6 +534,7 @@ static int run_rotation_econ_for_arity(secp256k1_context *ctx, regtest_t *rt,
 
     /* Build B's tree, close B cooperatively. */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kpsB, N, 2, 4);
     factory_set_arity(f, arity);
@@ -756,6 +758,7 @@ int test_regtest_econ_ps_advance(void) {
     TEST_ASSERT(fund_vout != UINT32_MAX, "locate vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, N, 2, 4);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -1057,6 +1060,7 @@ int test_regtest_econ_buy_liquidity_arity2(void) {
            (unsigned long long)fund_amount);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, N, 2, 4);
     factory_set_arity(f, FACTORY_ARITY_2);

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -106,6 +106,7 @@ int test_factory_build_tree(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);  /* step=2, states=4 */
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -196,6 +197,7 @@ int test_factory_sign_all(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -259,6 +261,7 @@ int test_factory_sign_all_retry(void) {
     unsigned char fake_txid[32]; memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -306,6 +309,7 @@ int test_factory_advance(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);  /* step=2, states_per_layer=4 */
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -506,6 +510,7 @@ int test_regtest_factory_tree(void) {
     /* Init factory, build tree, then advance to newest state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);  /* step=1, states=4 */
 
@@ -593,6 +598,7 @@ int test_factory_sign_split_round_step_by_step(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -708,6 +714,7 @@ int test_factory_split_round_with_pool(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -869,6 +876,7 @@ int test_factory_advance_split_round(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);  /* step=2, states_per_layer=4 */
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -966,6 +974,7 @@ int test_factory_l_stock_with_burn_path(void) {
 
     /* Build factory WITHOUT shachain */
     factory_t *f_plain = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_plain);
     if (!f_plain) return 0;
     factory_init(f_plain, ctx, kps, 5, 2, 4);
     factory_set_funding(f_plain, fake_txid, 0, 100000, fund_spk, 34);
@@ -973,6 +982,7 @@ int test_factory_l_stock_with_burn_path(void) {
 
     /* Build factory WITH shachain */
     factory_t *f_sc = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_sc);
     if (!f_sc) return 0;
     factory_init(f_sc, ctx, kps, 5, 2, 4);
     factory_set_shachain_seed(f_sc, test_shachain_seed);
@@ -1039,6 +1049,7 @@ int test_factory_burn_tx_construction(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_shachain_seed(f, test_shachain_seed);
@@ -1073,6 +1084,7 @@ int test_factory_burn_tx_construction(void) {
        on the L-stock SPK).  Verify the no-shachain case produces a valid
        poison TX too. */
     factory_t *f_no_sc = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_no_sc);
     if (!f_no_sc) return 0;
     factory_init(f_no_sc, ctx, kps, 5, 2, 4);
     factory_set_funding(f_no_sc, fake_txid, 0, 100000, fund_spk, 34);
@@ -1113,6 +1125,7 @@ int test_factory_advance_with_shachain(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_shachain_seed(f, test_shachain_seed);
@@ -1292,6 +1305,7 @@ int test_regtest_burn_tx(void) {
     /* Init factory WITH shachain, build tree, then advance to max state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);  /* step=1, states=4 */
     factory_set_shachain_seed(f, test_shachain_seed);
@@ -1426,6 +1440,7 @@ int test_factory_cooperative_close(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1522,6 +1537,7 @@ int test_factory_cooperative_close_balances(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1679,6 +1695,7 @@ int test_regtest_factory_coop_close(void) {
 
     /* Init factory, build tree (but don't broadcast tree!) */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     factory_set_funding(f, fund_txid_bytes, (uint32_t)found_vout,
@@ -1761,6 +1778,7 @@ int test_factory_lifecycle_states(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1807,6 +1825,7 @@ int test_factory_lifecycle_queries(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1848,6 +1867,7 @@ int test_factory_distribution_tx(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1950,6 +1970,7 @@ int test_factory_distribution_tx_distributed(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2031,6 +2052,7 @@ int test_factory_distribution_tx_default(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 50000, fund_spk, 34);
@@ -2086,6 +2108,7 @@ int test_factory_advance_leaf_left(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2135,6 +2158,7 @@ int test_factory_advance_leaf_right(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2180,6 +2204,7 @@ int test_factory_advance_leaf_independence(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2225,6 +2250,7 @@ int test_factory_advance_leaf_exhaustion(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2271,6 +2297,7 @@ int test_factory_advance_leaf_preserves_parent_txids(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2324,6 +2351,7 @@ int test_factory_build_tree_arity1(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree arity-1");
@@ -2385,6 +2413,7 @@ int test_factory_arity1_leaf_outputs(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2417,6 +2446,7 @@ int test_factory_arity1_sign_all(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2438,6 +2468,7 @@ int test_factory_arity1_advance(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2466,6 +2497,7 @@ int test_factory_arity1_advance_leaf(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2494,6 +2526,7 @@ int test_factory_arity1_leaf_independence(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2526,6 +2559,7 @@ int test_factory_arity1_coop_close(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2560,6 +2594,7 @@ int test_factory_arity1_client_to_leaf(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2587,6 +2622,7 @@ int test_factory_arity1_cltv_strict_ordering(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     f->cltv_timeout = 200;  /* Enough room for 5 tiers of TIMEOUT_STEP_BLOCKS=5 */
@@ -2629,6 +2665,7 @@ int test_factory_arity1_min_funding_reject(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
 
@@ -2662,6 +2699,7 @@ int test_factory_arity1_input_amounts_consistent(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2692,6 +2730,7 @@ int test_factory_arity1_split_round_leaf_advance(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2829,6 +2868,7 @@ int test_factory_tier_b_state_advance_root_rollover(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup arity-1 factory");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -3022,6 +3062,7 @@ int test_factory_build_tree_n3(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=3 (LSP + 2 clients), arity-2: 1 leaf with 2 clients, depth=0 */
@@ -3051,6 +3092,7 @@ int test_factory_build_tree_n7(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[7];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=7 (LSP + 6 clients), arity-2: 3 leaves, depth=2 */
@@ -3082,6 +3124,7 @@ int test_factory_build_tree_n9(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[9];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=9 (LSP + 8 clients), arity-2: 4 leaves, depth=2 */
@@ -3112,6 +3155,7 @@ int test_factory_build_tree_n16(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[16];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=16 (LSP + 15 clients), arity-1 only (arity-2 would need 8 leaves, still ok) */
@@ -3142,6 +3186,7 @@ int test_factory_build_tree_n32(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(32, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n32");
 
     /* N=32, arity-2: 16 leaves, depth=4 */
@@ -3173,6 +3218,7 @@ int test_factory_build_tree_n64(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(64, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n64");
 
     /* N=64, arity-2: 32 leaves, depth=5 */
@@ -3198,6 +3244,7 @@ int test_factory_build_tree_n128(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(128, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n128");
 
     /* N=128, arity-2: 64 leaves, depth=6, 254 factory nodes.
@@ -3301,6 +3348,7 @@ int test_regtest_tree_ordering(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 
@@ -3458,6 +3506,7 @@ int test_regtest_dw_exhaustion_close(void) {
 
     /* Small DW counter for fast exhaustion */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     factory_set_funding(f, fund_txid_bytes, (uint32_t)found_vout,
@@ -3541,6 +3590,7 @@ int test_factory_flat_secrets_round_trip(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 10, 8);
 
@@ -3628,6 +3678,7 @@ int test_factory_path_to_root(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3676,6 +3727,7 @@ int test_factory_subtree_clients(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3731,6 +3783,7 @@ int test_factory_find_leaf_for_client(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3801,6 +3854,7 @@ int test_factory_nav_variable_n(void) {
         memset(fake_txid, 0xAA, 32);
 
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         if (!f) return 0;
         factory_init(f, ctx, kps, (size_t)n, 2, 4);
         factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3853,6 +3907,7 @@ int test_factory_timeout_spend_tx(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;
@@ -3911,6 +3966,7 @@ int test_factory_timeout_spend_mid_node(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;
@@ -3967,6 +4023,7 @@ int test_placement_sequential(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_SEQUENTIAL;
@@ -4016,6 +4073,7 @@ int test_placement_inward(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_INWARD;
@@ -4078,6 +4136,7 @@ int test_placement_outward(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_OUTWARD;
@@ -4144,6 +4203,7 @@ int test_placement_timezone_cluster(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_TIMEZONE_CLUSTER;
@@ -4203,6 +4263,7 @@ int test_placement_timezone_cluster(void) {
 int test_economic_mode_validation(void) {
     /* Test that profit_share_bps are preserved and can be validated */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     /* calloc already zeroes f */
     f->economic_mode = ECON_PROFIT_SHARED;
@@ -4261,6 +4322,7 @@ int test_nonce_pool_factory_creation(void) {
 
     /* Build + sign using standard factory_sign_all (on-demand nonces) */
     factory_t *f1 = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f1);
     if (!f1) return 0;
     factory_init(f1, ctx, kps, 5, 2, 4);
     factory_set_funding(f1, fake_txid, 0, 100000, fund_spk, 34);
@@ -4273,6 +4335,7 @@ int test_nonce_pool_factory_creation(void) {
 
     /* Build + sign using pool-drawn nonces via split-round API */
     factory_t *f2 = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f2);
     if (!f2) return 0;
     factory_init(f2, ctx, kps, 5, 2, 4);
     factory_set_funding(f2, fake_txid, 0, 100000, fund_spk, 34);
@@ -4372,6 +4435,7 @@ int test_factory_count_nodes_for_participant(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4416,6 +4480,7 @@ int test_factory_sessions_init_path(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4454,6 +4519,7 @@ int test_factory_rebuild_path_unsigned(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4500,6 +4566,7 @@ int test_factory_sign_path(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4580,6 +4647,7 @@ int test_factory_advance_and_rebuild_path(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4618,6 +4686,7 @@ int test_arity2_leaf_advance(void) {
     memset(fake_txid, 0xBB, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 4, 4);
     factory_set_arity(f, FACTORY_ARITY_2);
@@ -4705,6 +4774,7 @@ int test_distribution_tx_has_anchor(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4838,6 +4908,7 @@ int test_factory_variable_arity_build(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[9];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     uint8_t arities[] = {1, 1, 2};
     TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 9, arities, 3, 5000000),
@@ -4864,6 +4935,7 @@ int test_factory_variable_arity_sign(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     uint8_t arities[] = {1, 2};
     TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 5, arities, 2, 2000000),
@@ -4890,8 +4962,10 @@ int test_factory_variable_arity_backward_compat(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps1[5], kps2[5];
     factory_t *f1 = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f1);
     if (!f1) return 0;
     factory_t *f2 = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f2);
     if (!f2) { free(f1); return 0; }
 
     TEST_ASSERT(setup_n_factory(f1, ctx, kps1, 5, FACTORY_ARITY_2, 2000000), "setup f1");
@@ -4930,6 +5004,7 @@ int test_factory_derive_scid(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 10, 100);
     f->cltv_timeout = 1000;
@@ -4982,6 +5057,7 @@ int test_factory_set_leaf_amounts(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_SEQUENTIAL;
@@ -5055,6 +5131,7 @@ int test_leaf_realloc_signing(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_SEQUENTIAL;
@@ -5144,6 +5221,7 @@ int test_leaf_realloc_signing_arity1(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_arity(f, FACTORY_ARITY_1);
@@ -5247,6 +5325,7 @@ int test_factory_config_custom(void) {
     cfg.dust_limit_sats = 1000;
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     int ok = factory_init_with_config(f, ctx, keypairs, 5, 10, 4, &cfg);
     TEST_ASSERT(ok, "factory_init_with_config should succeed");
@@ -5290,6 +5369,7 @@ int test_factory_config_default(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     int ok = factory_init(f, ctx, keypairs, 3, 10, 4);
     TEST_ASSERT(ok, "factory_init should succeed");
@@ -5339,6 +5419,7 @@ int test_factory_ps_leaf_build(void) {
     memset(fake_txid, 0xBB, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 3, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -5434,6 +5515,7 @@ int test_factory_ps_subfactory_k2_n4(void) {
     memset(fake_txid, 0xDD, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -5572,6 +5654,7 @@ int test_factory_ps_subfactory_chain_extension(void) {
     memset(fake_txid, 0xFE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -5821,6 +5904,7 @@ int test_factory_ps_subfactory_chain_tx_validity(void) {
     memset(fake_txid, 0xFA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -6000,6 +6084,7 @@ int test_factory_ps_subfactory_poison_tx_k2_n4(void) {
     memset(fake_txid, 0xDD, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -6114,6 +6199,7 @@ int test_factory_lstock_client_mirror(void) {
     /* LSP: hashlock ON — derives per-node H from its seed. */
     secp256k1_keypair kl[3];
     factory_t *lsp = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(lsp);
     TEST_ASSERT(lsp, "alloc lsp");
     TEST_ASSERT(setup_variable_arity_factory(lsp, ctx, kl, 3, arities, 1, 5000000),
                 "setup lsp");
@@ -6127,6 +6213,7 @@ int test_factory_lstock_client_mirror(void) {
     /* CLIENT: NO seed; mirror the LSP's per-node H (simulated FACTORY_PROPOSE). */
     secp256k1_keypair kc[3];
     factory_t *cli = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(cli);
     TEST_ASSERT(cli, "alloc cli");
     TEST_ASSERT(setup_variable_arity_factory(cli, ctx, kc, 3, arities, 1, 5000000),
                 "setup cli");
@@ -6174,6 +6261,7 @@ int test_factory_lstock_client_mirror(void) {
     /* CONTROL: a client WITHOUT the mirror builds a DIFFERENT (single-leaf) SPK. */
     secp256k1_keypair kb[3];
     factory_t *bare = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(bare);
     TEST_ASSERT(bare, "alloc bare");
     TEST_ASSERT(setup_variable_arity_factory(bare, ctx, kb, 3, arities, 1, 5000000),
                 "setup bare");
@@ -6231,6 +6319,7 @@ int test_factory_subfactory_lstock_per_state_hash(void) {
     memset(fake_txid, 0xFE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -6292,6 +6381,7 @@ int test_factory_subfactory_lstock_per_state_hash(void) {
 
     /* (d) CONTROL: a non-hashlock sub keeps a STATIC sales-stock SPK across advances. */
     factory_t *g = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(g);
     TEST_ASSERT(g, "alloc control factory");
     factory_init(g, ctx, kps, 5, 6, 10);
     factory_set_arity(g, FACTORY_ARITY_PS);
@@ -6355,6 +6445,7 @@ int test_regtest_lstock_hashlock_poison(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -6550,6 +6641,7 @@ int test_regtest_lstock_poison_ceremony(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -6731,6 +6823,7 @@ int test_factory_anchor_lstock_advance(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -6796,6 +6889,7 @@ int test_regtest_lstock_poison_old_state(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -6980,6 +7074,7 @@ int test_factory_ps_leaf_build_n64(void) {
     memset(fake_txid, 0xEE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     /* step=4, states_per_layer=3 — modest values so tree depth with 63
        clients stays within DW_MAX_LAYERS=8. */
@@ -7093,6 +7188,7 @@ int test_factory_ps_build_n128(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "factory alloc");
     /* step=4, states_per_layer=3 keeps DW total states modest; the layer count
        (8) is the binding constraint at N=128, not the per-layer state count. */
@@ -7165,6 +7261,7 @@ int test_factory_ps_leaf_advance(void) {
     memset(fake_txid, 0xDD, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 6, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7251,6 +7348,7 @@ int test_factory_ps_amount_invariant(void) {
     memset(fake_txid, 0xF1, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 1, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7317,6 +7415,7 @@ int test_factory_ps_dust_limit(void) {
     memset(fake_txid, 0xF2, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 1, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7369,6 +7468,7 @@ int test_factory_ps_mixed_arity(void) {
     memset(fake_txid, 0xEE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 5, 6, 10);
 
@@ -7435,6 +7535,7 @@ int test_factory_ps_split_round_leaf_advance(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 1, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7601,6 +7702,7 @@ int test_factory_ps_matrix(void) {
         memset(fake_txid, (unsigned char)(0xC0 + c), 32);
 
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc factory");
         factory_init(f, ctx, kps, N, 4, 3);
         factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7709,6 +7811,7 @@ int test_factory_nway_n12_arity_2_4(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[12];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[2] = {2, 4};
@@ -7767,6 +7870,7 @@ int test_factory_nway_n64_arity_2_4_8(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(64, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n64");
 
     uint8_t arities[3] = {2, 4, 8};
@@ -7849,6 +7953,7 @@ int test_factory_nway_arity_8_leaf_outputs(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[9];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[1] = {8};
@@ -7914,7 +8019,9 @@ int test_factory_nway_backward_compat(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps_legacy[8], kps_nway[8];
     factory_t *f_legacy = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_legacy);
     factory_t *f_nway = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_nway);
     TEST_ASSERT(f_legacy && f_nway, "alloc");
 
     /* Legacy: factory_set_arity(FACTORY_ARITY_2) — uniform arity-2 */
@@ -8005,6 +8112,7 @@ int test_factory_static_near_root_basic(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[12];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[2] = {2, 4};
@@ -8090,6 +8198,7 @@ int test_factory_static_near_root_n128_arity_2_4_8_static_2(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(128, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n128");
 
     /* {2,4,8}: depth 0 arity-2, depth 1 arity-4, depth 2+ arity-8 */
@@ -8191,6 +8300,7 @@ int test_factory_static_near_root_node_nsequence(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[12];
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[2] = {2, 4};
@@ -8245,7 +8355,9 @@ int test_factory_static_near_root_backward_compat(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps_a[12], kps_b[12];
     factory_t *f_a = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_a);
     factory_t *f_b = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_b);
     TEST_ASSERT(f_a && f_b, "alloc");
 
     uint8_t arities[2] = {2, 4};
@@ -8392,6 +8504,7 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[5];
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc arity-1 factory");
         ensure_seckeys_n();
         for (int i = 0; i < 5; i++)
@@ -8420,6 +8533,7 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[5];
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc arity-2 factory");
         ensure_seckeys_n();
         for (int i = 0; i < 5; i++)
@@ -8451,6 +8565,7 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[5];
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc PS factory");
         ensure_seckeys_n();
         for (int i = 0; i < 5; i++)
@@ -8481,6 +8596,7 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[12];
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc mixed {2,4} factory");
         uint8_t arities[2] = { 2, 4 };
         TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 12, arities, 2,
@@ -8498,6 +8614,7 @@ int test_factory_client_to_leaf_roundtrip(void) {
         const size_t N = 17;  /* 1 LSP + 16 clients */
         secp256k1_keypair *kps = calloc(N, sizeof(secp256k1_keypair));
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         TEST_ASSERT(kps && f, "alloc mixed {2,4,8} factory");
         uint8_t arities[3] = { 2, 4, 8 };
         TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, N, arities, 3,

--- a/tests/test_factory_multi_input_keyagg.c
+++ b/tests/test_factory_multi_input_keyagg.c
@@ -125,6 +125,7 @@ int test_factory_multi_input_keyagg(void)
     memset(fake_txid, 0xBE, 32);
 
     factory_t *f = (factory_t *)calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);

--- a/tests/test_jit.c
+++ b/tests/test_jit.c
@@ -1094,6 +1094,7 @@ int test_regtest_jit_daemon_trigger(void) {
     /* Create minimal factory with short lifecycle */
     int base_height = regtest_get_block_height(&rt);
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     factory_set_lifecycle(f, (uint32_t)base_height, 5, 5);

--- a/tests/test_ladder.c
+++ b/tests/test_ladder.c
@@ -789,6 +789,7 @@ int test_regtest_ladder_distribution_fallback(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid, (uint32_t)found_vout,
@@ -1004,6 +1005,7 @@ int test_rotation_context_save_restore(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
 
@@ -1179,6 +1181,7 @@ int test_regtest_ptlc_no_coop_close(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid, (uint32_t)found_vout,
@@ -1346,6 +1349,7 @@ int test_regtest_all_offline_recovery(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid, (uint32_t)found_vout,
@@ -2020,6 +2024,7 @@ int test_regtest_funding_double_spend_rejected(void) {
 
     /* Init factory, build tree, sign all (creates kickoff tx) */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid_bytes, (uint32_t)found_vout,

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -1076,6 +1076,7 @@ int test_persist_factory_round_trip(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     f->use_tree_anchor = 1;  /* #56: mirror production — persist_load_factory rebuilds
@@ -1091,6 +1092,7 @@ int test_persist_factory_round_trip(void) {
 
     /* Load factory into new struct */
     factory_t *f2 = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f2);
     if (!f2) return 0;
     TEST_ASSERT(persist_load_factory(&db, 0, f2, ctx), "load factory");
 
@@ -1490,6 +1492,7 @@ int test_lsp_recovery_round_trip(void) {
     if (!secp256k1_ec_pubkey_create(ctx, &pks[4], extra_sec4)) return 0;  /* Client 3 */
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     f->cltv_timeout = 200;
@@ -1590,6 +1593,7 @@ int test_lsp_recovery_round_trip(void) {
 
     /* Now recover: load factory from DB, init channels from DB */
     factory_t *rec_f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(rec_f);
     if (!rec_f) { lsp_channels_cleanup(&mgr); return 0; }
 
     TEST_ASSERT(persist_load_factory(&db, 0, rec_f, ctx), "load factory");
@@ -1897,6 +1901,7 @@ int test_persist_validate_factory_load(void) {
     TEST_ASSERT(rc == SQLITE_OK, "insert invalid factory");
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     int loaded = persist_load_factory(&db, 10, f, ctx);
@@ -2004,6 +2009,7 @@ int test_persist_crash_stress(void) {
     if (!secp256k1_ec_pubkey_create(ctx, &pks[4], extra_sec4)) return 0;
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     f->cltv_timeout = 200;
@@ -2096,6 +2102,7 @@ int test_persist_crash_stress(void) {
         persist_t db;
         TEST_ASSERT(persist_open(&db, path), "c1 reopen");
         factory_t *rec_f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(rec_f);
         if (!rec_f) return 0;
 
         TEST_ASSERT(persist_load_factory(&db, 0, rec_f, ctx), "c1 load factory");
@@ -2208,6 +2215,7 @@ int test_persist_crash_stress(void) {
         persist_t db;
         TEST_ASSERT(persist_open(&db, path), "c2 reopen");
         factory_t *rec_f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(rec_f);
         if (!rec_f) return 0;
 
         TEST_ASSERT(persist_load_factory(&db, 0, rec_f, ctx), "c2 load factory");
@@ -2318,6 +2326,7 @@ int test_persist_crash_stress(void) {
         persist_t db;
         TEST_ASSERT(persist_open(&db, path), "c3 reopen");
         factory_t *rec_f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(rec_f);
         if (!rec_f) return 0;
 
         TEST_ASSERT(persist_load_factory(&db, 0, rec_f, ctx), "c3 load factory");
@@ -2414,6 +2423,7 @@ int test_persist_crash_stress(void) {
         persist_t db;
         TEST_ASSERT(persist_open(&db, path), "c4 reopen");
         factory_t *rec_f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(rec_f);
         if (!rec_f) return 0;
 
         TEST_ASSERT(persist_load_factory(&db, 0, rec_f, ctx), "c4 load factory");
@@ -2481,6 +2491,7 @@ int test_persist_crash_dw_state(void) {
     if (!secp256k1_ec_pubkey_create(ctx, &pks[4], s4)) return 0;
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
 
@@ -2527,7 +2538,9 @@ int test_persist_crash_dw_state(void) {
     /* Zero factory DW state */
     memset(&f->counter, 0, sizeof(f->counter));
     f->per_leaf_enabled = 0;
-    memset(f->leaf_layers, 0, sizeof(f->leaf_layers));
+    /* leaf_layers is dynamic (sized to config.max_leaves) since the O(N log N)
+       refactor — sizeof(pointer) would zero 8 bytes. */
+    memset(f->leaf_layers, 0, f->config.max_leaves * sizeof(dw_layer_t));
     f->n_leaf_nodes = 0;
 
     /* Recover cycle 1 */

--- a/tests/test_property.c
+++ b/tests/test_property.c
@@ -428,6 +428,7 @@ int test_prop_persist_factory_roundtrip(void) {
         uint32_t states = 2 + (rand_r(&seed) % 6);  /* 2-7 */
 
         factory_t *f = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(f);
         if (!f) return 0;
 
         f->n_participants = n;
@@ -462,6 +463,7 @@ int test_prop_persist_factory_roundtrip(void) {
 
         /* Load and compare */
         factory_t *loaded = calloc(1, sizeof(factory_t));
+        factory_alloc_default_arrays(loaded);
         if (!loaded) return 0;
 
         int loaded_ok = persist_load_factory(&db, fid, loaded, ctx);

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -180,6 +180,7 @@ int test_reconnect_pubkey_match(void) {
         all_pks[i + 1] = client_pks[i];
 
     factory_t *factory = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(factory);
     if (!factory) { free(lsp->client_fds); free(lsp->client_pubkeys); free(lsp); return 0; }
     factory_init_from_pubkeys(factory, ctx, all_pks, 5, 10, 4);
 
@@ -396,6 +397,7 @@ int test_client_persist_reload(void) {
 
     /* Build factory */
     factory_t *factory = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     factory_init_from_pubkeys(factory, ctx, pks, 5, 10, 4);
 
@@ -433,6 +435,7 @@ int test_client_persist_reload(void) {
 
     /* Load factory back */
     factory_t *loaded_factory = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(loaded_factory);
     if (!loaded_factory) return 0;
     TEST_ASSERT(persist_load_factory(&db, 0, loaded_factory, ctx), "persist_load_factory");
     TEST_ASSERT_EQ(loaded_factory->funding_amount_sats, factory->funding_amount_sats,
@@ -564,6 +567,7 @@ int test_balance_reporting(void) {
     }
 
     factory_t *factory = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     factory_init_from_pubkeys(factory, ctx, pks, 5, 10, 4);
 
@@ -1755,6 +1759,7 @@ int test_mine_blocks_non_regtest(void) {
 /* Test: factory lifecycle state transitions ACTIVE→DYING→EXPIRED */
 int test_factory_lifecycle_daemon_check(void) {
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* Set lifecycle: created at block 100, active 20 blocks, dying 10 blocks */
@@ -1938,6 +1943,7 @@ int test_ladder_daemon_integration(void) {
 
     /* Manually populate slot 0 */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     factory_set_lifecycle(f, 100, 20, 10);
@@ -1986,6 +1992,7 @@ int test_distribution_tx_amounts(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 
@@ -2579,6 +2586,7 @@ int test_reconnect_commitment_mismatch_rollback(void) {
     unsigned char client_secs[4][32];
     secp256k1_pubkey client_pks[4];
     factory_t *factory = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     lsp_t *lsp = calloc(1, sizeof(lsp_t));
     if (!lsp) { free(factory); return 0; }
@@ -2648,6 +2656,7 @@ int test_reconnect_commitment_mismatch_reject(void) {
     unsigned char client_secs[4][32];
     secp256k1_pubkey client_pks[4];
     factory_t *factory = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     lsp_t *lsp = calloc(1, sizeof(lsp_t));
     if (!lsp) { free(factory); return 0; }
@@ -2722,6 +2731,7 @@ int test_reconnect_htlc_replay(void) {
     unsigned char client_secs[4][32];
     secp256k1_pubkey client_pks[4];
     factory_t *factory = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     lsp_t *lsp = calloc(1, sizeof(lsp_t));
     if (!lsp) { free(factory); return 0; }

--- a/tests/test_regtest.c
+++ b/tests/test_regtest.c
@@ -1643,6 +1643,7 @@ int test_regtest_ps_basic_close(void) {
         regtest_mine_blocks(&rt, 101, mine_addr);
 
     f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT_GOTO(f, "alloc factory");
     secp256k1_keypair kps[3];
     char fund_txid[65];
@@ -1704,6 +1705,7 @@ int test_regtest_ps_chain_close(void) {
         regtest_mine_blocks(&rt, 101, mine_addr);
 
     f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT_GOTO(f, "alloc factory");
     secp256k1_keypair kps[3];
     char fund_txid[65];
@@ -1808,6 +1810,7 @@ int test_regtest_ps_old_state_response(void) {
         regtest_mine_blocks(&rt, 101, mine_addr);
 
     f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     TEST_ASSERT_GOTO(f, "alloc factory");
     secp256k1_keypair kps[3];
     char fund_txid[65];

--- a/tests/test_tapscript.c
+++ b/tests/test_tapscript.c
@@ -269,6 +269,7 @@ int test_factory_tree_with_timeout(void) {
 
     /* Build factory WITH cltv_timeout */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;  /* some block height */
@@ -294,6 +295,7 @@ int test_factory_tree_with_timeout(void) {
 
     /* Build factory WITHOUT cltv_timeout for comparison */
     factory_t *f2 = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f2);
     if (!f2) return 0;
     factory_init(f2, ctx, kps, 5, 2, 4);
     f2->cltv_timeout = 0;
@@ -542,6 +544,7 @@ int test_regtest_timeout_spend(void) {
     /* Init factory with timeout, build tree, then advance to max state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     f->cltv_timeout = cltv_timeout;
@@ -759,6 +762,7 @@ int test_multi_level_timeout_unit(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -71,6 +71,7 @@ int test_wire_pubkey_only_factory(void) {
 
     /* Build factory with keypairs (reference) */
     factory_t *f_ref = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_ref);
     if (!f_ref) return 0;
     factory_init(f_ref, ctx, kps, 5, 10, 4);
 
@@ -87,6 +88,7 @@ int test_wire_pubkey_only_factory(void) {
     }
 
     factory_t *f_pk = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_pk);
     if (!f_pk) return 0;
     factory_init_from_pubkeys(f_pk, ctx, pks, 5, 10, 4);
     factory_set_funding(f_pk, fake_txid, 0, 10000000, fake_spk, 34);
@@ -632,6 +634,7 @@ int test_wire_close_unsigned(void) {
 
     /* Build reference factory */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 10, 4);
 
@@ -699,6 +702,7 @@ int test_wire_distributed_signing(void) {
 
     /* Build reference factory with all keypairs, sign it the old way */
     factory_t *f_ref = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f_ref);
     if (!f_ref) return 0;
     factory_init(f_ref, ctx, kps, 5, 10, 4);
 
@@ -920,6 +924,7 @@ int test_basepoint_independence(void) {
 
     /* Build a factory for testing */
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32];
@@ -1746,6 +1751,7 @@ int test_placement_profiles_wire_round_trip(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
+    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     unsigned char fake_txid[32];

--- a/tools/test_inproc_factory_lifecycle.c
+++ b/tools/test_inproc_factory_lifecycle.c
@@ -164,6 +164,22 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    if (argc >= 4 && !strcmp(argv[1], "dumpkeys")) {
+        /* Emit one hex private key per close-output index (0 = LSP, 1..N = clients),
+           i.e. kps[j] for j=0..N.  Close output index == key index, so a sweep can
+           map each rawtr(key) output back to its spender.  Used only for signet
+           fund-recovery; never on mainnet. */
+        size_t N = strtoull(argv[2], NULL, 10);
+        const char *seed = argv[3];
+        for (size_t j = 0; j <= N; j++) {
+            unsigned char sk[32];
+            if (!derive_seckey(ctx, seed, j, sk)) { fprintf(stderr, "derive %zu failed\n", j); return 1; }
+            char hx[65]; hex_encode(sk, 32, hx); hx[64] = 0;
+            printf("%zu %s\n", j, hx);
+        }
+        return 0;
+    }
+
     if (argc >= 8 && !strcmp(argv[1], "paylifecycle")) {
         size_t N = strtoull(argv[2], NULL, 10);       /* clients (= channels) */
         const char *seed = argv[3];
@@ -173,6 +189,7 @@ int main(int argc, char **argv) {
         const char *outfile = argv[7];
         uint64_t fee_rate = (argc >= 9) ? strtoull(argv[8], NULL, 10) : 1;
         size_t P = (argc >= 10) ? strtoull(argv[9], NULL, 10) : 4;  /* payments/channel */
+        const char *audit_dir = (argc >= 11) ? argv[10] : NULL;     /* extra proof/audit records */
         size_t ns = N + 1;
 
         secp256k1_keypair *kps = calloc(ns, sizeof(*kps));
@@ -208,12 +225,27 @@ int main(int argc, char **argv) {
         printf("  channels: %zu real 2-of-2 LN channels wired to leaves\n", mgr.n_channels);
 
         uint64_t init_client_total = 0;
-        for (size_t c = 0; c < N; c++) init_client_total += mgr.entries[c].channel.remote_amount;
+        uint64_t *init_local  = audit_dir ? calloc(N, sizeof(uint64_t)) : NULL;
+        uint64_t *init_remote = audit_dir ? calloc(N, sizeof(uint64_t)) : NULL;
+        for (size_t c = 0; c < N; c++) {
+            init_client_total += mgr.entries[c].channel.remote_amount;
+            if (init_local)  init_local[c]  = mgr.entries[c].channel.local_amount;
+            if (init_remote) init_remote[c] = mgr.entries[c].channel.remote_amount;
+        }
 
         /* --- REAL HTLC payments: channel_add_htlc(SHA256 hash) -> channel_fulfill_htlc(preimage).
                These move real balance with reserve/dust/fee enforcement and bump the
                commitment number.  3-of-4 are LSP->client, 1-of-4 client->LSP, so a net
                flow of sats reaches the clients through genuine HTLCs. --- */
+        /* Audit: per-HTLC ledger (channel, direction, amount, hash, PREIMAGE, and
+           balances before/after) — an independently-verifiable record of every
+           real payment.  Only written when an audit dir is supplied. */
+        FILE *af = NULL;
+        if (audit_dir) {
+            char pth[600]; snprintf(pth, sizeof pth, "%s/payments.jsonl", audit_dir);
+            af = fopen(pth, "w");
+            if (!af) fprintf(stderr, "warn: cannot open %s\n", pth);
+        }
         uint64_t gross_moved = 0, commit_sum = 0;
         size_t n_pay = 0, n_skip = 0;
         for (size_t c = 0; c < N; c++) {
@@ -227,12 +259,25 @@ int main(int argc, char **argv) {
                 pre[0] = (unsigned char)c; pre[1] = (unsigned char)(c >> 8);
                 pre[2] = (unsigned char)p; pre[3] = 0xA5;
                 sha256(pre, 32, hash);
+                uint64_t lb = ch->local_amount, rb = ch->remote_amount;
                 uint64_t id;
                 if (!channel_add_htlc(ch, dir, amt, hash, 100, &id)) { n_skip++; continue; }
                 if (!channel_fulfill_htlc(ch, id, pre))              { n_skip++; continue; }
                 gross_moved += amt; n_pay++;
+                if (af) {
+                    char hh[65], ph[65]; hex_encode(hash, 32, hh); hh[64] = 0; hex_encode(pre, 32, ph); ph[64] = 0;
+                    fprintf(af, "{\"i\":%zu,\"channel\":%zu,\"dir\":\"%s\",\"amount\":%llu,"
+                                "\"payment_hash\":\"%s\",\"preimage\":\"%s\","
+                                "\"local_before\":%llu,\"remote_before\":%llu,"
+                                "\"local_after\":%llu,\"remote_after\":%llu}\n",
+                            n_pay, c, (dir == HTLC_OFFERED) ? "lsp->client" : "client->lsp",
+                            (unsigned long long)amt, hh, ph,
+                            (unsigned long long)lb, (unsigned long long)rb,
+                            (unsigned long long)ch->local_amount, (unsigned long long)ch->remote_amount);
+                }
             }
         }
+        if (af) fclose(af);
         uint64_t final_client_total = 0;
         for (size_t c = 0; c < N; c++) {
             final_client_total += mgr.entries[c].channel.remote_amount;
@@ -248,10 +293,56 @@ int main(int argc, char **argv) {
         size_t n_out = lsp_channels_build_close_outputs(&mgr, f, outs, close_fee, NULL, 0);
         if (n_out == 0) { fprintf(stderr, "build_close_outputs FAILED (funding < client_total+fee?)\n"); return 1; }
         tx_buf_t close_tx; tx_buf_init(&close_tx, 1u << 20);
-        if (!factory_build_cooperative_close(f, &close_tx, NULL, outs, n_out, 0)) {
+        unsigned char close_txid[32];
+        if (!factory_build_cooperative_close(f, &close_tx, close_txid, outs, n_out, 0)) {
             fprintf(stderr, "factory_build_cooperative_close FAILED\n"); return 1;
         }
         uint64_t out_sum = 0; for (size_t i = 0; i < n_out; i++) out_sum += outs[i].amount_sats;
+
+        /* Audit: per-channel balances + close-output map (output index j maps to
+           key kps[j]: output 0 = LSP, outputs 1..N = client j).  This is the
+           record a sweep/verifier reads to reconstruct + recover every output. */
+        if (audit_dir) {
+            char pth[600];
+            snprintf(pth, sizeof pth, "%s/channels.csv", audit_dir);
+            FILE *cf = fopen(pth, "w");
+            if (cf) {
+                fprintf(cf, "channel,client_pubkey,init_local,init_remote,final_local,final_remote,commitment_number\n");
+                for (size_t c = 0; c < N; c++) {
+                    const channel_t *ch = &mgr.entries[c].channel;
+                    unsigned char pkser[33]; size_t pl = 33; char pkhex[67];
+                    secp256k1_ec_pubkey_serialize(ctx, pkser, &pl, &pks[c + 1], SECP256K1_EC_COMPRESSED);
+                    hex_encode(pkser, 33, pkhex); pkhex[66] = 0;
+                    fprintf(cf, "%zu,%s,%llu,%llu,%llu,%llu,%llu\n", c, pkhex,
+                            (unsigned long long)(init_local ? init_local[c] : 0),
+                            (unsigned long long)(init_remote ? init_remote[c] : 0),
+                            (unsigned long long)ch->local_amount, (unsigned long long)ch->remote_amount,
+                            (unsigned long long)ch->commitment_number);
+                }
+                fclose(cf);
+            }
+            unsigned char ctxid_disp[32]; memcpy(ctxid_disp, close_txid, 32); reverse_bytes(ctxid_disp, 32);
+            char ctxhex[65]; hex_encode(ctxid_disp, 32, ctxhex); ctxhex[64] = 0;
+            snprintf(pth, sizeof pth, "%s/close.json", audit_dir);
+            FILE *jf = fopen(pth, "w");
+            if (jf) {
+                fprintf(jf, "{\"close_txid\":\"%s\",\"n_outputs\":%zu,\"funding\":%llu,"
+                            "\"close_fee\":%llu,\"out_sum\":%llu,\"conserves\":%s,\"outputs\":[",
+                        ctxhex, n_out, (unsigned long long)amount,
+                        (unsigned long long)close_fee, (unsigned long long)out_sum,
+                        (out_sum + close_fee == amount) ? "true" : "false");
+                for (size_t i = 0; i < n_out; i++) {
+                    char spkhex[69]; hex_encode(outs[i].script_pubkey, outs[i].script_pubkey_len, spkhex);
+                    spkhex[outs[i].script_pubkey_len * 2] = 0;
+                    fprintf(jf, "%s{\"index\":%zu,\"role\":\"%s\",\"key_index\":%zu,\"spk\":\"%s\",\"amount\":%llu}",
+                            i ? "," : "", i, i == 0 ? "lsp" : "client", i, spkhex,
+                            (unsigned long long)outs[i].amount_sats);
+                }
+                fprintf(jf, "]}\n");
+                fclose(jf);
+            }
+            free(init_local); free(init_remote);
+        }
 
         FILE *fp = fopen(outfile, "w"); if (!fp) { fprintf(stderr, "cannot write %s\n", outfile); return 1; }
         char *hx = malloc(close_tx.len * 2 + 1); hex_encode(close_tx.data, close_tx.len, hx); hx[close_tx.len * 2] = 0;

--- a/tools/test_inproc_factory_lifecycle.c
+++ b/tools/test_inproc_factory_lifecycle.c
@@ -106,7 +106,18 @@ int main(int argc, char **argv) {
         /* --- REAL factory: init -> set_funding -> build_tree -> sign_all --- */
         factory_t *f = calloc(1, sizeof(factory_t));
         if (!f) { fprintf(stderr, "oom factory_t (%zu MB)\n", sizeof(factory_t) >> 20); return 1; }
-        factory_init(f, ctx, kps, ns, 1, 4);
+        /* Config sized to THIS factory: max_signers = ns.  The default cap is
+           FACTORY_MAX_SIGNERS (256), which would reject N>255 at factory_init /
+           factory_build_tree.  We raise the cap PER INSTANCE rather than bumping
+           the compile-time #define, so the daemon's fixed [FACTORY_MAX_SIGNERS]
+           arrays stay small — only this single-process manager grows.  max_nodes
+           is seeded generously for the PS shape (~4 nodes/client); build_tree
+           grows it by realloc if needed. */
+        factory_config_t cfg; factory_config_default(&cfg);
+        cfg.max_signers = (uint32_t)ns;
+        cfg.max_leaves  = (uint32_t)(N + 1);          /* PS: one leaf per client */
+        cfg.max_nodes   = (uint32_t)(ns * 8 + 64);
+        factory_init_with_config(f, ctx, kps, ns, 1, 4, &cfg);
         factory_set_arity(f, FACTORY_ARITY_PS);
         unsigned char txid_le[32];
         if (hex_decode(txid_hex, txid_le, 32) != 32) { fprintf(stderr, "bad txid\n"); return 1; }

--- a/tools/test_inproc_factory_lifecycle.c
+++ b/tools/test_inproc_factory_lifecycle.c
@@ -1,0 +1,160 @@
+/* test_inproc_factory_lifecycle.c — single-process REAL-factory lifecycle at scale.
+ *
+ * Builds a REAL Decker-Wattenhofer factory (real tree + real node signatures) with
+ * N+1 signers, then cooperatively closes it to per-client outputs — all in ONE
+ * process holding ONE factory_t (~53 MB), no daemons, no wire, no reconnect races.
+ * This is why it fits a small box: the 70 MB/client cost of the daemon harness was
+ * N separate factory_t copies; here there is exactly one.
+ *
+ * Uses the in-process factory API the test suite already exercises:
+ *   factory_init -> factory_set_arity(PS) -> factory_set_funding ->
+ *   factory_build_tree -> factory_sign_all_with_retry ->
+ *   factory_build_cooperative_close   (which uses the >=253-output sighash fix)
+ *
+ * Milestone 1 (this file): CREATE + SIGN + CLOSE at N, proving one-process scale.
+ * Payments are modelled as a per-client settlement distribution; faithful HTLC
+ * flow (factory_advance_leaf) is milestone 2.
+ *
+ * Modes (crypto only; signet fund/broadcast handled by the wrapper .sh):
+ *   addr      <N> <SEED>                    -> funding output x-only key (hex)
+ *   lifecycle <N> <M_FUNDED> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_RATE]
+ *             -> build+sign the factory, cooperatively close to M funded clients,
+ *                write the signed close hex; print tree/sign/close status + size.
+ */
+#include "superscalar/factory.h"
+#include "superscalar/musig.h"
+#include "superscalar/tx_builder.h"
+#include "superscalar/sha256.h"
+#include <secp256k1.h>
+#include <secp256k1_extrakeys.h>
+#include <secp256k1_schnorrsig.h>
+#include <secp256k1_musig.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void hex_encode(const unsigned char *data, size_t len, char *out);
+extern int  hex_decode(const char *hex, unsigned char *out, size_t out_len);
+extern void reverse_bytes(unsigned char *data, size_t len);
+
+#define DUST_LIMIT 546
+
+static int derive_seckey(const secp256k1_context *ctx, const char *seed, size_t i, unsigned char sk[32]) {
+    char buf[160];
+    for (uint32_t b = 0; b < 1024; b++) {
+        int n = snprintf(buf, sizeof buf, "%s:%zu:%u", seed, i, b);
+        secp256k1_tagged_sha256(ctx, sk, (const unsigned char *)"SSInprocFactory", 15,
+                                (const unsigned char *)buf, (size_t)n);
+        if (secp256k1_ec_seckey_verify(ctx, sk)) return 1;
+    }
+    return 0;
+}
+
+/* N+1 keypairs (idx 0 = LSP) + the taproot funding output key/spk. */
+static int build_keys(const secp256k1_context *ctx, const char *seed, size_t n_signers,
+                      secp256k1_keypair *kps, secp256k1_pubkey *pks,
+                      secp256k1_xonly_pubkey *fund_key, unsigned char fund_spk[34]) {
+    for (size_t i = 0; i < n_signers; i++) {
+        unsigned char sk[32];
+        if (!derive_seckey(ctx, seed, i, sk) ||
+            !secp256k1_keypair_create(ctx, &kps[i], sk) ||
+            !secp256k1_keypair_pub(ctx, &pks[i], &kps[i])) return 0;
+    }
+    musig_keyagg_t ka;
+    if (!musig_aggregate_keys(ctx, &ka, pks, n_signers)) return 0;
+    unsigned char ser[32], tweak[32];
+    if (!secp256k1_xonly_pubkey_serialize(ctx, ser, &ka.agg_pubkey)) return 0;
+    sha256_tagged("TapTweak", ser, 32, tweak);
+    musig_keyagg_t tmp = ka; secp256k1_pubkey tw;
+    if (!secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tw, &tmp.cache, tweak)) return 0;
+    if (!secp256k1_xonly_pubkey_from_pubkey(ctx, fund_key, NULL, &tw)) return 0;
+    build_p2tr_script_pubkey(fund_spk, fund_key);
+    return 1;
+}
+
+int main(int argc, char **argv) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    if (argc >= 4 && !strcmp(argv[1], "addr")) {
+        size_t N = strtoull(argv[2], NULL, 10), ns = N + 1;
+        secp256k1_keypair *kps = calloc(ns, sizeof(*kps));
+        secp256k1_pubkey  *pks = calloc(ns, sizeof(*pks));
+        secp256k1_xonly_pubkey fk; unsigned char spk[34];
+        if (!kps || !pks || !build_keys(ctx, argv[3], ns, kps, pks, &fk, spk)) { fprintf(stderr, "keygen failed\n"); return 1; }
+        unsigned char ser[32]; secp256k1_xonly_pubkey_serialize(ctx, ser, &fk);
+        char hex[65]; hex_encode(ser, 32, hex); hex[64] = 0; printf("%s\n", hex);
+        return 0;
+    }
+
+    if (argc >= 9 && !strcmp(argv[1], "lifecycle")) {
+        size_t N = strtoull(argv[2], NULL, 10);       /* clients */
+        size_t M = strtoull(argv[3], NULL, 10);       /* funded clients */
+        const char *seed = argv[4];
+        const char *txid_hex = argv[5];
+        uint32_t vout = (uint32_t)strtoul(argv[6], NULL, 10);
+        uint64_t amount = strtoull(argv[7], NULL, 10);
+        const char *outfile = argv[8];
+        uint64_t fee_rate = (argc >= 10) ? strtoull(argv[9], NULL, 10) : 1;
+        size_t ns = N + 1;
+        if (M > N) { fprintf(stderr, "M(%zu) > N(%zu)\n", M, N); return 1; }
+
+        secp256k1_keypair *kps = calloc(ns, sizeof(*kps));
+        secp256k1_pubkey  *pks = calloc(ns, sizeof(*pks));
+        secp256k1_xonly_pubkey fund_key; unsigned char fund_spk[34];
+        if (!kps || !pks || !build_keys(ctx, seed, ns, kps, pks, &fund_key, fund_spk)) { fprintf(stderr, "keygen failed\n"); return 1; }
+
+        /* --- REAL factory: init -> set_funding -> build_tree -> sign_all --- */
+        factory_t *f = calloc(1, sizeof(factory_t));
+        if (!f) { fprintf(stderr, "oom factory_t (%zu MB)\n", sizeof(factory_t) >> 20); return 1; }
+        factory_init(f, ctx, kps, ns, 1, 4);
+        factory_set_arity(f, FACTORY_ARITY_PS);
+        unsigned char txid_le[32];
+        if (hex_decode(txid_hex, txid_le, 32) != 32) { fprintf(stderr, "bad txid\n"); return 1; }
+        reverse_bytes(txid_le, 32);
+        factory_set_funding(f, txid_le, vout, amount, fund_spk, 34);
+        if (!factory_build_tree(f)) { fprintf(stderr, "factory_build_tree FAILED\n"); return 1; }
+        printf("  factory: tree built (%zu nodes, %zu-signer PS)\n", f->n_nodes, ns);
+        if (!factory_sign_all_with_retry(f, 3)) { fprintf(stderr, "factory_sign_all FAILED\n"); return 1; }
+        printf("  factory: all nodes signed\n");
+
+        /* --- Settlement distribution: M funded clients (varied), LSP gets remainder.
+               (Milestone 1: models payment outcome; faithful HTLC flow is next.) --- */
+        tx_output_t *outs = calloc(M + 1, sizeof(tx_output_t));
+        size_t n_out = 1; uint64_t client_sum = 0;
+        for (size_t i = 1; i <= M; i++) {
+            uint64_t amt = 700 + (uint64_t)(i % 600);
+            secp256k1_xonly_pubkey xo; secp256k1_keypair_xonly_pub(ctx, &xo, NULL, &kps[i]);
+            build_p2tr_script_pubkey(outs[n_out].script_pubkey, &xo);
+            outs[n_out].script_pubkey_len = 34; outs[n_out].amount_sats = amt;
+            client_sum += amt; n_out++;
+        }
+        uint64_t est_vsize = 11 + 58 + (uint64_t)n_out * 43;
+        uint64_t fee = est_vsize * fee_rate;
+        if (amount < client_sum + fee + DUST_LIMIT) { fprintf(stderr, "funding too small\n"); return 1; }
+        secp256k1_xonly_pubkey lxo; secp256k1_keypair_xonly_pub(ctx, &lxo, NULL, &kps[0]);
+        build_p2tr_script_pubkey(outs[0].script_pubkey, &lxo);
+        outs[0].script_pubkey_len = 34; outs[0].amount_sats = amount - client_sum - fee;
+
+        /* --- Cooperative close (uses the >=253-output sighash fix) --- */
+        tx_buf_t close_tx; tx_buf_init(&close_tx, 1u << 20);
+        if (!factory_build_cooperative_close(f, &close_tx, NULL, outs, n_out, 0)) {
+            fprintf(stderr, "factory_build_cooperative_close FAILED\n"); return 1;
+        }
+        FILE *fp = fopen(outfile, "w"); if (!fp) { fprintf(stderr, "cannot write %s\n", outfile); return 1; }
+        char *hx = malloc(close_tx.len * 2 + 1); hex_encode(close_tx.data, close_tx.len, hx); hx[close_tx.len * 2] = 0;
+        fputs(hx, fp); fclose(fp);
+        printf("inproc-lifecycle: signers=%zu funded=%zu outputs=%zu  close_tx=%zu B  conserves=%s\n",
+               ns, M, n_out, close_tx.len,
+               (amount == outs[0].amount_sats + client_sum + fee) ? "yes" : "NO");
+        printf("  hex -> %s\n", outfile);
+        free(hx); free(outs);
+        return 0;
+    }
+
+    fprintf(stderr,
+        "usage:\n"
+        "  %s addr      <N> <SEED>\n"
+        "  %s lifecycle <N> <M_FUNDED> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_RATE]\n",
+        argv[0], argv[0]);
+    return 1;
+}

--- a/tools/test_inproc_factory_lifecycle.c
+++ b/tools/test_inproc_factory_lifecycle.c
@@ -25,6 +25,8 @@
 #include "superscalar/musig.h"
 #include "superscalar/tx_builder.h"
 #include "superscalar/sha256.h"
+#include "superscalar/channel.h"
+#include "superscalar/lsp_channels.h"
 #include <secp256k1.h>
 #include <secp256k1_extrakeys.h>
 #include <secp256k1_schnorrsig.h>
@@ -162,10 +164,118 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    if (argc >= 8 && !strcmp(argv[1], "paylifecycle")) {
+        size_t N = strtoull(argv[2], NULL, 10);       /* clients (= channels) */
+        const char *seed = argv[3];
+        const char *txid_hex = argv[4];
+        uint32_t vout = (uint32_t)strtoul(argv[5], NULL, 10);
+        uint64_t amount = strtoull(argv[6], NULL, 10);
+        const char *outfile = argv[7];
+        uint64_t fee_rate = (argc >= 9) ? strtoull(argv[8], NULL, 10) : 1;
+        size_t P = (argc >= 10) ? strtoull(argv[9], NULL, 10) : 4;  /* payments/channel */
+        size_t ns = N + 1;
+
+        secp256k1_keypair *kps = calloc(ns, sizeof(*kps));
+        secp256k1_pubkey  *pks = calloc(ns, sizeof(*pks));
+        secp256k1_xonly_pubkey fund_key; unsigned char fund_spk[34];
+        if (!kps || !pks || !build_keys(ctx, seed, ns, kps, pks, &fund_key, fund_spk)) { fprintf(stderr, "keygen failed\n"); return 1; }
+
+        /* --- Build + sign the factory tree (same path proven to 10k) --- */
+        factory_t *f = calloc(1, sizeof(factory_t));
+        if (!f) { fprintf(stderr, "oom factory_t\n"); return 1; }
+        factory_config_t cfg; factory_config_default(&cfg);
+        cfg.max_signers = (uint32_t)ns;
+        cfg.max_leaves  = (uint32_t)(N + 1);
+        cfg.max_nodes   = (uint32_t)(ns * 8 + 64);
+        factory_init_with_config(f, ctx, kps, ns, 1, 4, &cfg);
+        factory_set_arity(f, FACTORY_ARITY_PS);
+        unsigned char txid_le[32];
+        if (hex_decode(txid_hex, txid_le, 32) != 32) { fprintf(stderr, "bad txid\n"); return 1; }
+        reverse_bytes(txid_le, 32);
+        factory_set_funding(f, txid_le, vout, amount, fund_spk, 34);
+        if (!factory_build_tree(f)) { fprintf(stderr, "factory_build_tree FAILED\n"); return 1; }
+        if (!factory_sign_all_with_retry(f, 3)) { fprintf(stderr, "factory_sign_all FAILED\n"); return 1; }
+        printf("  factory: %zu nodes, %zu-signer PS, all signed\n", f->n_nodes, ns);
+
+        /* --- Wire a REAL Lightning channel to every leaf (LSP=local, client=remote).
+               lsp_channels_init discovers the PS keyagg ordering and funds each
+               channel from factory->nodes[leaf].outputs[vout]. --- */
+        unsigned char lsp_sec[32];
+        if (!secp256k1_keypair_sec(ctx, lsp_sec, &kps[0])) { fprintf(stderr, "lsp sec\n"); return 1; }
+        lsp_channel_mgr_t mgr; memset(&mgr, 0, sizeof mgr);
+        mgr.lsp_balance_pct = 50;   /* 50/50 initial split per channel */
+        if (!lsp_channels_init(&mgr, ctx, f, lsp_sec, N)) { fprintf(stderr, "lsp_channels_init FAILED\n"); return 1; }
+        printf("  channels: %zu real 2-of-2 LN channels wired to leaves\n", mgr.n_channels);
+
+        uint64_t init_client_total = 0;
+        for (size_t c = 0; c < N; c++) init_client_total += mgr.entries[c].channel.remote_amount;
+
+        /* --- REAL HTLC payments: channel_add_htlc(SHA256 hash) -> channel_fulfill_htlc(preimage).
+               These move real balance with reserve/dust/fee enforcement and bump the
+               commitment number.  3-of-4 are LSP->client, 1-of-4 client->LSP, so a net
+               flow of sats reaches the clients through genuine HTLCs. --- */
+        uint64_t gross_moved = 0, commit_sum = 0;
+        size_t n_pay = 0, n_skip = 0;
+        for (size_t c = 0; c < N; c++) {
+            channel_t *ch = &mgr.entries[c].channel;
+            for (size_t p = 0; p < P; p++) {
+                htlc_direction_t dir = (p % 4 == 3) ? HTLC_RECEIVED : HTLC_OFFERED;
+                uint64_t amt = 1000 + (uint64_t)((c + p) % 400);
+                uint64_t offerer = (dir == HTLC_OFFERED) ? ch->local_amount : ch->remote_amount;
+                if (offerer < amt + CHANNEL_RESERVE_SATS + 500) { n_skip++; continue; }
+                unsigned char pre[32] = {0}, hash[32];
+                pre[0] = (unsigned char)c; pre[1] = (unsigned char)(c >> 8);
+                pre[2] = (unsigned char)p; pre[3] = 0xA5;
+                sha256(pre, 32, hash);
+                uint64_t id;
+                if (!channel_add_htlc(ch, dir, amt, hash, 100, &id)) { n_skip++; continue; }
+                if (!channel_fulfill_htlc(ch, id, pre))              { n_skip++; continue; }
+                gross_moved += amt; n_pay++;
+            }
+        }
+        uint64_t final_client_total = 0;
+        for (size_t c = 0; c < N; c++) {
+            final_client_total += mgr.entries[c].channel.remote_amount;
+            commit_sum         += mgr.entries[c].channel.commitment_number;
+        }
+
+        /* --- Cooperative close from the REAL post-payment balances (output 0 = LSP =
+               funding - sum(client remotes) - close_fee; outputs 1..N = each client's
+               remote_amount).  NULL close_spk => real per-client + LSP close addresses. --- */
+        tx_output_t *outs = calloc(N + 1, sizeof(tx_output_t));
+        uint64_t est_vsize = 11 + 58 + (uint64_t)(N + 1) * 43;
+        uint64_t close_fee = est_vsize * fee_rate;
+        size_t n_out = lsp_channels_build_close_outputs(&mgr, f, outs, close_fee, NULL, 0);
+        if (n_out == 0) { fprintf(stderr, "build_close_outputs FAILED (funding < client_total+fee?)\n"); return 1; }
+        tx_buf_t close_tx; tx_buf_init(&close_tx, 1u << 20);
+        if (!factory_build_cooperative_close(f, &close_tx, NULL, outs, n_out, 0)) {
+            fprintf(stderr, "factory_build_cooperative_close FAILED\n"); return 1;
+        }
+        uint64_t out_sum = 0; for (size_t i = 0; i < n_out; i++) out_sum += outs[i].amount_sats;
+
+        FILE *fp = fopen(outfile, "w"); if (!fp) { fprintf(stderr, "cannot write %s\n", outfile); return 1; }
+        char *hx = malloc(close_tx.len * 2 + 1); hex_encode(close_tx.data, close_tx.len, hx); hx[close_tx.len * 2] = 0;
+        fputs(hx, fp); fclose(fp); free(hx);
+
+        printf("inproc-pay: N=%zu channels=%zu payments=%zu (skipped %zu) gross_moved=%llu sats\n",
+               N, mgr.n_channels, n_pay, n_skip, (unsigned long long)gross_moved);
+        printf("inproc-pay: client_total %llu -> %llu (net %+lld to clients)  commitment_bumps=%llu\n",
+               (unsigned long long)init_client_total, (unsigned long long)final_client_total,
+               (long long)final_client_total - (long long)init_client_total,
+               (unsigned long long)commit_sum);
+        printf("inproc-pay: close outputs=%zu  close_tx=%zu B  out_sum=%llu funding=%llu fee=%llu  conserves=%s\n",
+               n_out, close_tx.len, (unsigned long long)out_sum, (unsigned long long)amount,
+               (unsigned long long)close_fee, (out_sum + close_fee == amount) ? "yes" : "NO");
+        printf("  hex -> %s\n", outfile);
+        lsp_channels_cleanup(&mgr);
+        return 0;
+    }
+
     fprintf(stderr,
         "usage:\n"
-        "  %s addr      <N> <SEED>\n"
-        "  %s lifecycle <N> <M_FUNDED> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_RATE]\n",
-        argv[0], argv[0]);
+        "  %s addr         <N> <SEED>\n"
+        "  %s lifecycle    <N> <M_FUNDED> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_RATE]\n"
+        "  %s paylifecycle <N> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_RATE] [PAYMENTS_PER_CH]\n",
+        argv[0], argv[0], argv[0]);
     return 1;
 }

--- a/tools/test_signet_paylifecycle.sh
+++ b/tools/test_signet_paylifecycle.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# test_signet_paylifecycle.sh — end-to-end signet proof of the in-process manager:
+#   fund factory -> real HTLC payments -> cooperative close (broadcast+confirm) ->
+#   verify outputs on-chain -> sweep every output back to ss_sig_n127.
+# Keeps a full audit bundle. Gates every broadcast with testmempoolaccept so a bad
+# tx never spends. Since the seed is saved, the funding output is always recoverable
+# via a rebuilt close even if a later step fails.
+#
+# Usage: test_signet_paylifecycle.sh <N> [P_PER_CH] [SATS_PER_LEAF] [FEE_RATE]
+set -uo pipefail
+
+N="${1:?usage: <N> [P] [SATS_PER_LEAF] [FEE_RATE]}"
+P="${2:-4}"
+PER_LEAF="${3:-15000}"        # >2*CHANNEL_RESERVE(5000) so payments have room
+FEE_RATE="${4:-1}"            # sat/vB for close + sweep (signet is cheap)
+AMOUNT=$(( N * PER_LEAF ))
+
+BIN=/root/SuperScalar-lsppay/build-lsppay/test_inproc_factory_lifecycle
+CONF=/var/lib/bitcoind-signet/bitcoin.conf
+CLI="bitcoin-cli -signet -conf=$CONF"
+W="-rpcwallet=ss_sig_n127"
+TAG="paylife_N${N}_$$"                 # UNIQUE per run — never reuse (seed-collision hazard)
+SEED="ss_${TAG}"
+AUDIT="/root/paylife_audit/${TAG}"
+mkdir -p "$AUDIT"
+LOG="$AUDIT/run.log"
+exec > >(tee -a "$LOG") 2>&1
+
+sat2btc(){ awk "BEGIN{printf \"%.8f\", $1/100000000}"; }
+say(){ echo "[$(date -u +%H:%M:%S)] $*"; }
+wait_conf(){ # txid -> block until >=1 confirmation (txindex=1, works for any tx)
+  local txid="$1" i
+  for i in $(seq 1 480); do
+    local c=$($CLI getrawtransaction "$txid" 1 2>/dev/null | jq -r '.confirmations // 0')
+    [ "${c:-0}" -ge 1 ] && { echo "$c"; return 0; }
+    sleep 15
+  done
+  return 1
+}
+
+say "RUN $TAG  N=$N P=$P per_leaf=$PER_LEAF amount=$AMOUNT fee_rate=$FEE_RATE"
+RET=$($CLI $W getnewaddress "${TAG}_ret" bech32m)
+git -C /root/SuperScalar-lsppay rev-parse HEAD > "$AUDIT/git_commit.txt" 2>/dev/null || true
+cat > "$AUDIT/manifest.json" <<EOF
+{"tag":"$TAG","seed":"$SEED","N":$N,"payments_per_channel":$P,"sats_per_leaf":$PER_LEAF,
+ "funding_amount":$AMOUNT,"fee_rate":$FEE_RATE,"return_addr":"$RET"}
+EOF
+
+# ---- 1. factory funding address (tweaked N-of-N aggregate) ----
+FX=$($BIN addr "$N" "$SEED") || { say "addr FAILED"; exit 1; }
+DESC=$($CLI getdescriptorinfo "rawtr($FX)" | jq -r .descriptor)
+FADDR=$($CLI deriveaddresses "$DESC" | jq -r '.[0]')
+say "funding addr=$FADDR (xonly=$FX)"
+echo "$FADDR" > "$AUDIT/funding_addr.txt"
+
+# ---- 2. fund it ----
+FTXID=$($CLI -named $W sendtoaddress address="$FADDR" amount="$(sat2btc $AMOUNT)" fee_rate=$FEE_RATE) \
+  || { say "fund send FAILED"; exit 1; }
+say "funding txid=$FTXID (waiting for confirmation)"
+wait_conf "$FTXID" >/dev/null || { say "funding not confirmed"; exit 1; }
+VOUT=$($CLI getrawtransaction "$FTXID" 1 | jq -r --arg a "$FADDR" '.vout[] | select(.scriptPubKey.address==$a) | .n' | head -1)
+say "funding confirmed, vout=$VOUT"
+echo "{\"funding_txid\":\"$FTXID\",\"vout\":$VOUT}" > "$AUDIT/funding.json"
+
+# ---- 3. real payments + cooperative close (in-process) ----
+say "running paylifecycle (real HTLC payments + close)"
+$BIN paylifecycle "$N" "$SEED" "$FTXID" "$VOUT" "$AMOUNT" "$AUDIT/close.hex" "$FEE_RATE" "$P" "$AUDIT" \
+  || { say "paylifecycle FAILED"; exit 1; }
+CLOSE_HEX=$(cat "$AUDIT/close.hex")
+
+# ---- 4. GATE: testmempoolaccept before spending ----
+ACC=$($CLI testmempoolaccept "[\"$CLOSE_HEX\"]" | jq -r '.[0].allowed')
+say "close testmempoolaccept allowed=$ACC"
+[ "$ACC" = "true" ] || { say "close REJECTED by mempool — aborting (funding recoverable via seed)"; $CLI testmempoolaccept "[\"$CLOSE_HEX\"]"; exit 1; }
+
+# ---- 5. broadcast close + confirm ----
+CTXID=$($CLI sendrawtransaction "$CLOSE_HEX") || { say "close broadcast FAILED"; exit 1; }
+say "close broadcast txid=$CTXID (waiting for confirmation)"
+wait_conf "$CTXID" >/dev/null || say "warn: close not confirmed within timeout (check later)"
+CH=$($CLI getrawtransaction "$CTXID" 1 2>/dev/null | jq -r '.blockheight // empty')
+say "close confirmed txid=$CTXID height=${CH:-pending}"
+
+# ---- 6. verify outputs on-chain ----
+NOUT=$($CLI getrawtransaction "$CTXID" 1 | jq -r '.vout | length')
+OUTSUM=$($CLI getrawtransaction "$CTXID" 1 | jq -r '[.vout[].value] | add')
+say "on-chain close: outputs=$NOUT sum=${OUTSUM} BTC"
+
+# ---- 7. sweep every output back to ss_sig_n127 ----
+say "sweeping $NOUT outputs back to $RET"
+$BIN dumpkeys "$N" "$SEED" > "$AUDIT/keys.txt"
+python3 - "$AUDIT/keys.txt" "$CH" > "$AUDIT/import.json" <<'PY'
+import sys,hashlib,json
+def b58(b):
+    a='123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';n=int.from_bytes(b,'big');s=''
+    while n>0:n,r=divmod(n,58);s=a[r]+s
+    for c in b:
+        if c==0:s='1'+s
+        else:break
+    return s
+def wif(h):
+    p=b'\xef'+bytes.fromhex(h)+b'\x01';c=hashlib.sha256(hashlib.sha256(p).digest()).digest()[:4];return b58(p+c)
+IN="0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
+CS="qpzry9x8gf2tvdw0s3jn54khce6mua7l";G=[0xf5dee51989,0xa9fdca3312,0x1bab10e32d,0x3706b1677a,0x644d626ffd]
+def pm(c,v):
+    c0=c>>35;c=((c&0x7ffffffff)<<5)^v
+    for i in range(5):c^=G[i] if((c0>>i)&1) else 0
+    return c
+def dsum(s):
+    c=1;cl=0;cc=0
+    for ch in s:
+        p=IN.find(ch)
+        c=pm(c,p&31);cl=cl*3+(p>>5);cc+=1
+        if cc==3:c=pm(c,cl);cl=0;cc=0
+    if cc>0:c=pm(c,cl)
+    for _ in range(8):c=pm(c,0)
+    c^=1
+    return ''.join(CS[(c>>(5*(7-j)))&31] for j in range(8))
+keys=[l.split()[1] for l in open(sys.argv[1]) if l.strip()]
+ts=1
+descs=[]
+for h in keys:
+    d="rawtr(%s)"%wif(h); d=d+"#"+dsum(d)
+    descs.append({"desc":d,"timestamp":ts,"active":False,"internal":False})
+print(json.dumps(descs))
+PY
+SWEEPW="sweep_${TAG}"
+$CLI -named createwallet wallet_name="$SWEEPW" blank=true disable_private_keys=false >/dev/null 2>&1 || true
+$CLI -rpcwallet="$SWEEPW" importdescriptors "$(cat $AUDIT/import.json)" >/dev/null 2>&1
+RS_FROM=${CH:-1}
+$CLI -rpcwallet="$SWEEPW" rescanblockchain "$RS_FROM" >/dev/null 2>&1
+SWBAL=$($CLI -rpcwallet="$SWEEPW" getbalance)
+say "sweep wallet holds $SWBAL BTC across $NOUT outputs"
+STXID=$($CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate="$FEE_RATE" 2>&1 | jq -r '.txid // empty')
+if [ -z "$STXID" ]; then say "sendall FAILED:"; $CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate="$FEE_RATE"; else
+  say "sweep broadcast txid=$STXID"; wait_conf "$STXID" >/dev/null 2>&1 || true
+  say "sweep confirmed txid=$STXID"
+fi
+
+# ---- 8. finalize manifest ----
+cat > "$AUDIT/onchain.json" <<EOF
+{"funding_txid":"$FTXID","funding_vout":$VOUT,"funding_addr":"$FADDR","funding_amount":$AMOUNT,
+ "close_txid":"$CTXID","close_height":"${CH:-}","close_outputs":$NOUT,"close_out_sum_btc":"$OUTSUM",
+ "sweep_txid":"${STXID:-}","return_addr":"$RET"}
+EOF
+say "DONE. audit bundle in $AUDIT"
+ls -la "$AUDIT"

--- a/tools/test_signet_paylifecycle.sh
+++ b/tools/test_signet_paylifecycle.sh
@@ -77,7 +77,9 @@ say "close testmempoolaccept allowed=$ACC"
 CTXID=$($CLI sendrawtransaction "$CLOSE_HEX") || { say "close broadcast FAILED"; exit 1; }
 say "close broadcast txid=$CTXID (waiting for confirmation)"
 wait_conf "$CTXID" >/dev/null || say "warn: close not confirmed within timeout (check later)"
-CH=$($CLI getrawtransaction "$CTXID" 1 2>/dev/null | jq -r '.blockheight // empty')
+# getrawtransaction has no blockheight field — derive it from the block hash.
+BH=$($CLI getrawtransaction "$CTXID" 1 2>/dev/null | jq -r '.blockhash // empty')
+CH=""; [ -n "$BH" ] && CH=$($CLI getblock "$BH" 2>/dev/null | jq -r '.height')
 say "close confirmed txid=$CTXID height=${CH:-pending}"
 
 # ---- 6. verify outputs on-chain ----
@@ -116,18 +118,24 @@ def dsum(s):
     c^=1
     return ''.join(CS[(c>>(5*(7-j)))&31] for j in range(8))
 keys=[l.split()[1] for l in open(sys.argv[1]) if l.strip()]
-ts=1
 descs=[]
 for h in keys:
     d="rawtr(%s)"%wif(h); d=d+"#"+dsum(d)
-    descs.append({"desc":d,"timestamp":ts,"active":False,"internal":False})
+    # timestamp "now" => no genesis rescan at import; we rescan the small
+    # [close_height, tip] range explicitly below (fast + reliable).
+    descs.append({"desc":d,"timestamp":"now","active":False,"internal":False})
 print(json.dumps(descs))
 PY
 SWEEPW="sweep_${TAG}"
 $CLI -named createwallet wallet_name="$SWEEPW" blank=true disable_private_keys=false >/dev/null 2>&1 || true
-$CLI -rpcwallet="$SWEEPW" importdescriptors "$(cat $AUDIT/import.json)" >/dev/null 2>&1
-RS_FROM=${CH:-1}
-$CLI -rpcwallet="$SWEEPW" rescanblockchain "$RS_FROM" >/dev/null 2>&1
+# importdescriptors via -stdin: the descriptor JSON is >ARG_MAX for large N
+# (1024 descriptors ~141 KB), so it cannot be passed as a command-line argument.
+IMPOK=$(printf '%s' "$(cat $AUDIT/import.json)" | $CLI -rpcwallet="$SWEEPW" -stdin importdescriptors | jq -c '[.[].success]|{ok:all,n:length}')
+say "importdescriptors: $IMPOK"
+TIP=$($CLI getblockcount)
+RS_FROM=$(( ${CH:-$((TIP-30))} - 3 ))    # small margin around the close block
+say "rescanning [$RS_FROM,$TIP] for close outputs"
+$CLI -rpcwallet="$SWEEPW" rescanblockchain "$RS_FROM" "$TIP" >/dev/null 2>&1
 SWBAL=$($CLI -rpcwallet="$SWEEPW" getbalance)
 say "sweep wallet holds $SWBAL BTC across $NOUT outputs"
 STXID=$($CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate="$FEE_RATE" 2>&1 | jq -r '.txid // empty')


### PR DESCRIPTION
Makes a **single process** build, sign, pay through, and cooperatively close a factory with **thousands** of clients — then proves it end-to-end on **real signet**, with every sat accounted for and swept home.

## What changed

**1. O(N log N) factory memory (`7dfa7cd`, `e339ed0`)**
`factory_t` was O(N²): every one of ~4N tree nodes carried per-signer arrays sized to the *global* max — dominated by two `musig_signing_session_t` per node at ~34 KB of `pubnonces` each. But a DW node's N-of-N is only over its **subtree's** signers, and the ceremony code already indexes those arrays by **local slot** (`signer_indices[]` is a local→global map). So sizing each node's arrays to `node->n_signers` needed **no change to the signing logic**. Also made dynamic: factory-level `keypairs`/`pubkeys`/`profiles`/`dist_partial_sigs` (→ `config.max_signers`) and `leaf_layers`/`leaf_node_indices` (→ `config.max_leaves`). Compile-time `FACTORY_MAX_*` defaults are unchanged, so the multi-process daemon keeps its small fixed arrays; only a factory created with a raised per-instance config grows.

*Real bug fixed on the way:* `factory_set_arity`'s `dw_layer_init` loop silently overran the fixed `leaf_layers[256]` into the adjacent `config` for N≥256 (PS = one leaf per client) — memory corruption that made `config.max_signers` read back as `1`.

Measured (one process, create + sign every node + N-of-N close, all conserve):
`255→30 MB · 1024→104 MB · 4096→400 MB · 10000→976 MB` (~100 KB/client, 39,998 nodes at 10k).

**2. Real Lightning payments through the leaves (`0a441c6`, `519ba41`)**
`lsp_channels_init` wires a real 2-of-2 `channel_t` to every factory leaf (PS keyagg auto-discovered against the on-chain leaf script). Each payment now runs the daemon's **exact BOLT-2 commitment ceremony**, ported from `htlc_commit_add_and_sign` minus the sockets: `update_add_htlc` on both endpoints → `channel_create_commitment_partial_sig` → peer **cryptographically verifies** the partial sig and aggregates (`channel_verify_and_aggregate_commitment_sig`) → `revoke_and_ack` both directions (per-commitment secret reveal + `receive_revocation_flat` + next-PCP advance) → `fulfill` → second full signed round. Real client-side mirror channels per leaf carry the basepoints, PCS chains and pubnonce pools that `MSG_CHANNEL_BASEPOINTS`/`MSG_CHANNEL_NONCES` carry on the wire.

`LSP_PCT=100` starts every client at **zero**, so every client sat at close arrived through a real HTLC — asserted per channel, alongside an exact mirror-book check. Fees are sat/kvB (`100` = 0.1 sat/vB). The cooperative close is built from the **actual post-payment balances** (`lsp_channels_build_close_outputs` → `factory_build_cooperative_close`).

**3. Two crash fixes the ceremony exposed (`519ba41`)**
- `musig_session_init` read the struct it was initializing (reuse-or-free of `pubnonces`), but `channel.c`/`lsp.c`/`client.c`/`adaptor.c` declare sessions **on the stack** — first-init read garbage and `free()`d it: a latent SIGSEGV in the per-payment commitment path. Fixed with an inline buffer for ≤`MUSIG_SESSION_SMALL` (8) signers (no heap, exact pre-refactor behavior for every stack user), heap only for large subtree sessions, `musig_session_free` before every re-init of a live embedded session.
- ~211 call sites build a `factory_t` by hand (`calloc` + field-poke) rather than via `factory_init*()`; with the arrays dynamic, `f->profiles[0] = …` was a NULL write. Added NULL-safe, idempotent `factory_alloc_default_arrays()` and applied it at every such site.
- Fixed `memset(f->leaf_layers, 0, sizeof(pointer))` in `test_persist.c` — a compile error that had been failing the suite target, so gates were re-running a **stale** `test_superscalar` binary. Gates now hard-fail on build errors.

**4. Signet harness (`5a0e445`, `11d6144`)**
`tools/test_signet_paylifecycle.sh`: fund → real payments → close (gated by `testmempoolaccept`) → confirm → verify outputs on-chain → sweep every output home. Per-run audit bundle: `payments.jsonl` (every HTLC's hash + **preimage** + balances before/after), `channels.csv`, `close.json`, `onchain.json`. Sweep fixes found live: `importdescriptors` must go through `bitcoin-cli -stdin` (1024 descriptors ≈ 141 KB > `ARG_MAX`, which failed **silently**), close height from the block **hash** (`getrawtransaction` has no `blockheight`), and a bounded rescan range instead of a genesis rescan.

## Proof on real signet — 1023 clients + LSP

| | |
|---|---|
| funding | `147ac8f364329b5bf2e8c679eef00bcc6ead8fc9e9c1dfa88257df217eb352ef` |
| **close** | **`a8b97362a5740c3db7fa0ccd14f46f487e960deb647224ddca2d6d8e32615719`** — block 315065, **1,024 outputs, 44,153 B**, one 64-byte 1024-of-1024 MuSig2 signature |
| sweep | `c96342173de2f95773b3073776f40878c9a7676c36749f114b275e96417465e6` — 1,024 inputs, all funds recovered |

Independently re-verified against the chain and the audit bundle: on-chain conservation exact (`61,380,000 = 61,335,899 + 44,101`); every close output equals its channel's post-payment balance (**1,023 channels, 0 mismatches**); ledger net matches the balance delta to the sat; **4,092 / 4,092 preimages** satisfy `SHA256(preimage) == payment_hash`; 0 per-channel conservation violations.

In-memory at the same scale with the full ceremony: **16,368 aggregate signatures verified, 16,368 revocations exchanged**, payment-borne verified, 76 s, 355 MB.

## Test gate
`test_superscalar` **1522/1522** on a freshly-built binary (the first trustworthy green after the stale-binary discovery above).

## Scope / honesty
Payments are off-chain by construction — the chain sees funding, the close, and the sweep; the close pays out exactly what the payments produced. This harness is **co-location**: one process holds all 1,024 keys and drives both endpoints of every ceremony, so it proves the protocol, the crypto and the settlement at 1,024 scale — *not* 1,024 independent parties surviving a real network. The distributed daemon path remains proven to N=127, where the binding constraint is liveness (a 24 h soak lost 30/127 daemons and N-of-N coop close needs all), not tx size or cryptography.

Remaining lean-up (not blocking): `input_signer_indices[16][256]` is still fixed at 16 KB/node and unused for default k=1 PS — making it lazy would cut the 10k footprint to ~340 MB.
