### PR TITLE
Recover unlanded work: BOLT-2 commitment ceremony harness + LSP->client inbound payments

### DIFF
--- a/include/superscalar/lsp_channels.h
+++ b/include/superscalar/lsp_channels.h
@@ -492,6 +492,14 @@ int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                     size_t from_client, size_t to_client,
                                     uint64_t amount_sats);
 
+/* lsppay: LSP -> client inbound payment over the factory channel (the final
+   hop of a real inbound LN payment; the external payer is simulated by the
+   LSP).  For the pct-100 onboarding model where clients start with zero
+   balance.  Invoice + OFFERED-HTLC leg + fulfill; no sender client, no
+   back-propagation.  Returns 1 on success. */
+int lsp_channels_lsppay(lsp_channel_mgr_t *mgr, lsp_t *lsp,
+                          size_t to_client, uint64_t amount_sats);
+
 /* Create an external invoice so a client can receive from the LN via bridge.
    Sends MSG_CREATE_INVOICE, waits for MSG_INVOICE_CREATED, drains
    MSG_REGISTER_INVOICE, and forwards MSG_BRIDGE_REGISTER to bridge.

--- a/src/factory.c
+++ b/src/factory.c
@@ -878,6 +878,10 @@ void factory_init_from_pubkeys(factory_t *f, secp256k1_context *ctx,
 }
 
 void factory_set_arity(factory_t *f, factory_arity_t arity) {
+    if (!f) return;
+    /* Callable BEFORE factory_init (see factory_set_level_arity). */
+    factory_alloc_default_arrays(f);
+    if (!f->leaf_layers) return;
     f->leaf_arity = arity;
     f->n_level_arity = 0;  /* clear variable arity */
     size_t nc = (f->n_participants > 1) ? f->n_participants - 1 : 1;
