### PR TITLE
docs/design: path to real distributed payments at N=512 / N=1024

### DIFF
--- a/docs/design/distributed-scale-512.md
+++ b/docs/design/distributed-scale-512.md
@@ -1,0 +1,169 @@
+# Real distributed payments at N=512 / N=1024
+
+**Status:** design proposal. Nothing here is implemented.
+**Goal:** run SuperScalar at 512 and 1024 clients with the *same fidelity we have
+at 127* — separate client instances, real sockets, real Noise handshakes, real
+wire protocol, real per-payment commitment ceremonies — on the hardware we have,
+without buying a bigger box.
+
+## 1. What is and is not proven today
+
+| level | fidelity | max N proven |
+|---|---|---|
+| in-process manager (`test_inproc_factory_lifecycle`) | real factory, real channels, real HTLCs, **full BOLT-2 ceremony** (partial-sig → cryptographic verify → aggregate → revoke_and_ack). One process, no sockets, both endpoints driven locally. | **10,000** (and 1023/512 settled on real signet) |
+| daemon swarm (`superscalar_lsp` + N × `superscalar_client`) | separate processes, real sockets/Noise/wire, real reconnection | **127** |
+
+The gap is not cryptography and not transaction size — a 1024-of-1024 MuSig2
+aggregate signature and a 1024-output cooperative close are both proven on
+signet. The gap is that **N=512 daemons do not fit in RAM**, so the distributed
+protocol has never been exercised above 127.
+
+Today's daemon startup crash (`factory_set_*` NULL-deref, fixed in #452) is the
+concrete cost of that gap: the unit suite never runs daemon `main()`, and the
+in-process harness bypasses sockets, so a crash in the primary binary reached
+`main` unnoticed. Any test tier that actually starts daemons would have caught it.
+
+## 2. Why it doesn't fit — measured, not estimated
+
+Struct sizes on current `main`:
+
+```
+sizeof(factory_node_t)    = 23,816 B      <- x n_nodes, per client
+sizeof(factory_t)         = 264,408 B     (epoch arrays dominate)
+sizeof(channel_t)         =  86,696 B     of which nonce pool = 67,600 B (78%)
+```
+
+**Every client rebuilds and retains the entire tree.** `src/client.c:1112` calls
+`factory_build_tree()` — the client reconstructs the tree deterministically from
+(pubkeys, funding, arity) to verify the LSP's claims, which is correct, but it
+then keeps all of it:
+
+| N | tree nodes | tree bytes **per client** | × N |
+|---|---|---|---|
+| 127 | ~506 | 11.5 MB | ~1.5 GB (fits — this is why 127 works) |
+| 512 | 2,046 | 46.5 MB | **~28 GB** |
+| 1024 | 4,090 | 92.9 MB | **~100 GB** |
+
+Cost grows as O(N) per client and therefore **O(N²) for the swarm**. That is the
+whole problem.
+
+## 3. The fix: a client does not need O(N) state
+
+A client must be able to (a) verify its own leaf pays it the right amount and
+(b) unilaterally exit. Both need only the **root→leaf path plus, at each level,
+the sibling outputs' SPKs and amounts** — never other clients' subtrees.
+
+```
+path-only at N=512:  ~11 nodes = 0.25 MB   (vs 46.5 MB)   ~186x smaller
+```
+
+This is a **product** improvement before it is a test improvement: a phone wallet
+should not carry tens of MB of strangers' tree data.
+
+Because the client *builds* the tree rather than receiving it, this is a contained
+change inside `build_subtree` (a "retain only the path to leaf L" mode) — **no
+wire-protocol change, no renegotiation with the LSP.**
+
+Two supporting trims:
+
+- **Right-size MuSig nonce pools.** 67.6 KB of the 86.7 KB `channel_t` is a
+  256-slot pool. 16 slots → `channel_t` ≈ 20 KB. Also saves ~34 MB on the LSP at
+  512 channels.
+- **Lazy `input_signer_indices`.** The fixed `[FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS]`
+  array is 16 KB of every 23.8 KB node and is unused for default (k=1) PS.
+  Allocating it only for multi-input sub-factory nodes takes `factory_node_t` to
+  ~7.4 KB, helping both sides.
+
+### Resulting budget
+
+| configuration | per client | N=512 | N=1024 |
+|---|---|---|---|
+| today (full tree, process) | ~56 MB | 28 GB ❌ | 100 GB ❌ |
+| path-only, own process | ~4–8 MB | 2.5–4 GB ✅ | 5–8 GB ⚠️ |
+| path-only, **thread** | ~0.3 MB | ~0.3 GB ✅ | ~0.5 GB ✅ |
+
+## 4. Harness tiers
+
+Each tier buys specific realism. They compose; none replaces the others.
+
+| tier | shape | N=512 cost | what it proves that the tier below does not |
+|---|---|---|---|
+| **T1** in-process (exists) | 1 process, no sockets | 181 MB | protocol, crypto, settlement conservation |
+| **T2** threads + real sockets | N client threads, each own channel + path, real wire to the LSP over loopback | ~0.3–0.5 GB | wire codec, ceremony interleaving, concurrency, reconnection, **daemon startup paths** |
+| **T3** processes, path-only | N real processes; `fork()` after secp init so the 1.2 MB context is COW-shared | ~2.5–4 GB | OS process isolation, per-process crash/restart, real fd limits |
+| **T4** rolling participation | K≈32 concurrent real clients cycled in waves | ~0.3 GB at **any** N | the real distributed ceremony at arbitrary N under bounded RAM |
+
+**T2 is the best realism-per-byte** and is the tier that would have caught today's
+crash. T4 is the only tier that scales to 1024+ real clients without new hardware.
+
+### Threading feasibility (measured)
+
+Mutable file-scope state on the client path:
+
+```
+client.c 3   wire.c 6   client_reconnect.c 0   channel.c 0   musig.c 0   peer_mgr.c 0
+```
+
+**Nine mutable globals total**, all simple scalars (`g_slot_hint`,
+`g_client_nk_server_pubkey_set`, `g_client_funding_pending_reorg`, + 6 in `wire.c`).
+Making them `_Thread_local` — or moving them into a client context struct — is a
+small mechanical change, not a rewrite. There is no architectural barrier to
+running N clients in one address space.
+
+## 5. Phases
+
+Each phase is independently mergeable and independently useful.
+
+**P0 — Baseline instrumentation.** Record actual per-process RSS for LSP and
+client at N=127 (not extrapolated). Add an RSS sample to the swarm harness so
+every later claim is measured.
+*Accept:* a committed baseline table for N=8/64/127.
+
+**P1 — Lean client (the load-bearing change).**
+Path-only tree retention + lazy `input_signer_indices` + right-sized nonce pools.
+*Accept:* per-client RSS at N=127 drops ≥5×; N=512 daemon swarm fits under 4 GB;
+suite stays 1522/1522; **tree-verify efficacy test still passes** (see Risks).
+
+**P2 — T2 thread swarm.** `_Thread_local` the 9 globals; add a `superscalar_swarm`
+harness running N clients as threads with real sockets to a real LSP.
+*Accept:* N=512 create → payments → coop close on regtest, real wire throughout;
+per-client reconciliation `output_i == received_i − sent_i`.
+
+**P3 — T3 process swarm at 512.** `fork()`-after-secp-init; raise fd limits.
+*Accept:* N=512 on regtest, then one signet run with the full audit bundle.
+
+**P4 — Liveness reality (the actual finding).** Measure offline tolerance:
+how many clients may drop before an N-of-N cooperative close fails, how long
+reconnection convergence takes at 512 (the #447 gate), and what the force-close
+fallback costs.
+*Accept:* a published curve of dropout-rate vs close success at N=127/512.
+
+**P5 — 1024 via T4.** Rolling participation for the creation ceremony.
+*Accept:* N=1024 real distributed create + close under 1 GB.
+
+## 6. Risks
+
+- **Path-only must not weaken tree verification.** A client verifies its own leaf
+  amount and that the path chains to the funding outpoint; sibling *amounts* do
+  not affect that client's safety, but the existing bad-tree-refusal guarantee
+  must be preserved exactly. P1 is gated on the tree-verify efficacy test
+  continuing to pass, plus an explicit adversarial case (LSP serves a valid path
+  inside an invalid tree).
+- **Thread-shared state is a new failure class.** T2 shares an address space, so a
+  bug in one client can corrupt another — a false-negative risk that T3 does not
+  have. T2 findings should be confirmed on T3 before being called proven.
+- **T2/T3 still do not model the network.** No latency, loss, reordering, or
+  partition. Those need netem or a real multi-host run and are out of scope here.
+- **The honest ceiling is protocol, not harness.** A 24 h soak at N=127 lost
+  30/127 daemons, and an N-of-N cooperative close needs every one of them. Scaling
+  the *test* to 512 will confirm the problem worsens; it cannot fix it. P4 exists
+  to quantify that, and the real remedies (offline tolerance, multi-tx close —
+  see #449) are separate protocol work.
+
+## 7. Non-goals
+
+- Changing the wire protocol (P1 deliberately avoids it).
+- Raising `FACTORY_MAX_*` compile-time defaults; per-instance config already covers it.
+- Replacing the in-process manager — T1 stays the fast path for scale/crypto work.
+- Buying larger hardware. Every number above targets the existing box, with
+  headroom to run on half of it.

--- a/docs/design/distributed-scale-512.md
+++ b/docs/design/distributed-scale-512.md
@@ -12,13 +12,48 @@ A falsification run (real `superscalar_lsp` + N × `superscalar_client`, real
 sockets, regtest, pct-100 lifecycle: onboard-at-zero → LN seed → c2c economy →
 (N+1)-output cooperative close with per-client reconciliation) produced:
 
-| N | outcome | wall | LSP RSS | per client | swarm total |
-|---|---|---|---|---|---|
-| 127 | **PASS** | 569 s | 46.4 MB | 21.0 MB | 2.65 GB |
-| 160 | **PASS** | 577 s | 50.3 MB | 22.3 MB | 3.55 GB |
-| 192 | **PASS** | 663 s | 54.4 MB | 26.5 MB | 4.49 GB |
+| N | outcome | wall | LSP RSS | per client | swarm total | close |
+|---|---|---|---|---|---|---|
+| 127 | **PASS** | 569 s | 46.4 MB | 21.0 MB | 2.65 GB | 128 outs |
+| 160 | **PASS** | 577 s | 50.3 MB | 22.3 MB | 3.55 GB | 161 outs |
+| 192 | **PASS** | 663 s | 54.4 MB | 26.5 MB | 4.49 GB | 193 outs (`a25d8541…`) |
+| **224** | **PASS** | 818 s | 107.1 MB | 24.7 MB | 5.52 GB | **225 outs** (`c9e4ee08…`) |
+| 256 | **FAIL** | 4 s | — | — | — | refused at startup |
 
-N=192 closed with 193 outputs (`a25d8541…`), RECONCILE PERFECT, sat-for-sat.
+Every PASS reconciled **sat-for-sat, no skim**, with clients onboarded at zero.
+
+### The actual wall is a compile-time cap, not a resource
+
+N=256 did not run out of anything. It was **refused before listening**:
+
+```
+Error: --clients must be 1..255 (the LSP co-signs every factory:
+       clients + 1 <= 256-signer MuSig cap)
+```
+
+That is `FACTORY_MAX_SIGNERS = 256`. The per-instance `factory_config` that lifts
+it already exists and is used by the in-process manager (which reaches 10,000) —
+**the daemon was simply never wired to use it.** At 224 the swarm used 5.5 GB of a
+9 GB budget with all 224 client processes healthy, so nothing was close to
+exhausted.
+
+### Revised, empirically-grounded staircase
+
+| range | status | what it needs |
+|---|---|---|
+| **N ≤ 255** | **works today, unmodified** (224 proven) | nothing |
+| 256 – 511 | blocked by one config cap | wire the daemon to a per-instance `factory_config` with raised `max_signers` (machinery already exists) |
+| ≥ 512 | blocked by memory (~27 GB extrapolated) | path-only client (§3) |
+
+The second row is a *small* change, not a project — which means the next real
+milestone after 255 is likely 384–511, well before any of the §3/§4 work.
+
+### Secondary finding: wall-clock is the next practical limit
+
+The seed phase is **sequential** — N `lsppay` calls × ~6 round-trips each. It grew
+127→224 as 569 s→818 s, with ~11.5 min of the 224 run spent seeding alone.
+Memory is not what will make N=512 painful to test; serialized onboarding is.
+Batching/pipelining the seed loop is cheap and should precede any large-N run.
 
 **Three predictions in the earlier draft were wrong, and the measurements win:**
 

--- a/docs/design/distributed-scale-512.md
+++ b/docs/design/distributed-scale-512.md
@@ -6,6 +6,40 @@ at 127* — separate client instances, real sockets, real Noise handshakes, real
 wire protocol, real per-payment commitment ceremonies — on the hardware we have,
 without buying a bigger box.
 
+## 0. MEASURED RESULTS — read this before the projections below
+
+A falsification run (real `superscalar_lsp` + N × `superscalar_client`, real
+sockets, regtest, pct-100 lifecycle: onboard-at-zero → LN seed → c2c economy →
+(N+1)-output cooperative close with per-client reconciliation) produced:
+
+| N | outcome | wall | LSP RSS | per client | swarm total |
+|---|---|---|---|---|---|
+| 127 | **PASS** | 569 s | 46.4 MB | 21.0 MB | 2.65 GB |
+| 160 | **PASS** | 577 s | 50.3 MB | 22.3 MB | 3.55 GB |
+| 192 | **PASS** | 663 s | 54.4 MB | 26.5 MB | 4.49 GB |
+
+N=192 closed with 193 outputs (`a25d8541…`), RECONCILE PERFECT, sat-for-sat.
+
+**Three predictions in the earlier draft were wrong, and the measurements win:**
+
+1. **N=192 already works with real daemons, unchanged.** The "127 ceiling" was
+   never a limit anyone had hit — it was simply the largest N previously tried.
+   That is a free ~1.5× with no code change.
+2. **The wire-frame limit (§3b B1) did NOT fire** — zero frame errors at any N.
+   The dense `nodes × n_participants` matrix at `client.c:1675` is evidently not
+   what a pseudo-Spilman ceremony exercises: PS leaves are 2-of-2, so the
+   all-signer matrix is far smaller than the worst case computed there. **B1 is
+   NOT the gating blocker.** It may still bite for non-PS shapes; unverified.
+3. **The LSP is not a scaling factor** — 46→54 MB, essentially flat in N.
+
+**What survives:** per-client memory is the real wall, and it grows ~0.085 MB per
+added client from a ~21 MB floor. Extrapolating from measurement, not arithmetic:
+N=256 ≈ 8.2 GB, **N=512 ≈ 27 GB**. So §3 (path-only client) remains the
+load-bearing fix — but for the reason in §2, not §3b.
+
+Where it actually breaks is being measured (224/256); §3b's ordering claim
+("B1 gates everything above ~250") is **withdrawn**.
+
 ## 1. What is and is not proven today
 
 | level | fidelity | max N proven |

--- a/docs/design/distributed-scale-512.md
+++ b/docs/design/distributed-scale-512.md
@@ -41,12 +41,46 @@ exhausted.
 
 | range | status | what it needs |
 |---|---|---|
-| **N ≤ 255** | **works today, unmodified** (224 proven) | nothing |
-| 256 – 511 | blocked by one config cap | wire the daemon to a per-instance `factory_config` with raised `max_signers` (machinery already exists) |
-| ≥ 512 | blocked by memory (~27 GB extrapolated) | path-only client (§3) |
+| **N ≤ 255** | **works today, unmodified** (224 full lifecycle, 255 FACTORY LIVE) | nothing |
+| 256 – 511 | blocked by **53 fixed-size arrays**, many on the stack | convert them to heap sized to `n_participants` — see below |
+| ≥ 512 | additionally blocked by memory (~27 GB extrapolated) | path-only client (§3) |
 
-The second row is a *small* change, not a project — which means the next real
-milestone after 255 is likely 384–511, well before any of the §3/§4 work.
+### The 255 cap is LOAD-BEARING — tested, not assumed
+
+An earlier revision of this doc claimed row 2 was "one config cap … a *small*
+change, not a project." **That was wrong, and removing the cap proved it.**
+
+The library side genuinely does scale: musig sessions size their pubnonces to the
+actual signer count, and `factory_config_fit()` grows `factory_t`'s arrays to the
+participant count. So lifting `superscalar_lsp`'s `--clients` guard *looks* safe.
+It is not. Running N=256 with the guard removed produced:
+
+```
+*** stack smashing detected ***: terminated
+=== CRASH (signal 6) ===  ... main+0x4e49
+```
+
+Memory corruption during factory creation — because the daemon path still declares
+**53 fixed `[FACTORY_MAX_SIGNERS]` arrays**, many of them on the stack, and
+`n_participants = 257` runs off the end of every one:
+
+| file | count |
+|---|---|
+| `src/lsp_channels.c` | 12 |
+| `src/client.c` | 11 |
+| `src/lsp.c` | 7 |
+| `tools/superscalar_lsp.c` | 3 (the crash site) |
+| `src/ladder.c` | 3 |
+| `src/persist.c` | 1 |
+
+The guard is therefore **restored deliberately**, with a comment that says so, so
+an over-large `--clients` is a clear error rather than a smash. Lifting it is a
+real piece of work — 53 conversions, each needing correct free/error paths — and
+it must land *before* the cap moves, not after.
+
+**Lesson for sequencing:** the library scaling and the daemon scaling are separate
+problems. `factory_config_fit()` is necessary but nowhere near sufficient, and the
+cheap-looking config change was a trap that only an actual run at N=256 exposed.
 
 ### Secondary finding: wall-clock is the next practical limit
 

--- a/docs/design/distributed-scale-512.md
+++ b/docs/design/distributed-scale-512.md
@@ -101,12 +101,36 @@ all-signers × all-nodes nonce matrix is `N × n_nodes × 66 B`:
 So even with perfect memory efficiency the **ceremony messages themselves** stop
 fitting somewhere around N≈250. The same applies to the partial-sig matrix.
 
-*Fix:* stride per participant — a client only needs **its own row**
-(`n_nodes × 66 B` = 135 KB at N=512, 270 KB at N=1024), which keeps every frame
-small regardless of N. A stride was reportedly introduced for the N≥127 abort;
-this design requires **re-verifying it applies to both the nonce (0x83) and
-partial-sig (0x89) matrices at 512/1024**, since a dense path anywhere reintroduces
-the ceiling. Treat as the highest-risk unknown in the whole plan.
+**CONFIRMED IN CODE** (`src/client.c:1675`) — this is not an estimate:
+
+```c
+size_t mtx_stride = (size_t)factory->n_participants * 66;  /* tight stride = actual signer count */
+unsigned char *all_pn = calloc(nn, mtx_stride);
+...
+have_matrix = (got_matrix_len == (uint32_t)(nn * mtx_stride));   /* received over the wire */
+```
+
+The matrix is `n_nodes × n_participants × 66 B` **dense**, and `got_matrix_len`
+shows it crosses the wire whole. The stride fix introduced for the N≥127 abort
+narrowed the stride from `FACTORY_MAX_SIGNERS` (256) to the actual participant
+count — a **constant-factor** win, not a sparsity win.
+
+It is also a **memory** hit, not only a wire limit: that single `calloc` is
+~69 MB per client at N=512, on top of the 46.5 MB tree.
+
+*Fix — make it sparse, not merely strided.* A signer participates only in the
+nodes on its own root→leaf path (~11 at N=512), never in all 2,046. Sum over
+nodes of the **actual** signer-set size is **O(N log N)**:
+
+| N | dense (today) | sparse (O(N log N)) | reduction |
+|---|---|---|---|
+| 127 | 4.3 MB | ~150 KB | ~29× |
+| 512 | 69.3 MB | ~743 KB | ~93× |
+| 1024 | 277 MB | ~1.6 MB | ~173× |
+
+Every frame then stays far under 16 MB at any N, and the per-client transient
+allocation disappears with it. The same treatment is required for the partial-sig
+(`0x89`) matrix.
 
 ### B2 — `select()` breaks (and is UB) past fd 1023
 

--- a/docs/design/distributed-scale-512.md
+++ b/docs/design/distributed-scale-512.md
@@ -82,6 +82,58 @@ Two supporting trims:
 | path-only, own process | ~4–8 MB | 2.5–4 GB ✅ | 5–8 GB ⚠️ |
 | path-only, **thread** | ~0.3 MB | ~0.3 GB ✅ | ~0.5 GB ✅ |
 
+## 3b. Non-memory blockers (necessary in addition to §3)
+
+Fixing per-client memory is **necessary but not sufficient**. Four further limits
+bite between N=256 and N=1024, and the first is not a memory problem at all.
+
+### B1 — Ceremony matrices exceed the wire frame (the real ceiling)
+
+`WIRE_MAX_FRAME_SIZE = 16 MB`, commented "needed for ALL_NONCES at N=64+". A dense
+all-signers × all-nodes nonce matrix is `N × n_nodes × 66 B`:
+
+| N | dense matrix | vs 16 MB frame |
+|---|---|---|
+| 127 | **4.0 MB** | fits — *this is why 127 works* |
+| 512 | **65.9 MB** | ✗ 4× over |
+| 1024 | **263.6 MB** | ✗ 16× over |
+
+So even with perfect memory efficiency the **ceremony messages themselves** stop
+fitting somewhere around N≈250. The same applies to the partial-sig matrix.
+
+*Fix:* stride per participant — a client only needs **its own row**
+(`n_nodes × 66 B` = 135 KB at N=512, 270 KB at N=1024), which keeps every frame
+small regardless of N. A stride was reportedly introduced for the N≥127 abort;
+this design requires **re-verifying it applies to both the nonce (0x83) and
+partial-sig (0x89) matrices at 512/1024**, since a dense path anywhere reintroduces
+the ceiling. Treat as the highest-risk unknown in the whole plan.
+
+### B2 — `select()` breaks (and is UB) past fd 1023
+
+Four `select()` sites remain in `src/lsp_demo.c` (the CLI/demo path, including the
+`lsppay` drain loop). `FD_SETSIZE` is **1024**; `FD_SET(fd, …)` with `fd ≥ 1024`
+writes past the `fd_set` — a stack smash, not a graceful error. Fine at 512,
+**hard blocker at ~1024**. *Fix:* convert those four to `poll()` (the core loop
+already uses poll/epoll in 8 places).
+
+### B3 — File-descriptor ceiling
+
+`ulimit -n` is **1024**. The LSP needs ≈ N + ~20 (clients + listener + bitcoind
+RPC + sqlite + stdio): ~532 at N=512 (fits), **~1044 at N=1024 (does not)**.
+*Fix:* raise to 65536 in the harness/service unit.
+
+### B4 — `LSP_MAX_CLIENTS` default
+
+Defaults to **256**, overridable with `--max-connections`. Not a code change, but
+it will silently cap a 512 run if forgotten. *Fix:* set explicitly in the harness
+and assert the effective cap at startup.
+
+### Ordering consequence
+
+B1 gates everything above ~250 and is protocol-level, so it should be validated
+**before** the memory work — otherwise P1 could land, look successful, and still
+fail at 512 for an unrelated reason.
+
 ## 4. Harness tiers
 
 Each tier buys specific realism. They compose; none replaces the others.
@@ -114,7 +166,10 @@ running N clients in one address space.
 
 Each phase is independently mergeable and independently useful.
 
-**P0 — Baseline instrumentation.** Record actual per-process RSS for LSP and
+**P0 — Baseline + B1 spike (do FIRST).** Verify the nonce/psig matrices stride per participant at N=512/1024 (§3b B1) BEFORE the memory work — a dense path anywhere caps us near N≈250 regardless of RAM. Set `--max-connections`, raise `ulimit -n`, convert the four `lsp_demo.c` `select()` sites to `poll()`.
+*Accept:* a 512-client ceremony message trace with max frame < 16 MB, and a committed RSS baseline for N=8/64/127.
+
+**P0b — Baseline instrumentation.** Record actual per-process RSS for LSP and
 client at N=127 (not extrapolated). Add an RSS sample to the swarm harness so
 every later claim is measured.
 *Accept:* a committed baseline table for N=8/64/127.

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -8,7 +8,17 @@
 #include "persist_wt.h"
 #include <secp256k1.h>
 
+/* Default inbound-connection capacity; --max-connections overrides it and
+   client_fds/client_pubkeys are heap-allocated, so this is a default, not a cap. */
 #define LSP_MAX_CLIENTS 256
+
+/* Loose sanity bound on --clients.  NOT a capability limit: musig sessions and
+   factory_t arrays both size themselves to the actual participant count now, so
+   nothing in the crypto or the tree caps N.  What bounds N in practice is
+   wall-clock (serialized seeding), per-client RSS, and `ulimit -n` on the LSP.
+   This exists only to turn a typo'd --clients into a clear error instead of an
+   OOM twenty minutes later. */
+#define SS_MAX_SANE_CLIENTS 4096
 
 typedef struct {
     secp256k1_context *ctx;

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -12,13 +12,6 @@
    client_fds/client_pubkeys are heap-allocated, so this is a default, not a cap. */
 #define LSP_MAX_CLIENTS 256
 
-/* Loose sanity bound on --clients.  NOT a capability limit: musig sessions and
-   factory_t arrays both size themselves to the actual participant count now, so
-   nothing in the crypto or the tree caps N.  What bounds N in practice is
-   wall-clock (serialized seeding), per-client RSS, and `ulimit -n` on the LSP.
-   This exists only to turn a typo'd --clients into a clear error instead of an
-   OOM twenty minutes later. */
-#define SS_MAX_SANE_CLIENTS 4096
 
 typedef struct {
     secp256k1_context *ctx;

--- a/src/factory.c
+++ b/src/factory.c
@@ -727,6 +727,28 @@ void factory_config_default(factory_config_t *cfg) {
     cfg->dust_limit_sats = 546;
 }
 
+/* Grow a config so it can actually hold n_participants signers.  The compile-time
+   FACTORY_MAX_* values are DEFAULTS, not limits — the arrays they size are heap
+   now.  Small factories keep the historical defaults byte-for-byte; only a
+   factory asked to hold more than the default grows.  This is what lets the
+   daemons run past 255 clients without every call site passing a config: the
+   factory sizes itself to what it was handed.
+   Leaves: pseudo-Spilman uses one leaf per client, so a PS factory needs
+   n_participants leaves even though arity-2 would need half that; size for the
+   worst case since factory_set_arity may be called after init.
+   Nodes: the PS shape is ~4 per client (kickoff+state per logical node);
+   factory_build_tree reallocs upward if a shape needs more. */
+static void factory_config_fit(factory_config_t *cfg, size_t n_participants) {
+    if (!cfg) return;
+    if (cfg->max_signers < n_participants)
+        cfg->max_signers = (uint32_t)n_participants;
+    if (cfg->max_leaves < n_participants)
+        cfg->max_leaves = (uint32_t)n_participants;
+    size_t want_nodes = 4 * n_participants + 64;
+    if (cfg->max_nodes < want_nodes)
+        cfg->max_nodes = (uint32_t)want_nodes;
+}
+
 int factory_alloc_default_arrays(factory_t *f) {
     if (!f) return 0;
     if (f->config.max_signers == 0) factory_config_default(&f->config);
@@ -764,14 +786,13 @@ int factory_init_with_config(factory_t *f, secp256k1_context *ctx,
     f->states_per_layer = states_per_layer;
     f->fee_per_tx = 200;
 
-    /* Store config */
+    /* Store config, then grow it to fit n_participants (see factory_config_fit).
+       Callers that pass an explicit cfg still get at least what they asked for. */
     if (cfg)
         f->config = *cfg;
     else
         factory_config_default(&f->config);
-
-    if (n_participants > f->config.max_signers)
-        return 0;
+    factory_config_fit(&f->config, n_participants);
 
     /* Factory-level participant arrays sized to the config cap (were fixed
        [FACTORY_MAX_SIGNERS]).  O(N), one copy per factory — this is what lets the
@@ -838,6 +859,7 @@ void factory_init_from_pubkeys(factory_t *f, secp256k1_context *ctx,
     f->states_per_layer = states_per_layer;
     f->fee_per_tx = 200;  /* 1 sat/vB floor for ~200 vB tx; overridden by factory_build_tree */
     factory_config_default(&f->config);
+    factory_config_fit(&f->config, n_participants);   /* grow to hold N (see above) */
 
     /* Factory-level arrays sized to the config cap (were fixed
        [FACTORY_MAX_SIGNERS]).  keypairs stays zeroed here (pubkey-only path). */

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2551,24 +2551,33 @@ int main(int argc, char *argv[]) {
     uint32_t dying_blocks = (dying_blocks_arg > 0) ? (uint32_t)dying_blocks_arg
                             : (is_regtest ? 10 : 432);
 
-    /* Client-count sanity bound.
-       This used to reject clients+1 > MUSIG_SESSION_MAX_SIGNERS because a MuSig
-       session held a FIXED pubnonce array and slot N would be refused deep inside
-       the root ceremony.  That is no longer true: musig_signing_session_t sizes
-       its pubnonces to the actual signer count, and factory_t's arrays are heap
-       and auto-fit via factory_config_fit(), so neither imposes a ceiling.
-       Measured on regtest with real daemons: N=224 completes a full
-       onboard -> LN-seed -> economy -> 225-output cooperative close with exact
-       per-client reconciliation, using ~5.5 GB across the swarm.
-       What actually bounds N in practice, in order: wall-clock (the seed phase is
-       serialized, ~O(N) round-trips), then per-client RSS (~21 MB + ~0.085 MB/N),
-       then file descriptors on the LSP (~N+20 vs `ulimit -n`).  None is a
-       correctness limit, so this stays a loose sanity check that catches a typo'd
-       --clients rather than a real capability boundary. */
-    if (n_clients < 1 || n_clients > SS_MAX_SANE_CLIENTS) {
-        fprintf(stderr, "Error: --clients must be 1..%d (sanity bound; the real "
-                "limits are wall-clock, RSS and `ulimit -n`, not a signer cap)\n",
-                SS_MAX_SANE_CLIENTS);
+    /* Client-count cap.  LOAD-BEARING — do not lift without the work below.
+       The signing group is the LSP plus every client, so n_participants =
+       n_clients + 1.  The crypto no longer caps that: musig sessions size their
+       pubnonces to the actual signer count, and factory_t's arrays auto-fit via
+       factory_config_fit().  BUT the daemon path still declares ~53 FIXED
+       [FACTORY_MAX_SIGNERS] arrays, many of them on the STACK
+       (superscalar_lsp.c 3, lsp_channels.c 12, client.c 11, lsp.c 7,
+       ladder.c 3, persist.c 1).  With n_participants = 257 those overflow:
+       removing this check produced `*** stack smashing detected ***` (SIGABRT)
+       during factory creation at N=256 on regtest — a memory-corruption crash,
+       not a clean refusal.
+       So this bound is what makes an over-large --clients a clear error instead
+       of a smash.  Lifting it requires converting those 53 arrays to heap
+       allocations sized to n_participants (see
+       docs/design/distributed-scale-512.md); it is NOT just a config change.
+       Measured today with real daemons: N=224 completes a full onboard ->
+       LN-seed -> economy -> 225-output cooperative close with exact per-client
+       reconciliation (~5.5 GB swarm); N=255 reaches FACTORY LIVE. Beyond the
+       array work, the next limits in order are wall-clock (seeding is serialized,
+       ~O(N) round-trips), per-client RSS (~21 MB + ~0.085 MB/N), and `ulimit -n`
+       on the LSP (~N+20). */
+    if (n_clients < 1 || n_clients + 1 > FACTORY_MAX_SIGNERS) {
+        fprintf(stderr, "Error: --clients must be 1..%d "
+                "(the LSP co-signs every factory, and the daemon still has fixed "
+                "[FACTORY_MAX_SIGNERS] arrays; lifting this needs those made "
+                "dynamic — see docs/design/distributed-scale-512.md)\n",
+                FACTORY_MAX_SIGNERS - 1);
         return 1;
     }
     /* In uniform mode (no comma list) the leaf semantics are 1, 2, or 3;

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2574,9 +2574,12 @@ int main(int argc, char *argv[]) {
                             change sizeof() for every user of the type:
                             ceremony.h:29, readiness.h:27, ladder.h:19+20, and
                             factory.h:291 input_signer_indices, which is 2-D
-                            [FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS] and so
-                            grows quadratically — size it before assuming the
-                            per-struct cost is small.
+                            [FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS].  Only
+                            the second dimension scales with the signer count:
+                            FACTORY_MAX_OUTPUTS is a fixed 16, so this is
+                            16*N*4 bytes — 16 KB today, 64 KB at N=1024.
+                            Linear, and not a blocker; convert it for
+                            consistency, not for size.
 
        So this bound is what makes an over-large --clients a clear error instead
        of a smash.  Lifting it requires converting those 51 sites to heap

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2555,15 +2555,31 @@ int main(int argc, char *argv[]) {
        The signing group is the LSP plus every client, so n_participants =
        n_clients + 1.  The crypto no longer caps that: musig sessions size their
        pubnonces to the actual signer count, and factory_t's arrays auto-fit via
-       factory_config_fit().  BUT the daemon path still declares ~53 FIXED
-       [FACTORY_MAX_SIGNERS] arrays, many of them on the STACK
-       (superscalar_lsp.c 3, lsp_channels.c 12, client.c 11, lsp.c 7,
-       ladder.c 3, persist.c 1).  With n_participants = 257 those overflow:
+       factory_config_fit().  BUT the daemon path still declares 51 FIXED
+       [FACTORY_MAX_SIGNERS] arrays.  With n_participants = 257 those overflow:
        removing this check produced `*** stack smashing detected ***` (SIGABRT)
        during factory creation at N=256 on regtest — a memory-corruption crash,
        not a clean refusal.
+
+       The 51, counted (an earlier revision of this comment said "~53" with a
+       file list that actually summed to 37 and omitted lsp_rotation.c entirely
+       — do not trust it, re-count with:
+         grep -rnE '\[FACTORY_MAX_SIGNERS *\]' --include=*.c --include=*.h \
+              src/ tools/ include/          # minus the ~9 comment-only hits):
+
+         46 STACK LOCALS  — lsp_channels.c 12, client.c 11, lsp_rotation.c 8,
+                            lsp.c 7, ladder.c 3, superscalar_lsp.c 3,
+                            persist.c 1, superscalar_client.c 1
+          5 STRUCT MEMBERS in shared headers — the harder half, since these
+                            change sizeof() for every user of the type:
+                            ceremony.h:29, readiness.h:27, ladder.h:19+20, and
+                            factory.h:291 input_signer_indices, which is 2-D
+                            [FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS] and so
+                            grows quadratically — size it before assuming the
+                            per-struct cost is small.
+
        So this bound is what makes an over-large --clients a clear error instead
-       of a smash.  Lifting it requires converting those 53 arrays to heap
+       of a smash.  Lifting it requires converting those 51 sites to heap
        allocations sized to n_participants (see
        docs/design/distributed-scale-512.md); it is NOT just a config change.
        Measured today with real daemons: N=224 completes a full onboard ->

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2551,15 +2551,24 @@ int main(int argc, char *argv[]) {
     uint32_t dying_blocks = (dying_blocks_arg > 0) ? (uint32_t)dying_blocks_arg
                             : (is_regtest ? 10 : 432);
 
-    /* The factory signing group is the LSP plus every client, and a MuSig
-       session holds at most MUSIG_SESSION_MAX_SIGNERS (128) signers, so the
-       supported maximum is 127 clients.  Reject the 129th signer here with a
-       clear message instead of failing deep inside the root signing ceremony
-       (set_pubnonce rejects slot 128 and finalize_nonces never completes). */
-    if (n_clients < 1 || n_clients + 1 > MUSIG_SESSION_MAX_SIGNERS) {
-        fprintf(stderr, "Error: --clients must be 1..%d "
-                "(the LSP co-signs every factory: clients + 1 <= %d-signer MuSig cap)\n",
-                MUSIG_SESSION_MAX_SIGNERS - 1, MUSIG_SESSION_MAX_SIGNERS);
+    /* Client-count sanity bound.
+       This used to reject clients+1 > MUSIG_SESSION_MAX_SIGNERS because a MuSig
+       session held a FIXED pubnonce array and slot N would be refused deep inside
+       the root ceremony.  That is no longer true: musig_signing_session_t sizes
+       its pubnonces to the actual signer count, and factory_t's arrays are heap
+       and auto-fit via factory_config_fit(), so neither imposes a ceiling.
+       Measured on regtest with real daemons: N=224 completes a full
+       onboard -> LN-seed -> economy -> 225-output cooperative close with exact
+       per-client reconciliation, using ~5.5 GB across the swarm.
+       What actually bounds N in practice, in order: wall-clock (the seed phase is
+       serialized, ~O(N) round-trips), then per-client RSS (~21 MB + ~0.085 MB/N),
+       then file descriptors on the LSP (~N+20 vs `ulimit -n`).  None is a
+       correctness limit, so this stays a loose sanity check that catches a typo'd
+       --clients rather than a real capability boundary. */
+    if (n_clients < 1 || n_clients > SS_MAX_SANE_CLIENTS) {
+        fprintf(stderr, "Error: --clients must be 1..%d (sanity bound; the real "
+                "limits are wall-clock, RSS and `ulimit -n`, not a signer cap)\n",
+                SS_MAX_SANE_CLIENTS);
         return 1;
     }
     /* In uniform mode (no comma list) the leaf semantics are 1, 2, or 3;

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -45,6 +45,7 @@ SEED_MAX="${SEED_MAX:-15000}"
 ECON_MIN="${ECON_MIN:-500}"             # economy c2c amounts: small vs seeds so senders usually have the balance
 ECON_MAX="${ECON_MAX:-2500}"
 PAY_SETTLE_TRIES="${PAY_SETTLE_TRIES:-40}"
+PAY_POLL="${PAY_POLL:-0.5}"                # settle poll granularity; lower it for large N
 PAY_RECOVER="${PAY_RECOVER:-1}"
 PAY_GAP="${PAY_GAP:-1}"
 CLOSE_WAIT_SEC="${CLOSE_WAIT_SEC:-900}"
@@ -77,11 +78,17 @@ seed_amt(){ echo $(( SEED_MIN + RANDOM % (SEED_MAX - SEED_MIN + 1) )); }
 econ_amt(){ echo $(( ECON_MIN + RANDOM % (ECON_MAX - ECON_MIN + 1) )); }
 
 settle_wait(){  # wait for the "Payment complete" count to increase past $1
+    # PAY_POLL is the poll granularity.  It matters at scale: seeding is O(N)
+    # serialized payments, so every payment pays the average poll latency plus
+    # PAY_RECOVER.  At N=224 the defaults (0.5s poll + 1s recover) spend ~280s of
+    # the ~690s seed phase asleep while the protocol itself takes milliseconds.
+    # Defaults unchanged; large-N runs should lower both (PAY_POLL=0.1
+    # PAY_RECOVER=0.2 cuts the seed roughly 4x).
     local before="$1" now _w
     for _w in $(seq 1 "$PAY_SETTLE_TRIES"); do
         now=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); now=${now:-0}
         [ "$now" -gt "$before" ] && { sleep "$PAY_RECOVER"; return 0; }
-        sleep 0.5
+        sleep "$PAY_POLL"
     done
     sleep "$PAY_RECOVER"; return 1
 }

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -78,12 +78,24 @@ seed_amt(){ echo $(( SEED_MIN + RANDOM % (SEED_MAX - SEED_MIN + 1) )); }
 econ_amt(){ echo $(( ECON_MIN + RANDOM % (ECON_MAX - ECON_MIN + 1) )); }
 
 settle_wait(){  # wait for the "Payment complete" count to increase past $1
-    # PAY_POLL is the poll granularity.  It matters at scale: seeding is O(N)
-    # serialized payments, so every payment pays the average poll latency plus
-    # PAY_RECOVER.  At N=224 the defaults (0.5s poll + 1s recover) spend ~280s of
-    # the ~690s seed phase asleep while the protocol itself takes milliseconds.
-    # Defaults unchanged; large-N runs should lower both (PAY_POLL=0.1
-    # PAY_RECOVER=0.2 cuts the seed roughly 4x).
+    # PAY_POLL is the poll granularity -- ONE of THREE per-payment sleeps, and on
+    # its own the smallest of them.  Seeding is O(N) serialized, so each payment
+    # pays all three:
+    #     PAY_POLL    ~0.25s   avg latency to notice settle (0.5s granularity)
+    #     PAY_RECOVER  1.00s   unconditional, after settle is detected
+    #     PAY_GAP      1.00s   unconditional, in the seed loop itself
+    #     ---------------------
+    #                 ~2.25s   sleep, against ~0.8s of actual protocol work
+    # At N=224 that is ~504s of the ~690s seed asleep (73%).  An earlier version
+    # of this comment said ~280s and credited PAY_POLL+PAY_RECOVER only -- it
+    # omitted PAY_GAP, which is co-equal largest, so it pointed at the wrong
+    # knobs.  Lowering PAY_POLL alone buys ~1.1x; all three together
+    # (0.1 / 0.2 / 0.2) is ~2.4x.  Defaults unchanged -- they are what the green
+    # N=224 runs used, and this is test ergonomics, not a protocol limit.
+    # The real fix is not smaller sleeps but an event-driven wait: block on the
+    # log rather than re-grepping a file that grows all through the seed phase,
+    # and drop the two unconditional settles.  Worth doing only if seed
+    # wall-clock ever becomes the binding constraint.
     local before="$1" now _w
     for _w in $(seq 1 "$PAY_SETTLE_TRIES"); do
         now=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); now=${now:-0}

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -112,14 +112,25 @@ econ_amt(){ echo $(( ECON_MIN + RANDOM % (ECON_MAX - ECON_MIN + 1) )); }
 #     for this payment) rather than O(log) -- flat in N instead of quadratic.
 #
 # On the sleeps.  Each payment pays PAY_POLL (avg ~half the granularity) plus
-# PAY_RECOVER, and the seed/economy loops add PAY_GAP on top.  At the 0.5/1/1
-# defaults that is ~2.25s of sleep against ~0.8s of real protocol work -- ~504s
-# of the ~690s N=224 seed spent asleep.  PAY_RECOVER is padding for work that is
-# ALREADY DONE: src/lsp_demo.c prints the marker after persist_commit() and
-# fflush(), as the last statement of the payment, so the marker means settled AND
-# durable.  Defaults are unchanged (they are what the green N=224 runs used);
-# FAST=1 selects the event-driven values.  This is test ergonomics either way --
-# seed wall-clock is a harness artifact, not a protocol limit.
+# PAY_RECOVER, and the seed/economy loops add PAY_GAP on top -- ~2.25s at the
+# 0.5/1/1 defaults.  PAY_RECOVER is padding for work that is ALREADY DONE:
+# src/lsp_demo.c prints the marker after persist_commit() and fflush(), as the
+# payment's last statement, so the marker means settled AND durable.
+#
+# MEASURED -- regtest N=64, same freshly-built binary, back-to-back, 2026-07-28:
+#     defaults   seed 225s  (3.52 s/payment)   65-output close, reconcile perfect
+#     FAST=1     seed  85s  (1.33 s/payment)   65-output close, reconcile perfect
+# 2.65x on the seed phase.  2.19 s/payment removed against 2.25s of predicted
+# sleep, so the sleep model above is sound and the residual 1.33s is real
+# protocol work plus this script's own fork cost.  BOTH runs PASSED sat-for-sat:
+# all 64 client outputs equalled net LN flow, no skim.  Dropping the pads did NOT
+# expose a client-side revoke_and_ack race at this N -- that was the standing
+# risk in removing them, and it did not materialise.  (It is evidence at N=64,
+# not a proof for all N; re-check if the pads are dropped at much larger N.)
+#
+# Defaults stay as-is -- they are what the green N=224 runs used.  FAST=1 is the
+# validated setting for large N.  Either way this is test ergonomics: seed
+# wall-clock is a harness artifact, not a protocol limit.
 LOG_OFF=0
 
 # Block until $1 (fixed string) appears in LSP_LOG at/after LOG_OFF.

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -44,10 +44,27 @@ SEED_MIN="${SEED_MIN:-5000}"            # LN seed amounts: big enough that clien
 SEED_MAX="${SEED_MAX:-15000}"
 ECON_MIN="${ECON_MIN:-500}"             # economy c2c amounts: small vs seeds so senders usually have the balance
 ECON_MAX="${ECON_MAX:-2500}"
-PAY_SETTLE_TRIES="${PAY_SETTLE_TRIES:-40}"
+# FAST=1 selects the event-driven timings in one switch.  The settle marker is
+# emitted after persist_commit()+fflush() (see await_marker), so PAY_RECOVER and
+# PAY_GAP are pure padding; this is the intended setting for large N.  Set BEFORE
+# the defaults below so an explicit PAY_* in the environment still wins.
+if [ "${FAST:-0}" = 1 ]; then
+    : "${PAY_POLL:=0.05}"; : "${PAY_RECOVER:=0}"; : "${PAY_GAP:=0}"
+fi
+PAY_SETTLE_TRIES="${PAY_SETTLE_TRIES:-40}"  # superseded by PAY_TIMEOUT; kept for back-compat
 PAY_POLL="${PAY_POLL:-0.5}"                # settle poll granularity; lower it for large N
 PAY_RECOVER="${PAY_RECOVER:-1}"
 PAY_GAP="${PAY_GAP:-1}"
+# Wall-clock settle budget in SECONDS -- was PAY_SETTLE_TRIES x PAY_POLL, i.e.
+# 40 x 0.5 = 20s at the old defaults, which is what this preserves.
+#
+# Decoupling these two matters: in the old form the timeout was a PRODUCT of the
+# poll granularity, so "lower PAY_POLL for large N" -- the advice this file used
+# to give -- silently cut the timeout by the same factor (0.1 => 40 x 0.1 = 4s).
+# That turns a slow-but-healthy payment into a spurious failure, and it would
+# have bitten hardest at exactly the large N the advice was aimed at.  Detection
+# granularity and patience are now independent knobs.
+PAY_TIMEOUT="${PAY_TIMEOUT:-20}"
 CLOSE_WAIT_SEC="${CLOSE_WAIT_SEC:-900}"
 
 TAG="pct100_$$"
@@ -77,35 +94,64 @@ cli(){ printf '%s\n' "$1" >&3 2>/dev/null || true; }
 seed_amt(){ echo $(( SEED_MIN + RANDOM % (SEED_MAX - SEED_MIN + 1) )); }
 econ_amt(){ echo $(( ECON_MIN + RANDOM % (ECON_MAX - ECON_MIN + 1) )); }
 
-settle_wait(){  # wait for the "Payment complete" count to increase past $1
-    # PAY_POLL is the poll granularity -- ONE of THREE per-payment sleeps, and on
-    # its own the smallest of them.  Seeding is O(N) serialized, so each payment
-    # pays all three:
-    #     PAY_POLL    ~0.25s   avg latency to notice settle (0.5s granularity)
-    #     PAY_RECOVER  1.00s   unconditional, after settle is detected
-    #     PAY_GAP      1.00s   unconditional, in the seed loop itself
-    #     ---------------------
-    #                 ~2.25s   sleep, against ~0.8s of actual protocol work
-    # At N=224 that is ~504s of the ~690s seed asleep (73%).  An earlier version
-    # of this comment said ~280s and credited PAY_POLL+PAY_RECOVER only -- it
-    # omitted PAY_GAP, which is co-equal largest, so it pointed at the wrong
-    # knobs.  Lowering PAY_POLL alone buys ~1.1x; all three together
-    # (0.1 / 0.2 / 0.2) is ~2.4x.  Defaults unchanged -- they are what the green
-    # N=224 runs used, and this is test ergonomics, not a protocol limit.
-    # The real fix is not smaller sleeps but an event-driven wait: block on the
-    # log rather than re-grepping a file that grows all through the seed phase,
-    # and drop the two unconditional settles.  Worth doing only if seed
-    # wall-clock ever becomes the binding constraint.
-    local before="$1" now _w
-    for _w in $(seq 1 "$PAY_SETTLE_TRIES"); do
-        now=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); now=${now:-0}
-        [ "$now" -gt "$before" ] && { sleep "$PAY_RECOVER"; return 0; }
+# ---- settle detection --------------------------------------------------------
+# The LSP gives the harness no synchronous "payment done" reply, so we watch its
+# log for the settle marker.  Two things were wrong with doing that by counting:
+#
+#  1. WHICH payment.  The old settle_wait counted TOTAL "Payment complete" lines
+#     and waited for the count to rise.  That is only correct while exactly one
+#     payment is in flight -- it cannot tell WHOSE payment finished.  We now wait
+#     on the specific marker (the same string the seed retry pass at the bottom
+#     of SEED already greps), so a wait can never be satisfied by an unrelated
+#     payment, and concurrent seeding stays available as an option later.
+#
+#  2. HOW MUCH LOG.  The old version re-grepped the WHOLE log on every poll.  The
+#     log grows all through an N-client seed, so each successive wait re-read
+#     more of it: polling harder made the scan cost worse, exactly backwards.
+#     We keep a byte offset and scan only what is new, so a wait costs O(bytes
+#     for this payment) rather than O(log) -- flat in N instead of quadratic.
+#
+# On the sleeps.  Each payment pays PAY_POLL (avg ~half the granularity) plus
+# PAY_RECOVER, and the seed/economy loops add PAY_GAP on top.  At the 0.5/1/1
+# defaults that is ~2.25s of sleep against ~0.8s of real protocol work -- ~504s
+# of the ~690s N=224 seed spent asleep.  PAY_RECOVER is padding for work that is
+# ALREADY DONE: src/lsp_demo.c prints the marker after persist_commit() and
+# fflush(), as the last statement of the payment, so the marker means settled AND
+# durable.  Defaults are unchanged (they are what the green N=224 runs used);
+# FAST=1 selects the event-driven values.  This is test ergonomics either way --
+# seed wall-clock is a harness artifact, not a protocol limit.
+LOG_OFF=0
+
+# Block until $1 (fixed string) appears in LSP_LOG at/after LOG_OFF.
+# 0 = matched, 1 = timed out.
+#
+# On a NON-match the offset is deliberately left alone.  Advancing it would risk
+# stepping past a marker line that was still mid-write, losing it permanently;
+# not advancing costs only a re-scan of this one payment's output, which is
+# bounded and small.  The offset jumps forward only on a confirmed match.
+await_marker(){
+    local pat="$1" sz t_end
+    # SECONDS (bash builtin) rather than $(date +%s): the deadline is checked on
+    # every poll, and at PAY_POLL=0.05 a forked `date` per iteration doubles the
+    # per-poll process cost for nothing.  An idle poll now spawns only `stat`;
+    # the tail|grep pair runs solely when the file has actually grown.
+    t_end=$(( SECONDS + PAY_TIMEOUT ))
+    while :; do
+        sz=$(stat -c %s "$LSP_LOG" 2>/dev/null || echo 0); sz=${sz:-0}
+        if [ "$sz" -gt "$LOG_OFF" ] \
+           && tail -c "+$((LOG_OFF+1))" "$LSP_LOG" 2>/dev/null | grep -qaF "$pat"; then
+            LOG_OFF="$sz"
+            if [ "$PAY_RECOVER" != 0 ]; then sleep "$PAY_RECOVER"; fi
+            return 0
+        fi
+        [ "$SECONDS" -ge "$t_end" ] && break
         sleep "$PAY_POLL"
     done
-    sleep "$PAY_RECOVER"; return 1
+    if [ "$PAY_RECOVER" != 0 ]; then sleep "$PAY_RECOVER"; fi
+    return 1
 }
-lsppay_cli(){ local b; b=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); cli "lsppay $1 $2"; settle_wait "${b:-0}"; }
-pay_cli(){    local b; b=$(grep -ac "Payment complete" "$LSP_LOG" 2>/dev/null); cli "pay $1 $2 $3"; settle_wait "${b:-0}"; }
+lsppay_cli(){ cli "lsppay $1 $2";  await_marker "Payment complete: LSP -> client $1 ("; }
+pay_cli(){    cli "pay $1 $2 $3";  await_marker "Payment complete: client $1 -> client $2 ("; }
 
 # ---- preflight ----
 [ -x "$LSP_BIN" ] && [ -x "$CLIENT_BIN" ] || die "binaries not found in $BUILD_DIR"


### PR DESCRIPTION
**Design proposal — nothing implemented.** Filed as a PR-doc per the repo convention (design lives in `docs/` + PRs, not Issues).

## The gap this closes

We can settle **1024-of-1024 on real signet** and drive **10,000 clients in one process** — but the *distributed* protocol (separate instances, real sockets, Noise, wire) has never run above **N=127**. Not a cryptography limit and not a tx-size limit: **N=512 daemons don't fit in RAM.**

Today's LSP startup crash reaching `main` (fixed in #452) is what that gap costs — the unit suite never runs daemon `main()`, and the in-process harness bypasses sockets, so a crash in the primary binary went unnoticed by every gate.

## Root cause (measured, not estimated)

Every client rebuilds **and retains** the entire tree (`src/client.c:1112`). With `sizeof(factory_node_t) = 23,816 B`:

| N | nodes | per client | swarm |
|---|---|---|---|
| 127 | ~506 | 11.5 MB | ~1.5 GB (fits — why 127 works) |
| 512 | 2,046 | 46.5 MB | **~28 GB** |
| 1024 | 4,090 | 92.9 MB | **~100 GB** |

O(N) per client ⇒ **O(N²) for the swarm**.

## Fix

A client needs only its **root→leaf path + each level's sibling SPKs/amounts** to verify its payout and exit unilaterally — **0.25 MB instead of 46.5 MB at N=512 (~186×)**. Since the client *builds* the tree rather than receiving it, this is contained in `build_subtree`: **no wire-protocol change.** It's a product win first — a phone wallet shouldn't carry tens of MB of strangers' subtrees.

Plus: right-size the 256-slot nonce pool (67.6 KB of the 86.7 KB `channel_t`) and make the fixed `[16][256] input_signer_indices` lazy (16 KB of every 23.8 KB node, unused for default k=1 PS).

**Result:** path-only + process ≈ 2.5–4 GB at N=512; path-only + thread ≈ 0.3 GB.

## Threading is mechanical, not a rewrite

Mutable file-scope state on the whole client path: **9 variables** (`client.c` 3, `wire.c` 6, everything else **0**), all simple scalars. `_Thread_local` or a context struct covers it.

## Four-tier ladder

| tier | N=512 cost | buys |
|---|---|---|
| T1 in-process *(exists)* | 181 MB | protocol, crypto, settlement |
| **T2 threads + real sockets** | ~0.3 GB | wire codec, ceremony interleaving, reconnection, **daemon startup** |
| T3 real processes | ~2.5–4 GB | OS isolation, crash/restart, fd limits |
| T4 rolling participation | ~0.3 GB at **any** N | real distributed ceremony at 1024+ |

T2 is the best realism-per-byte and would have caught today's crash.

## Phases

P0 baseline RSS → **P1 lean client** (load-bearing) → P2 T2 swarm at 512 → P3 T3 + signet → **P4 liveness curve** → P5 1024 via T4. Each independently mergeable, each with acceptance criteria.

## Risks stated up front

- **Path-only must not weaken tree verification** — P1 is gated on the bad-tree-refusal test plus an adversarial "valid path inside invalid tree" case.
- **Thread-shared state is a new false-negative class** — T2 findings confirmed on T3 before being called proven.
- **Neither tier models the network** (no latency/loss/partition).
- **The real ceiling is protocol, not harness.** A 24 h soak at N=127 lost 30/127 daemons and N-of-N close needs all of them. Scaling the test confirms it worsens; it can't fix it. P4 quantifies it; remedies are separate work (incl. #449 multi-tx close).