@@ -1034,6 +1038,10 @@ void factory_set_ps_subfactory_arity(factory_t *f, uint32_t k) {
     /* Cap at FACTORY_MAX_OUTPUTS - 1 so the leaf's k sub-factory entry
        outputs + 1 L-stock output fit within FACTORY_MAX_OUTPUTS.  k=0
        is treated as k=1 (no sub-factories). */
+    if (!f) return;
+    /* Callable BEFORE factory_init (see factory_set_level_arity). */
+    factory_alloc_default_arrays(f);
+    if (!f->leaf_layers) return;
     if (k == 0) k = 1;
     if (k > (uint32_t)(FACTORY_MAX_OUTPUTS - 1))
         k = (uint32_t)(FACTORY_MAX_OUTPUTS - 1);
@@ -1132,6 +1140,13 @@ int factory_client_to_leaf(const factory_t *f, size_t client_idx,
 }
 
 void factory_set_level_arity(factory_t *f, const uint8_t *arities, size_t n) {
+    if (!f) return;
+    /* The dynamic arrays (leaf_layers here) used to be inline storage, so a
+       zeroed factory_t was usable immediately and callers could shape the tree
+       BEFORE factory_init.  superscalar_lsp's main() does exactly that on its
+       embedded lsp->factory.  Restore that contract: NULL-safe + idempotent. */
+    factory_alloc_default_arrays(f);
+    if (!f->leaf_layers) return;
     if (n > FACTORY_MAX_LEVELS) n = FACTORY_MAX_LEVELS;
     memcpy(f->level_arity, arities, n);
     f->n_level_arity = n;
@@ -1150,6 +1165,10 @@ void factory_set_level_arity(factory_t *f, const uint8_t *arities, size_t n) {
 }
 
 void factory_set_static_near_root(factory_t *f, uint32_t threshold) {
+    if (!f) return;
+    /* Callable BEFORE factory_init (see factory_set_level_arity). */
+    factory_alloc_default_arrays(f);
+    if (!f->leaf_layers) return;
     f->static_threshold_depth = threshold;
     /* Recompute n_layers based on current arity/level configuration, since
        the threshold shrinks the DW counter shape. */

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -6574,6 +6574,28 @@ int lsp_channels_handle_cli_line(lsp_channel_mgr_t *mgr, void *lsp_ptr,
             printf("CLI: usage: %s <from> <to> <amount>\n", cmd_name);
         }
         fflush(stdout);
+    } else if (strncmp(line, "lsppay ", 7) == 0) {
+        /* lsppay <to> <amount>: LSP -> client inbound payment (final hop of a
+           real inbound LN payment; external payer simulated by the LSP).  For
+           the pct-100 realistic model where clients onboard with zero funds. */
+        unsigned int to;
+        unsigned long long amt;
+        if (sscanf(line + 7, "%u %llu", &to, &amt) == 2) {
+            if (to >= mgr->n_channels) {
+                printf("CLI: invalid client index (max %zu)\n",
+                       mgr->n_channels - 1);
+            } else {
+                printf("CLI: lsppay -> %u (%llu sats)\n", to, amt);
+                fflush(stdout);
+                if (lsp_channels_lsppay(mgr, lsp, (size_t)to, (uint64_t)amt))
+                    printf("CLI: lsppay succeeded\n");
+                else
+                    printf("CLI: lsppay FAILED\n");
+            }
+        } else {
+            printf("CLI: usage: lsppay <to> <amount>\n");
+        }
+        fflush(stdout);
     } else if (strcmp(line, "status") == 0) {
         printf("--- Factory Status ---\n");
         printf("  Channels: %zu\n", mgr->n_channels);

--- a/src/lsp_demo.c
+++ b/src/lsp_demo.c
@@ -118,6 +118,341 @@ static int wait_for_msg(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
 }
 
+/* lsppay: LSP -> client inbound payment over the factory channel.
+   This is the final hop of a real inbound LN payment -- the same OFFERED-HTLC
+   leg the bridge drives (lsp_bridge.c) -- with the external payer simulated by
+   the LSP itself.  Exists for the pct-100 realistic onboarding model: clients
+   join with ZERO balance, so their first sats can only arrive over LN.
+   Flow = invoice steps of lsp_channels_initiate_payment + its dest leg
+   (OFFERED HTLC -> commitment -> fulfill -> commitment -> revocations), with
+   no sender client and no back-propagation.  Fragments are verbatim from that
+   proven path, including watchtower revocation registration + persistence. */
+int lsp_channels_lsppay(lsp_channel_mgr_t *mgr, lsp_t *lsp,
+                          size_t to_client, uint64_t amount_sats) {
+    if (!mgr || !lsp) return 0;
+    if (to_client >= mgr->n_channels) return 0;
+    if (lsp->client_fds[to_client] < 0) {
+        fprintf(stderr, "LSP lsppay: client %zu not connected\n", to_client);
+        return 0;
+    }
+
+    uint64_t amount_msat = amount_sats * 1000;
+    uint32_t htlc_cltv = lsp->factory.cltv_timeout > FACTORY_CLTV_DELTA_DEFAULT
+                        ? lsp->factory.cltv_timeout - FACTORY_CLTV_DELTA_DEFAULT
+                        : 500;  /* fallback for tests without cltv_timeout */
+
+    /* 1. Send MSG_CREATE_INVOICE to receiving client */
+    {
+        cJSON *inv_req = wire_build_create_invoice(amount_msat);
+        if (!wire_send(lsp->client_fds[to_client], MSG_CREATE_INVOICE, inv_req)) {
+            cJSON_Delete(inv_req);
+            fprintf(stderr, "LSP lsppay: send CREATE_INVOICE failed\n");
+            return 0;
+        }
+        cJSON_Delete(inv_req);
+    }
+
+    /* 2. Wait for MSG_INVOICE_CREATED from receiver */
+    unsigned char payment_hash[32];
+    {
+        wire_msg_t inv_resp;
+        if (!wait_for_msg(mgr, lsp, lsp->client_fds[to_client],
+                            MSG_INVOICE_CREATED, &inv_resp, 60)) {
+            fprintf(stderr, "LSP lsppay: timeout waiting for INVOICE_CREATED\n");
+            return 0;
+        }
+        uint64_t resp_amount;
+        if (!wire_parse_invoice_created(inv_resp.json, payment_hash, &resp_amount)) {
+            cJSON_Delete(inv_resp.json);
+            fprintf(stderr, "LSP lsppay: bad INVOICE_CREATED\n");
+            return 0;
+        }
+        cJSON_Delete(inv_resp.json);
+    }
+
+    /* 3. Drain any pending MSG_REGISTER_INVOICE from receiver */
+    {
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(lsp->client_fds[to_client], &rfds);
+        struct timeval tv = { .tv_sec = 0, .tv_usec = 200000 }; /* 200ms */
+        while (select(lsp->client_fds[to_client] + 1, &rfds, NULL, NULL, &tv) > 0) {
+            wire_msg_t drain_msg;
+            if (!wire_recv_timeout(lsp->client_fds[to_client], &drain_msg, 2)) break;
+            if (drain_msg.msg_type == MSG_REGISTER_INVOICE) {
+                unsigned char ph[32], pre[32];
+                uint64_t am;
+                size_t dc;
+                if (wire_parse_register_invoice(drain_msg.json, ph, pre, &am, &dc))
+                    lsp_channels_register_invoice(mgr, ph, pre, dc, am);
+            }
+            cJSON_Delete(drain_msg.json);
+            FD_ZERO(&rfds);
+            FD_SET(lsp->client_fds[to_client], &rfds);
+            tv.tv_sec = 0;
+            tv.tv_usec = 200000;
+        }
+    }
+
+    /* 4. Offer the HTLC on the destination channel, funded from the LSP side */
+    channel_t *dest_ch = &mgr->entries[to_client].channel;
+
+    /* Capture amounts and HTLC state before add_htlc changes them (for watchtower) */
+    uint64_t old_dest_local = dest_ch->local_amount;
+    uint64_t old_dest_remote = dest_ch->remote_amount;
+    size_t old_dest_n_htlcs = dest_ch->n_htlcs;
+    htlc_t *old_dest_htlcs = old_dest_n_htlcs > 0
+        ? malloc(old_dest_n_htlcs * sizeof(htlc_t)) : NULL;
+    if (old_dest_n_htlcs > 0 && !old_dest_htlcs) return 0;
+    if (old_dest_n_htlcs > 0)
+        memcpy(old_dest_htlcs, dest_ch->htlcs, old_dest_n_htlcs * sizeof(htlc_t));
+
+    uint64_t dest_htlc_id;
+    if (!channel_add_htlc(dest_ch, HTLC_OFFERED, amount_sats,
+                           payment_hash, htlc_cltv, &dest_htlc_id)) {
+        fprintf(stderr, "LSP lsppay: add_htlc failed (LSP-side balance/reserve?)\n");
+        free(old_dest_htlcs);
+        return 0;
+    }
+
+    {
+        cJSON *fwd = wire_build_update_add_htlc(dest_htlc_id, amount_msat,
+                                                   payment_hash, htlc_cltv);
+        if (!wire_send(lsp->client_fds[to_client], MSG_UPDATE_ADD_HTLC, fwd)) {
+            cJSON_Delete(fwd);
+            free(old_dest_htlcs);
+            return 0;
+        }
+        cJSON_Delete(fwd);
+    }
+    {
+        unsigned char psig32[32];
+        uint32_t nonce_idx;
+        if (!channel_create_commitment_partial_sig(dest_ch, psig32, &nonce_idx)) {
+            free(old_dest_htlcs);
+            return 0;
+        }
+        cJSON *cs = wire_build_commitment_signed(
+            mgr->entries[to_client].channel_id,
+            dest_ch->commitment_number, psig32, nonce_idx);
+        if (!wire_send(lsp->client_fds[to_client], MSG_COMMITMENT_SIGNED, cs)) {
+            cJSON_Delete(cs);
+            free(old_dest_htlcs);
+            return 0;
+        }
+        cJSON_Delete(cs);
+    }
+
+    /* 5. Wait for REVOKE_AND_ACK from dest */
+    {
+        wire_msg_t ack_msg;
+        if (!wait_for_msg(mgr, lsp, lsp->client_fds[to_client],
+                            MSG_REVOKE_AND_ACK, &ack_msg, 60)) {
+            fprintf(stderr, "LSP lsppay: expected REVOKE_AND_ACK from dest\n");
+            free(old_dest_htlcs);
+            return 0;
+        }
+        uint32_t ack_chan_id;
+        unsigned char rev_secret[32], next_point[33];
+        if (wire_parse_revoke_and_ack(ack_msg.json, &ack_chan_id,
+                                        rev_secret, next_point)) {
+            uint64_t old_cn = dest_ch->commitment_number - 1;
+            channel_receive_revocation(dest_ch, old_cn, rev_secret);
+            /* PTLC snapshot for revocation registration (mirrors c2c path). */
+            size_t old_dest_n_ptlcs = dest_ch->n_ptlcs;
+            ptlc_t *old_dest_ptlcs = NULL;
+            if (old_dest_n_ptlcs > 0) {
+                old_dest_ptlcs = malloc(old_dest_n_ptlcs * sizeof(ptlc_t));
+                if (old_dest_ptlcs)
+                    memcpy(old_dest_ptlcs, dest_ch->ptlcs,
+                           old_dest_n_ptlcs * sizeof(ptlc_t));
+            }
+            watchtower_watch_revoked_commitment(mgr->watchtower, dest_ch,
+                (uint32_t)to_client, old_cn,
+                old_dest_local, old_dest_remote,
+                old_dest_htlcs, old_dest_n_htlcs,
+                old_dest_ptlcs, old_dest_n_ptlcs);
+            free(old_dest_ptlcs);
+            secp256k1_pubkey next_pcp;
+            if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
+                channel_set_remote_pcp(dest_ch, dest_ch->commitment_number + 1, &next_pcp);
+            /* Bidirectional: send LSP's own revocation to dest */
+            lsp_send_revocation(mgr, lsp, to_client, old_cn);
+        }
+        cJSON_Delete(ack_msg.json);
+    }
+    free(old_dest_htlcs);
+    old_dest_htlcs = NULL;
+
+    /* Persist dest channel balance + HTLC + PCS/PCP */
+    if (mgr->persist) {
+        persist_t *db = (persist_t *)mgr->persist;
+        int own_txn = !persist_in_transaction(db);
+        if (own_txn) persist_begin(db);
+
+        persist_update_channel_balance(db, (uint32_t)to_client,
+            dest_ch->local_amount, dest_ch->remote_amount,
+            dest_ch->commitment_number);
+
+        htlc_t dp;
+        memset(&dp, 0, sizeof(dp));
+        dp.id = dest_htlc_id;
+        dp.direction = HTLC_OFFERED;
+        dp.state = HTLC_STATE_ACTIVE;
+        dp.amount_sats = amount_sats;
+        memcpy(dp.payment_hash, payment_hash, 32);
+        dp.cltv_expiry = htlc_cltv;
+        persist_save_htlc(db, (uint32_t)to_client, &dp);
+
+        unsigned char pcs[32];
+        if (channel_get_local_pcs(dest_ch, dest_ch->commitment_number, pcs))
+            persist_save_local_pcs(db, (uint32_t)to_client,
+                dest_ch->commitment_number, pcs);
+        if (channel_get_local_pcs(dest_ch, dest_ch->commitment_number + 1, pcs))
+            persist_save_local_pcs(db, (uint32_t)to_client,
+                dest_ch->commitment_number + 1, pcs);
+        memset(pcs, 0, 32);
+
+        {
+            unsigned char ser[33];
+            size_t slen = 33;
+            secp256k1_pubkey saved_pcp;
+            if (channel_get_remote_pcp(dest_ch,
+                    dest_ch->commitment_number + 1, &saved_pcp) &&
+                secp256k1_ec_pubkey_serialize(mgr->ctx, ser, &slen,
+                    &saved_pcp, SECP256K1_EC_COMPRESSED))
+                persist_save_remote_pcp(db, (uint32_t)to_client,
+                    dest_ch->commitment_number + 1, ser);
+        }
+
+        if (own_txn) persist_commit(db);
+    }
+
+    /* 6. Wait for FULFILL_HTLC from dest (client fulfills with real preimage) */
+    {
+        wire_msg_t ful_msg;
+        if (!wait_for_msg(mgr, lsp, lsp->client_fds[to_client],
+                            MSG_UPDATE_FULFILL_HTLC, &ful_msg, 60)) {
+            fprintf(stderr, "LSP lsppay: expected FULFILL from dest\n");
+            return 0;
+        }
+        uint64_t ful_htlc_id;
+        unsigned char preimage[32];
+        if (!wire_parse_update_fulfill_htlc(ful_msg.json, &ful_htlc_id, preimage)) {
+            cJSON_Delete(ful_msg.json);
+            return 0;
+        }
+        cJSON_Delete(ful_msg.json);
+
+        /* Capture amounts and HTLC state before fulfill changes them (for watchtower) */
+        uint64_t old_dest_ful_local = dest_ch->local_amount;
+        uint64_t old_dest_ful_remote = dest_ch->remote_amount;
+        size_t old_dest_ful_n_htlcs = dest_ch->n_htlcs;
+        htlc_t *old_dest_ful_htlcs = old_dest_ful_n_htlcs > 0
+            ? malloc(old_dest_ful_n_htlcs * sizeof(htlc_t)) : NULL;
+        if (old_dest_ful_n_htlcs > 0 && !old_dest_ful_htlcs) return 0;
+        if (old_dest_ful_n_htlcs > 0)
+            memcpy(old_dest_ful_htlcs, dest_ch->htlcs, old_dest_ful_n_htlcs * sizeof(htlc_t));
+
+        /* Fulfill on dest channel */
+        channel_fulfill_htlc(dest_ch, ful_htlc_id, preimage);
+
+        /* Send COMMITMENT_SIGNED to dest */
+        {
+            unsigned char psig32[32];
+            uint32_t nonce_idx;
+            if (!channel_create_commitment_partial_sig(dest_ch, psig32, &nonce_idx)) {
+                free(old_dest_ful_htlcs);
+                return 0;
+            }
+            cJSON *cs = wire_build_commitment_signed(
+                mgr->entries[to_client].channel_id,
+                dest_ch->commitment_number, psig32, nonce_idx);
+            wire_send(lsp->client_fds[to_client], MSG_COMMITMENT_SIGNED, cs);
+            cJSON_Delete(cs);
+        }
+
+        /* Wait for REVOKE_AND_ACK from dest */
+        {
+            wire_msg_t ack;
+            if (wait_for_msg(mgr, lsp, lsp->client_fds[to_client],
+                               MSG_REVOKE_AND_ACK, &ack, 60)) {
+                uint32_t ack_chan_id;
+                unsigned char rev_secret[32], next_point[33];
+                if (wire_parse_revoke_and_ack(ack.json, &ack_chan_id,
+                                                rev_secret, next_point)) {
+                    uint64_t old_cn = dest_ch->commitment_number - 1;
+                    channel_receive_revocation(dest_ch, old_cn, rev_secret);
+                    /* PTLC snapshot for revocation registration (mirrors c2c path). */
+                    size_t old_dest_ful_n_ptlcs = dest_ch->n_ptlcs;
+                    ptlc_t *old_dest_ful_ptlcs = NULL;
+                    if (old_dest_ful_n_ptlcs > 0) {
+                        old_dest_ful_ptlcs = malloc(old_dest_ful_n_ptlcs * sizeof(ptlc_t));
+                        if (old_dest_ful_ptlcs)
+                            memcpy(old_dest_ful_ptlcs, dest_ch->ptlcs,
+                                   old_dest_ful_n_ptlcs * sizeof(ptlc_t));
+                    }
+                    watchtower_watch_revoked_commitment(mgr->watchtower, dest_ch,
+                        (uint32_t)to_client, old_cn,
+                        old_dest_ful_local, old_dest_ful_remote,
+                        old_dest_ful_htlcs, old_dest_ful_n_htlcs,
+                        old_dest_ful_ptlcs, old_dest_ful_n_ptlcs);
+                    free(old_dest_ful_ptlcs);
+                    secp256k1_pubkey next_pcp;
+                    if (secp256k1_ec_pubkey_parse(mgr->ctx, &next_pcp, next_point, 33))
+                        channel_set_remote_pcp(dest_ch, dest_ch->commitment_number + 1, &next_pcp);
+                    /* Bidirectional: send LSP's own revocation to dest */
+                    lsp_send_revocation(mgr, lsp, to_client, old_cn);
+                }
+                cJSON_Delete(ack.json);
+            }
+        }
+        free(old_dest_ful_htlcs);
+        old_dest_ful_htlcs = NULL;
+
+        /* Persist dest channel after fulfill + PCS/PCP */
+        if (mgr->persist) {
+            persist_t *db = (persist_t *)mgr->persist;
+            int own_txn = !persist_in_transaction(db);
+            if (own_txn) persist_begin(db);
+
+            persist_update_channel_balance(db, (uint32_t)to_client,
+                dest_ch->local_amount, dest_ch->remote_amount,
+                dest_ch->commitment_number);
+            persist_delete_htlc(db, (uint32_t)to_client, ful_htlc_id);
+
+            unsigned char pcs[32];
+            if (channel_get_local_pcs(dest_ch, dest_ch->commitment_number, pcs))
+                persist_save_local_pcs(db, (uint32_t)to_client,
+                    dest_ch->commitment_number, pcs);
+            if (channel_get_local_pcs(dest_ch, dest_ch->commitment_number + 1, pcs))
+                persist_save_local_pcs(db, (uint32_t)to_client,
+                    dest_ch->commitment_number + 1, pcs);
+            memset(pcs, 0, 32);
+
+            {
+                unsigned char ser[33];
+                size_t slen = 33;
+                secp256k1_pubkey saved_pcp;
+                if (channel_get_remote_pcp(dest_ch,
+                        dest_ch->commitment_number + 1, &saved_pcp) &&
+                    secp256k1_ec_pubkey_serialize(mgr->ctx, ser, &slen,
+                        &saved_pcp, SECP256K1_EC_COMPRESSED))
+                    persist_save_remote_pcp(db, (uint32_t)to_client,
+                        dest_ch->commitment_number + 1, ser);
+            }
+
+            if (own_txn) persist_commit(db);
+        }
+    }
+
+    /* Same settle marker the harness counts for c2c payments. */
+    printf("  Payment complete: LSP -> client %zu (%llu sats)\n",
+           to_client, (unsigned long long)amount_sats);
+    fflush(stdout);
+    return 1;
+}
+
 int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                     size_t from_client, size_t to_client,
                                     uint64_t amount_sats) {

--- a/src/lsp_demo.c
+++ b/src/lsp_demo.c
@@ -207,6 +207,15 @@ int lsp_channels_lsppay(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     if (old_dest_n_htlcs > 0)
         memcpy(old_dest_htlcs, dest_ch->htlcs, old_dest_n_htlcs * sizeof(htlc_t));
 
+    /* CONTRACT (no rollback past this point): once the HTLC is added, our side
+       has committed the amount out of local_amount.  Every failure below returns
+       0 leaving that HTLC ACTIVE rather than unwinding it — deliberately, since
+       the peer may already have it and a unilateral local removal would desync
+       the channel worse than leaving it pending.  Resolution is the normal LN
+       path: the HTLC expires at htlc_cltv and channel_check_htlc_timeouts fails
+       it back, and a reconnect resyncs commitment state.  Callers must therefore
+       treat a 0 return as "payment did not settle, funds may be briefly pending",
+       not as "nothing happened". */
     uint64_t dest_htlc_id;
     if (!channel_add_htlc(dest_ch, HTLC_OFFERED, amount_sats,
                            payment_hash, htlc_cltv, &dest_htlc_id)) {
@@ -354,8 +363,21 @@ int lsp_channels_lsppay(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         if (old_dest_ful_n_htlcs > 0)
             memcpy(old_dest_ful_htlcs, dest_ch->htlcs, old_dest_ful_n_htlcs * sizeof(htlc_t));
 
-        /* Fulfill on dest channel */
-        channel_fulfill_htlc(dest_ch, ful_htlc_id, preimage);
+        /* Fulfill on dest channel.  MUST check: channel_fulfill_htlc verifies
+           SHA256(preimage) == payment_hash and returns 0 on mismatch, leaving
+           balances untouched.  Ignoring it would let a client that sends a bad
+           preimage drive us on to sign a fresh commitment, arm a watchtower
+           entry and persist as though the payment settled — no fund loss (the
+           balances never moved) but our view of the channel would desync from
+           the client's.  Bail instead; the HTLC stays active and resolves via
+           the CLTV timeout path. */
+        if (!channel_fulfill_htlc(dest_ch, ful_htlc_id, preimage)) {
+            fprintf(stderr, "LSP lsppay: fulfill REJECTED for htlc %llu "
+                    "(preimage does not match payment_hash)\n",
+                    (unsigned long long)ful_htlc_id);
+            free(old_dest_ful_htlcs);
+            return 0;
+        }
 
         /* Send COMMITMENT_SIGNED to dest */
         {
@@ -368,8 +390,14 @@ int lsp_channels_lsppay(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             cJSON *cs = wire_build_commitment_signed(
                 mgr->entries[to_client].channel_id,
                 dest_ch->commitment_number, psig32, nonce_idx);
-            wire_send(lsp->client_fds[to_client], MSG_COMMITMENT_SIGNED, cs);
+            int cs_sent = wire_send(lsp->client_fds[to_client],
+                                    MSG_COMMITMENT_SIGNED, cs);
             cJSON_Delete(cs);
+            if (!cs_sent) {
+                fprintf(stderr, "LSP lsppay: send COMMITMENT_SIGNED (fulfill) failed\n");
+                free(old_dest_ful_htlcs);
+                return 0;
+            }
         }
 
         /* Wait for REVOKE_AND_ACK from dest */

--- a/tools/test_inproc_factory_lifecycle.c
+++ b/tools/test_inproc_factory_lifecycle.c
@@ -74,6 +74,116 @@ static int build_keys(const secp256k1_context *ctx, const char *seed, size_t n_s
     return 1;
 }
 
+/* ---- Full BOLT-2 commitment ceremony (in-process mirror pair) ----
+   S initiated a state update (add/fulfill already applied to BOTH sides).
+   Runs the daemon's exact sequence from htlc_commit_add_and_sign, minus wire:
+     S: channel_create_commitment_partial_sig        (commitment_signed ->)
+     R: channel_verify_and_aggregate_commitment_sig  (verify partial + aggregate)
+     R: reveal pcs(cn-1) + advertise pcp(cn+1)       (revoke_and_ack ->)
+     S: channel_receive_revocation_flat + set_remote_pcp
+     ...then the symmetric R->S half.
+   Every partial sig is cryptographically verified (musig_verify_partial_sig
+   inside verify_and_aggregate) and every superseded state is revoked — the two
+   gaps flagged in the earlier realism audit. */
+static int bolt2_commit_round(channel_t *S, channel_t *R,
+                              size_t *n_aggsigs, size_t *n_revocations) {
+    unsigned char partial[32], full[64], pcs[32];
+    uint32_t nidx;
+    secp256k1_pubkey next_pcp;
+
+    /* S signs R's new commitment; R verifies the partial + aggregates */
+    if (!channel_create_commitment_partial_sig(S, partial, &nidx)) return 0;
+    if (!channel_verify_and_aggregate_commitment_sig(R, partial, nidx, full)) return 0;
+    (*n_aggsigs)++;
+    /* R revokes its previous state toward S */
+    if (R->commitment_number > 0) {
+        if (!channel_get_per_commitment_secret(R, R->commitment_number - 1, pcs)) return 0;
+        if (!channel_receive_revocation_flat(S, S->commitment_number - 1, pcs)) return 0;
+        if (!channel_get_per_commitment_point(R, R->commitment_number + 1, &next_pcp)) return 0;
+        channel_set_remote_pcp(S, S->commitment_number + 1, &next_pcp);
+        (*n_revocations)++;
+    }
+    /* R signs S's new commitment; S verifies + aggregates */
+    if (!channel_create_commitment_partial_sig(R, partial, &nidx)) return 0;
+    if (!channel_verify_and_aggregate_commitment_sig(S, partial, nidx, full)) return 0;
+    (*n_aggsigs)++;
+    /* S revokes its previous state toward R */
+    if (S->commitment_number > 0) {
+        if (!channel_get_per_commitment_secret(S, S->commitment_number - 1, pcs)) return 0;
+        if (!channel_receive_revocation_flat(R, R->commitment_number - 1, pcs)) return 0;
+        if (!channel_get_per_commitment_point(S, S->commitment_number + 1, &next_pcp)) return 0;
+        channel_set_remote_pcp(R, R->commitment_number + 1, &next_pcp);
+        (*n_revocations)++;
+    }
+    return 1;
+}
+
+/* Build the client-side mirror of an LSP channel entry: same funding outpoint
+   and 2-of-2 keyagg (signer_idx flipped), flipped balance perspective, its own
+   random basepoints + PCS chain + nonce pool; then exchange basepoints, initial
+   PCPs (cn 0 and 1), and the serialized pubnonce pools both ways — the same
+   material MSG_CHANNEL_BASEPOINTS / MSG_CHANNEL_NONCES carry over the wire. */
+static int setup_mirror_channel(secp256k1_context *ctx, channel_t *L, channel_t *C,
+                                const secp256k1_keypair *client_kp,
+                                const secp256k1_pubkey *client_pub,
+                                const secp256k1_pubkey *lsp_pub,
+                                size_t n_states) {
+    unsigned char csec[32];
+    if (!secp256k1_keypair_sec(ctx, csec, client_kp)) return 0;
+    int ok = channel_init(C, ctx, csec, client_pub, lsp_pub,
+                          L->funding_txid, L->funding_vout, L->funding_amount,
+                          L->funding_spk, L->funding_spk_len,
+                          L->remote_amount, L->local_amount,   /* flipped view */
+                          CHANNEL_DEFAULT_CSV_DELAY);
+    memset(csec, 0, 32);
+    if (!ok) return 0;
+    C->funder_is_local = 0;                   /* the LSP funded the channel */
+    C->use_cpfp_anchor = L->use_cpfp_anchor;  /* MUST match or the sighash diverges */
+    C->funding_keyagg = L->funding_keyagg;    /* same aggregate, opposite seat */
+    C->local_funding_signer_idx = 1 - L->local_funding_signer_idx;
+    C->has_chan_merkle_root = L->has_chan_merkle_root;
+    memcpy(C->chan_merkle_root, L->chan_merkle_root, 32);
+
+    if (!channel_generate_random_basepoints(C)) return 0;
+    /* basepoint exchange, both directions */
+    channel_set_remote_basepoints(L, &C->local_payment_basepoint,
+                                  &C->local_delayed_payment_basepoint,
+                                  &C->local_revocation_basepoint);
+    channel_set_remote_htlc_basepoint(L, &C->local_htlc_basepoint);
+    channel_set_remote_basepoints(C, &L->local_payment_basepoint,
+                                  &L->local_delayed_payment_basepoint,
+                                  &L->local_revocation_basepoint);
+    channel_set_remote_htlc_basepoint(C, &L->local_htlc_basepoint);
+
+    /* per-commitment secret chains on both sides */
+    for (size_t cn = L->n_local_pcs; cn < n_states; cn++)
+        if (!channel_generate_local_pcs(L, cn)) return 0;
+    for (size_t cn = C->n_local_pcs; cn < n_states; cn++)
+        if (!channel_generate_local_pcs(C, cn)) return 0;
+
+    /* initial per-commitment points (cn 0 and 1), both directions */
+    for (uint64_t cn = 0; cn <= 1; cn++) {
+        secp256k1_pubkey p;
+        if (!channel_get_per_commitment_point(L, cn, &p)) return 0;
+        channel_set_remote_pcp(C, cn, &p);
+        if (!channel_get_per_commitment_point(C, cn, &p)) return 0;
+        channel_set_remote_pcp(L, cn, &p);
+    }
+
+    /* nonce pools + full pubnonce exchange */
+    if (!channel_init_nonce_pool(C, MUSIG_NONCE_POOL_MAX)) return 0;
+    {
+        static unsigned char ser[MUSIG_NONCE_POOL_MAX][66];
+        for (size_t i = 0; i < L->local_nonce_pool.count; i++)
+            if (!musig_pubnonce_serialize(ctx, ser[i], &L->local_nonce_pool.nonces[i].pubnonce)) return 0;
+        if (!channel_set_remote_pubnonces(C, ser, L->local_nonce_pool.count)) return 0;
+        for (size_t i = 0; i < C->local_nonce_pool.count; i++)
+            if (!musig_pubnonce_serialize(ctx, ser[i], &C->local_nonce_pool.nonces[i].pubnonce)) return 0;
+        if (!channel_set_remote_pubnonces(L, ser, C->local_nonce_pool.count)) return 0;
+    }
+    return 1;
+}
+
 int main(int argc, char **argv) {
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
@@ -187,9 +297,12 @@ int main(int argc, char **argv) {
         uint32_t vout = (uint32_t)strtoul(argv[5], NULL, 10);
         uint64_t amount = strtoull(argv[6], NULL, 10);
         const char *outfile = argv[7];
-        uint64_t fee_rate = (argc >= 9) ? strtoull(argv[8], NULL, 10) : 1;
+        uint64_t fee_kvb = (argc >= 9) ? strtoull(argv[8], NULL, 10) : 1000; /* sat/KILOvbyte: 100 = 0.1 sat/vB */
         size_t P = (argc >= 10) ? strtoull(argv[9], NULL, 10) : 4;  /* payments/channel */
         const char *audit_dir = (argc >= 11) ? argv[10] : NULL;     /* extra proof/audit records */
+        unsigned lsp_pct = (argc >= 12) ? (unsigned)strtoul(argv[11], NULL, 10) : 50;
+        /* lsp_pct = LSP's initial share per channel.  100 => clients start at ZERO:
+           every sat a client holds at close arrived via a real HTLC payment. */
         size_t ns = N + 1;
 
         secp256k1_keypair *kps = calloc(ns, sizeof(*kps));
@@ -220,9 +333,24 @@ int main(int argc, char **argv) {
         unsigned char lsp_sec[32];
         if (!secp256k1_keypair_sec(ctx, lsp_sec, &kps[0])) { fprintf(stderr, "lsp sec\n"); return 1; }
         lsp_channel_mgr_t mgr; memset(&mgr, 0, sizeof mgr);
-        mgr.lsp_balance_pct = 50;   /* 50/50 initial split per channel */
+        mgr.lsp_balance_pct = (uint16_t)lsp_pct;
         if (!lsp_channels_init(&mgr, ctx, f, lsp_sec, N)) { fprintf(stderr, "lsp_channels_init FAILED\n"); return 1; }
-        printf("  channels: %zu real 2-of-2 LN channels wired to leaves\n", mgr.n_channels);
+        printf("  channels: %zu real 2-of-2 LN channels wired to leaves (LSP share %u%%%s)\n",
+               mgr.n_channels, lsp_pct,
+               lsp_pct >= 100 ? " — clients start at 0, all client sats payment-borne" : "");
+
+        /* --- Client-side mirror channels: the full BOLT-2 ceremony needs BOTH
+               endpoints live (basepoints, PCS chains, PCPs, nonce pools). --- */
+        channel_t *cli = calloc(N, sizeof(channel_t));
+        if (!cli) { fprintf(stderr, "oom client mirrors\n"); return 1; }
+        size_t n_states = 2 * P + 4;   /* cn advances twice per payment */
+        for (size_t c = 0; c < N; c++) {
+            if (!setup_mirror_channel(ctx, &mgr.entries[c].channel, &cli[c],
+                                      &kps[c + 1], &pks[c + 1], &pks[0], n_states)) {
+                fprintf(stderr, "mirror channel %zu setup FAILED\n", c); return 1;
+            }
+        }
+        printf("  mirrors:  %zu client-side channels (basepoints+PCS+pubnonce pools exchanged)\n", N);
 
         uint64_t init_client_total = 0;
         uint64_t *init_local  = audit_dir ? calloc(N, sizeof(uint64_t)) : NULL;
@@ -247,37 +375,84 @@ int main(int argc, char **argv) {
             if (!af) fprintf(stderr, "warn: cannot open %s\n", pth);
         }
         uint64_t gross_moved = 0, commit_sum = 0;
-        size_t n_pay = 0, n_skip = 0;
+        size_t n_pay = 0, n_skip = 0, n_aggsigs = 0, n_revocations = 0;
+        uint64_t *paid_to_client = calloc(N, sizeof(uint64_t));
         for (size_t c = 0; c < N; c++) {
-            channel_t *ch = &mgr.entries[c].channel;
+            channel_t *L = &mgr.entries[c].channel;
+            channel_t *C = &cli[c];
             for (size_t p = 0; p < P; p++) {
-                htlc_direction_t dir = (p % 4 == 3) ? HTLC_RECEIVED : HTLC_OFFERED;
+                /* payment-borne mode: every payment flows LSP->client so each
+                   client's entire close balance came through real HTLCs.
+                   Mixed mode keeps the 3:1 bidirectional pattern. */
+                int lsp_to_client = (lsp_pct >= 100) ? 1 : (p % 4 != 3);
                 uint64_t amt = 1000 + (uint64_t)((c + p) % 400);
-                uint64_t offerer = (dir == HTLC_OFFERED) ? ch->local_amount : ch->remote_amount;
-                if (offerer < amt + CHANNEL_RESERVE_SATS + 500) { n_skip++; continue; }
+                uint64_t offerer = lsp_to_client ? L->local_amount : L->remote_amount;
+                if (offerer < amt + CHANNEL_RESERVE_SATS + 500) {
+                    if (lsp_pct >= 100) { fprintf(stderr, "ch %zu p %zu unaffordable — sizing bug\n", c, p); return 1; }
+                    n_skip++; continue;
+                }
                 unsigned char pre[32] = {0}, hash[32];
                 pre[0] = (unsigned char)c; pre[1] = (unsigned char)(c >> 8);
                 pre[2] = (unsigned char)p; pre[3] = 0xA5;
                 sha256(pre, 32, hash);
-                uint64_t lb = ch->local_amount, rb = ch->remote_amount;
-                uint64_t id;
-                if (!channel_add_htlc(ch, dir, amt, hash, 100, &id)) { n_skip++; continue; }
-                if (!channel_fulfill_htlc(ch, id, pre))              { n_skip++; continue; }
+                uint64_t lb = L->local_amount, rb = L->remote_amount;
+                channel_t *S = lsp_to_client ? L : C;   /* update initiator */
+                channel_t *R = lsp_to_client ? C : L;
+                uint64_t idS, idR;
+                /* update_add_htlc: offered on the sender, mirrored received on the peer */
+                if (!channel_add_htlc(S, HTLC_OFFERED,  amt, hash, 100, &idS) ||
+                    !channel_add_htlc(R, HTLC_RECEIVED, amt, hash, 100, &idR)) {
+                    fprintf(stderr, "add_htlc FAILED ch %zu p %zu\n", c, p); return 1;
+                }
+                /* commitment_signed / revoke_and_ack round for the HTLC-pending state */
+                if (!bolt2_commit_round(S, R, &n_aggsigs, &n_revocations)) {
+                    fprintf(stderr, "BOLT2 round (add) FAILED ch %zu p %zu\n", c, p); return 1;
+                }
+                /* update_fulfill_htlc: recipient reveals the preimage; both books settle */
+                if (!channel_fulfill_htlc(R, idR, pre) ||
+                    !channel_fulfill_htlc(S, idS, pre)) {
+                    fprintf(stderr, "fulfill FAILED ch %zu p %zu\n", c, p); return 1;
+                }
+                /* second signed round for the settled state, initiated by the fulfiller */
+                if (!bolt2_commit_round(R, S, &n_aggsigs, &n_revocations)) {
+                    fprintf(stderr, "BOLT2 round (fulfill) FAILED ch %zu p %zu\n", c, p); return 1;
+                }
                 gross_moved += amt; n_pay++;
+                if (lsp_to_client) paid_to_client[c] += amt;
                 if (af) {
                     char hh[65], ph[65]; hex_encode(hash, 32, hh); hh[64] = 0; hex_encode(pre, 32, ph); ph[64] = 0;
                     fprintf(af, "{\"i\":%zu,\"channel\":%zu,\"dir\":\"%s\",\"amount\":%llu,"
                                 "\"payment_hash\":\"%s\",\"preimage\":\"%s\","
                                 "\"local_before\":%llu,\"remote_before\":%llu,"
-                                "\"local_after\":%llu,\"remote_after\":%llu}\n",
-                            n_pay, c, (dir == HTLC_OFFERED) ? "lsp->client" : "client->lsp",
+                                "\"local_after\":%llu,\"remote_after\":%llu,"
+                                "\"cn\":%llu,\"aggsigs\":4,\"revocations\":4}\n",
+                            n_pay, c, lsp_to_client ? "lsp->client" : "client->lsp",
                             (unsigned long long)amt, hh, ph,
                             (unsigned long long)lb, (unsigned long long)rb,
-                            (unsigned long long)ch->local_amount, (unsigned long long)ch->remote_amount);
+                            (unsigned long long)L->local_amount, (unsigned long long)L->remote_amount,
+                            (unsigned long long)L->commitment_number);
                 }
             }
         }
         if (af) fclose(af);
+
+        /* HARD verification: (a) both endpoints' books agree exactly;
+           (b) in payment-borne mode each client's balance equals the sum of
+           its received payments — no other source of client sats exists. */
+        {
+            size_t bad_mirror = 0, bad_borne = 0;
+            for (size_t c = 0; c < N; c++) {
+                channel_t *L = &mgr.entries[c].channel, *C = &cli[c];
+                if (L->local_amount != C->remote_amount ||
+                    L->remote_amount != C->local_amount) bad_mirror++;
+                if (lsp_pct >= 100 && L->remote_amount != paid_to_client[c]) bad_borne++;
+            }
+            if (bad_mirror || bad_borne) {
+                fprintf(stderr, "VERIFY FAILED: mirror_mismatch=%zu payment_borne_mismatch=%zu\n",
+                        bad_mirror, bad_borne);
+                return 1;
+            }
+        }
         uint64_t final_client_total = 0;
         for (size_t c = 0; c < N; c++) {
             final_client_total += mgr.entries[c].channel.remote_amount;
@@ -289,7 +464,7 @@ int main(int argc, char **argv) {
                remote_amount).  NULL close_spk => real per-client + LSP close addresses. --- */
         tx_output_t *outs = calloc(N + 1, sizeof(tx_output_t));
         uint64_t est_vsize = 11 + 58 + (uint64_t)(N + 1) * 43;
-        uint64_t close_fee = est_vsize * fee_rate;
+        uint64_t close_fee = (est_vsize * fee_kvb + 999) / 1000;   /* sat/kvB, round up */
         size_t n_out = lsp_channels_build_close_outputs(&mgr, f, outs, close_fee, NULL, 0);
         if (n_out == 0) { fprintf(stderr, "build_close_outputs FAILED (funding < client_total+fee?)\n"); return 1; }
         tx_buf_t close_tx; tx_buf_init(&close_tx, 1u << 20);
@@ -350,6 +525,9 @@ int main(int argc, char **argv) {
 
         printf("inproc-pay: N=%zu channels=%zu payments=%zu (skipped %zu) gross_moved=%llu sats\n",
                N, mgr.n_channels, n_pay, n_skip, (unsigned long long)gross_moved);
+        printf("inproc-pay: BOLT2: aggsigs_verified=%zu revocations_exchanged=%zu mirror_books=exact%s\n",
+               n_aggsigs, n_revocations,
+               lsp_pct >= 100 ? "  payment_borne=VERIFIED (every client sat arrived via HTLC)" : "");
         printf("inproc-pay: client_total %llu -> %llu (net %+lld to clients)  commitment_bumps=%llu\n",
                (unsigned long long)init_client_total, (unsigned long long)final_client_total,
                (long long)final_client_total - (long long)init_client_total,
@@ -358,6 +536,8 @@ int main(int argc, char **argv) {
                n_out, close_tx.len, (unsigned long long)out_sum, (unsigned long long)amount,
                (unsigned long long)close_fee, (out_sum + close_fee == amount) ? "yes" : "NO");
         printf("  hex -> %s\n", outfile);
+        for (size_t c = 0; c < N; c++) channel_cleanup(&cli[c]);
+        free(cli); free(paid_to_client);
         lsp_channels_cleanup(&mgr);
         return 0;
     }
@@ -365,8 +545,10 @@ int main(int argc, char **argv) {
     fprintf(stderr,
         "usage:\n"
         "  %s addr         <N> <SEED>\n"
+        "  %s dumpkeys     <N> <SEED>\n"
         "  %s lifecycle    <N> <M_FUNDED> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_RATE]\n"
-        "  %s paylifecycle <N> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_RATE] [PAYMENTS_PER_CH]\n",
-        argv[0], argv[0], argv[0]);
+        "  %s paylifecycle <N> <SEED> <FUND_TXID> <VOUT> <AMOUNT> <OUTFILE> [FEE_KVB] [P] [AUDIT_DIR] [LSP_PCT]\n"
+        "                  FEE_KVB in sat/kvB (100 = 0.1 sat/vB); LSP_PCT=100 => clients start at 0\n",
+        argv[0], argv[0], argv[0], argv[0]);
     return 1;
 }

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# test_regtest_pct100_lifecycle.sh — REALISTIC pct-100 lifecycle on REGTEST.
+#
+#   ONBOARD : N clients join with ZERO balance (--lsp-balance-pct 100: the LSP
+#             holds every leaf's full capacity as inbound liquidity).
+#   SEED    : the LSP pays EVERY client once over LN via the new `lsppay` CLI
+#             (random PAY_MIN..PAY_MAX sats) -> each client's first sats arrive
+#             as a real settled HTLC.  A 0-balance client cannot have a close
+#             output, so the seed phase is what makes the (N+1)-output close
+#             possible.
+#   ECONOMY : MAX_PAYS random client->client payments among the funded clients
+#             (random sizes) -> circulation + a real balance spread.  Insufficient-
+#             balance failures are EXPECTED capacity behavior and are counted.
+#   CLOSE   : CLI `close` -> convergence gate -> single 1-input (N+1)-output
+#             cooperative close; assert nout == N+1 + conservation on-chain.
+#   MATH    : reconcile EVERY close output as output_i == received_i - sent_i
+#             (implied baseline 0 for every client -> the strictest no-skim proof).
+#
+# Doubles as the N=127 MAX-FINDER: N_CLIENTS=127 MAX_PAYS=300 PAY_GAP=2 finds the
+# true payment ceiling (auto-stops on the first conservation violation).
+#
+# Usage: bash test_regtest_pct100_lifecycle.sh [BUILD_DIR]
+# Env: N_CLIENTS(3) MAX_PAYS(6) PAY_MIN(1000) PAY_MAX(6000) PORT(9970)
+#      PAY_SETTLE_TRIES(40) PAY_RECOVER(1) PAY_GAP(1) CLOSE_WAIT_SEC(900)
+set -uo pipefail
+
+BUILD_DIR="${1:-/root/SuperScalar-lsppay/build-lsppay}"
+LSP_BIN="$BUILD_DIR/superscalar_lsp"
+CLIENT_BIN="$BUILD_DIR/superscalar_client"
+REGTEST_CONF="${REGTEST_CONF:-/var/lib/bitcoind-regtest/bitcoin.conf}"
+BCLI="bitcoin-cli -regtest -conf=$REGTEST_CONF"
+RU=$(awk -F= '/^[[:space:]]*rpcuser/{gsub(/ /,"",$2);print $2;exit}' "$REGTEST_CONF"); RU=${RU:-rpcuser}
+RP=$(awk -F= '/^[[:space:]]*rpcpassword/{gsub(/ /,"",$2);print $2;exit}' "$REGTEST_CONF"); RP=${RP:-rpcpass}
+RPORT=$(awk -F= '/^[[:space:]]*rpcport/{gsub(/ /,"",$2);print $2;exit}' "$REGTEST_CONF"); RPORT=${RPORT:-18443}
+MINERW="${MINERW:-ss_cheat_leaf_miner}"
+
+N_CLIENTS="${N_CLIENTS:-3}"
+ARITY="${ARITY:-2,4,8}"
+STATIC_NEAR_ROOT="${STATIC_NEAR_ROOT:-2}"
+AMOUNT="${AMOUNT:-$(( N_CLIENTS * 100000 ))}"
+PORT="${PORT:-9970}"
+MAX_PAYS="${MAX_PAYS:-6}"               # c2c economy payments AFTER the seed
+SEED_MIN="${SEED_MIN:-5000}"            # LN seed amounts: big enough that clients can afford economy sends
+SEED_MAX="${SEED_MAX:-15000}"
+ECON_MIN="${ECON_MIN:-500}"             # economy c2c amounts: small vs seeds so senders usually have the balance
+ECON_MAX="${ECON_MAX:-2500}"
+PAY_SETTLE_TRIES="${PAY_SETTLE_TRIES:-40}"
+PAY_RECOVER="${PAY_RECOVER:-1}"
+PAY_GAP="${PAY_GAP:-1}"
+CLOSE_WAIT_SEC="${CLOSE_WAIT_SEC:-900}"
+
+TAG="pct100_$$"
+LSP_DB="/tmp/ss_${TAG}.db"
+LSP_LOG="/tmp/ss_${TAG}_lsp.log"
+FIFO="/tmp/ss_${TAG}.cli"
+
+red(){   printf '\033[31m%s\033[0m\n' "$*"; }
+green(){ printf '\033[32m%s\033[0m\n' "$*"; }
+info(){  printf '\033[36m[pct100]\033[0m %s\n' "$*"; }
+ts(){ date -u +%H:%M:%S; }
+die(){ red "FAIL: $*"; exit 1; }
+
+declare -A CPID CDB CSK
+LSP_PID=""; MINER_PID=""; CLI_FD_OPEN=0
+cleanup(){
+    [ "$CLI_FD_OPEN" = 1 ] && { exec 3>&- 2>/dev/null || true; }
+    [ -n "$MINER_PID" ] && kill -9 "$MINER_PID" 2>/dev/null || true
+    [ -n "${LSP_PID:-}" ] && kill -9 "$LSP_PID" 2>/dev/null || true
+    for i in "${!CPID[@]}"; do kill -9 "${CPID[$i]}" 2>/dev/null || true; done
+    pkill -9 -f "superscalar_client --network regtest.*--port $PORT" 2>/dev/null || true
+    rm -f "$FIFO" 2>/dev/null || true
+    cp "$LSP_LOG" /tmp/pct100_last_lsp.log 2>/dev/null || true
+}
+trap cleanup EXIT
+cli(){ printf '%s\n' "$1" >&3 2>/dev/null || true; }
+seed_amt(){ echo $(( SEED_MIN + RANDOM % (SEED_MAX - SEED_MIN + 1) )); }
+econ_amt(){ echo $(( ECON_MIN + RANDOM % (ECON_MAX - ECON_MIN + 1) )); }
+
+settle_wait(){  # wait for the "Payment complete" count to increase past $1
+    local before="$1" now _w
+    for _w in $(seq 1 "$PAY_SETTLE_TRIES"); do
+        now=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); now=${now:-0}
+        [ "$now" -gt "$before" ] && { sleep "$PAY_RECOVER"; return 0; }
+        sleep 0.5
+    done
+    sleep "$PAY_RECOVER"; return 1
+}
+lsppay_cli(){ local b; b=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); cli "lsppay $1 $2"; settle_wait "${b:-0}"; }
+pay_cli(){    local b; b=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); cli "pay $1 $2 $3"; settle_wait "${b:-0}"; }
+
+# ---- preflight ----
+[ -x "$LSP_BIN" ] && [ -x "$CLIENT_BIN" ] || die "binaries not found in $BUILD_DIR"
+$BCLI getblockcount >/dev/null 2>&1 || die "regtest bitcoind not reachable ($REGTEST_CONF)"
+$BCLI -named createwallet wallet_name="$MINERW" load_on_startup=false 2>/dev/null || $BCLI loadwallet "$MINERW" 2>/dev/null || true
+MINE_ADDR=$($BCLI -rpcwallet="$MINERW" getnewaddress 2>/dev/null); [ -n "$MINE_ADDR" ] || die "miner wallet unusable"
+mine(){ $BCLI -rpcwallet="$MINERW" generatetoaddress "${1:-1}" "$MINE_ADDR" >/dev/null 2>&1 || true; }
+BAL=$($BCLI -rpcwallet="$MINERW" getbalance 2>/dev/null || echo 0)
+awk "BEGIN{exit !($BAL+0>0.01)}" || { mine 110; }   # top up if needed (regtest: fresh coinbase maturity)
+rm -f "$LSP_DB" "$LSP_DB"-shm "$LSP_DB"-wal "$LSP_LOG" "$FIFO"
+rm -f /tmp/ss_${TAG}_c*.log /tmp/ss_${TAG}_c*.db /tmp/ss_${TAG}_c*.db-shm /tmp/ss_${TAG}_c*.db-wal
+
+# ---- keys (keygen's only RPC is offline getdescriptorinfo math) ----
+eval "$(python3 "$(dirname "$0")/signet_strong_keygen.py" "$N_CLIENTS" "$TAG")"
+[ -n "${LSP_PUBKEY:-}" ] && [ -s "${CLIENT_KEYS_FILE:-/nonexistent}" ] || die "keygen failed"
+for i in $(seq 1 "$N_CLIENTS"); do
+    CSK[$i]=$(sed -n "${i}p" "$CLIENT_KEYS_FILE"); CDB[$i]="/tmp/ss_${TAG}_c${CSK[$i]:0:8}.db"
+done
+
+echo "=== N=$N_CLIENTS REGTEST pct-100 REALISTIC lifecycle: onboard@0 -> LN seed -> economy($MAX_PAYS) -> $((N_CLIENTS+1))-output close + exact accounting ==="
+
+# ---- BIRTH ----
+mkfifo "$FIFO"; exec 3<>"$FIFO"; CLI_FD_OPEN=1
+nohup "$LSP_BIN" --network regtest --port "$PORT" \
+    --clients "$N_CLIENTS" --arity "$ARITY" --static-near-root "$STATIC_NEAR_ROOT" \
+    --amount "$AMOUNT" \
+    --active-blocks 500 --dying-blocks 20 --step-blocks 5 --states-per-layer 2 \
+    --fee-rate 1000 --lsp-balance-pct 100 --confirm-timeout 600 \
+    --max-conn-rate 100000 --max-handshakes 256 \
+    --seckey "$LSP_SECKEY" \
+    --rpcuser "$RU" --rpcpassword "$RP" --rpcport "$RPORT" \
+    --wallet "$MINERW" --db "$LSP_DB" \
+    --daemon --cli < "$FIFO" >> "$LSP_LOG" 2>&1 &
+LSP_PID=$!
+for i in $(seq 1 60); do sleep 1; grep -q "listening on port $PORT" "$LSP_LOG" 2>/dev/null && break; kill -0 "$LSP_PID" 2>/dev/null || { tail -25 "$LSP_LOG"; die "LSP died before listening"; }; done
+grep -q "listening on port $PORT" "$LSP_LOG" || { tail -25 "$LSP_LOG"; die "LSP never listened"; }
+info "$(ts) LSP listening; launching $N_CLIENTS zero-balance clients + block miner..."
+for i in $(seq 1 "$N_CLIENTS"); do
+    nohup "$CLIENT_BIN" --network regtest --host 127.0.0.1 --port "$PORT" \
+        --seckey "${CSK[$i]}" --fee-rate 1000 --lsp-balance-pct 100 \
+        --lsp-pubkey "$LSP_PUBKEY" --participant-id "$i" \
+        --rpcuser "$RU" --rpcpassword "$RP" --rpcport "$RPORT" \
+        --wallet "$MINERW" --db "${CDB[$i]}" \
+        --daemon >> "/tmp/ss_${TAG}_c${CSK[$i]:0:8}.log" 2>&1 &
+    CPID[$i]=$!
+    sleep 0.1
+done
+( while kill -0 "$LSP_PID" 2>/dev/null; do mine 1; sleep 2; done ) & MINER_PID=$!
+
+CDEAD=$(( $(date +%s) + 420 )); CREATED=0
+while [ "$(date +%s)" -lt "$CDEAD" ]; do
+    grep -q "entering daemon mode" "$LSP_LOG" 2>/dev/null && { CREATED=1; break; }
+    grep -qE "event loop failed|channel init failed|ceremony failed|FATAL" "$LSP_LOG" 2>/dev/null && { tail -30 "$LSP_LOG"; die "LSP creation failure"; }
+    kill -0 "$LSP_PID" 2>/dev/null || { tail -30 "$LSP_LOG"; die "LSP died during creation"; }
+    sleep 3
+done
+[ "$CREATED" = 1 ] || { tail -30 "$LSP_LOG"; die "factory not created in 420s"; }
+green "$(ts) FACTORY LIVE — $N_CLIENTS clients onboarded with ZERO balance (pct-100)"
+
+# ---- SEED: every client's first sats arrive over LN ----
+info "$(ts) SEED: LSP pays each of the $N_CLIENTS clients over LN (lsppay, random $SEED_MIN..$SEED_MAX sats)..."
+for i in $(seq 0 $((N_CLIENTS-1))); do
+    lsppay_cli "$i" "$(seed_amt)" || red "$(ts)   seed of client $i did not settle (retry pass follows)"
+    sleep "$PAY_GAP"
+done
+for i in $(seq 0 $((N_CLIENTS-1))); do
+    grep -aq "Payment complete: LSP -> client $i (" "$LSP_LOG" 2>/dev/null || { info "$(ts)   retrying client $i"; lsppay_cli "$i" "$(seed_amt)" || true; }
+done
+SEEDED=$(grep -aoE "Payment complete: LSP -> client [0-9]+ \(" "$LSP_LOG" 2>/dev/null | sort -u | wc -l); SEEDED=${SEEDED:-0}
+[ "$SEEDED" -ge "$N_CLIENTS" ] && green "$(ts) SEED complete: $SEEDED/$N_CLIENTS funded over LN" \
+                                || red   "$(ts) SEED INCOMPLETE: $SEEDED/$N_CLIENTS (close will have $((SEEDED+1)) outputs)"
+
+# ---- ECONOMY: bounded random c2c circulation (auto-stop on conservation violation) ----
+info "$(ts) ECONOMY: up to $MAX_PAYS random client->client payments..."
+ECON_OK=0; ECON_FAIL=0
+for _k in $(seq 1 "$MAX_PAYS"); do
+    if grep -aqE "CONSERVATION VIOLATION|conservation violated" "$LSP_LOG" 2>/dev/null; then
+        red "$(ts) conservation violation detected after $ECON_OK settled -> STOP economy (this IS the measured ceiling)"
+        break
+    fi
+    s=$((RANDOM % N_CLIENTS)); d=$((RANDOM % N_CLIENTS)); [ "$s" = "$d" ] && d=$(( (d+1) % N_CLIENTS ))
+    if pay_cli "$s" "$d" "$(econ_amt)"; then ECON_OK=$((ECON_OK+1)); else ECON_FAIL=$((ECON_FAIL+1)); fi
+    sleep "$PAY_GAP"
+done
+info "$(ts) economy done: $ECON_OK settled, $ECON_FAIL not settled (insufficient balance / timeout = expected capacity behavior)"
+
+# ---- CLOSE ----
+sleep 10
+info "$(ts) issuing CLI close -> $((N_CLIENTS+1))-output cooperative payout..."
+cli "close"
+CLOSE_TXID=""; CDEAD=$(( $(date +%s) + CLOSE_WAIT_SEC ))
+while [ "$(date +%s)" -lt "$CDEAD" ]; do
+    CLOSE_TXID=$(grep -aoE "cooperative close confirmed! txid: [0-9a-f]{64}" "$LSP_LOG" 2>/dev/null | tail -1 | awk '{print $NF}')
+    [ -n "$CLOSE_TXID" ] && break
+    grep -qE "cooperative close failed" "$LSP_LOG" 2>/dev/null && break
+    sleep 3
+done
+[ -n "$CLOSE_TXID" ] || { tail -30 "$LSP_LOG"; die "cooperative close did not confirm in ${CLOSE_WAIT_SEC}s"; }
+info "$(ts) close txid: $CLOSE_TXID"
+
+# ---- VERIFY on-chain + EXACT accounting ----
+FAILED=0
+RES=$($BCLI getrawtransaction "$CLOSE_TXID" true 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+nout = len(d['vout']); nin = len(d['vin'])
+out = round(sum(v['value'] for v in d['vout']) * 1e8)
+print('nin=%d nout=%d out=%d confs=%d' % (nin, nout, out, d.get('confirmations', 0)))
+")
+info "close: $RES"
+eval "$RES"
+[ "${confs:-0}" -ge 1 ] || { red "  CHECK FAIL: not confirmed"; FAILED=1; }
+[ "${nin:-0}" -eq 1 ] || { red "  CHECK FAIL: nin=${nin:-?} != 1"; FAILED=1; }
+[ "${nout:-0}" -eq $((N_CLIENTS+1)) ] && green "  ok: exactly $((N_CLIENTS+1)) outputs (every onboarded-at-zero client got an LN-earned payout)" \
+                                       || { red "  CHECK FAIL: nout=${nout:-?} != $((N_CLIENTS+1))"; FAILED=1; }
+
+info "=== EXACT accounting: output_i == received_i - sent_i (baseline 0) ==="
+python3 - "$LSP_LOG" "$N_CLIENTS" <<'PYEOF'
+import sys, re
+from collections import defaultdict
+txt = open(sys.argv[1], errors="replace").read()
+n = int(sys.argv[2])
+c2c = re.findall(r"Payment complete: client (\d+) -> client (\d+) \((\d+) sats\)", txt)
+lsp = re.findall(r"Payment complete: LSP -> client (\d+) \((\d+) sats\)", txt)
+net = defaultdict(int)
+for s, d, a in c2c: net[int(s)] -= int(a); net[int(d)] += int(a)
+for d, a in lsp:    net[int(d)] += int(a)
+i = txt.rfind("Close outputs:")
+close = {int(k): int(v) for k, v in re.findall(r"Client (\d+):\s+(\d+) sats", txt[i:] if i >= 0 else "")}
+print("  LN inbound (seed): %d payments, %d sats;  c2c: %d payments, %d sats moved"
+      % (len(lsp), sum(int(a) for _, a in lsp), len(c2c), sum(int(a) for *_, a in c2c)))
+bad = 0
+for c in range(n):
+    o, e = close.get(c), net.get(c, 0)
+    tag = "OK " if o == e else "MISMATCH"
+    if o != e: bad += 1
+    print("  client %3d: output=%-8s expected(recv-sent)=%-8d %s" % (c, o, e, tag))
+if bad == 0 and len(close) == n:
+    print("  RECONCILE PERFECT: every output equals exactly the client's net LN flow (baseline 0) -> NO SKIM, sat-for-sat")
+else:
+    print("  RECONCILE FAILED: %d mismatches, %d/%d outputs present" % (bad, len(close), n)); sys.exit(1)
+PYEOF
+[ $? -eq 0 ] || FAILED=1
+
+if [ "$FAILED" -eq 0 ]; then
+    green "PASS: N=$N_CLIENTS pct-100 REALISTIC lifecycle — clients onboarded with ZERO sats, every sat in every"
+    green "      close output was delivered over LN, and the $((N_CLIENTS+1))-output close reconciles sat-for-sat ($CLOSE_TXID)"
+    exit 0
+else
+    die "verification gate failed (see CHECK FAIL / RECONCILE above)"
+fi

--- a/tools/test_signet_paylifecycle.sh
+++ b/tools/test_signet_paylifecycle.sh
@@ -9,11 +9,13 @@
 # Usage: test_signet_paylifecycle.sh <N> [P_PER_CH] [SATS_PER_LEAF] [FEE_RATE]
 set -uo pipefail
 
-N="${1:?usage: <N> [P] [SATS_PER_LEAF] [FEE_RATE]}"
+N="${1:?usage: <N> [P] [SATS_PER_LEAF] [FEE_KVB] [LSP_PCT]}"
 P="${2:-4}"
-PER_LEAF="${3:-15000}"        # >2*CHANNEL_RESERVE(5000) so payments have room
-FEE_RATE="${4:-1}"            # sat/vB for close + sweep (signet is cheap)
+PER_LEAF="${3:-60000}"        # sized so payments never skip (see sizing runs)
+FEE_KVB="${4:-1000}"          # sat/kvB: 100 = 0.1 sat/vB (node relay floor 0.01)
+LSP_PCT="${5:-50}"            # 100 => clients start at 0; all client sats payment-borne
 AMOUNT=$(( N * PER_LEAF ))
+FEE_VB=$(awk "BEGIN{printf \"%g\", $FEE_KVB/1000}")   # for wallet RPCs (may floor at 1)
 
 BIN=/root/SuperScalar-lsppay/build-lsppay/test_inproc_factory_lifecycle
 CONF=/var/lib/bitcoind-signet/bitcoin.conf
@@ -38,12 +40,12 @@ wait_conf(){ # txid -> block until >=1 confirmation (txindex=1, works for any tx
   return 1
 }
 
-say "RUN $TAG  N=$N P=$P per_leaf=$PER_LEAF amount=$AMOUNT fee_rate=$FEE_RATE"
+say "RUN $TAG  N=$N P=$P per_leaf=$PER_LEAF amount=$AMOUNT fee_kvb=$FEE_KVB (${FEE_VB} sat/vB) lsp_pct=$LSP_PCT"
 RET=$($CLI $W getnewaddress "${TAG}_ret" bech32m)
 git -C /root/SuperScalar-lsppay rev-parse HEAD > "$AUDIT/git_commit.txt" 2>/dev/null || true
 cat > "$AUDIT/manifest.json" <<EOF
 {"tag":"$TAG","seed":"$SEED","N":$N,"payments_per_channel":$P,"sats_per_leaf":$PER_LEAF,
- "funding_amount":$AMOUNT,"fee_rate":$FEE_RATE,"return_addr":"$RET"}
+ "funding_amount":$AMOUNT,"fee_kvb":$FEE_KVB,"lsp_pct":$LSP_PCT,"return_addr":"$RET"}
 EOF
 
 # ---- 1. factory funding address (tweaked N-of-N aggregate) ----
@@ -54,7 +56,8 @@ say "funding addr=$FADDR (xonly=$FX)"
 echo "$FADDR" > "$AUDIT/funding_addr.txt"
 
 # ---- 2. fund it ----
-FTXID=$($CLI -named $W sendtoaddress address="$FADDR" amount="$(sat2btc $AMOUNT)" fee_rate=$FEE_RATE) \
+FTXID=$($CLI -named $W sendtoaddress address="$FADDR" amount="$(sat2btc $AMOUNT)" fee_rate=$FEE_VB 2>/dev/null) \
+  || FTXID=$($CLI -named $W sendtoaddress address="$FADDR" amount="$(sat2btc $AMOUNT)" fee_rate=1) \
   || { say "fund send FAILED"; exit 1; }
 say "funding txid=$FTXID (waiting for confirmation)"
 wait_conf "$FTXID" >/dev/null || { say "funding not confirmed"; exit 1; }
@@ -64,7 +67,7 @@ echo "{\"funding_txid\":\"$FTXID\",\"vout\":$VOUT}" > "$AUDIT/funding.json"
 
 # ---- 3. real payments + cooperative close (in-process) ----
 say "running paylifecycle (real HTLC payments + close)"
-$BIN paylifecycle "$N" "$SEED" "$FTXID" "$VOUT" "$AMOUNT" "$AUDIT/close.hex" "$FEE_RATE" "$P" "$AUDIT" \
+$BIN paylifecycle "$N" "$SEED" "$FTXID" "$VOUT" "$AMOUNT" "$AUDIT/close.hex" "$FEE_KVB" "$P" "$AUDIT" "$LSP_PCT" \
   || { say "paylifecycle FAILED"; exit 1; }
 CLOSE_HEX=$(cat "$AUDIT/close.hex")
 
@@ -138,8 +141,9 @@ say "rescanning [$RS_FROM,$TIP] for close outputs"
 $CLI -rpcwallet="$SWEEPW" rescanblockchain "$RS_FROM" "$TIP" >/dev/null 2>&1
 SWBAL=$($CLI -rpcwallet="$SWEEPW" getbalance)
 say "sweep wallet holds $SWBAL BTC across $NOUT outputs"
-STXID=$($CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate="$FEE_RATE" 2>&1 | jq -r '.txid // empty')
-if [ -z "$STXID" ]; then say "sendall FAILED:"; $CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate="$FEE_RATE"; else
+STXID=$($CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate="$FEE_VB" 2>/dev/null | jq -r '.txid // empty')
+[ -z "$STXID" ] && STXID=$($CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate=1 2>&1 | jq -r '.txid // empty')
+if [ -z "$STXID" ]; then say "sendall FAILED:"; $CLI -rpcwallet="$SWEEPW" -named sendall recipients="[\"$RET\"]" fee_rate=1; else
   say "sweep broadcast txid=$STXID"; wait_conf "$STXID" >/dev/null 2>&1 || true
   say "sweep confirmed txid=$STXID"
 fi


### PR DESCRIPTION
Recovers two bodies of work that were **written, proven, and then never landed** — found by auditing every VPS worktree for unpushed/uncommitted code.

## 1. The BOLT-2 ceremony harness (`28b6d1c`) — my own miss

This is the code that produced the payment-borne signet proof. It was left uncommitted when the accompanying crash fixes were staged: the amend covered `src/ include/ tests/` but **not `tools/`**, so `main` received `factory_alloc_default_arrays` and `MUSIG_SESSION_SMALL` while `bolt2_commit_round`, `setup_mirror_channel`, `LSP_PCT` and `payment_borne` stayed on a local disk. Verified against `main` by grep, not by trusting the earlier PR text.

- Every payment runs the daemon's **real commitment ceremony**, ported from `htlc_commit_add_and_sign` minus sockets: `update_add` both endpoints → `channel_create_commitment_partial_sig` → peer **cryptographically verifies** + aggregates (`channel_verify_and_aggregate_commitment_sig`) → `revoke_and_ack` both directions (per-commitment secret reveal + `receive_revocation_flat` + next-PCP advance) → `fulfill` → second full signed round.
- `setup_mirror_channel()`: a real client-side endpoint per leaf carrying the basepoints, PCS chains and pubnonce pools that `MSG_CHANNEL_BASEPOINTS` / `MSG_CHANNEL_NONCES` carry on the wire.
- `LSP_PCT=100` ⇒ clients start at **zero**, so every client sat at close arrived through a real HTLC — hard-verified per channel (final balance == sum of that channel's received payments) plus an exact mirror-book check.
- Fees in sat/kvB (`100` = 0.1 sat/vB).

**Signet proof:** close `3aa38531aade4a57c05e293956150166d879ae85553b00e567f871efca5973cd` (block 315102, 1,024 outputs, 44,153 B, **0.10001 sat/vB**), sweep `cc1c7c87cd36be93e40067b4cfcc475e5522a18acc296d75f67e8f0d6259f55e` (1,024 inputs). 4,092 payments · **16,368 aggregate sigs verified** · **16,368 revocations** · clients 0 → 4,830,750 sats. Independent re-verification against chain + audit bundle: 6/6 checks clean, including *each client's final balance == the sum of its own payments* (0 mismatches).

## 2. lsppay inbound + pct-100 lifecycle (`0e126a8`)

Recovered from `feat/lsppay-inbound`, which **had never been pushed to GitHub** (the VPS holds no push credentials), extracted as a patch and rebased onto current `main`. Its duplicate copy of `tools/test_signet_soak_lifecycle.sh` is dropped — that file already landed via #443.

- `lsp_channels_lsppay()`: LSP→client payment over the factory channel — the final hop of a real inbound LN payment (invoice + OFFERED-HTLC destination leg of the proven c2c path, including watchtower registration and persistence). CLI: `lsppay <to> <amt>`.
- `test_regtest_pct100_lifecycle.sh`: full realistic lifecycle on regtest — onboard clients at **zero** → LSP seeds everyone over LN → bounded c2c economy → (N+1)-output cooperative close → **exact per-client reconciliation** (`output_i == received_i - sent_i`). Proven at N=3: closes `481e4e91`/`a8700504`, reconciliation perfect sat-for-sat.

Original author of that work: Jason Todd `<disturbedjasonx@gmail.com>` (commit `a5aa480`).

## Gate

Fresh clone of this branch → cmake configure → **all targets build** → `test_superscalar` **1522/1522**.

## Audit note

The same sweep checked every other VPS worktree with unpushed commits (`cheat-lstock`, `cheat-scb`, `crash-half-b`, `prometheus`, `fix-conservation`, `residual-sweep`, the `cli_arity` mainnet step-floor guard). Every one of those **features is already in `main`** — their patches were reworked before landing, so `git cherry` flags them while the functionality is present. Nothing obsolete is included here.
