### PR TITLE
scale: dynamic per-client state + poll() — groundwork for N=512/1024 real daemons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,15 @@ jobs:
         env:
           # ASan: leaks fail the job (exitcode=23). Suppressions in test/sanitizer_suppressions/lsan.supp.
           # TSan: data races fail the job (halt_on_error=1). Suppressions in test/sanitizer_suppressions/tsan.supp.
+          # Suppressions paths MUST be absolute.  The test step below does
+          # `cd build`, and the sanitizers resolve a relative suppressions path
+          # against the process cwd -- so `test/sanitizer_suppressions/...`
+          # became `build/test/sanitizer_suppressions/...`, which does not
+          # exist.  LSan then aborted with "failed to read suppressions file"
+          # and exited 23, failing the job AFTER every test had already passed.
           ASAN_OPTIONS: ${{ matrix.sanitizers && 'detect_leaks=1' || 'detect_leaks=0' }}
-          LSAN_OPTIONS: ${{ matrix.sanitizers && 'exitcode=23:suppressions=test/sanitizer_suppressions/lsan.supp:print_suppressions=0' || '' }}
-          TSAN_OPTIONS: ${{ matrix.tsan && 'halt_on_error=1:second_deadlock_stack=1:suppressions=test/sanitizer_suppressions/tsan.supp:print_suppressions=0' || '' }}
+          LSAN_OPTIONS: ${{ matrix.sanitizers && format('exitcode=23:suppressions={0}/test/sanitizer_suppressions/lsan.supp:print_suppressions=0', github.workspace) || '' }}
+          TSAN_OPTIONS: ${{ matrix.tsan && format('halt_on_error=1:second_deadlock_stack=1:suppressions={0}/test/sanitizer_suppressions/tsan.supp:print_suppressions=0', github.workspace) || '' }}
         run: |
           ulimit -s unlimited 2>/dev/null || ulimit -s 65520 2>/dev/null || true
           cd build && ./test_superscalar --unit
@@ -265,7 +271,7 @@ jobs:
           # which preloads libstdbuf.so via LD_PRELOAD before the ASan
           # runtime — without the override ASan aborts at libinit.
           ASAN_OPTIONS: detect_leaks=1:abort_on_error=0:verify_asan_link_order=0
-          LSAN_OPTIONS: exitcode=23:suppressions=test/sanitizer_suppressions/lsan.supp:print_suppressions=0
+          LSAN_OPTIONS: exitcode=23:suppressions=${{ github.workspace }}/test/sanitizer_suppressions/lsan.supp:print_suppressions=0
           REGTEST_CONF: /home/runner/.bitcoin/bitcoin.conf
         run: |
           ulimit -s unlimited 2>/dev/null || ulimit -s 65520 2>/dev/null || true
@@ -278,7 +284,7 @@ jobs:
       - name: Multi-process k² sub-factory BREACH (under ASan+LSan)
         env:
           ASAN_OPTIONS: detect_leaks=1:abort_on_error=0:verify_asan_link_order=0
-          LSAN_OPTIONS: exitcode=23:suppressions=test/sanitizer_suppressions/lsan.supp:print_suppressions=0
+          LSAN_OPTIONS: exitcode=23:suppressions=${{ github.workspace }}/test/sanitizer_suppressions/lsan.supp:print_suppressions=0
           REGTEST_CONF: /home/runner/.bitcoin/bitcoin.conf
         run: |
           ulimit -s unlimited 2>/dev/null || ulimit -s 65520 2>/dev/null || true
@@ -289,7 +295,7 @@ jobs:
           # which preloads libstdbuf.so via LD_PRELOAD before the ASan
           # runtime — without the override ASan aborts at libinit.
           ASAN_OPTIONS: detect_leaks=1:abort_on_error=0:verify_asan_link_order=0
-          LSAN_OPTIONS: exitcode=23:suppressions=test/sanitizer_suppressions/lsan.supp:print_suppressions=0
+          LSAN_OPTIONS: exitcode=23:suppressions=${{ github.workspace }}/test/sanitizer_suppressions/lsan.supp:print_suppressions=0
           REGTEST_CONF: /home/runner/.bitcoin/bitcoin.conf
         run: |
           ulimit -s unlimited 2>/dev/null || ulimit -s 65520 2>/dev/null || true
@@ -303,7 +309,7 @@ jobs:
       - name: Multi-process distribution co-signed-path regression (under ASan+LSan)
         env:
           ASAN_OPTIONS: detect_leaks=1:abort_on_error=0:verify_asan_link_order=0
-          LSAN_OPTIONS: exitcode=23:suppressions=test/sanitizer_suppressions/lsan.supp:print_suppressions=0
+          LSAN_OPTIONS: exitcode=23:suppressions=${{ github.workspace }}/test/sanitizer_suppressions/lsan.supp:print_suppressions=0
           REGTEST_CONF: /home/runner/.bitcoin/bitcoin.conf
         run: |
           ulimit -s unlimited 2>/dev/null || ulimit -s 65520 2>/dev/null || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,3 +529,14 @@ add_executable(test_inproc_factory_lifecycle tools/test_inproc_factory_lifecycle
 target_include_directories(test_inproc_factory_lifecycle PRIVATE ${secp256k1-zkp_SOURCE_DIR}/include)
 target_include_directories(test_inproc_factory_lifecycle PRIVATE ${cjson_SOURCE_DIR})
 target_link_libraries(test_inproc_factory_lifecycle PRIVATE superscalar superscalar_secrets project_warnings)
+# Every other executable here links project_sanitizers under ENABLE_SANITIZERS;
+# this target was added without it, so the sanitizer CI job compiled its deps
+# with -fsanitize=undefined and then linked without the runtime:
+#     undefined reference to `__ubsan_handle_*'   (build/_deps/cjson-src/cJSON.c)
+#     collect2: error: ld returned 1 exit status
+# That is a LINK failure ~40s in, so the sanitizer job never ran a single test --
+# and because it is a build-config fault it reproduces on any branch, which is
+# why a PR adding only shell scripts was also red.
+if(ENABLE_SANITIZERS)
+    target_link_libraries(test_inproc_factory_lifecycle PRIVATE project_sanitizers)
+endif()

--- a/docs/design/sparse-nonce-matrix.md
+++ b/docs/design/sparse-nonce-matrix.md
@@ -1,0 +1,173 @@
+# Sparse nonce matrix for `MSG_FACTORY_LSP_RESPONSE` (0x87)
+
+Status: designed, not yet implemented. Tracked as internal task #131.
+
+## Problem
+
+The factory-creation ceremony forwards every signer's per-node pubnonce to
+every client so each can build the aggnonce for the multi-signer nodes it
+signs. Today that ships as a **dense** matrix: `n_nodes x n_participants`
+cells of 66 bytes, hex-encoded into one flat string under
+`all_signer_pubnonces` (`src/lsp.c:659-666`, `src/wire.c:1783`).
+
+Almost all of it is zeros. A node's signer set is its subtree's clients plus
+the LSP (`src/factory.c:1676-1680`), so a node at depth d has far fewer than
+`n_participants` signers. Only slots `[0, n_signers)` of each row are ever
+written; the rest are `calloc` zeros that are serialized, hex-encoded,
+AEAD-encrypted, transmitted, parsed and decoded — and never read.
+
+Measured density on the default PS shape (`--arity 3`):
+
+| clients | n_nodes | dense cells | used cells | density |
+|---|---|---|---|---|
+| 128 | 510 | 65,790 | 2,558 | 3.89% |
+| 300 | 1,198 | 360,598 | 6,774 | **1.88%** |
+| 512 | 2,046 | 1,049,598 | 12,286 | 1.17% |
+
+**98% of what we transmit at N=300 is padding.**
+
+### This is a correctness wall, not just a slow path
+
+The dense message breaches `WIRE_MAX_FRAME_SIZE` (16 MB,
+`include/superscalar/wire.h:229`):
+
+- default PS shape: over the cap at **N ~ 178**
+- our harness shape (`ARITY=2,4,8`, `--static-near-root 2`): 5.84 MB/client at
+  N=300 and 9.95 MB at N=512 — fits — but at N=1024 the tree gains a level
+  (64 leaves x capacity 8 = 512 clients max), `n_nodes` jumps 147 -> 1171 and
+  the message becomes **~158 MB**.
+
+So **N=1024 is unreachable without this change.** N=512 is reachable without
+it.
+
+Until this lands, `wire_send` and `wire_send_many` refuse oversize frames with
+a clear error naming the message type and size, instead of writing a frame the
+peer rejects as malformed (commit `d51ce6a`).
+
+## What a client actually needs — verified
+
+A client reads a nonce cell at exactly one site, `src/client.c:1815`, and the
+loop around it is bounded twice over:
+
+- `src/client.c:1794` — `if (my_slot[nidx] < 0) continue;` skips every node the
+  client does not sign
+- `src/client.c:1811` — `size_t ns = factory->nodes[nidx].n_signers;` bounds the
+  slot loop by the node's own signer count, not `n_participants`
+
+MuSig agrees: `musig_session_set_pubnonce` rejects `slot >= n_signers`
+(`src/musig.c:312`) and `musig_session_finalize_nonces` requires exactly
+`n_signers` collected (`src/musig.c:330`).
+
+Nothing else needs the matrix. Tree verification is nonce-free — the client
+rebuilds the tree and Schnorr-verifies each `signed_tx` against
+`node->tweaked_pubkey` (`src/factory.c:2345-2367`). The LSP's per-node partial
+sigs are explicitly discarded client-side (`(void)lsp_psig_per_node;`,
+`src/client.c:1787`), and `musig_verify_partial_sig` is never called on the
+factory path at all (only `src/channel.c:1664`).
+
+## Two candidate layouts
+
+**A. Per-client path slice.** Send each client only the rows for nodes on its
+own root->leaf path. Smallest possible payload (~117 kB/client at N=300), but
+the plaintext differs per client, so it gives up `wire_send_many`'s
+serialize-once optimization (`src/wire.c:409-424`) and needs N cJSON builds
+and N prints.
+
+**B. Global sparse blob.** Send all nodes but only `n_signers` slots each,
+same bytes to everyone. Larger per client (~1.08 MiB at N=300) but identical
+for all peers, so `wire_send_many` still prints once and only the AEAD is
+per-peer.
+
+### Decision: B
+
+Measured LSP-side cost at N=300 (crypto-profiling agent, Release build):
+
+| | build | print | AEAD x300 | LSP total |
+|---|---|---|---|---|
+| dense (today) | 137.4 ms | 96.7 ms | 16.7 s | **27.4 s** |
+| B, global sparse | 1.10 ms | 2.00 ms | ~180 ms | **~0.18 s** |
+| A, per-client path | ~N x 0.3 ms | — | ~21 ms | ~0.11 s |
+
+A is ~70 ms better than B out of a 27.4 s starting point. That is not worth
+the extra machinery: B keeps the broadcast path intact, mirrors a pattern
+already proven in this repo, and is a far smaller diff.
+
+B also clears the frame cap with room to spare — the blob is `sum(n_signers)`
+cells, which grows about `N x depth`, not `N^2`. At N=512 that is ~12.3k cells
+= 1.62 MiB hex against a 16 MB cap.
+
+## Format
+
+Precedent: the Tier-B state-advance ceremony **already does exactly this** —
+variable stride, prefix offsets recomputed independently on both sides
+(`src/lsp_channels.c:2546-2561` builds it, `src/client.c:4823-4828` reads it),
+with a strict total-length assert at `src/client.c:4852`. Factory creation is
+the outlier still using a fixed stride.
+
+Layout: iterate `nidx = 0 .. n_nodes-1` ascending; append each node's
+`n_signers x 66` bytes, slots ascending. Both sides derive:
+
+```
+offset[j] = sum over i<j of n_signers(i)      /* one O(n_nodes) pass */
+cell(node j, slot s) = blob + (offset[j] + s) * 66
+```
+
+Field name changes to `sparse_signer_pubnonces` so the layout is explicit
+rather than inferred from a length, with the dense `all_signer_pubnonces` still
+parsed on receive during the transition.
+
+### Do NOT sparsify
+
+- **`all_dist_pubnonces`** — a separate field (`src/lsp.c:839-840`), not part of
+  the matrix. The distribution TX is one root-level N-of-N session and the
+  client consumes every slot (`src/client.c:1766`). Irreducibly `66*(N+1)`.
+- **`dist_client_amounts`** — the client rebuilds the identical dist TX from
+  every client's amount (`src/client.c:1755`).
+
+## Compatibility
+
+Old client + new LSP: `have_matrix` length-inference fails
+(`src/client.c:1789`), co-signer nonces never get set, and the ceremony dies
+loudly at `factory_session_finalize_node` (`nonces_collected != n_signers`).
+Not silent corruption, but a hard break — so the new client must accept both
+layouts, keyed on which field is present.
+
+No persistence impact: creation persists only the ceremony row and participant
+phases (`src/lsp.c:411`, `:588`, `:1025`). No nonce matrix is stored, so no
+schema migration.
+
+A capability hook already exists if staged rollout is wanted — `HELLO` carries
+feature booleans (`src/wire.c:676`) parsed at `src/lsp.c:250-253`.
+
+## Risk
+
+Packed offsets make both sides depend on agreeing about every node's
+`n_signers`, where the dense layout only depended on `n_participants`. A tree
+mismatch therefore yields garbage nonces rather than a later mismatch. The
+failure is still safe — bad partial sigs are caught by the LSP's ceremony-time
+`factory_verify_all`, which triggers the bounded `SS_NONCE_RETRY_MAX` retry and
+then aborts, broadcasting nothing — but it would present as flakiness. Mitigate
+with the exact total-length assert, as Tier B does.
+
+## Call sites
+
+- LSP `src/lsp.c` (all in `lsp_run_factory_creation_stateless`): `:659` stride,
+  `:666`/`:668` alloc + dist row, `:705`/`:761` dist writes, `:725`/`:780`
+  nonce writes, `:829-831` response build, `:860-884` broadcast
+- Codec `src/wire.c:1762-1824`, `include/superscalar/wire.h:659-670`
+- Client `src/client.c`: `:1675-1687` alloc/parse, `:1789` `have_matrix`,
+  `:1810-1826` the read
+
+Rotation shares this message (`lsp_rotation.c:988` -> `lsp.c:1053` ->
+`lsp_run_factory_creation_stateless`), so it must be re-tested too.
+
+There is **no codec unit test** for `wire_build/parse_factory_lsp_response`
+today. Add one covering both layouts and the length assert.
+
+## Not fixed by this
+
+Every client calls `factory_build_tree()` (`src/client.c:1112`, `:2338`) and so
+derives every node's aggregate key — ~380 ms at N=300, about 75% of it in
+`musig_aggregate_keys`, times N clients. That is inherent to the trust model
+(the client must independently derive what it signs), so reducing it means
+path-only verification, which is a design change and not this change.

--- a/include/superscalar/ceremony.h
+++ b/include/superscalar/ceremony.h
@@ -24,17 +24,41 @@ typedef enum {
     CLIENT_ERROR,
 } client_ceremony_state_t;
 
+/* Ceremonies with <= this many clients use the inline buffer: no heap, safe on
+   an uninitialized stack ceremony_t, and nothing to free.  Unit tests all sit
+   below it; real ceremonies take the heap path. */
+#define CEREMONY_SMALL 8
+
 typedef struct {
     ceremony_state_t state;
-    client_ceremony_state_t clients[FACTORY_MAX_SIGNERS];
+    /* Points at clients_small or heap.  SELF-REFERENTIAL in the small case, so a
+       ceremony_t must never be copied by value.
+       Was client_ceremony_state_t[FACTORY_MAX_SIGNERS].  The fixed array was an
+       overread waiting to happen: ceremony_init clamped only the WRITE loop
+       (`i < n_clients && i < FACTORY_MAX_SIGNERS`) while setting n_clients to the
+       untruncated count, so every later query -- ceremony_count_in_state,
+       ceremony_has_quorum, ceremony_get_active_clients -- loops to n_clients and
+       reads past the end once n_clients > 256.  Clamping the write made it look
+       guarded while leaving the reads unbounded. */
+    client_ceremony_state_t *clients;
+    size_t clients_cap;
+    client_ceremony_state_t clients_small[CEREMONY_SMALL];
     size_t n_clients;
     int per_client_timeout_sec;  /* per-client response deadline (seconds) */
     int min_clients;             /* minimum for viable factory (default: 2) */
 } ceremony_t;
 
-/* Initialize ceremony for n_clients with given timeout and minimum. */
-void ceremony_init(ceremony_t *c, size_t n_clients,
-                   int per_client_timeout_sec, int min_clients);
+/* Initialize ceremony for n_clients.  1 on success, 0 if the per-client array
+   could not be allocated (ceremony left valid but empty, so every accessor is
+   still safe).  Was void; ignoring the result still compiles.
+   TREATS *c AS UNINITIALIZED -- callers pass stack ceremony_t.  Call
+   ceremony_free() before re-initializing an existing one. */
+int ceremony_init(ceremony_t *c, size_t n_clients,
+                  int per_client_timeout_sec, int min_clients);
+
+/* Release the per-client array.  Safe on a zeroed ceremony, safe twice, no-op
+   for ceremonies that fit the inline buffer. */
+void ceremony_free(ceremony_t *c);
 
 /* Parallel select: wait for any of the given fds to become readable.
    client_fds[n_clients], timeout in seconds.

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -297,7 +297,7 @@ typedef struct {
        Length equals ps_n_prev_outputs (= n_inputs).  Only used by
        advanced PS sub-factory nodes per #207. */
     musig_signing_session_t *input_signing_sessions;        /* length n_input_sessions */
-    secp256k1_musig_partial_sig *input_partial_sigs;        /* length n_input_sessions * FACTORY_MAX_SIGNERS */
+    secp256k1_musig_partial_sig *input_partial_sigs;        /* length n_input_sessions * input_signers_stride */
     int input_partial_sigs_received[FACTORY_MAX_OUTPUTS];   /* per-input count */
     size_t n_input_sessions;
 

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -34,6 +34,22 @@
  * deployment is RAM-bound, and shrinking factory_t (dynamic leaf_layers) is a
  * worthwhile follow-up. */
 #define FACTORY_MAX_SIGNERS 256
+
+/* Absolute ceiling on participants in ONE factory, for validating counts that
+   arrive over the wire.
+ *
+ * FACTORY_MAX_SIGNERS is a DEFAULT (what factory_config_fit starts from and
+ * grows past); this is a HARD sanity bound.  The distinction matters because a
+ * client sizes buffers from the participant count in the LSP's HELLO_ACK, which
+ * is peer-supplied: without a ceiling a malicious LSP could name a huge count
+ * and make the client allocate arbitrarily.  Validate wire-supplied counts
+ * against THIS, never against a buffer size, and never let a wire value size a
+ * stack allocation.
+ *
+ * 4096 is far above any realistic factory (the DW tree and the close TX both
+ * become impractical long before it) while keeping the worst-case client
+ * allocation bounded and small. */
+#define SS_MAX_PARTICIPANTS 4096
 /* FACTORY_MAX_LEAVES: one channel (leaf) per client, so this bounds the client
  * count.  Raised 128 -> 256 to support up to 255-client factories.  Cost:
  * leaf_layers[FACTORY_MAX_LEAVES] is embedded in factory_t, so this enlarges

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -288,7 +288,23 @@ typedef struct {
        for input k.  These arrays are allocated by ensure_input_sessions_alloc
        alongside input_signing_sessions and parallel-indexed by input_idx. */
     musig_keyagg_t   *input_keyaggs;          /* length n_input_sessions */
-    uint32_t          input_signer_indices[FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS];
+
+    /* Per-input signer sets.  WAS a fixed
+       [FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS] = 16 x 256 x 4 = 16 KB carried
+       by EVERY node, whether or not that node had any input sessions at all --
+       and only multi-input PS sub-factory chain-advance nodes ever use it.
+       Since nodes[] is sized to the participant count, that made this single
+       field the dominant per-client cost: at N=224 it was 960 nodes x 16 KB =
+       15.7 MB, essentially the entire measured 15.9 MB client footprint, and it
+       is what made a co-located swarm scale as O(N^2).
+       Now allocated only for nodes that actually have input sessions, sized to
+       that node's own signer count, in ensure_input_sessions_alloc next to the
+       siblings above (which were already dynamic -- this one was simply never
+       converted with them).
+       Index it via factory_node_input_signers(node, input_idx)[j]; never with
+       [i][j], and never sizeof() it -- it is a pointer now. */
+    uint32_t         *input_signer_indices;   /* n_input_sessions * input_signers_stride */
+    size_t            input_signers_stride;   /* = n_signers at alloc time */
     size_t            input_n_signers[FACTORY_MAX_OUTPUTS];
     unsigned char     input_merkle_root[FACTORY_MAX_OUTPUTS][32];
     int               input_has_merkle_root[FACTORY_MAX_OUTPUTS];
@@ -319,6 +335,21 @@ typedef struct {
        (nsequence == 0xFFFFFFFE, no BIP-68 CSV). */
     int is_static_only;
 } factory_node_t;
+
+/* Signer set for one input of a multi-input chain advance.
+   Returns NULL when the node has no input sessions allocated (the common case --
+   only PS sub-factory chain-advance nodes do), so callers must NULL-check.
+   Valid entries are [0, node->input_n_signers[input_idx]). */
+static inline uint32_t *factory_node_input_signers(factory_node_t *node,
+                                                     size_t input_idx) {
+    if (!node || !node->input_signer_indices) return NULL;
+    return node->input_signer_indices + input_idx * node->input_signers_stride;
+}
+static inline const uint32_t *factory_node_input_signers_const(
+        const factory_node_t *node, size_t input_idx) {
+    if (!node || !node->input_signer_indices) return NULL;
+    return node->input_signer_indices + input_idx * node->input_signers_stride;
+}
 
 typedef struct {
     secp256k1_context *ctx;

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -50,6 +50,13 @@
  * become impractical long before it) while keeping the worst-case client
  * allocation bounded and small. */
 #define SS_MAX_PARTICIPANTS 4096
+
+/* Hard ceiling on a peer-supplied NODE index, the tree-shaped counterpart to
+   SS_MAX_PARTICIPANTS.  The DW tree carries roughly 4N nodes (a kickoff and a
+   state node per level), so this bounds the shape SS_MAX_PARTICIPANTS implies
+   with headroom.  Like SS_MAX_PARTICIPANTS this is a validation ceiling for
+   untrusted input, NOT an allocation size -- f->nodes grows on demand. */
+#define SS_MAX_NODE_INDEX (4 * SS_MAX_PARTICIPANTS + 64)
 /* FACTORY_MAX_LEAVES: one channel (leaf) per client, so this bounds the client
  * count.  Raised 128 -> 256 to support up to 255-client factories.  Cost:
  * leaf_layers[FACTORY_MAX_LEAVES] is embedded in factory_t, so this enlarges

--- a/include/superscalar/factory.h
+++ b/include/superscalar/factory.h
@@ -12,6 +12,10 @@
 #include <secp256k1_extrakeys.h>
 
 #define FACTORY_MAX_NODES   512
+/* Initial nodes[] capacity; factory_grow_nodes() doubles from here up to
+   config.max_nodes.  Small on purpose: the point of growing on demand is that a
+   factory costs what its own tree costs, not what the worst-case config would. */
+#define FACTORY_NODES_INITIAL 32
 /* FACTORY_MAX_OUTPUTS: max outputs per tree node. Sized for arity-15 leaves
  * (15 client channels + 1 L-stock = 16 outputs) under the upcoming N-way
  * mixed-arity work (Phase 2 of mixed-arity implementation plan). Internal
@@ -369,6 +373,17 @@ typedef struct {
                                 (a 255-client PS factory needs ~1018 nodes) without
                                 bloating every factory_t. */
     size_t n_nodes;
+    /* Entries currently ALLOCATED in nodes[] / node_l_stock_hashes[] /
+       node_l_stock_hash_valid[] -- the three are parallel and grow together.
+       add_node() grows them geometrically and config.max_nodes is the hard cap.
+       Previously all three were allocated at config.max_nodes up front, which
+       factory_config_fit sets to 4N+64.  That is NOT an over-estimate in
+       general -- PS-uniform and ARITY_1 really do build 3.98 nodes per
+       participant, so the constant cannot simply be lowered -- but the common
+       PS + level-arity configuration plateaus around 150 nodes, so at N=1024 it
+       reserved ~31 MB of factory_node_t per client to use ~1 MB.  Growing on
+       demand sizes each factory to the tree its own config actually builds. */
+    size_t nodes_cap;
 
     /* Funding UTXO */
     unsigned char funding_txid[32];  /* internal byte order */
@@ -764,6 +779,12 @@ void factory_set_funding(factory_t *f,
                          const unsigned char *txid, uint32_t vout,
                          uint64_t amount_sats,
                          const unsigned char *spk, size_t spk_len);
+
+/* Grow nodes[] and its two parallel node-indexed arrays to hold `want` entries.
+   1 on success, 0 on OOM or when `want` exceeds config.max_nodes.
+   INVALIDATES any factory_node_t* the caller is holding -- index via
+   f->nodes[i] across calls that may add nodes. */
+int factory_grow_nodes(factory_t *f, size_t want);
 
 int factory_build_tree(factory_t *f);
 int factory_sign_all(factory_t *f);

--- a/include/superscalar/ladder.h
+++ b/include/superscalar/ladder.h
@@ -7,6 +7,23 @@
 
 #define LADDER_MAX_FACTORIES 8  /* demo: 3-4 overlapping is sufficient */
 
+/* Participant capacity of the per-client turnover arrays below.
+ *
+ * This is a REAL cap on the PTLC ladder, unlike FACTORY_MAX_SIGNERS elsewhere
+ * in the tree, which is now only a default.  client_departed[] and
+ * extracted_keys[] are fixed members of ladder_factory_t, which is itself a
+ * fixed member of ladder_t, and both are indexed by factory n_participants --
+ * so ladder_add_factory MUST refuse anything larger or those writes run off
+ * the end of the struct.  The refusal and the array bound are expressed with
+ * this one constant precisely so they cannot drift apart.
+ *
+ * Lifting it means converting both members to pointers with an owning
+ * alloc/free on ladder_factory_t.  Not done here: the assisted-exit PTLC flow
+ * that drives client turnover is built but not yet originated, so the ladder
+ * caps out well below the sizes the rest of the stack now supports.  A factory
+ * larger than this simply does not get a ladder entry; nothing truncates. */
+#define LADDER_MAX_PARTICIPANTS FACTORY_MAX_SIGNERS
+
 typedef struct {
     factory_t factory;
     uint32_t factory_id;           /* sequential: 0, 1, 2, ... */
@@ -16,8 +33,8 @@ typedef struct {
     tx_buf_t distribution_tx;      /* pre-signed nLockTime fallback */
 
     /* Per-client key turnover state */
-    int client_departed[FACTORY_MAX_SIGNERS];     /* 1 if PTLC complete */
-    unsigned char extracted_keys[FACTORY_MAX_SIGNERS][32]; /* revealed scalars */
+    int client_departed[LADDER_MAX_PARTICIPANTS];     /* 1 if PTLC complete */
+    unsigned char extracted_keys[LADDER_MAX_PARTICIPANTS][32]; /* revealed scalars */
     size_t n_departed;
 
     int partial_rotation_done;   /* 1 = old factory retired via partial rotation */

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -106,7 +106,29 @@ typedef struct {
      * follow in Phase 1b.2.  See docs/watchtower-trustless-schema.md
      * for the trust model. */
     persist_wt_t *wt_db;
+
+    /* Ceremony scratch, sized to expected_clients+1 by lsp_ensure_scratch() and
+       released in lsp_cleanup().
+       These were fixed [FACTORY_MAX_SIGNERS] STACK arrays, which is what capped
+       the daemon at 255 clients: at n_participants = 257 they overflow, and
+       lifting the --clients guard without converting them produced
+       `*** stack smashing detected ***`, not a clean refusal (ASan named
+       src/lsp.c:238 'seen' as the first to go).
+       They live on the struct rather than as heap locals because the functions
+       using them have several early returns; a local would need a free() on
+       every one, which is where leaks and double-frees get introduced. One
+       allocation, one free, no per-return bookkeeping.
+       Capacity is +1 because 'seen' is indexed by SLOT (1..n_clients), not by
+       client index, and pubkeys carries the LSP at [0]. */
+    int              *scratch_slot_hints;  /* [scratch_cap] by client index */
+    int              *scratch_seen;        /* [scratch_cap] by slot number */
+    secp256k1_pubkey *scratch_pubkeys;     /* [scratch_cap]: LSP then clients */
+    size_t            scratch_cap;
 } lsp_t;
+
+/* Ensure the ceremony scratch holds `want` entries. 1 on success, 0 on OOM.
+   Idempotent and safe on a zeroed lsp_t; grows, never shrinks. */
+int lsp_ensure_scratch(lsp_t *lsp, size_t want);
 
 /* Initialize LSP state. Returns 1 on success, 0 on failure. */
 int lsp_init(lsp_t *lsp, secp256k1_context *ctx,

--- a/include/superscalar/lsp.h
+++ b/include/superscalar/lsp.h
@@ -123,6 +123,11 @@ typedef struct {
     int              *scratch_slot_hints;  /* [scratch_cap] by client index */
     int              *scratch_seen;        /* [scratch_cap] by slot number */
     secp256k1_pubkey *scratch_pubkeys;     /* [scratch_cap]: LSP then clients */
+    /* Save/restore buffer for factory.profiles across the stateless-creation
+       re-init.  Was participant_profile_t[FACTORY_MAX_SIGNERS] on the stack and
+       copied with sizeof(the array) -- as a pointer that would silently become
+       sizeof(void*), so the two memcpys now carry explicit element counts. */
+    participant_profile_t *scratch_profiles; /* [scratch_cap] */
     size_t            scratch_cap;
 } lsp_t;
 

--- a/include/superscalar/readiness.h
+++ b/include/superscalar/readiness.h
@@ -23,16 +23,50 @@ typedef struct {
  * readiness_all_ready could report true with 63 clients still not ready),
  * and the entries are the source of truth anyway — every query derives
  * from them directly. */
+/* Trackers with <= this many clients use the inline buffer: no heap, safe on an
+   uninitialized stack tracker, and nothing to free.  The unit tests all run at
+   n_clients=4 and so never touch the allocator; real daemons run far above this
+   and take the heap path. */
+#define READINESS_SMALL 8
+
 typedef struct {
-    readiness_entry_t clients[FACTORY_MAX_SIGNERS];
+    /* Points at clients_small (n_clients <= READINESS_SMALL) or at heap.
+       SELF-REFERENTIAL in the small case, so a readiness_tracker_t must never
+       be copied or moved by value -- the copy's pointer would still address the
+       original's inline buffer.  (factory_t had exactly this bug.)  Every user
+       today holds it by pointer, and ->clients is private to readiness.c. */
+    readiness_entry_t *clients;
+    size_t   clients_cap;
+    readiness_entry_t clients_small[READINESS_SMALL];
     size_t   n_clients;
     uint32_t factory_id;
     persist_t *db;              /* may be NULL */
 } readiness_tracker_t;
 
-/* Initialize tracker. Zeros all state. db may be NULL. */
-void readiness_init(readiness_tracker_t *rt, uint32_t factory_id,
-                    size_t n_clients, persist_t *db);
+/* Initialize tracker for n_clients.  db may be NULL.  Returns 1 on success,
+   0 if the per-client array could not be allocated (tracker is left valid but
+   empty, so every accessor is still safe to call).
+   Was void; ignoring the result still compiles.
+
+   TREATS *rt AS UNINITIALIZED MEMORY.  It must not read any pre-existing field,
+   because callers legitimately declare a readiness_tracker_t on the stack and
+   call this on it first thing (the unit tests do exactly that).  Consequence:
+   calling init on a tracker that is ALREADY initialized leaks its heap array --
+   call readiness_free() first.  src/lsp_channels.c does this when a rotation
+   re-inits the tracker.
+
+   No longer clamps n_clients to FACTORY_MAX_SIGNERS.  The old clamp was a
+   silent-corruption bug waiting at scale: above 255 clients the tracker
+   quietly forgot the surplus, and readiness_all_ready() would then report
+   "all ready" while untracked clients were still missing -- the same class of
+   bug as the uint64_t bitmap removed earlier (see the note above). */
+int readiness_init(readiness_tracker_t *rt, uint32_t factory_id,
+                   size_t n_clients, persist_t *db);
+
+/* Release the per-client array.  Safe on a zeroed tracker, safe to call twice,
+   and a no-op for trackers that fit the inline buffer.  Leaves *rt valid and
+   empty, so accessors called afterwards return zero/false rather than crash. */
+void readiness_free(readiness_tracker_t *rt);
 
 /* Mark client as connected/disconnected. */
 void readiness_set_connected(readiness_tracker_t *rt, uint32_t client_idx,

--- a/include/superscalar/wire.h
+++ b/include/superscalar/wire.h
@@ -280,6 +280,15 @@ int wire_connect_direct_internal(const char *host, int port);
 /* Send: writes [4-byte big-endian length][1-byte type][JSON bytes]. Returns 1 on success. */
 int wire_send(int fd, uint8_t msg_type, cJSON *json);
 
+/* Broadcast to many peers, serializing the JSON once instead of once per peer.
+   Use this for ceremony fan-out: wire_send() in a loop re-prints the whole tree
+   per client, which is O(N * message) and became the dominant cost of factory
+   creation at scale.  Negative fds are skipped.  1 if all peers were written;
+   on failure returns 0 and stores the failing peer's index in *first_fail
+   (may be NULL). */
+int wire_send_many(const int *fds, size_t n_fds, uint8_t msg_type, cJSON *json,
+                   size_t *first_fail);
+
 /* Recv: reads one frame. Caller must cJSON_Delete(msg->json). Returns 1 on success, 0 on EOF/error. */
 int wire_recv(int fd, wire_msg_t *msg);
 

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <time.h>
 
 void bridge_init(bridge_t *br) {
@@ -384,27 +384,37 @@ int bridge_run(bridge_t *br) {
     if (br->lsp_fd < 0) return 0;
 
     while (1) {
-        fd_set rfds;
-        FD_ZERO(&rfds);
-        int max_fd = br->lsp_fd;
-        FD_SET(br->lsp_fd, &rfds);
-
+        /* poll(), not select(): FD_SET(fd,&set) indexes bit `fd` in a fixed
+           1024-bit fd_set, so any descriptor >= FD_SETSIZE overflows it.  Only
+           two or three descriptors are watched here, but that was never the
+           issue -- the descriptor VALUE is, and the bridge shares a process
+           whose descriptors run past 1024 at large client counts.
+           Slots are fixed: 0 = LSP, 1 = plugin or plugin listener. */
+        struct pollfd pfds[2];
+        nfds_t nfds = 0;
+        pfds[nfds].fd = br->lsp_fd; pfds[nfds].events = POLLIN; nfds++;
+        int plugin_slot = -1, listen_slot = -1;
         if (br->plugin_fd >= 0) {
-            FD_SET(br->plugin_fd, &rfds);
-            if (br->plugin_fd > max_fd) max_fd = br->plugin_fd;
+            plugin_slot = (int)nfds;
+            pfds[nfds].fd = br->plugin_fd; pfds[nfds].events = POLLIN; nfds++;
         } else if (br->plugin_listen_fd >= 0) {
-            FD_SET(br->plugin_listen_fd, &rfds);
-            if (br->plugin_listen_fd > max_fd) max_fd = br->plugin_listen_fd;
+            listen_slot = (int)nfds;
+            pfds[nfds].fd = br->plugin_listen_fd; pfds[nfds].events = POLLIN; nfds++;
         }
 
-        /* Use heartbeat interval as select timeout (or 60s if no heartbeat) */
+        /* Use heartbeat interval as poll timeout (or 60s if no heartbeat) */
         int timeout_sec = (br->heartbeat_interval > 0) ? br->heartbeat_interval : 60;
-        struct timeval tv = { .tv_sec = timeout_sec, .tv_usec = 0 };
-        int ret = select(max_fd + 1, &rfds, NULL, NULL, &tv);
+        int ret = poll(pfds, nfds, timeout_sec * 1000);
         if (ret < 0) {
-            perror("Bridge: select");
+            perror("Bridge: poll");
             return 0;
         }
+        /* Readiness flags for the FD_ISSET sites below. */
+        int lsp_ready    = (pfds[0].revents & (POLLIN|POLLHUP|POLLERR|POLLNVAL)) != 0;
+        int plugin_ready = plugin_slot >= 0 &&
+            (pfds[plugin_slot].revents & (POLLIN|POLLHUP|POLLERR|POLLNVAL)) != 0;
+        int listen_ready = listen_slot >= 0 &&
+            (pfds[listen_slot].revents & POLLIN) != 0;
 
         /* Heartbeat: check for stale LSP connection on timeout */
         if (ret == 0) {
@@ -436,12 +446,12 @@ int bridge_run(bridge_t *br) {
 
         /* Accept pending plugin connection */
         if (br->plugin_listen_fd >= 0 && br->plugin_fd < 0 &&
-            FD_ISSET(br->plugin_listen_fd, &rfds)) {
+            listen_ready) {
             bridge_accept_plugin(br);
         }
 
         /* Handle LSP messages */
-        if (FD_ISSET(br->lsp_fd, &rfds)) {
+        if (lsp_ready) {
             wire_msg_t msg;
             if (!wire_recv(br->lsp_fd, &msg)) {
                 fprintf(stderr, "Bridge: LSP connection lost\n");
@@ -468,7 +478,7 @@ int bridge_run(bridge_t *br) {
         }
 
         /* Handle plugin messages */
-        if (br->plugin_fd >= 0 && FD_ISSET(br->plugin_fd, &rfds)) {
+        if (br->plugin_fd >= 0 && plugin_ready) {
             char *line = bridge_read_plugin_line(br);
             if (!line) {
                 fprintf(stderr, "Bridge: plugin connection lost\n");

--- a/src/ceremony.c
+++ b/src/ceremony.c
@@ -1,6 +1,7 @@
 #include "superscalar/ceremony.h"
 #include <string.h>
-#include <sys/select.h>
+#include <stdlib.h>
+#include <poll.h>
 
 void ceremony_init(ceremony_t *c, size_t n_clients,
                    int per_client_timeout_sec, int min_clients) {
@@ -13,37 +14,61 @@ void ceremony_init(ceremony_t *c, size_t n_clients,
         c->clients[i] = CLIENT_WAITING;
 }
 
+/* poll(), not select().
+ *
+ * select() is unusable in an LSP that serves many clients, and the reason is
+ * NOT the number of watched descriptors -- it is their VALUE.  FD_SET(fd,&set)
+ * sets bit `fd` inside a fixed FD_SETSIZE-bit (1024) bitmap, so a single
+ * descriptor numbered >= 1024 writes off the end of `fd_set`.  With one socket
+ * per client plus the listener, DB handles and log files, an LSP serving ~1000
+ * clients hands out descriptors past 1024 and every FD_SET here becomes a stack
+ * buffer overflow -- silent corruption, not a clean error, in exactly the way
+ * the fixed [FACTORY_MAX_SIGNERS] arrays smashed the stack at N=256.
+ *
+ * poll() takes an explicit array and cares only about the count, so descriptor
+ * values are irrelevant and the array is sized to n_clients at call time.
+ *
+ * Semantics are preserved exactly:
+ *   -1  no usable descriptor in the set (was: maxfd < 0)
+ *    0  timeout, ready_out all zero
+ *   >0  number ready, ready_out[i] = 1 for each readable client_fds[i]
+ * POLLHUP/POLLERR count as ready, matching select(), which reports a hung-up
+ * peer as readable so the caller's read() sees EOF and detects the disconnect.
+ */
 int ceremony_select_all(const int *client_fds, size_t n_clients,
                         int timeout_sec, int *ready_out) {
-    fd_set rfds;
-    FD_ZERO(&rfds);
-    int maxfd = -1;
+    if (!client_fds || !ready_out || n_clients == 0) return -1;
 
+    struct pollfd *pfds = (struct pollfd *)calloc(n_clients, sizeof(*pfds));
+    size_t *owner = (size_t *)calloc(n_clients, sizeof(*owner)); /* pfd -> client idx */
+    if (!pfds || !owner) { free(pfds); free(owner); return -1; }
+
+    nfds_t nfds = 0;
     for (size_t i = 0; i < n_clients; i++) {
-        if (client_fds[i] < 0) continue;
-        FD_SET(client_fds[i], &rfds);
-        if (client_fds[i] > maxfd)
-            maxfd = client_fds[i];
+        if (client_fds[i] < 0) continue;   /* skipped, as select() did */
+        pfds[nfds].fd = client_fds[i];
+        pfds[nfds].events = POLLIN;
+        owner[nfds] = i;
+        nfds++;
     }
+    if (nfds == 0) { free(pfds); free(owner); return -1; }
 
-    if (maxfd < 0) return -1;
+    /* select() with a negative tv_sec returns immediately; keep that. */
+    int ms = timeout_sec > 0 ? timeout_sec * 1000 : 0;
+    int ret = poll(pfds, nfds, ms);
 
-    struct timeval tv = { .tv_sec = timeout_sec, .tv_usec = 0 };
-    int ret = select(maxfd + 1, &rfds, NULL, NULL, &tv);
-    if (ret <= 0) {
-        memset(ready_out, 0, n_clients * sizeof(int));
-        return ret;
-    }
+    memset(ready_out, 0, n_clients * sizeof(int));
+    if (ret <= 0) { free(pfds); free(owner); return ret; }
 
     int count = 0;
-    for (size_t i = 0; i < n_clients; i++) {
-        if (client_fds[i] >= 0 && FD_ISSET(client_fds[i], &rfds)) {
-            ready_out[i] = 1;
+    for (nfds_t k = 0; k < nfds; k++) {
+        if (pfds[k].revents & (POLLIN | POLLHUP | POLLERR | POLLNVAL)) {
+            ready_out[owner[k]] = 1;
             count++;
-        } else {
-            ready_out[i] = 0;
         }
     }
+    free(pfds);
+    free(owner);
     return count;
 }
 

--- a/src/ceremony.c
+++ b/src/ceremony.c
@@ -3,15 +3,48 @@
 #include <stdlib.h>
 #include <poll.h>
 
-void ceremony_init(ceremony_t *c, size_t n_clients,
-                   int per_client_timeout_sec, int min_clients) {
+int ceremony_init(ceremony_t *c, size_t n_clients,
+                  int per_client_timeout_sec, int min_clients) {
+    if (!c) return 0;
+    /* Must not read *c first: callers pass uninitialized stack ceremony_t. */
     memset(c, 0, sizeof(*c));
     c->state = CEREMONY_INIT;
-    c->n_clients = n_clients;
     c->per_client_timeout_sec = per_client_timeout_sec;
     c->min_clients = min_clients > 0 ? min_clients : 2;
-    for (size_t i = 0; i < n_clients && i < FACTORY_MAX_SIGNERS; i++)
+
+    if (n_clients <= CEREMONY_SMALL) {
+        c->clients = c->clients_small;
+        c->clients_cap = CEREMONY_SMALL;
+    } else {
+        c->clients = (client_ceremony_state_t *)
+            calloc(n_clients, sizeof(client_ceremony_state_t));
+        if (!c->clients) {
+            /* Valid-but-empty: accessors bound by n_clients become safe no-ops
+               and has_quorum reports false -- fail closed. */
+            c->clients = c->clients_small;
+            c->clients_cap = CEREMONY_SMALL;
+            c->n_clients = 0;
+            return 0;
+        }
+        c->clients_cap = n_clients;
+    }
+
+    /* No `&& i < FACTORY_MAX_SIGNERS` clamp any more.  The old clamp bounded
+       only this write while n_clients stayed untruncated, so the array was
+       under-filled AND every later read ran off the end. */
+    c->n_clients = n_clients;
+    for (size_t i = 0; i < n_clients; i++)
         c->clients[i] = CLIENT_WAITING;
+    return 1;
+}
+
+void ceremony_free(ceremony_t *c) {
+    if (!c) return;
+    if (c->clients && c->clients != c->clients_small)
+        free(c->clients);
+    c->clients = NULL;
+    c->clients_cap = 0;
+    c->n_clients = 0;
 }
 
 /* poll(), not select().

--- a/src/client.c
+++ b/src/client.c
@@ -1969,20 +1969,39 @@ int client_run_with_channels(secp256k1_context *ctx,
     }
     uint32_t my_index = (uint32_t)pi_item->valuedouble;
     size_t n_participants = (size_t)cJSON_GetArraySize(all_pk_arr);
-    if (n_participants < 2 || n_participants > FACTORY_MAX_SIGNERS) {
-        fprintf(stderr, "Client: bad participant count %zu\n", n_participants);
+    /* Validate against the ABSOLUTE ceiling, not a buffer size.  This is the
+       check that refused every factory above 256 participants: the LSP would
+       build a 300-client factory, every client rejected the HELLO_ACK with
+       "bad participant count" and hung up, and the LSP then reported
+       "send FACTORY_PROPOSE to client 0 failed" -- which reads like a wire bug
+       and is not.  n_participants is PEER-SUPPLIED, so it is bounded by
+       SS_MAX_PARTICIPANTS and then used to size a HEAP (never stack)
+       allocation -- a wire-sized VLA here would be a remote stack-clash. */
+    if (n_participants < 2 || n_participants > SS_MAX_PARTICIPANTS) {
+        fprintf(stderr, "Client: bad participant count %zu (max %d)\n",
+                n_participants, SS_MAX_PARTICIPANTS);
         cJSON_Delete(msg.json);
         wire_close(fd);
         return 0;
     }
 
-    secp256k1_pubkey all_pubkeys[FACTORY_MAX_SIGNERS];
+    secp256k1_pubkey *all_pubkeys =
+        (secp256k1_pubkey *)calloc(n_participants, sizeof(secp256k1_pubkey));
+    if (!all_pubkeys) {
+        fprintf(stderr, "Client: out of memory for %zu participant keys\n",
+                n_participants);
+        cJSON_Delete(msg.json);
+        wire_close(fd);
+        free(all_pubkeys);
+        return 0;
+    }
     for (size_t i = 0; i < n_participants; i++) {
         cJSON *pk_hex = cJSON_GetArrayItem(all_pk_arr, (int)i);
         if (!pk_hex || !cJSON_IsString(pk_hex)) {
             fprintf(stderr, "Client: bad pubkey entry %zu\n", i);
             cJSON_Delete(msg.json);
             wire_close(fd);
+            free(all_pubkeys);
             return 0;
         }
         unsigned char pk_buf[33];
@@ -1991,6 +2010,7 @@ int client_run_with_channels(secp256k1_context *ctx,
             fprintf(stderr, "Client: invalid pubkey %zu\n", i);
             cJSON_Delete(msg.json);
             wire_close(fd);
+            free(all_pubkeys);
             return 0;
         }
     }
@@ -2003,6 +2023,7 @@ int client_run_with_channels(secp256k1_context *ctx,
         fprintf(stderr, "Client: participant_index %u out of range (%zu)\n",
                 my_index, n_participants);
         wire_close(fd);
+        free(all_pubkeys);
         return 0;
     }
     {
@@ -2017,6 +2038,7 @@ int client_run_with_channels(secp256k1_context *ctx,
             fprintf(stderr, "Client: REFUSING — pubkey at index %u does not "
                     "match our key (identity mismatch)\n", my_index);
             wire_close(fd);
+            free(all_pubkeys);
             return 0;
         }
     }
@@ -2027,6 +2049,7 @@ int client_run_with_channels(secp256k1_context *ctx,
         fprintf(stderr, "Client: expected FACTORY_PROPOSE\n");
         if (msg.json) cJSON_Delete(msg.json);
         wire_close(fd);
+        free(all_pubkeys);
         return 0;
     }
 
@@ -2044,6 +2067,7 @@ int client_run_with_channels(secp256k1_context *ctx,
             fprintf(stderr, "Client: malformed FACTORY_PROPOSE\n");
             cJSON_Delete(msg.json);
             wire_close(fd);
+            free(all_pubkeys);
             return 0;
         }
     }
@@ -2060,6 +2084,7 @@ int client_run_with_channels(secp256k1_context *ctx,
     if (!fv_item || !fa_item || !sb_item || !spl_item || !ct_item || !fpt_item) {
         fprintf(stderr, "Client: FACTORY_PROPOSE missing required fields\n");
         cJSON_Delete(msg.json);
+        free(all_pubkeys);
         return 0;
     }
     uint32_t funding_vout = (uint32_t)fv_item->valuedouble;
@@ -2199,6 +2224,7 @@ int client_run_with_channels(secp256k1_context *ctx,
                     (unsigned long long)funding_amount);
             client_send_error(fd, "funding_tx_verification_failed");
             wire_close(fd);
+            free(all_pubkeys);
             return 0;
         }
     } else {
@@ -2223,6 +2249,7 @@ int client_run_with_channels(secp256k1_context *ctx,
     if (!factory) return 0;
     factory_init_from_pubkeys(factory, ctx, all_pubkeys, n_participants,
                               step_blocks, states_per_layer);
+    free(all_pubkeys);   /* copied into the factory above */
     factory->cltv_timeout = cltv_timeout;
     factory->use_tree_anchor = 1;  /* #56: P2A CPFP anchors on tree txs (matches LSP) */
     factory->fee_per_tx = fee_per_tx;

--- a/src/client.c
+++ b/src/client.c
@@ -2353,6 +2353,7 @@ int client_run_with_channels(secp256k1_context *ctx,
             fprintf(stderr, "Client %u: REFUSING — profit_share %u bps < "
                     "minimum %u bps (use --min-profit-bps to adjust)\n",
                     my_index, my_bps, g_min_profit_bps);
+            factory_free(factory);   /* nine heap arrays; free() alone orphans them */
             free(factory);
             client_send_error(fd, "profit_share_too_low");
             wire_close(fd);

--- a/src/client.c
+++ b/src/client.c
@@ -632,8 +632,15 @@ int client_do_close_ceremony(int fd, secp256k1_context *ctx,
     uint32_t close_height = (ht && cJSON_IsNumber(ht))
                             ? (uint32_t)ht->valuedouble : current_height;
 
+    /* A cooperative close has one output per client plus the LSP, so this
+       bound IS the factory size limit for closing.  It was FACTORY_MAX_SIGNERS
+       (256), which meant a 512-client factory could be created and funded but
+       never cooperatively closed -- the client would refuse the CLOSE_PROPOSE
+       as malformed.  close_outputs below is already calloc'd to n_outputs, so
+       this is purely a sanity ceiling on peer-supplied input, not a capacity
+       limit; use the same hard ceiling as every other peer-supplied count. */
     size_t n_outputs = (size_t)cJSON_GetArraySize(outputs_arr);
-    if (n_outputs == 0 || n_outputs > FACTORY_MAX_SIGNERS) {
+    if (n_outputs == 0 || n_outputs > (size_t)SS_MAX_PARTICIPANTS + 1) {
         fprintf(stderr, "Client: bad output count %zu\n", n_outputs);
         if (!initial_msg) cJSON_Delete(msg.json);
         return 0;
@@ -1037,12 +1044,14 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
     int rot_econ = (rem_item && cJSON_IsNumber(rem_item)) ? (int)rem_item->valuedouble : 0;
 
     /* Parse participant profiles (optional) */
-    participant_profile_t rot_profiles[FACTORY_MAX_SIGNERS];
+    /* Sized to n_participants (a parameter of this function) rather than a
+       compile-time 256 -- see the matching note in client_run_with_channels. */
+    participant_profile_t rot_profiles[n_participants ? n_participants : 1];
     memset(rot_profiles, 0, sizeof(rot_profiles));
     cJSON *rprof_arr = cJSON_GetObjectItem(pj, "profiles");
     if (rprof_arr && cJSON_IsArray(rprof_arr)) {
         int n_prof = cJSON_GetArraySize(rprof_arr);
-        for (int rpi = 0; rpi < n_prof && rpi < FACTORY_MAX_SIGNERS; rpi++) {
+        for (int rpi = 0; rpi < n_prof && (size_t)rpi < n_participants; rpi++) {
             cJSON *rpe = cJSON_GetArrayItem(rprof_arr, rpi);
             if (!rpe) continue;
             cJSON *rv;
@@ -1060,12 +1069,12 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
     }
 
     /* Parse per-client distribution amounts (optional, for rotation) */
-    uint64_t rot_dist_amounts[FACTORY_MAX_SIGNERS];
+    uint64_t rot_dist_amounts[n_participants ? n_participants : 1];
     size_t rot_n_dist_amounts = 0;
     cJSON *rda_arr = cJSON_GetObjectItem(pj, "dist_amounts");
     if (rda_arr && cJSON_IsArray(rda_arr)) {
         int rda_n = cJSON_GetArraySize(rda_arr);
-        for (int rdi = 0; rdi < rda_n && rdi < FACTORY_MAX_SIGNERS; rdi++) {
+        for (int rdi = 0; rdi < rda_n && (size_t)rdi < n_participants; rdi++) {
             cJSON *rda = cJSON_GetArrayItem(rda_arr, rdi);
             if (rda && cJSON_IsNumber(rda))
                 rot_dist_amounts[rot_n_dist_amounts++] = (uint64_t)rda->valuedouble;
@@ -1103,7 +1112,7 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
        the end of the allocation (at N=127: 129 profiles, ~3KB of heap). */
     {
         size_t np = factory_out->config.max_signers;
-        if (np > FACTORY_MAX_SIGNERS) np = FACTORY_MAX_SIGNERS;
+        if (np > n_participants) np = n_participants;
         memcpy(factory_out->profiles, rot_profiles,
                np * sizeof(participant_profile_t));
     }
@@ -1227,9 +1236,12 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
     {
         int dist_slot = factory_find_signer_slot(factory_out, 0, my_index);
         if (dist_slot >= 0 && factory_out->cltv_timeout > 0) {
-            tx_output_t dist_outputs[FACTORY_MAX_SIGNERS + 1];
+            /* N+1: one output per client plus the LSP.  Fixed at 257 this
+               could not express the payout set of a factory past 256. */
+            tx_output_t dist_outputs[(size_t)factory_out->n_participants + 1];
             size_t n_dist = factory_compute_distribution_outputs_balanced(
-                factory_out, dist_outputs, FACTORY_MAX_SIGNERS + 1, 500,
+                factory_out, dist_outputs,
+                (size_t)factory_out->n_participants + 1, 500,
                 rot_n_dist_amounts > 0 ? rot_dist_amounts : NULL,
                 rot_n_dist_amounts);
             if (n_dist > 0 &&
@@ -1713,7 +1725,12 @@ static int client_factory_creation_stateless_signing(
         if (wire_json_get_hex(lr.json, "lsp_dist_pubnonce", lsp_dist_pn, 66) == 66) {
             unsigned char *all_dist_pn = calloc((size_t)factory->n_participants, 66);
             unsigned char *amt_le = calloc((size_t)factory->n_participants, 8);
-            uint64_t dist_amounts[FACTORY_MAX_SIGNERS];
+            /* VLA sized to the real participant count, matching its two
+               calloc'd siblings above.  As a fixed [FACTORY_MAX_SIGNERS] it
+               could not hold the amounts for a factory past 256, and the
+               n_amt bound below would reject the message outright. */
+            uint64_t dist_amounts[factory->n_participants ?
+                                  (size_t)factory->n_participants : 1];
             int ok = (all_dist_pn && amt_le);
             size_t n_amt = 0;
             uint32_t dist_nlock = 0;
@@ -1763,9 +1780,9 @@ static int client_factory_creation_stateless_signing(
             /* Rebuild the IDENTICAL unsigned dist TX from the LSP-sent amounts,
                then co-sign over our own computed sighash. */
             if (ok) {
-                tx_output_t douts[FACTORY_MAX_SIGNERS + 1];
+                tx_output_t douts[(size_t)factory->n_participants + 1];
                 size_t nd = factory_compute_distribution_outputs_balanced(
-                    factory, douts, FACTORY_MAX_SIGNERS + 1, 500,
+                    factory, douts, (size_t)factory->n_participants + 1, 500,
                     (n_amt > 0) ? dist_amounts : NULL, n_amt);
                 if (nd > 0 && dist_nlock > 0 &&
                     factory_build_distribution_tx_unsigned(factory, douts, nd,
@@ -2163,12 +2180,17 @@ int client_run_with_channels(secp256k1_context *ctx,
     int economic_mode = (em_item && cJSON_IsNumber(em_item)) ? (int)em_item->valuedouble : 0;
 
     /* Parse participant profiles (optional) */
-    participant_profile_t profiles[FACTORY_MAX_SIGNERS];
+    /* Sized to the actual participant count, not a compile-time 256.  As a
+       fixed array this silently DROPPED every participant at index >= 256:
+       the loop clamped rather than overflowed, so an N=300 factory simply
+       lost profiles 256..299 with no error.  A VLA keeps sizeof() correct at
+       runtime and needs no free on the many return paths below. */
+    participant_profile_t profiles[n_participants ? n_participants : 1];
     memset(profiles, 0, sizeof(profiles));
     cJSON *prof_arr = cJSON_GetObjectItem(msg.json, "profiles");
     if (prof_arr && cJSON_IsArray(prof_arr)) {
         int n_prof = cJSON_GetArraySize(prof_arr);
-        for (int pi = 0; pi < n_prof && pi < FACTORY_MAX_SIGNERS; pi++) {
+        for (int pi = 0; pi < n_prof && (size_t)pi < n_participants; pi++) {
             cJSON *pe = cJSON_GetArrayItem(prof_arr, pi);
             if (!pe) continue;
             cJSON *v;
@@ -2185,13 +2207,19 @@ int client_run_with_channels(secp256k1_context *ctx,
         }
     }
     /* Parse per-client distribution amounts (optional, for rotation) */
-    uint64_t init_dist_amounts[FACTORY_MAX_SIGNERS];
+    /* Sized to the participant count -- see the note on profiles above.  This
+       one had teeth: dist_amounts feeds the distribution TX the client
+       REBUILDS and checks its own payout against, so dropping entries >= 256
+       made every such client compute a mismatched dist TX and fall back to
+       "no signed dist TX".  At N=300 that silently disabled dist-TX
+       co-signing rather than reporting anything. */
+    uint64_t init_dist_amounts[n_participants ? n_participants : 1];
     size_t init_n_dist_amounts = 0;
     {
         cJSON *ida_arr = cJSON_GetObjectItem(msg.json, "dist_amounts");
         if (ida_arr && cJSON_IsArray(ida_arr)) {
             int ida_n = cJSON_GetArraySize(ida_arr);
-            for (int idi = 0; idi < ida_n && idi < FACTORY_MAX_SIGNERS; idi++) {
+            for (int idi = 0; idi < ida_n && (size_t)idi < n_participants; idi++) {
                 cJSON *ida = cJSON_GetArrayItem(ida_arr, idi);
                 if (ida && cJSON_IsNumber(ida))
                     init_dist_amounts[init_n_dist_amounts++] = (uint64_t)ida->valuedouble;
@@ -2283,13 +2311,14 @@ int client_run_with_channels(secp256k1_context *ctx,
     factory->fee_per_tx = fee_per_tx;
     factory->placement_mode = (placement_mode_t)placement_mode;
     factory->economic_mode = (economic_mode_t)economic_mode;
-    /* Bound by the destination allocation — see the note on the identical
-       copy in the rotation path.  factory->profiles is heap, sized to
-       config.max_signers; profiles[] here is still a fixed
-       [FACTORY_MAX_SIGNERS] stack array. */
+    /* Bound by the SMALLER of source and destination.  Both are now sized to
+       the participant count (profiles[] is a VLA of n_participants;
+       factory->profiles is calloc'd to config.max_signers), so these should
+       agree -- but they are set on different paths, and this copy is exactly
+       where a mismatch turns into heap corruption. */
     {
         size_t np = factory->config.max_signers;
-        if (np > FACTORY_MAX_SIGNERS) np = FACTORY_MAX_SIGNERS;
+        if (np > n_participants) np = n_participants;
         memcpy(factory->profiles, profiles, np * sizeof(participant_profile_t));
     }
     /* SF-followup #145: register active factory so MSG_FUNDING_REORG handler
@@ -2307,7 +2336,7 @@ int client_run_with_channels(secp256k1_context *ctx,
         printf("Client %u: factory terms — economic_mode=%s",
                my_index, econ_str);
         uint16_t my_bps = 0;
-        if (my_index >= 1 && my_index < FACTORY_MAX_SIGNERS)
+        if (my_index >= 1 && my_index < n_participants)
             my_bps = profiles[my_index].profit_share_bps;
         if (economic_mode == 1)
             printf(", my profit_share=%u bps (%.2f%%)", my_bps, my_bps / 100.0);
@@ -2523,9 +2552,10 @@ int client_run_with_channels(secp256k1_context *ctx,
     {
         int dist_slot = factory_find_signer_slot(factory, 0, my_index);
         if (dist_slot >= 0 && factory->cltv_timeout > 0) {
-            tx_output_t dist_outputs[FACTORY_MAX_SIGNERS + 1];
+            tx_output_t dist_outputs[(size_t)factory->n_participants + 1];
             size_t n_dist = factory_compute_distribution_outputs_balanced(
-                factory, dist_outputs, FACTORY_MAX_SIGNERS + 1, 500,
+                factory, dist_outputs,
+                (size_t)factory->n_participants + 1, 500,
                 init_n_dist_amounts > 0 ? init_dist_amounts : NULL,
                 init_n_dist_amounts);
             if (n_dist > 0 &&

--- a/src/client.c
+++ b/src/client.c
@@ -1985,6 +1985,22 @@ int client_run_with_channels(secp256k1_context *ctx,
         return 0;
     }
 
+    /* Scale patience with the factory size we just agreed to join.
+       The LSP fans ceremony messages out SERIALLY, so the k-th client waits for
+       the k-1 sends ahead of it; with a flat 120s timeout the tail of a large
+       factory always times out first, drops, and its EPIPE aborts the whole
+       ceremony for everyone. Observed exactly that at N=300: the broadcast died
+       at client 113, then 227 once serialization was fixed -- the index moved
+       with throughput, which is the signature of a deadline, not a bound.
+       n_participants is peer-supplied but already bounded by
+       SS_MAX_PARTICIPANTS above, so the worst case is a bounded wait, and a
+       client that waits too long is merely slow -- one that gives up too early
+       breaks the factory for all N. */
+    {
+        int scaled = WIRE_DEFAULT_TIMEOUT_SEC + (int)n_participants;
+        wire_set_timeout(fd, scaled);
+    }
+
     secp256k1_pubkey *all_pubkeys =
         (secp256k1_pubkey *)calloc(n_participants, sizeof(secp256k1_pubkey));
     if (!all_pubkeys) {

--- a/src/client.c
+++ b/src/client.c
@@ -1094,7 +1094,19 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
     factory_out->fee_per_tx = fee_per_tx;
     factory_out->placement_mode = (placement_mode_t)rot_placement;
     factory_out->economic_mode = (economic_mode_t)rot_econ;
-    memcpy(factory_out->profiles, rot_profiles, sizeof(rot_profiles));
+    /* Bound by the DESTINATION allocation, not by sizeof(source).
+       factory_out->profiles used to be a fixed participant_profile_t
+       [FACTORY_MAX_SIGNERS] inside factory_t, so copying sizeof(rot_profiles)
+       matched exactly.  It is now heap, calloc'd to config.max_signers, which
+       factory_config_default_for() sets to the actual participant count -- so
+       for any factory smaller than FACTORY_MAX_SIGNERS this was writing past
+       the end of the allocation (at N=127: 129 profiles, ~3KB of heap). */
+    {
+        size_t np = factory_out->config.max_signers;
+        if (np > FACTORY_MAX_SIGNERS) np = FACTORY_MAX_SIGNERS;
+        memcpy(factory_out->profiles, rot_profiles,
+               np * sizeof(participant_profile_t));
+    }
     if (rot_n_level_arity > 0)
         factory_set_level_arity(factory_out, rot_level_arities, rot_n_level_arity);
     else if (rot_leaf_arity == 1)
@@ -2271,7 +2283,15 @@ int client_run_with_channels(secp256k1_context *ctx,
     factory->fee_per_tx = fee_per_tx;
     factory->placement_mode = (placement_mode_t)placement_mode;
     factory->economic_mode = (economic_mode_t)economic_mode;
-    memcpy(factory->profiles, profiles, sizeof(profiles));
+    /* Bound by the destination allocation — see the note on the identical
+       copy in the rotation path.  factory->profiles is heap, sized to
+       config.max_signers; profiles[] here is still a fixed
+       [FACTORY_MAX_SIGNERS] stack array. */
+    {
+        size_t np = factory->config.max_signers;
+        if (np > FACTORY_MAX_SIGNERS) np = FACTORY_MAX_SIGNERS;
+        memcpy(factory->profiles, profiles, np * sizeof(participant_profile_t));
+    }
     /* SF-followup #145: register active factory so MSG_FUNDING_REORG handler
        can reset sub-factory chain state.  Cleared at all factory_free paths
        below. */

--- a/src/client.c
+++ b/src/client.c
@@ -1287,7 +1287,12 @@ int client_do_factory_rotation(int fd, secp256k1_context *ctx,
     }
     {
         cJSON *nonces_arr = cJSON_GetObjectItem(msg.json, "nonces");
-        size_t cap = (size_t)FACTORY_MAX_NODES * FACTORY_MAX_SIGNERS;
+        /* Real dimensions, not the compile-time product.  512*256 =
+           131072 entries is at once a large over-allocation for a small
+           factory AND too small for a big one: at N=512 the tree can
+           carry ~2046 nodes x 513 signers, roughly 8x this bound. */
+        size_t cap = (size_t)factory_out->n_nodes *
+                     ((size_t)factory_out->n_participants + 1);
         wire_bundle_entry_t *all_entries = calloc(cap, sizeof(wire_bundle_entry_t));
         if (!all_entries) {
             cJSON_Delete(msg.json); free(secnonces); free(nonce_entries); return 0;
@@ -2611,7 +2616,12 @@ int client_run_with_channels(secp256k1_context *ctx,
 
     {
         cJSON *nonces_arr = cJSON_GetObjectItem(msg.json, "nonces");
-        size_t cap = (size_t)FACTORY_MAX_NODES * FACTORY_MAX_SIGNERS;
+        /* Real dimensions, not the compile-time product.  512*256 =
+           131072 entries is at once a large over-allocation for a small
+           factory AND too small for a big one: at N=512 the tree can
+           carry ~2046 nodes x 513 signers, roughly 8x this bound. */
+        size_t cap = (size_t)factory->n_nodes *
+                     ((size_t)factory->n_participants + 1);
         wire_bundle_entry_t *all_entries = calloc(cap, sizeof(wire_bundle_entry_t));
         if (!all_entries) {
             cJSON_Delete(msg.json);
@@ -3162,13 +3172,19 @@ int client_handle_leaf_realloc(int fd, secp256k1_context *ctx,
         return 0;
     }
 
-    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
-    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
+    /* Sized to THIS node's signer set, not a compile-time 256.  Two wins:
+       the pair stops costing ~34KB of stack on every call for a node that
+       usually has 2 signers, and passing the real count as the parse capacity
+       means an over-long nonce list is REJECTED rather than truncated. */
+    size_t poison_cap = factory->nodes[node_idx].n_signers;
+    if (poison_cap == 0) poison_cap = 1;
+    unsigned char all_pubnonces[poison_cap][66];
+    unsigned char all_poison_pubnonces[poison_cap][66];
     size_t n_signers;
     int an_parse_rc = wire_parse_leaf_realloc_all_nonces(
         all_msg.json, all_pubnonces,
         realloc_poison_prepared ? all_poison_pubnonces : NULL,
-        FACTORY_MAX_SIGNERS, &n_signers);
+        poison_cap, &n_signers);
     cJSON_Delete(all_msg.json);
     if (an_parse_rc == 0) {
         fprintf(stderr, "Client %u: realloc parse all_nonces failed\n", my_index);
@@ -3462,7 +3478,11 @@ static int client_handle_subfactory_advance_stateless_multi(
         free(my_secnonces);
         return 0;
     }
-    unsigned char all_poison_pn_sub[FACTORY_MAX_SIGNERS][66];
+    /* Sized to the sub-factory node's own signer set — see the note in
+       client_handle_leaf_realloc. */
+    size_t poison_cap = factory->nodes[sub_node_i].n_signers;
+    if (poison_cap == 0) poison_cap = 1;
+    unsigned char all_poison_pn_sub[poison_cap][66];
     unsigned char lsp_poison_psig_ser[32];
     uint32_t got_all_len = 0, got_poison_len = 0;
     memset(all_poison_pn_sub, 0, sizeof(all_poison_pn_sub));
@@ -3956,8 +3976,13 @@ static int client_handle_subfactory_advance_stateless(int fd,
         return 0;
     }
     unsigned char lsp_pubnonce_ser[66], lsp_psig_ser[32];
-    unsigned char all_pn_sub[FACTORY_MAX_SIGNERS][66];
-    unsigned char all_poison_pn_sub[FACTORY_MAX_SIGNERS][66];
+    /* Sized to the sub-factory node's own signer set — see the note in
+       client_handle_leaf_realloc.  sizeof() on these VLAs is evaluated at
+       runtime, so the capacity passed to the parser below stays correct. */
+    size_t poison_cap = factory->nodes[sub_node_i].n_signers;
+    if (poison_cap == 0) poison_cap = 1;
+    unsigned char all_pn_sub[poison_cap][66];
+    unsigned char all_poison_pn_sub[poison_cap][66];
     unsigned char lsp_poison_psig_ser[32];
     uint32_t got_all_pn_len = 0, got_poison_len = 0;
     memset(all_poison_pn_sub, 0, sizeof(all_poison_pn_sub));

--- a/src/factory.c
+++ b/src/factory.c
@@ -2012,7 +2012,7 @@ int factory_session_get_input_signer_slot(const factory_t *f,
     size_t n = node->input_n_signers[input_idx];
     if (n == 0 || n > (size_t)FACTORY_MAX_SIGNERS) return -1;
     for (size_t i = 0; i < n; i++) {
-        if (node->input_signer_indices[input_idx][i] == participant_idx)
+        if (factory_node_input_signers_const(node, input_idx)[i] == participant_idx)
             return (int)i;
     }
     return -1;
@@ -3101,9 +3101,12 @@ static int ensure_input_sessions_alloc(factory_node_t *node) {
     free(node->input_signing_sessions);
     free(node->input_partial_sigs);
     free(node->input_keyaggs);
+    free(node->input_signer_indices);
     node->input_signing_sessions = NULL;
     node->input_partial_sigs = NULL;
     node->input_keyaggs = NULL;
+    node->input_signer_indices = NULL;
+    node->input_signers_stride = 0;
     node->n_input_sessions = 0;
 
     node->input_signing_sessions =
@@ -3131,10 +3134,32 @@ static int ensure_input_sessions_alloc(factory_node_t *node) {
         node->input_partial_sigs = NULL;
         return 0;
     }
+
+    /* Per-input signer sets, sized to THIS node's signer count rather than a
+       fixed [FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS] carried by every node.
+       Stride is n_signers (the node's full set is the widest any one input can
+       need: derive_input_keyagg either copies signer_indices wholesale for the
+       sales-stock input, or writes 2 entries for a channel input). */
+    node->input_signers_stride = node->n_signers ? node->n_signers : 2;
+    node->input_signer_indices =
+        (uint32_t *)calloc(node->ps_n_prev_outputs * node->input_signers_stride,
+                             sizeof(uint32_t));
+    if (!node->input_signer_indices) {
+        free(node->input_signing_sessions);
+        free(node->input_partial_sigs);
+        free(node->input_keyaggs);
+        node->input_signing_sessions = NULL;
+        node->input_partial_sigs = NULL;
+        node->input_keyaggs = NULL;
+        node->input_signers_stride = 0;
+        return 0;
+    }
+
     memset(node->input_partial_sigs_received, 0,
            sizeof(node->input_partial_sigs_received));
     memset(node->input_n_signers, 0, sizeof(node->input_n_signers));
-    memset(node->input_signer_indices, 0, sizeof(node->input_signer_indices));
+    /* input_signer_indices is calloc'd above -- do NOT memset it with
+       sizeof(), which is now sizeof(pointer). */
     memset(node->input_merkle_root, 0, sizeof(node->input_merkle_root));
     memset(node->input_has_merkle_root, 0, sizeof(node->input_has_merkle_root));
     node->n_input_sessions = node->ps_n_prev_outputs;
@@ -3228,7 +3253,7 @@ static int derive_input_keyagg(const factory_t *f,
         node->input_keyaggs[input_idx] = node->keyagg;
         node->input_n_signers[input_idx] = node->n_signers;
         for (size_t i = 0; i < node->n_signers; i++)
-            node->input_signer_indices[input_idx][i] = node->signer_indices[i];
+            factory_node_input_signers(node, input_idx)[i] = node->signer_indices[i];
         if (!compute_factory_lstock_merkle(f,
                                             node->input_merkle_root[input_idx]))
             return 0;
@@ -3247,8 +3272,8 @@ static int derive_input_keyagg(const factory_t *f,
     if (!musig_aggregate_keys(f->ctx, &node->input_keyaggs[input_idx], pks, 2))
         return 0;
     node->input_n_signers[input_idx] = 2;
-    node->input_signer_indices[input_idx][0] = client_participant;
-    node->input_signer_indices[input_idx][1] = 0;
+    factory_node_input_signers(node, input_idx)[0] = client_participant;
+    factory_node_input_signers(node, input_idx)[1] = 0;
 
     int has_merkle = 0;
     if (!compute_factory_chan_cltv_merkle(f,
@@ -4997,6 +5022,11 @@ void factory_free(factory_t *f) {
         /* SF-MULTI-KEYAGG (#283): free per-input keyagg cache. */
         free(f->nodes[i].input_keyaggs);
         f->nodes[i].input_keyaggs = NULL;
+        /* Per-input signer sets: heap since the fixed 16 KB/node version was
+           the dominant per-client cost (see factory.h). */
+        free(f->nodes[i].input_signer_indices);
+        f->nodes[i].input_signer_indices = NULL;
+        f->nodes[i].input_signers_stride = 0;
         f->nodes[i].n_input_sessions = 0;
     }
     /* F4: factory-level distribution TX buffer (populated by

--- a/src/factory.c
+++ b/src/factory.c
@@ -429,7 +429,14 @@ static int apply_l_stock_hashlock(factory_t *f, factory_node_t *node) {
        2-leaf L-stock SPK as the LSP (else the leaf-state tx diverges + co-sign fails). */
     if (f->has_node_l_stock_hashes) {
         size_t idx = (size_t)(node - f->nodes);
-        if (idx < FACTORY_MAX_NODES && f->node_l_stock_hash_valid[idx]) {
+        /* Bound by the ALLOCATION (nodes_cap), not FACTORY_MAX_NODES.  These
+           two arrays are calloc'd to FACTORY_NODES_INITIAL and grown by
+           factory_grow_nodes, so nodes_cap -- not the compile-time 512 -- is
+           how many entries exist.  Today idx cannot exceed it (it is derived
+           from a pointer into nodes[]), so this is not currently reachable,
+           but it is the same wrong-bound shape that WAS a live out-of-bounds
+           write in factory_session_set_partial_sig_poison. */
+        if (idx < f->nodes_cap && f->node_l_stock_hash_valid[idx]) {
             memcpy(node->l_stock_hash, f->node_l_stock_hashes[idx], 32);
             node->has_l_stock_hash = 1;
         }
@@ -856,13 +863,20 @@ int factory_init_with_config(factory_t *f, secp256k1_context *ctx,
     f->leaf_layers       = calloc(f->config.max_leaves, sizeof(dw_layer_t));
     f->leaf_node_indices = calloc(f->config.max_leaves, sizeof(size_t));
     if (!f->keypairs || !f->pubkeys || !f->profiles || !f->dist_partial_sigs ||
-        !f->leaf_layers || !f->leaf_node_indices)
+        !f->leaf_layers || !f->leaf_node_indices) {
+        /* Partial allocation: release whatever DID succeed rather than
+           orphaning it.  f was memset at entry, so the failed ones are NULL
+           and factory_free is NULL-safe. */
+        factory_free(f);
         return 0;
+    }
 
     for (size_t i = 0; i < n_participants; i++) {
         f->keypairs[i] = keypairs[i];
-        if (!secp256k1_keypair_pub(ctx, &f->pubkeys[i], &keypairs[i]))
+        if (!secp256k1_keypair_pub(ctx, &f->pubkeys[i], &keypairs[i])) {
+            factory_free(f);     /* all nine arrays are live by now */
             return 0;
+        }
     }
 
     f->leaf_arity = FACTORY_ARITY_2;

--- a/src/factory.c
+++ b/src/factory.c
@@ -1110,7 +1110,6 @@ void factory_set_ps_subfactory_arity(factory_t *f, uint32_t k) {
     /* Cap at FACTORY_MAX_OUTPUTS - 1 so the leaf's k sub-factory entry
        outputs + 1 L-stock output fit within FACTORY_MAX_OUTPUTS.  k=0
        is treated as k=1 (no sub-factories). */
-    if (!f) return;
     /* Callable BEFORE factory_init (see factory_set_level_arity). */
     factory_alloc_default_arrays(f);
     if (!f->leaf_layers) return;

--- a/src/factory.c
+++ b/src/factory.c
@@ -148,6 +148,40 @@ static uint32_t node_nsequence(const factory_t *f, const factory_node_t *node) {
     return dw_current_nsequence(&f->counter.layers[node->dw_layer_index]);
 }
 
+/* Ensure nodes[] and its two parallel node-indexed arrays hold at least `want`
+   entries, growing geometrically.  Returns 1 on success, 0 on OOM or cap.
+   Callers must not hold a factory_node_t* across this -- realloc may move it.
+   New tail entries are zeroed so callers keep the calloc semantics they had. */
+int factory_grow_nodes(factory_t *f, size_t want) {
+    if (!f) return 0;
+    if (want > f->config.max_nodes) return 0;   /* hard cap unchanged */
+    if (want <= f->nodes_cap) return 1;
+
+    size_t ncap = f->nodes_cap ? f->nodes_cap * 2 : 32;
+    if (ncap < want) ncap = want;
+    if (ncap > f->config.max_nodes) ncap = f->config.max_nodes;
+
+    factory_node_t *nn = (factory_node_t *)realloc(f->nodes, ncap * sizeof(*nn));
+    if (!nn) return 0;
+    memset(nn + f->nodes_cap, 0, (ncap - f->nodes_cap) * sizeof(*nn));
+    f->nodes = nn;
+
+    unsigned char (*nh)[32] = (unsigned char (*)[32])
+        realloc(f->node_l_stock_hashes, ncap * 32);
+    if (!nh) return 0;                 /* nodes[] already grown; cap not bumped
+                                          yet, so state stays consistent */
+    memset(nh + f->nodes_cap, 0, (ncap - f->nodes_cap) * 32);
+    f->node_l_stock_hashes = nh;
+
+    int *nv = (int *)realloc(f->node_l_stock_hash_valid, ncap * sizeof(int));
+    if (!nv) return 0;
+    memset(nv + f->nodes_cap, 0, (ncap - f->nodes_cap) * sizeof(int));
+    f->node_l_stock_hash_valid = nv;
+
+    f->nodes_cap = ncap;
+    return 1;
+}
+
 /* Add a node to the factory. Returns node index or -1 on error.
    node_cltv: if > 0, build CLTV timeout taptree for this node's spending_spk. */
 static int add_node(
@@ -161,6 +195,11 @@ static int add_node(
     uint32_t node_cltv
 ) {
     if (f->n_nodes >= f->config.max_nodes) return -1;
+    /* Grow the three parallel node-indexed arrays on demand.  MUST happen before
+       any factory_node_t* is taken below, because realloc may move the block;
+       build_subtree and the other callers index through f->nodes[i] rather than
+       caching a pointer across add_node calls, which is what makes this safe. */
+    if (!factory_grow_nodes(f, f->n_nodes + 1)) return -1;
 
     int idx = (int)f->n_nodes++;
     factory_node_t *node = &f->nodes[idx];
@@ -409,6 +448,13 @@ static int apply_l_stock_hashlock(factory_t *f, factory_node_t *node) {
 void factory_set_node_l_stock_hash(factory_t *f, size_t node_idx,
                                    const unsigned char *h32) {
     if (!f || node_idx >= f->config.max_nodes || !h32) return;
+    /* The client mirrors per-(leaf,state) hashes off the wire, possibly for
+       nodes it has not built yet, so node_idx can run ahead of what is
+       allocated.  max_nodes is only the growth CAP now -- grow to fit before
+       writing.  The old check was sufficient purely because the arrays were
+       always allocated at max_nodes; ASan flagged this the moment they were
+       not (WRITE of size 32, 0 bytes after a 32-byte region). */
+    if (!factory_grow_nodes(f, node_idx + 1)) return;
     memcpy(f->node_l_stock_hashes[node_idx], h32, 32);
     f->node_l_stock_hash_valid[node_idx] = 1;
     f->has_node_l_stock_hashes = 1;
@@ -765,11 +811,13 @@ int factory_alloc_default_arrays(factory_t *f) {
     if (!f->leaf_node_indices)
         f->leaf_node_indices = calloc(f->config.max_leaves, sizeof(size_t));
     if (!f->nodes)
-        f->nodes = calloc(f->config.max_nodes, sizeof(factory_node_t));
+        f->nodes = calloc(FACTORY_NODES_INITIAL, sizeof(factory_node_t));
     if (!f->node_l_stock_hashes)
-        f->node_l_stock_hashes = calloc(f->config.max_nodes, 32);
+        f->node_l_stock_hashes = calloc(FACTORY_NODES_INITIAL, 32);
     if (!f->node_l_stock_hash_valid)
-        f->node_l_stock_hash_valid = calloc(f->config.max_nodes, sizeof(int));
+        f->node_l_stock_hash_valid = calloc(FACTORY_NODES_INITIAL, sizeof(int));
+    if (f->nodes && f->node_l_stock_hashes && f->node_l_stock_hash_valid)
+        f->nodes_cap = FACTORY_NODES_INITIAL;
     return f->keypairs && f->pubkeys && f->profiles && f->dist_partial_sigs &&
            f->leaf_layers && f->leaf_node_indices && f->nodes &&
            f->node_l_stock_hashes && f->node_l_stock_hash_valid;
@@ -836,9 +884,10 @@ int factory_init_with_config(factory_t *f, secp256k1_context *ctx,
 
     /* Dynamic node arrays (were inline [FACTORY_MAX_NODES]).  Allocate to the
        config cap; factory_build_tree grows them if the tree needs more nodes. */
-    f->nodes                  = calloc(f->config.max_nodes, sizeof(factory_node_t));
-    f->node_l_stock_hashes    = calloc(f->config.max_nodes, 32);
-    f->node_l_stock_hash_valid= calloc(f->config.max_nodes, sizeof(int));
+    f->nodes                  = calloc(FACTORY_NODES_INITIAL, sizeof(factory_node_t));
+    f->node_l_stock_hashes    = calloc(FACTORY_NODES_INITIAL, 32);
+    f->node_l_stock_hash_valid= calloc(FACTORY_NODES_INITIAL, sizeof(int));
+    f->nodes_cap              = FACTORY_NODES_INITIAL;
     return 1;
 }
 
@@ -894,9 +943,10 @@ void factory_init_from_pubkeys(factory_t *f, secp256k1_context *ctx,
 
     /* Dynamic node arrays (were inline [FACTORY_MAX_NODES]).  Allocate to the
        config cap; factory_build_tree grows them if the tree needs more nodes. */
-    f->nodes                  = calloc(f->config.max_nodes, sizeof(factory_node_t));
-    f->node_l_stock_hashes    = calloc(f->config.max_nodes, 32);
-    f->node_l_stock_hash_valid= calloc(f->config.max_nodes, sizeof(int));
+    f->nodes                  = calloc(FACTORY_NODES_INITIAL, sizeof(factory_node_t));
+    f->node_l_stock_hashes    = calloc(FACTORY_NODES_INITIAL, 32);
+    f->node_l_stock_hash_valid= calloc(FACTORY_NODES_INITIAL, sizeof(int));
+    f->nodes_cap              = FACTORY_NODES_INITIAL;
 }
 
 void factory_set_arity(factory_t *f, factory_arity_t arity) {
@@ -1437,6 +1487,12 @@ static int setup_ps_leaf_with_subfactories(
             fprintf(stderr, "Factory: add sub-factory node %u failed\n", si);
             return 0;
         }
+        /* REFRESH: add_node above may have grown nodes[] via realloc, which can
+           move the whole block.  `leaf` was taken before the loop, so without
+           this every write through it after the first growth lands in freed
+           memory.  This is the one place in factory.c that caches a node
+           pointer across an add_node call -- the rest index f->nodes[i]. */
+        leaf = &f->nodes[leaf_node_idx];
         leaf->subfactory_node_indices[si] = sub_idx;
 
         /* Wire leaf's vout[si] → sub-factory's spending_spk. */
@@ -1914,24 +1970,19 @@ int factory_build_tree(factory_t *f) {
     int n_dw_layers = dw_n_layers_for(tree_depth, f->static_threshold_depth);
     int total_nodes_ub = 2 * (2 * n_leaves - 1);  /* kickoff+state per logical node */
 
-    /* Grow the dynamic node arrays if this tree needs more than the current cap
-       (a 255-client PS factory needs ~1018 nodes vs the 512 default). */
-    if (total_nodes_ub > (int)f->config.max_nodes) {
-        size_t nn = (size_t)total_nodes_ub, old = f->config.max_nodes;
-        factory_node_t *gn = realloc(f->nodes, nn * sizeof(factory_node_t));
-        if (!gn) return 0;
-        f->nodes = gn;
-        unsigned char (*gh)[32] = realloc(f->node_l_stock_hashes, nn * 32);
-        if (!gh) return 0;
-        f->node_l_stock_hashes = gh;
-        int *gv = realloc(f->node_l_stock_hash_valid, nn * sizeof(int));
-        if (!gv) return 0;
-        f->node_l_stock_hash_valid = gv;
-        memset(f->nodes + old, 0, (nn - old) * sizeof(factory_node_t));
-        memset(f->node_l_stock_hashes + old, 0, (nn - old) * 32);
-        memset(f->node_l_stock_hash_valid + old, 0, (nn - old) * sizeof(int));
-        f->config.max_nodes = (uint32_t)nn;
-    }
+    /* Raise the CAP if this tree could need more than the current one (a
+       255-client PS factory needs ~1018 nodes vs the 512 default).  Nothing is
+       allocated here any more: add_node grows on demand up to the cap, so a
+       tree that ends up far below this upper bound never pays for it.
+       total_nodes_ub is exactly that -- an upper bound, 2*(2*n_leaves-1) -- and
+       the measured trees come in well under it.
+       This used to realloc to total_nodes_ub and zero from old =
+       config.max_nodes.  Once the arrays stopped being allocated at max_nodes,
+       that left [nodes_cap, max_nodes) uninitialised in the middle of the
+       array, because realloc does not zero.  Raising the cap and letting
+       factory_grow_nodes do the allocating keeps one zeroing path. */
+    if (total_nodes_ub > (int)f->config.max_nodes)
+        f->config.max_nodes = (uint32_t)total_nodes_ub;
     if (n_leaves > (int)f->config.max_leaves) return 0;
     if (n_dw_layers > DW_MAX_LAYERS) return 0;
 
@@ -1971,7 +2022,9 @@ int factory_build_tree(factory_t *f) {
         g_sort_factory = NULL;
     }
 
-    /* Build the tree recursively */
+    /* Build the tree recursively.  Reset the COUNT only -- nodes_cap tracks what
+       is still allocated, so a rebuild reuses the existing block instead of
+       shrinking to FACTORY_NODES_INITIAL and re-growing back up. */
     f->n_nodes = 0;
     int leaf_counter = 0;
     if (!build_subtree(f, clients, n_clients,
@@ -5036,6 +5089,7 @@ void factory_free(factory_t *f) {
     tx_buf_free(&f->dist_signed_tx);   /* #54 G1 */
     /* Zero node count so a second factory_free is a no-op (idempotent). */
     f->n_nodes = 0;
+    f->nodes_cap = 0;
     /* Factory-level distribution signing session's dynamic pubnonces. */
     musig_session_free(&f->dist_signing_session);
     /* Free the dynamic node arrays (were inline).  NULL after free so a second
@@ -5065,8 +5119,17 @@ void factory_detach_txbufs(factory_t *f) {
        (no double-free) and (b) the txbuf-zeroing below touches only this copy,
        not the original.  This reproduces the pre-dynamic inline-array copy
        semantics (per-node txbuf POINTERS stay shared, then get zeroed below). */
-    if (f->nodes && f->config.max_nodes > 0) {
-        size_t mn = f->config.max_nodes;
+    /* Copy exactly what is ALLOCATED (nodes_cap), not config.max_nodes.
+       max_nodes is the growth CAP, not the current extent: since nodes[] grows
+       on demand it is usually far smaller, and copying max_nodes reads off the
+       end.  ASan caught this the moment growth was forced on every add_node:
+         READ of size 3813376 (= 512 * sizeof(factory_node_t)) in
+         factory_detach_txbufs -> heap-buffer-overflow
+       Before grow-on-demand the array really was max_nodes entries, so this
+       was merely wasteful rather than wrong -- which is why it survived until
+       the allocation strategy changed underneath it. */
+    if (f->nodes && f->nodes_cap > 0) {
+        size_t mn = f->nodes_cap;
         factory_node_t *n2 = malloc(mn * sizeof(factory_node_t));
         if (n2) { memcpy(n2, f->nodes, mn * sizeof(factory_node_t)); f->nodes = n2; }
         unsigned char (*h2)[32] = malloc(mn * 32);

--- a/src/factory.c
+++ b/src/factory.c
@@ -2063,7 +2063,10 @@ int factory_session_get_input_signer_slot(const factory_t *f,
     if (!node->input_signing_sessions) return -1;
     if (input_idx >= node->n_input_sessions) return -1;
     size_t n = node->input_n_signers[input_idx];
-    if (n == 0 || n > (size_t)FACTORY_MAX_SIGNERS) return -1;
+    /* Bound by the allocation's stride, not the old compile-time cap: the
+       loop below reads factory_node_input_signers_const(node, input_idx)[i]
+       for i < n, and that row is input_signers_stride wide. */
+    if (n == 0 || n > node->input_signers_stride) return -1;
     for (size_t i = 0; i < n; i++) {
         if (factory_node_input_signers_const(node, input_idx)[i] == participant_idx)
             return (int)i;
@@ -3167,13 +3170,22 @@ static int ensure_input_sessions_alloc(factory_node_t *node) {
                                             sizeof(musig_signing_session_t));
     if (!node->input_signing_sessions) return 0;
 
+    /* ONE stride for BOTH per-input signer arrays, computed before either
+       allocation so they are indexed identically.  input_partial_sigs used a
+       fixed FACTORY_MAX_SIGNERS stride, which (a) hard-capped a node at 256
+       signers -- factory_session_set_partial_sig_input refused any slot at or
+       above it -- and (b) allocated 256 partial-sig slots per input on every
+       multi-input node regardless of the real signer count. */
+    node->input_signers_stride = node->n_signers ? node->n_signers : 2;
+
     node->input_partial_sigs =
         (secp256k1_musig_partial_sig *)calloc(
-            node->ps_n_prev_outputs * (size_t)FACTORY_MAX_SIGNERS,
+            node->ps_n_prev_outputs * node->input_signers_stride,
             sizeof(secp256k1_musig_partial_sig));
     if (!node->input_partial_sigs) {
         free(node->input_signing_sessions);
         node->input_signing_sessions = NULL;
+        node->input_signers_stride = 0;
         return 0;
     }
     /* SF-MULTI-KEYAGG (#283): per-input keyagg cache. */
@@ -3185,6 +3197,7 @@ static int ensure_input_sessions_alloc(factory_node_t *node) {
         free(node->input_partial_sigs);
         node->input_signing_sessions = NULL;
         node->input_partial_sigs = NULL;
+        node->input_signers_stride = 0;
         return 0;
     }
 
@@ -3192,8 +3205,8 @@ static int ensure_input_sessions_alloc(factory_node_t *node) {
        fixed [FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS] carried by every node.
        Stride is n_signers (the node's full set is the widest any one input can
        need: derive_input_keyagg either copies signer_indices wholesale for the
-       sales-stock input, or writes 2 entries for a channel input). */
-    node->input_signers_stride = node->n_signers ? node->n_signers : 2;
+       sales-stock input, or writes 2 entries for a channel input).  Set above,
+       shared with input_partial_sigs. */
     node->input_signer_indices =
         (uint32_t *)calloc(node->ps_n_prev_outputs * node->input_signers_stride,
                              sizeof(uint32_t));
@@ -3417,10 +3430,14 @@ int factory_session_set_partial_sig_input(factory_t *f, size_t node_idx, size_t 
     factory_node_t *node = &f->nodes[node_idx];
     if (!node->input_signing_sessions) return 0;
     if (input_idx >= node->n_input_sessions) return 0;
-    if (signer_slot >= (size_t)FACTORY_MAX_SIGNERS) return 0;
+    /* Bound by the ALLOCATION, not by the old compile-time cap.  The
+       input_n_signers check below is the semantic one; this is the memory
+       bound, and both now track input_signers_stride. */
+    if (node->input_signers_stride == 0) return 0;
+    if (signer_slot >= node->input_signers_stride) return 0;
     if (signer_slot >= node->input_n_signers[input_idx]) return 0;
     secp256k1_musig_partial_sig *slot =
-        &node->input_partial_sigs[input_idx * (size_t)FACTORY_MAX_SIGNERS + signer_slot];
+        &node->input_partial_sigs[input_idx * node->input_signers_stride + signer_slot];
     *slot = *psig;
     node->input_partial_sigs_received[input_idx]++;
     return 1;
@@ -3462,7 +3479,7 @@ int factory_session_assemble_signed_tx_multi(factory_t *f, size_t node_idx) {
     if (!sigs64) return 0;
     for (size_t i = 0; i < node->n_input_sessions; i++) {
         secp256k1_musig_partial_sig *psigs =
-            &node->input_partial_sigs[i * (size_t)FACTORY_MAX_SIGNERS];
+            &node->input_partial_sigs[i * node->input_signers_stride];
         /* SF-MULTI-KEYAGG (#283): aggregate with the per-input signer count
            (not the node-level n_signers). */
         if (!musig_aggregate_partial_sigs(f->ctx, sigs64 + 64 * i,
@@ -3666,8 +3683,15 @@ int factory_session_set_partial_sig_poison(factory_t *f, size_t node_idx,
                                              size_t signer_slot,
                                              const secp256k1_musig_partial_sig *psig) {
     if (!f || node_idx >= f->n_nodes || !psig) return 0;
-    if (signer_slot >= FACTORY_MAX_SIGNERS) return 0;
     factory_node_t *node = &f->nodes[node_idx];
+    /* Bound by the ALLOCATION.  poison_partial_sigs is calloc'd to this node's
+       n_signers, but the guard here was the old fixed FACTORY_MAX_SIGNERS --
+       so any slot in [n_signers, 256) was accepted and written past the end of
+       the array.  signer_slot arrives over the wire, so on a small node (a
+       2-of-2 leaf) a peer could write ~254 partial-sig structs of heap beyond
+       the allocation.  Nothing legitimate ever sends such a slot. */
+    if (!node->poison_partial_sigs) return 0;
+    if (signer_slot >= node->n_signers) return 0;
     memcpy(&node->poison_partial_sigs[signer_slot], psig,
            sizeof(secp256k1_musig_partial_sig));
     node->poison_partial_sigs_received++;

--- a/src/jit_channel.c
+++ b/src/jit_channel.c
@@ -14,7 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -155,11 +155,13 @@ int jit_channel_create(void *mgr_ptr, void *lsp_ptr,
     wire_msg_t accept_msg;
     int got_accept = 0;
     for (int attempt = 0; attempt < 30; attempt++) {
-        fd_set rfds;
-        FD_ZERO(&rfds);
-        FD_SET(lsp->client_fds[client_idx], &rfds);
-        struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
-        int ret = select(lsp->client_fds[client_idx] + 1, &rfds, NULL, NULL, &tv);
+        /* poll(), not select(): FD_SET(fd,&set) indexes bit `fd` in a fixed
+           1024-bit fd_set, so a single client socket numbered >= FD_SETSIZE
+           overflows it.  Watching just one descriptor is no protection -- the
+           descriptor VALUE is what matters, and an LSP with ~1000 clients hands
+           out values past 1024.  See src/ceremony.c for the same conversion. */
+        struct pollfd pfd = { .fd = lsp->client_fds[client_idx], .events = POLLIN };
+        int ret = poll(&pfd, 1, 1000);
         if (ret <= 0) continue;  /* 1s timeout, retry */
         if (!wire_recv(lsp->client_fds[client_idx], &accept_msg)) {
             fprintf(stderr, "LSP JIT: wire_recv failed waiting for JIT_ACCEPT\n");

--- a/src/ladder.c
+++ b/src/ladder.c
@@ -54,6 +54,9 @@ int ladder_create_factory(ladder_t *lad,
 
     /* Initialize factory */
     if (!factory_init(&lf->factory, lad->ctx, all_keypairs, n_participants, 1, 4)) {
+        /* factory_init memsets then allocates, so a mid-way failure can leave
+           some pointers live.  factory_free is NULL-safe. */
+        factory_free(&lf->factory);
         tx_buf_free(&lf->distribution_tx);
         return 0;
     }
@@ -68,6 +71,11 @@ int ladder_create_factory(ladder_t *lad,
 
     /* Build tree and sign */
     if (!factory_build_tree(&lf->factory)) {
+        /* factory_init succeeded, so the factory owns nine heap arrays; the
+           slot is abandoned WITHOUT n_factories++, so ladder_free will never
+           see it.  Releasing only the tx_buf here leaked ~303KB per failed
+           create. */
+        factory_free(&lf->factory);
         tx_buf_free(&lf->distribution_tx);
         return 0;
     }
@@ -77,6 +85,7 @@ int ladder_create_factory(ladder_t *lad,
         dw_counter_advance(&lf->factory.counter);
 
     if (!factory_sign_all_with_retry(&lf->factory, SS_NONCE_RETRY_MAX)) {
+        factory_free(&lf->factory);      /* same as the build_tree path above */
         tx_buf_free(&lf->distribution_tx);
         return 0;
     }

--- a/src/ladder.c
+++ b/src/ladder.c
@@ -32,7 +32,10 @@ int ladder_create_factory(ladder_t *lad,
 {
     if (lad->n_factories >= LADDER_MAX_FACTORIES)
         return 0;
-    if (n_clients + 1 > FACTORY_MAX_SIGNERS)
+    /* Bound by the turnover arrays in ladder_factory_t, which are indexed by
+       n_participants -- see LADDER_MAX_PARTICIPANTS in ladder.h. Fails closed:
+       an oversized factory gets no ladder entry rather than a partial one. */
+    if (n_clients + 1 > LADDER_MAX_PARTICIPANTS)
         return 0;
 
     size_t idx = lad->n_factories;
@@ -44,7 +47,7 @@ int ladder_create_factory(ladder_t *lad,
 
     /* Build combined keypair array: LSP + clients */
     size_t n_participants = n_clients + 1;
-    secp256k1_keypair all_keypairs[FACTORY_MAX_SIGNERS];
+    secp256k1_keypair all_keypairs[n_participants];
     all_keypairs[0] = lad->lsp_keypair;
     for (size_t i = 0; i < n_clients; i++)
         all_keypairs[i + 1] = client_keypairs[i];
@@ -179,7 +182,7 @@ int ladder_build_close(ladder_t *lad, uint32_t factory_id,
 
     /* Build a keypair array using extracted keys for departed clients */
     factory_t *f = &lf->factory;
-    secp256k1_keypair close_keypairs[FACTORY_MAX_SIGNERS];
+    secp256k1_keypair close_keypairs[f->n_participants ? f->n_participants : 1];
 
     for (size_t i = 0; i < f->n_participants; i++) {
         if (i == 0) {
@@ -197,7 +200,7 @@ int ladder_build_close(ladder_t *lad, uint32_t factory_id,
     }
 
     /* Temporarily swap keypairs in factory for signing */
-    secp256k1_keypair saved_keypairs[FACTORY_MAX_SIGNERS];
+    secp256k1_keypair saved_keypairs[f->n_participants ? f->n_participants : 1];
     memcpy(saved_keypairs, f->keypairs,
            f->n_participants * sizeof(secp256k1_keypair));
     /* cppcheck-suppress uninitvar ; loop above initializes all [0..n_participants) elements */

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -601,9 +601,13 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
        when all parties go offline.  (Legacy rotation also re-signs it later.)
        Proven e2e by tools/test_regtest_all_offline_recovery.sh (#54 G1c). */
     {
-        tx_output_t dist_outputs[FACTORY_MAX_SIGNERS + 1];
+        /* N+1 outputs: one per client plus the LSP.  Fixed at 257 this could
+           not express the payout set past 256 clients -- and this is the
+           all-offline safety-net TX, so a short one means the fallback that
+           pays everyone at the factory CLTV silently covers fewer clients. */
+        tx_output_t dist_outputs[(size_t)f->n_participants + 1];
         size_t n_dist = factory_compute_distribution_outputs_balanced(f,
-            dist_outputs, FACTORY_MAX_SIGNERS + 1, 500,
+            dist_outputs, (size_t)f->n_participants + 1, 500,
             lsp->dist_client_amounts, lsp->dist_n_client_amounts);
         if (n_dist > 0 && f->cltv_timeout > 0)
             (void)factory_build_distribution_tx_unsigned(

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -123,6 +123,11 @@ int lsp_ensure_scratch(lsp_t *lsp, size_t want) {
     if (!pk) return 0;
     lsp->scratch_pubkeys = pk;
 
+    participant_profile_t *pr = (participant_profile_t *)
+        realloc(lsp->scratch_profiles, want * sizeof(participant_profile_t));
+    if (!pr) return 0;
+    lsp->scratch_profiles = pr;
+
     lsp->scratch_cap = want;
     return 1;
 }
@@ -415,7 +420,16 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
 
     /* ---- Setup: identical to legacy lsp_run_factory_creation ---- */
     size_t n_total = 1 + lsp->n_clients;
-    secp256k1_pubkey all_pubkeys[FACTORY_MAX_SIGNERS];
+    /* ASan named this frame once the main() arrays were converted:
+         WRITE of size 64  src/lsp.c:421  in lsp_run_factory_creation_stateless
+       Scratch is sized by lsp_accept_clients; re-assert for callers that reach
+       creation by another route. */
+    if (!lsp_ensure_scratch(lsp, n_total)) {
+        fprintf(stderr, "LSP: out of memory sizing creation scratch for %zu participants\n",
+                n_total);
+        return 0;
+    }
+    secp256k1_pubkey *all_pubkeys = lsp->scratch_pubkeys;
     all_pubkeys[0] = lsp->lsp_pubkey;
     for (size_t i = 0; i < lsp->n_clients; i++)
         all_pubkeys[i + 1] = lsp->client_pubkeys[i];
@@ -431,8 +445,11 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     uint64_t saved_fee_per_tx = f->fee_per_tx;
     placement_mode_t saved_placement = f->placement_mode;
     economic_mode_t saved_econ = f->economic_mode;
-    participant_profile_t saved_profiles[FACTORY_MAX_SIGNERS];
-    memcpy(saved_profiles, f->profiles, sizeof(saved_profiles));
+    /* Explicit count: sizeof(saved_profiles) was the whole fixed array; as a
+       pointer that silently becomes sizeof(void*).  Copy exactly the
+       participants that exist, which is also all f->profiles is sized for. */
+    participant_profile_t *saved_profiles = lsp->scratch_profiles;
+    memcpy(saved_profiles, f->profiles, n_total * sizeof(participant_profile_t));
     int saved_has_shachain = f->has_shachain;
     int saved_use_flat = f->use_flat_secrets;
     size_t saved_n_secrets = f->n_revocation_secrets;
@@ -461,7 +478,7 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     f->use_tree_anchor = 1;  /* #56: P2A CPFP anchors on tree txs (matches client side) */
     f->placement_mode = saved_placement;
     f->economic_mode = saved_econ;
-    memcpy(f->profiles, saved_profiles, sizeof(saved_profiles));
+    memcpy(f->profiles, saved_profiles, n_total * sizeof(participant_profile_t));
     if (saved_has_shachain) {
         if (saved_use_flat && saved_secrets)
             factory_set_flat_secrets(f, saved_secrets, saved_n_secrets);
@@ -1395,6 +1412,8 @@ void lsp_cleanup(lsp_t *lsp) {
     free(lsp->scratch_slot_hints);
     free(lsp->scratch_seen);
     free(lsp->scratch_pubkeys);
+    free(lsp->scratch_profiles);
+    lsp->scratch_profiles = NULL;
     lsp->scratch_slot_hints = NULL;
     lsp->scratch_seen = NULL;
     lsp->scratch_pubkeys = NULL;

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -6,6 +6,7 @@
 #include "superscalar/crash_inject.h"
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/select.h>
@@ -459,9 +460,23 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
        simply untrue and untested -- the unit suite cannot see it because below
        256 the two counts coincide. */
     participant_profile_t *saved_profiles = lsp->scratch_profiles;
-    size_t n_prof = f->config.max_signers;
-    if (n_prof > lsp->scratch_cap) n_prof = lsp->scratch_cap;
-    memcpy(saved_profiles, f->profiles, n_prof * sizeof(participant_profile_t));
+    size_t n_prof = 0;
+    /* RETRY SAFETY: a failed creation attempt can leave the factory with its
+       dynamic arrays released, so f->profiles is NULL when attempt 2 re-enters
+       here.  This crashed the LSP outright at N=300:
+           === CRASH (signal 11) ===  lsp_run_factory_creation_stateless
+           src/lsp.c:465   (this memcpy)
+       after attempt 1 failed on "send LSP_RESPONSE to client 108 failed".
+       Pre-existing rather than new -- the old fixed-array version read from
+       f->profiles just the same -- but unreachable in practice because below
+       256 clients an attempt essentially never failed, so the retry path was
+       never exercised. A failed attempt must degrade to a retry, not kill the
+       daemon. Nothing to save when there are no profiles yet. */
+    if (f->profiles && lsp->scratch_profiles) {
+        n_prof = f->config.max_signers;
+        if (n_prof > lsp->scratch_cap) n_prof = lsp->scratch_cap;
+        memcpy(saved_profiles, f->profiles, n_prof * sizeof(participant_profile_t));
+    }
     int saved_has_shachain = f->has_shachain;
     int saved_use_flat = f->use_flat_secrets;
     size_t saved_n_secrets = f->n_revocation_secrets;
@@ -494,7 +509,11 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
        (the re-init above ran factory_config_fit, which grows max_signers to
        n_participants); the surplus stays zeroed from calloc, which is the same
        state the old fixed-256 save/restore left it in. */
-    memcpy(f->profiles, saved_profiles, n_prof * sizeof(participant_profile_t));
+    /* n_prof == 0 means nothing was saved (see the guard above), so there is
+       nothing to put back -- and f->profiles is freshly calloc'd by the re-init
+       either way, which is the correct state to leave it in. */
+    if (n_prof && f->profiles)
+        memcpy(f->profiles, saved_profiles, n_prof * sizeof(participant_profile_t));
     if (saved_has_shachain) {
         if (saved_use_flat && saved_secrets)
             factory_set_flat_secrets(f, saved_secrets, saved_n_secrets);
@@ -546,9 +565,16 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
             cJSON_AddItemToArray(da, cJSON_CreateNumber((double)lsp->dist_client_amounts[i]));
         cJSON_AddItemToObject(propose, "dist_amounts", da);
     }
-    for (size_t i = 0; i < lsp->n_clients; i++) {
-        if (!wire_send(lsp->client_fds[i], MSG_FACTORY_PROPOSE, propose)) {
-            fprintf(stderr, "LSP-stateless: send FACTORY_PROPOSE to client %zu failed\n", i);
+    {
+        size_t fail_i = 0;
+        /* Serialize once for the whole fan-out (see wire_send_many). */
+        if (!wire_send_many(lsp->client_fds, lsp->n_clients,
+                            MSG_FACTORY_PROPOSE, propose, &fail_i)) {
+            fprintf(stderr,
+                    "LSP-stateless: send FACTORY_PROPOSE to client %zu failed "
+                    "(fd=%d errno=%d %s, %zu/%zu sent)\n",
+                    fail_i, lsp->client_fds[fail_i], errno, strerror(errno),
+                    fail_i, lsp->n_clients);
             cJSON_Delete(propose);
             return 0;
         }
@@ -831,9 +857,26 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
                 }
             }
         }
-        for (size_t i = 0; i < lsp->n_clients; i++) {
-            if (!wire_send(lsp->client_fds[i], MSG_FACTORY_LSP_RESPONSE, response)) {
-                fprintf(stderr, "LSP-stateless: send LSP_RESPONSE to client %zu failed\n", i);
+        {
+            size_t fail_i = 0;
+            /* Serialize once, not once per client: this message carries the
+               whole nonce matrix (5.6 MB at N=301) and the per-peer loop was
+               re-printing it for every one of them. */
+            if (!wire_send_many(lsp->client_fds, lsp->n_clients,
+                                MSG_FACTORY_LSP_RESPONSE, response, &fail_i)) {
+                size_t i = fail_i;
+                /* Report WHY.  LSP_RESPONSE carries the whole nonce matrix and is
+                   the largest message in the protocol, so at scale this is the
+                   first send that can block: with N clients the LSP pushes
+                   N x (matrix bytes) and a slow reader stalls write_all.  Without
+                   errno and the fd state, "send failed to client 108" is
+                   indistinguishable between a dead peer, a full socket buffer and
+                   an oversize frame -- which cost a full diagnosis cycle. */
+                fprintf(stderr,
+                        "LSP-stateless: send LSP_RESPONSE to client %zu failed "
+                        "(fd=%d errno=%d %s, %zu/%zu sent)\n",
+                        i, lsp->client_fds[i], errno, strerror(errno),
+                        i, lsp->n_clients);
                 cJSON_Delete(response);
                 free(all_pn);
                 goto fail_pre;
@@ -1027,6 +1070,12 @@ int lsp_run_cooperative_close(lsp_t *lsp,
     int *close_wait_fds = NULL;
     int *close_ready = NULL;
     secp256k1_musig_partial_sig *all_psigs = NULL;
+    /* Hoisted for the same reason: ceremony_t now heap-allocates its per-client
+       state above CEREMONY_SMALL, and both ceremonies sit in blocks containing
+       `goto close_fail`.  Zero-initialised so ceremony_free is safe on every
+       path, including the ones that jump out before either is initialised. */
+    ceremony_t close_nonce_cer = {0};
+    ceremony_t close_psig_cer = {0};
 
     /* Build unsigned close tx + sighash */
     tx_buf_t unsigned_tx;
@@ -1119,7 +1168,6 @@ int lsp_run_cooperative_close(lsp_t *lsp,
     musig_pubnonce_serialize(lsp->ctx, all_pubnonces[0], &lsp_pubnonce);
 
     {
-        ceremony_t close_nonce_cer;
         ceremony_init(&close_nonce_cer, lsp->n_clients, 300, (int)lsp->n_clients);
         size_t close_nonces_received = 0;
 
@@ -1236,7 +1284,6 @@ int lsp_run_cooperative_close(lsp_t *lsp,
 
     /* Collect CLOSE_PSIG from all clients (parallel select) */
     {
-        ceremony_t close_psig_cer;
         ceremony_init(&close_psig_cer, lsp->n_clients, 300, (int)lsp->n_clients);
         size_t close_psigs_received = 0;
 
@@ -1360,11 +1407,13 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         cJSON_Delete(done);
     }
 
+    ceremony_free(&close_nonce_cer); ceremony_free(&close_psig_cer);
     free(all_pubnonces); free(close_wait_fds); free(close_ready); free(all_psigs);
     tx_buf_free(&unsigned_tx);
     return 1;
 
 close_fail:
+    ceremony_free(&close_nonce_cer); ceremony_free(&close_psig_cer);
     free(all_pubnonces); free(close_wait_fds); free(close_ready); free(all_psigs);
     if (clients_notified)
         lsp_abort_ceremony(lsp, "cooperative close failed");

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -446,10 +446,22 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     placement_mode_t saved_placement = f->placement_mode;
     economic_mode_t saved_econ = f->economic_mode;
     /* Explicit count: sizeof(saved_profiles) was the whole fixed array; as a
-       pointer that silently becomes sizeof(void*).  Copy exactly the
-       participants that exist, which is also all f->profiles is sized for. */
+       pointer that silently becomes sizeof(void*).
+       Bound by BOTH allocations.  f->profiles is sized to f->config.max_signers,
+       which at this point is still the pre-init default (256) -- the factory has
+       not been re-inited yet, so factory_config_fit has not grown it to
+       n_participants.  An earlier version of this copied n_total and ASan caught
+       it at N=520:
+           READ of size 16672 (= 521 * sizeof(participant_profile_t))
+           heap-buffer-overflow  src/lsp.c:452
+       i.e. reading 521 profiles out of a 256-entry array.  The comment here
+       previously asserted n_total was "all f->profiles is sized for", which was
+       simply untrue and untested -- the unit suite cannot see it because below
+       256 the two counts coincide. */
     participant_profile_t *saved_profiles = lsp->scratch_profiles;
-    memcpy(saved_profiles, f->profiles, n_total * sizeof(participant_profile_t));
+    size_t n_prof = f->config.max_signers;
+    if (n_prof > lsp->scratch_cap) n_prof = lsp->scratch_cap;
+    memcpy(saved_profiles, f->profiles, n_prof * sizeof(participant_profile_t));
     int saved_has_shachain = f->has_shachain;
     int saved_use_flat = f->use_flat_secrets;
     size_t saved_n_secrets = f->n_revocation_secrets;
@@ -478,7 +490,11 @@ int lsp_run_factory_creation_stateless(lsp_t *lsp,
     f->use_tree_anchor = 1;  /* #56: P2A CPFP anchors on tree txs (matches client side) */
     f->placement_mode = saved_placement;
     f->economic_mode = saved_econ;
-    memcpy(f->profiles, saved_profiles, n_total * sizeof(participant_profile_t));
+    /* Restore exactly what was saved.  f->profiles may now be LARGER than it was
+       (the re-init above ran factory_config_fit, which grows max_signers to
+       n_participants); the surplus stays zeroed from calloc, which is the same
+       state the old fixed-256 save/restore left it in. */
+    memcpy(f->profiles, saved_profiles, n_prof * sizeof(participant_profile_t));
     if (saved_has_shachain) {
         if (saved_use_flat && saved_secrets)
             factory_set_flat_secrets(f, saved_secrets, saved_n_secrets);

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1089,7 +1089,7 @@ int lsp_run_cooperative_close(lsp_t *lsp,
     clients_notified = 1;
 
     /* Collect CLOSE_NONCE from all clients */
-    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_pubnonces[lsp->n_clients + 1][66];
     musig_pubnonce_serialize(lsp->ctx, all_pubnonces[0], &lsp_pubnonce);
 
     {
@@ -1098,13 +1098,13 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         size_t close_nonces_received = 0;
 
         while (close_nonces_received < lsp->n_clients) {
-            int wait_fds[LSP_MAX_CLIENTS];
+            int wait_fds[lsp->n_clients ? lsp->n_clients : 1];
             for (size_t i = 0; i < lsp->n_clients; i++) {
                 wait_fds[i] = (close_nonce_cer.clients[i] == CLIENT_WAITING)
                               ? lsp->client_fds[i] : -1;
             }
 
-            int ready[LSP_MAX_CLIENTS];
+            int ready[lsp->n_clients ? lsp->n_clients : 1];
             int n_ready = ceremony_select_all(wait_fds, lsp->n_clients, close_nonce_cer.per_client_timeout_sec, ready);
             if (n_ready <= 0) {
                 for (size_t i = 0; i < lsp->n_clients; i++) {
@@ -1205,7 +1205,7 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         goto close_fail;
     }
 
-    secp256k1_musig_partial_sig all_psigs[FACTORY_MAX_SIGNERS];
+    secp256k1_musig_partial_sig all_psigs[lsp->n_clients + 1];
     all_psigs[0] = lsp_psig;
 
     /* Collect CLOSE_PSIG from all clients (parallel select) */
@@ -1215,13 +1215,13 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         size_t close_psigs_received = 0;
 
         while (close_psigs_received < lsp->n_clients) {
-            int wait_fds[LSP_MAX_CLIENTS];
+            int wait_fds[lsp->n_clients ? lsp->n_clients : 1];
             for (size_t i = 0; i < lsp->n_clients; i++) {
                 wait_fds[i] = (close_psig_cer.clients[i] == CLIENT_WAITING)
                               ? lsp->client_fds[i] : -1;
             }
 
-            int ready[LSP_MAX_CLIENTS];
+            int ready[lsp->n_clients ? lsp->n_clients : 1];
             int n_ready = ceremony_select_all(wait_fds, lsp->n_clients, close_psig_cer.per_client_timeout_sec, ready);
             if (n_ready <= 0) {
                 for (size_t i = 0; i < lsp->n_clients; i++) {

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1018,6 +1018,16 @@ int lsp_run_cooperative_close(lsp_t *lsp,
     size_t n_total = 1 + lsp->n_clients;
     int clients_notified = 0;  /* set after CLOSE_PROPOSE sent */
 
+    /* Declared NULL up here, allocated further down.  close_fail frees all four,
+       and several `goto close_fail` fire BEFORE the allocation point -- gcc
+       rightly rejected freeing them uninitialised
+       (-Werror=maybe-uninitialized).  free(NULL) is a no-op, so a NULL start
+       makes every path through the label safe. */
+    unsigned char (*all_pubnonces)[66] = NULL;
+    int *close_wait_fds = NULL;
+    int *close_ready = NULL;
+    secp256k1_musig_partial_sig *all_psigs = NULL;
+
     /* Build unsigned close tx + sighash */
     tx_buf_t unsigned_tx;
     tx_buf_init(&unsigned_tx, 256);
@@ -1095,12 +1105,10 @@ int lsp_run_cooperative_close(lsp_t *lsp,
        is unavailable here.  Allocated once above the first goto and released at
        the single cleanup label -- which is also why the inner wait_fds/ready are
        hoisted out of their loops rather than allocated per iteration. */
-    unsigned char (*all_pubnonces)[66] =
-        calloc(lsp->n_clients + 1, 66);
-    int *close_wait_fds = calloc(lsp->n_clients ? lsp->n_clients : 1, sizeof(int));
-    int *close_ready    = calloc(lsp->n_clients ? lsp->n_clients : 1, sizeof(int));
-    secp256k1_musig_partial_sig *all_psigs =
-        calloc(lsp->n_clients + 1, sizeof(secp256k1_musig_partial_sig));
+    all_pubnonces   = calloc(lsp->n_clients + 1, 66);
+    close_wait_fds  = calloc(lsp->n_clients ? lsp->n_clients : 1, sizeof(int));
+    close_ready     = calloc(lsp->n_clients ? lsp->n_clients : 1, sizeof(int));
+    all_psigs       = calloc(lsp->n_clients + 1, sizeof(secp256k1_musig_partial_sig));
     if (!all_pubnonces || !close_wait_fds || !close_ready || !all_psigs) {
         fprintf(stderr, "LSP close: out of memory for %zu-participant ceremony\n",
                 lsp->n_clients + 1);

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1089,7 +1089,25 @@ int lsp_run_cooperative_close(lsp_t *lsp,
     clients_notified = 1;
 
     /* Collect CLOSE_NONCE from all clients */
-    unsigned char all_pubnonces[lsp->n_clients + 1][66];
+    /* Heap, not VLA.  This ceremony uses `goto close_fail` and C forbids a jump
+       into the scope of a variably-modified type ("jump into scope of identifier
+       with variably modified type"), so the VLA idiom used elsewhere in the LSP
+       is unavailable here.  Allocated once above the first goto and released at
+       the single cleanup label -- which is also why the inner wait_fds/ready are
+       hoisted out of their loops rather than allocated per iteration. */
+    unsigned char (*all_pubnonces)[66] =
+        calloc(lsp->n_clients + 1, 66);
+    int *close_wait_fds = calloc(lsp->n_clients ? lsp->n_clients : 1, sizeof(int));
+    int *close_ready    = calloc(lsp->n_clients ? lsp->n_clients : 1, sizeof(int));
+    secp256k1_musig_partial_sig *all_psigs =
+        calloc(lsp->n_clients + 1, sizeof(secp256k1_musig_partial_sig));
+    if (!all_pubnonces || !close_wait_fds || !close_ready || !all_psigs) {
+        fprintf(stderr, "LSP close: out of memory for %zu-participant ceremony\n",
+                lsp->n_clients + 1);
+        free(all_pubnonces); free(close_wait_fds); free(close_ready); free(all_psigs);
+        tx_buf_free(&unsigned_tx);
+        return 0;
+    }
     musig_pubnonce_serialize(lsp->ctx, all_pubnonces[0], &lsp_pubnonce);
 
     {
@@ -1098,13 +1116,13 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         size_t close_nonces_received = 0;
 
         while (close_nonces_received < lsp->n_clients) {
-            int wait_fds[lsp->n_clients ? lsp->n_clients : 1];
+            int *wait_fds = close_wait_fds;
             for (size_t i = 0; i < lsp->n_clients; i++) {
                 wait_fds[i] = (close_nonce_cer.clients[i] == CLIENT_WAITING)
                               ? lsp->client_fds[i] : -1;
             }
 
-            int ready[lsp->n_clients ? lsp->n_clients : 1];
+            int *ready = close_ready;
             int n_ready = ceremony_select_all(wait_fds, lsp->n_clients, close_nonce_cer.per_client_timeout_sec, ready);
             if (n_ready <= 0) {
                 for (size_t i = 0; i < lsp->n_clients; i++) {
@@ -1205,7 +1223,7 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         goto close_fail;
     }
 
-    secp256k1_musig_partial_sig all_psigs[lsp->n_clients + 1];
+
     all_psigs[0] = lsp_psig;
 
     /* Collect CLOSE_PSIG from all clients (parallel select) */
@@ -1215,13 +1233,13 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         size_t close_psigs_received = 0;
 
         while (close_psigs_received < lsp->n_clients) {
-            int wait_fds[lsp->n_clients ? lsp->n_clients : 1];
+            int *wait_fds = close_wait_fds;
             for (size_t i = 0; i < lsp->n_clients; i++) {
                 wait_fds[i] = (close_psig_cer.clients[i] == CLIENT_WAITING)
                               ? lsp->client_fds[i] : -1;
             }
 
-            int ready[lsp->n_clients ? lsp->n_clients : 1];
+            int *ready = close_ready;
             int n_ready = ceremony_select_all(wait_fds, lsp->n_clients, close_psig_cer.per_client_timeout_sec, ready);
             if (n_ready <= 0) {
                 for (size_t i = 0; i < lsp->n_clients; i++) {
@@ -1334,10 +1352,12 @@ int lsp_run_cooperative_close(lsp_t *lsp,
         cJSON_Delete(done);
     }
 
+    free(all_pubnonces); free(close_wait_fds); free(close_ready); free(all_psigs);
     tx_buf_free(&unsigned_tx);
     return 1;
 
 close_fail:
+    free(all_pubnonces); free(close_wait_fds); free(close_ready); free(all_psigs);
     if (clients_notified)
         lsp_abort_ceremony(lsp, "cooperative close failed");
     tx_buf_free(&unsigned_tx);

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -103,6 +103,30 @@ int lsp_init(lsp_t *lsp, secp256k1_context *ctx,
     return 1;
 }
 
+/* Grow the ceremony scratch to `want` entries (see lsp.h for why it lives on
+   the struct).  Grows only; a later ceremony with fewer clients reuses the
+   larger block rather than reallocating down. */
+int lsp_ensure_scratch(lsp_t *lsp, size_t want) {
+    if (!lsp) return 0;
+    if (want <= lsp->scratch_cap) return 1;
+
+    int *sh = (int *)realloc(lsp->scratch_slot_hints, want * sizeof(int));
+    if (!sh) return 0;
+    lsp->scratch_slot_hints = sh;
+
+    int *sn = (int *)realloc(lsp->scratch_seen, want * sizeof(int));
+    if (!sn) return 0;
+    lsp->scratch_seen = sn;
+
+    secp256k1_pubkey *pk = (secp256k1_pubkey *)
+        realloc(lsp->scratch_pubkeys, want * sizeof(secp256k1_pubkey));
+    if (!pk) return 0;
+    lsp->scratch_pubkeys = pk;
+
+    lsp->scratch_cap = want;
+    return 1;
+}
+
 int lsp_accept_clients(lsp_t *lsp) {
     if ((int)lsp->expected_clients > lsp->max_connections) {
         fprintf(stderr, "ERROR: --clients %d exceeds --max-connections %d\n",
@@ -119,8 +143,15 @@ int lsp_accept_clients(lsp_t *lsp) {
     }
 
     lsp->n_clients = 0;
-    int hello_slot_hints[FACTORY_MAX_SIGNERS];
-    for (size_t k = 0; k < FACTORY_MAX_SIGNERS; k++) hello_slot_hints[k] = 0;
+    /* +1: 'seen' below is indexed by SLOT (1..n_clients), and the pubkey array
+       carries the LSP at [0].  Sized to the participant count, not a fixed 256. */
+    if (!lsp_ensure_scratch(lsp, lsp->expected_clients + 1)) {
+        fprintf(stderr, "LSP: out of memory sizing ceremony scratch for %zu clients\n",
+                lsp->expected_clients);
+        return 0;
+    }
+    int *hello_slot_hints = lsp->scratch_slot_hints;
+    for (size_t k = 0; k < lsp->scratch_cap; k++) hello_slot_hints[k] = 0;
 
     for (size_t i = 0; i < lsp->expected_clients; i++) {
         /* Timeout: wait for incoming connection with select() */
@@ -232,7 +263,8 @@ int lsp_accept_clients(lsp_t *lsp) {
        stranded on every restart. */
     {
         int all_hinted = 1;
-        int seen[FACTORY_MAX_SIGNERS] = {0};
+        int *seen = lsp->scratch_seen;
+        memset(seen, 0, lsp->scratch_cap * sizeof(int));
         for (size_t i = 0; i < lsp->n_clients; i++) {
             int s = hello_slot_hints[i];
             if (s < 1 || (size_t)s > lsp->n_clients || seen[s]) { all_hinted = 0; break; }
@@ -272,7 +304,7 @@ int lsp_accept_clients(lsp_t *lsp) {
 
     /* Build all_pubkeys array: [LSP, client0, client1, ...] */
     size_t n_total = 1 + lsp->n_clients;
-    secp256k1_pubkey all_pubkeys[FACTORY_MAX_SIGNERS];
+    secp256k1_pubkey *all_pubkeys = lsp->scratch_pubkeys;
     all_pubkeys[0] = lsp->lsp_pubkey;
     for (size_t i = 0; i < lsp->n_clients; i++)
         all_pubkeys[i + 1] = lsp->client_pubkeys[i];
@@ -1358,6 +1390,15 @@ void lsp_cleanup(lsp_t *lsp) {
     free(lsp->client_pubkeys);
     lsp->client_fds = NULL;
     lsp->client_pubkeys = NULL;
+    /* Ceremony scratch: the single free point for what used to be three fixed
+       stack arrays.  Safe on a zeroed lsp_t and safe to call twice. */
+    free(lsp->scratch_slot_hints);
+    free(lsp->scratch_seen);
+    free(lsp->scratch_pubkeys);
+    lsp->scratch_slot_hints = NULL;
+    lsp->scratch_seen = NULL;
+    lsp->scratch_pubkeys = NULL;
+    lsp->scratch_cap = 0;
     if (lsp->bridge_fd >= 0) {
         wire_close(lsp->bridge_fd);
         lsp->bridge_fd = -1;

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -7325,9 +7325,21 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                                are already present. */
                                             readiness_tracker_t *rt =
                                                 (readiness_tracker_t *)mgr->readiness;
-                                            readiness_init(rt, lf->factory_id,
-                                                           lsp->n_clients,
-                                                           (persist_t *)mgr->persist);
+                                            /* Re-init on a LIVE tracker: readiness_init
+                                               treats *rt as uninitialized and memsets it,
+                                               so without this free the previous rotation's
+                                               per-client array leaks once per rotation.
+                                               Safe on a zeroed/never-init'd tracker too. */
+                                            readiness_free(rt);
+                                            if (!readiness_init(rt, lf->factory_id,
+                                                                lsp->n_clients,
+                                                                (persist_t *)mgr->persist)) {
+                                                fprintf(stderr,
+                                                    "LSP: readiness tracker alloc failed for "
+                                                    "%zu clients — rotation readiness will "
+                                                    "report NOT ready (fail closed)\n",
+                                                    lsp->n_clients);
+                                            }
                                             persist_t *db = (persist_t *)mgr->persist;
                                             notify_t *nfy = (notify_t *)mgr->notify;
                                             for (size_t ci = 0; ci < lsp->n_clients; ci++) {

--- a/src/lsp_channels.c
+++ b/src/lsp_channels.c
@@ -1888,7 +1888,7 @@ static int lsp_advance_leaf_stateless(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         }
 
         /* Collect channel indices that live on this leaf node. */
-        uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+        uint32_t leaf_ch_ids[mgr->n_channels ? mgr->n_channels : 1];
         size_t n_leaf_ch = 0;
         for (size_t c = 0; c < mgr->n_channels; c++) {
             size_t c_node; uint32_t c_vout;
@@ -2722,7 +2722,7 @@ static int lsp_run_state_advance_stateless(lsp_channel_mgr_t *mgr,
                        "(%zu bytes, L-stock %llu sats)\n", affected[k], poison_len,
                        (unsigned long long)poison_old_l_amount[k]);
             }
-            uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+            uint32_t leaf_ch_ids[mgr->n_channels ? mgr->n_channels : 1];
             size_t n_leaf_ch = 0;
             for (size_t cc = 0; cc < mgr->n_channels; cc++) {
                 size_t c_node; uint32_t c_vout;
@@ -2989,9 +2989,9 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     }
 
     /* Get all client participant indices on this leaf (may be 1..N-1). */
-    uint32_t clients[FACTORY_MAX_SIGNERS];
+    uint32_t clients[node->n_signers ? node->n_signers : 1];
     size_t n_clients = factory_get_subtree_clients(f, (int)node_idx, clients,
-                                                     FACTORY_MAX_SIGNERS);
+                                                     node->n_signers ? node->n_signers : 1);
     if (n_clients != node->n_signers - 1) {
         fprintf(stderr, "LSP realloc: leaf %zu has %zu signers but %zu clients found\n",
                 node_idx, node->n_signers, n_clients);
@@ -3147,8 +3147,8 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
     cJSON_Delete(propose);
 
     /* Step 6: Recv REALLOC_NONCE from each client, set their nonces (state + poison). */
-    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
-    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_pubnonces[node->n_signers ? node->n_signers : 1][66];
+    unsigned char all_poison_pubnonces[node->n_signers ? node->n_signers : 1][66];
     memcpy(all_pubnonces[lsp_slot], lsp_pubnonce_ser, 66);
     if (realloc_poison_prepared)
         memcpy(all_poison_pubnonces[lsp_slot], lsp_poison_pn_ser, 66);
@@ -3362,7 +3362,7 @@ int lsp_realloc_leaf(lsp_channel_mgr_t *mgr, lsp_t *lsp,
        (#258), reproduced end-to-end by tools/test_regtest_cheat_realloc.sh. */
     if (mgr->watchtower && realloc_had_signed && node->is_signed &&
         node->signed_tx.len > 0) {
-        uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+        uint32_t leaf_ch_ids[mgr->n_channels ? mgr->n_channels : 1];
         size_t n_leaf_ch = 0;
         for (size_t cc = 0; cc < mgr->n_channels; cc++) {
             size_t c_node;
@@ -3725,7 +3725,7 @@ static int lsp_subfactory_chain_advance_stateless_multi(
     unsigned char *all_pn_per_input = calloc(sub->n_signers * n_inputs, 66);
     if (!all_pn_per_input) { factory_session_reset_poison(f, sub_node_i); return 0; }
     /* Poison side-channel is single-input: one poison nonce per signer. */
-    unsigned char all_poison_pn[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_poison_pn[sub->n_signers ? sub->n_signers : 1][66];
     memset(all_poison_pn, 0, sizeof(all_poison_pn));
 
     /* Step 4: collect each client's n_inputs pubnonces (+ 1 poison nonce). */
@@ -4312,7 +4312,7 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
 
     /* Sub-factory clients (one client per output != L-stock + LSP).
        Build sub_clients[] -- same shape as legacy. */
-    uint32_t sub_clients[FACTORY_MAX_SIGNERS];
+    uint32_t sub_clients[sub->n_signers ? sub->n_signers : 1];
     size_t n_clients_in_sub = 0;
     for (size_t s = 1; s < sub->n_signers; s++) {
         sub_clients[n_clients_in_sub++] = sub->signer_indices[s];
@@ -4480,8 +4480,8 @@ static int lsp_subfactory_chain_advance_stateless(lsp_channel_mgr_t *mgr,
     lsp_crash_checkpoint("subfactory_propose");
 
     /* Step 4: collect CLIENT_PUBNONCES from each client (state + poison). */
-    unsigned char all_pubnonces[FACTORY_MAX_SIGNERS][66];
-    unsigned char all_poison_pubnonces[FACTORY_MAX_SIGNERS][66];
+    unsigned char all_pubnonces[sub->n_signers ? sub->n_signers : 1][66];
+    unsigned char all_poison_pubnonces[sub->n_signers ? sub->n_signers : 1][66];
     memset(all_poison_pubnonces, 0, sizeof(all_poison_pubnonces));
     for (size_t ci = 0; ci < n_clients_in_sub; ci++) {
         size_t fd_idx = (size_t)(sub_clients[ci] - 1);
@@ -7704,9 +7704,9 @@ int lsp_channels_run_daemon_loop(lsp_channel_mgr_t *mgr, lsp_t *lsp,
                                 &lf->factory, (uint32_t)bh);
                             int urgency = readiness_compute_urgency(
                                 blocks_left, lf->factory.dying_blocks);
-                            uint32_t missing[FACTORY_MAX_SIGNERS];
+                            uint32_t missing[rt->n_clients ? rt->n_clients : 1];
                             size_t n_missing = readiness_get_missing(
-                                rt, missing, FACTORY_MAX_SIGNERS);
+                                rt, missing, rt->n_clients ? rt->n_clients : 1);
                             persist_t *db = (persist_t *)mgr->persist;
                             notify_t *nfy = (notify_t *)mgr->notify;
                             for (size_t mi = 0; mi < n_missing; mi++) {
@@ -8225,7 +8225,7 @@ int lsp_channels_rehydrate_watchtower_from_chains(lsp_channel_mgr_t *mgr) {
            what watchtower wants for old_txid32. */
 
         /* Collect channel ids on this leaf. */
-        uint32_t leaf_ch_ids[FACTORY_MAX_SIGNERS];
+        uint32_t leaf_ch_ids[mgr->n_channels ? mgr->n_channels : 1];
         size_t n_leaf_ch = 0;
         for (size_t c = 0; c < mgr->n_channels; c++) {
             size_t c_node; uint32_t c_vout;

--- a/src/lsp_demo.c
+++ b/src/lsp_demo.c
@@ -175,7 +175,13 @@ int lsp_channels_lsppay(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         fd_set rfds;
         FD_ZERO(&rfds);
         FD_SET(lsp->client_fds[to_client], &rfds);
-        struct timeval tv = { .tv_sec = 0, .tv_usec = 200000 }; /* 200ms */
+        /* Non-blocking: drain what has ALREADY arrived, never wait for more.
+           This loop can only exit on a select() timeout, so a 200ms tv was an
+           unconditional 200ms of dead time on every single payment -- 13% of
+           the per-payment cost, 60s across an N=300 seed.  Waiting buys
+           nothing: a REGISTER_INVOICE that arrives later is absorbed by
+           wait_for_msg inline (see above) or by the daemon loop. */
+        struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
         while (select(lsp->client_fds[to_client] + 1, &rfds, NULL, NULL, &tv) > 0) {
             wire_msg_t drain_msg;
             if (!wire_recv_timeout(lsp->client_fds[to_client], &drain_msg, 2)) break;
@@ -190,7 +196,7 @@ int lsp_channels_lsppay(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             FD_ZERO(&rfds);
             FD_SET(lsp->client_fds[to_client], &rfds);
             tv.tv_sec = 0;
-            tv.tv_usec = 200000;
+            tv.tv_usec = 0;
         }
     }
 
@@ -531,7 +537,13 @@ int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         fd_set rfds;
         FD_ZERO(&rfds);
         FD_SET(lsp->client_fds[to_client], &rfds);
-        struct timeval tv = { .tv_sec = 0, .tv_usec = 200000 }; /* 200ms */
+        /* Non-blocking: drain what has ALREADY arrived, never wait for more.
+           This loop can only exit on a select() timeout, so a 200ms tv was an
+           unconditional 200ms of dead time on every single payment -- 13% of
+           the per-payment cost, 60s across an N=300 seed.  Waiting buys
+           nothing: a REGISTER_INVOICE that arrives later is absorbed by
+           wait_for_msg inline (see above) or by the daemon loop. */
+        struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
         while (select(lsp->client_fds[to_client] + 1, &rfds, NULL, NULL, &tv) > 0) {
             wire_msg_t drain_msg;
             if (!wire_recv_timeout(lsp->client_fds[to_client], &drain_msg, 2)) break;
@@ -546,7 +558,7 @@ int lsp_channels_initiate_payment(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             FD_ZERO(&rfds);
             FD_SET(lsp->client_fds[to_client], &rfds);
             tv.tv_sec = 0;
-            tv.tv_usec = 200000;
+            tv.tv_usec = 0;
         }
     }
 
@@ -1104,7 +1116,8 @@ int lsp_channels_create_external_invoice(lsp_channel_mgr_t *mgr, lsp_t *lsp,
         fd_set rfds;
         FD_ZERO(&rfds);
         FD_SET(lsp->client_fds[client_idx], &rfds);
-        struct timeval tv = { .tv_sec = 0, .tv_usec = 200000 };
+        /* Non-blocking drain — see the note on the identical loop above. */
+        struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
         while (select(lsp->client_fds[client_idx] + 1, &rfds, NULL, NULL, &tv) > 0) {
             wire_msg_t drain_msg;
             if (!wire_recv(lsp->client_fds[client_idx], &drain_msg)) break;
@@ -1119,7 +1132,7 @@ int lsp_channels_create_external_invoice(lsp_channel_mgr_t *mgr, lsp_t *lsp,
             FD_ZERO(&rfds);
             FD_SET(lsp->client_fds[client_idx], &rfds);
             tv.tv_sec = 0;
-            tv.tv_usec = 200000;
+            tv.tv_usec = 0;
         }
     }
 

--- a/src/lsp_rotation.c
+++ b/src/lsp_rotation.c
@@ -174,8 +174,8 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
 
     /* Build combined keypair/pubkey arrays for adaptor protocol */
     size_t n_total = 1 + lsp->n_clients;
-    secp256k1_keypair rot_kps[FACTORY_MAX_SIGNERS];
-    secp256k1_pubkey rot_pks[FACTORY_MAX_SIGNERS];
+    secp256k1_keypair rot_kps[n_total];
+    secp256k1_pubkey rot_pks[n_total];
 
     secp256k1_keypair lsp_kp;
     if (!secp256k1_keypair_create(mgr->ctx, &lsp_kp, mgr->rot_lsp_seckey))
@@ -618,7 +618,7 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
                     "using factory funding SPK (funds may strand)\n");
         }
 
-        tx_output_t rot_outputs[FACTORY_MAX_SIGNERS];
+        tx_output_t rot_outputs[n_total];
         size_t close_vsize = 68 + 43 * n_total;
         uint64_t close_fee = fee_estimate(fe, close_vsize);
         if (close_fee == 0) {
@@ -876,8 +876,8 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
            (unsigned long long)fund_amount, fund_txid_hex, fund_vout);
 
     /* For partial rotation: remap client arrays to cooperative subset */
-    int saved_client_fds[LSP_MAX_CLIENTS];
-    secp256k1_pubkey saved_client_pks[LSP_MAX_CLIENTS];
+    int saved_client_fds[lsp->n_clients ? lsp->n_clients : 1];
+    secp256k1_pubkey saved_client_pks[lsp->n_clients ? lsp->n_clients : 1];
     size_t n_coop = 0;
 
     memset(saved_client_fds, -1, sizeof(saved_client_fds));
@@ -887,9 +887,9 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
         memcpy(saved_client_fds, lsp->client_fds, sizeof(saved_client_fds));
         memcpy(saved_client_pks, lsp->client_pubkeys, sizeof(saved_client_pks));
 
-        uint32_t coop[FACTORY_MAX_SIGNERS];
+        uint32_t coop[lsp->n_clients + 1];
         n_coop = ladder_get_cooperative_clients(lad, dying_id,
-                                                 coop, FACTORY_MAX_SIGNERS);
+                                                 coop, lsp->n_clients + 1);
 
         /* Remap to contiguous indices, skipping clients whose fd went stale */
         size_t n_online = 0;
@@ -978,8 +978,8 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
        For the current homogeneous-capacity design, funding_amount is the
        same across all channels; kept as a per-client array to prepare for
        heterogeneous-capacity factories. */
-    uint64_t rot_dist_amounts[FACTORY_MAX_SIGNERS];
-    for (size_t c = 0; c < mgr->n_channels && c < FACTORY_MAX_SIGNERS; c++)
+    uint64_t rot_dist_amounts[mgr->n_channels ? mgr->n_channels : 1];
+    for (size_t c = 0; c < mgr->n_channels; c++)
         rot_dist_amounts[c] = mgr->entries[c].channel.funding_amount;
     lsp->dist_client_amounts = rot_dist_amounts;
     lsp->dist_n_client_amounts = mgr->n_channels;
@@ -1069,9 +1069,9 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
 
     /* Close fds for uncooperative clients (partial rotation only) */
     if (partial) {
-        uint32_t uncoop[FACTORY_MAX_SIGNERS];
+        uint32_t uncoop[lsp->n_clients + 1];
         size_t n_uncoop = ladder_get_uncooperative_clients(lad, dying_id,
-                                                            uncoop, FACTORY_MAX_SIGNERS);
+                                                            uncoop, lsp->n_clients + 1);
         for (size_t i = 0; i < n_uncoop; i++) {
             int fd = saved_client_fds[uncoop[i] - 1];
             if (fd >= 0) wire_close(fd);
@@ -1121,9 +1121,9 @@ int lsp_channels_rotate_factory(lsp_channel_mgr_t *mgr, lsp_t *lsp) {
 
     /* Save channel balances so rotation preserves them (not reset to 50/50) */
     size_t saved_n_channels = mgr->n_channels;
-    uint64_t saved_ch_local[FACTORY_MAX_SIGNERS];
-    uint64_t saved_ch_remote[FACTORY_MAX_SIGNERS];
-    for (size_t c = 0; c < saved_n_channels && c < FACTORY_MAX_SIGNERS; c++) {
+    uint64_t saved_ch_local[saved_n_channels ? saved_n_channels : 1];
+    uint64_t saved_ch_remote[saved_n_channels ? saved_n_channels : 1];
+    for (size_t c = 0; c < saved_n_channels; c++) {
         saved_ch_local[c] = mgr->entries[c].channel.local_amount;
         saved_ch_remote[c] = mgr->entries[c].channel.remote_amount;
     }

--- a/src/musig.c
+++ b/src/musig.c
@@ -6,7 +6,41 @@
 
 #include "superscalar/sha256.h"
 
+/* Fill buf with len bytes of entropy, or return 0 having filled nothing the
+   caller may rely on.  The fail-closed contract is load-bearing: every caller
+   aborts the ceremony on 0, and a partial fill here would mean a reused or
+   guessable MuSig secnonce.
+ *
+ * getrandom(2) is preferred purely to avoid the open/read/close triple.
+ * musig_generate_nonce calls this TWICE per nonce inside a loop, so at N=300
+ * the creation ceremony did ~13.5k syscall triples per participant set -- it
+ * showed up as 3-6% of total CPU in a perf profile.  getrandom() is one
+ * syscall, holds no state, and is thread-safe, so nothing needs a cached fd
+ * or a lock.  Same kernel CSPRNG as /dev/urandom; no change in entropy
+ * quality.  The stdio path stays as the fallback for kernels/libcs without
+ * it. */
+#if defined(__linux__) && defined(__GLIBC__) && \
+    (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))
+#define SS_HAVE_GETRANDOM 1
+#include <sys/random.h>
+#include <errno.h>
+#endif
+
 static int fill_random(unsigned char *buf, size_t len) {
+#ifdef SS_HAVE_GETRANDOM
+    size_t got = 0;
+    while (got < len) {
+        /* Short reads are legal (>256 bytes, or a signal); EINTR is retryable.
+           Anything else is a hard failure -- fall through to the stdio path
+           rather than returning partially-filled entropy. */
+        ssize_t r = getrandom(buf + got, len - got, 0);
+        if (r > 0) { got += (size_t)r; continue; }
+        if (r < 0 && errno == EINTR) continue;
+        break;
+    }
+    if (got == len) return 1;
+    /* else: fall through and try /dev/urandom */
+#endif
     FILE *f = fopen("/dev/urandom", "rb");
     if (!f) return 0;
     size_t n = fread(buf, 1, len, f);

--- a/src/persist.c
+++ b/src/persist.c
@@ -2415,9 +2415,24 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
     unsigned char fund_spk[34];
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
-    /* Release any prior tree state (caller may reuse f across loads).
-       factory_init_from_pubkeys memsets f, which would leak existing tx_bufs. */
-    if (f->n_nodes > 0)
+    /* Release any prior state (caller may reuse f across loads).
+       factory_init_from_pubkeys memsets f, so anything f already owns must be
+       freed FIRST or it is orphaned.
+
+       The guard used to be `f->n_nodes > 0`, which tests TREE state -- but the
+       thing that needs freeing is the ARRAY SET, and factory_alloc_default_arrays
+       allocates all of it (nodes, keypairs, pubkeys, profiles,
+       dist_partial_sigs, leaf_layers, leaf_node_indices, the l_stock arrays)
+       while leaving n_nodes == 0.  So the common "pre-allocate, then load into
+       it" pattern skipped the free entirely and leaked the whole set on every
+       load -- ~260KB a time.  Harmless when factory_t carried those as fixed
+       members; a real leak now that they are heap.
+
+       Test with the ARRAYS, not the tree.  factory_free is safe here: its node
+       loop runs zero times when n_nodes == 0, and every free is NULL-safe. */
+    if (f->n_nodes > 0 || f->nodes || f->keypairs || f->pubkeys ||
+        f->profiles || f->dist_partial_sigs || f->leaf_layers ||
+        f->leaf_node_indices)
         factory_free(f);
 
     /* Reconstruct factory */

--- a/src/persist.c
+++ b/src/persist.c
@@ -2316,7 +2316,12 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
     int loaded_use_hashlock_poison = sqlite3_column_int(stmt, 9);  /* #59 restart-resume */
 
     /* Data validation (Phase 2: item 2.6) */
-    if (n_participants < 2 || n_participants > FACTORY_MAX_SIGNERS) {
+    /* Sanity ceiling on a value read back from the DB, not a capacity limit --
+       everything downstream is sized from n_participants.  At
+       FACTORY_MAX_SIGNERS this refused to load any factory over 256
+       participants, so such a factory could be created and persisted but
+       never restored after a restart. */
+    if (n_participants < 2 || n_participants > (size_t)SS_MAX_PARTICIPANTS) {
         fprintf(stderr, "persist_load_factory: invalid n_participants %zu\n",
                 n_participants);
         sqlite3_finalize(stmt);
@@ -2367,9 +2372,14 @@ int persist_load_factory(persist_t *p, uint32_t factory_id,
 
     sqlite3_bind_int(pk_stmt, 1, (int)factory_id);
 
-    secp256k1_pubkey pubkeys[FACTORY_MAX_SIGNERS];
+    /* Sized to n_participants, which is what the check below demands anyway.
+       As a fixed [FACTORY_MAX_SIGNERS] this truncated the pubkeys LOADED FROM
+       THE DB at 256, so `pk_count != n_participants` then failed and a
+       factory with more than 256 participants could never be restored. Fails
+       closed, but it makes restore impossible rather than wrong. */
+    secp256k1_pubkey pubkeys[n_participants ? n_participants : 1];
     size_t pk_count = 0;
-    while (sqlite3_step(pk_stmt) == SQLITE_ROW && pk_count < FACTORY_MAX_SIGNERS) {
+    while (sqlite3_step(pk_stmt) == SQLITE_ROW && pk_count < n_participants) {
         const char *pk_hex = (const char *)sqlite3_column_text(pk_stmt, 1);
         if (!pk_hex) continue;
         unsigned char pk_ser[33];

--- a/src/persist.c
+++ b/src/persist.c
@@ -3851,18 +3851,66 @@ void persist_log_wire_message(persist_t *p, int direction, uint8_t msg_type,
     const char *dir_str = direction ? "recv" : "sent";
     const char *msg_name = wire_msg_type_name(msg_type);
 
-    /* Truncated payload summary */
+    /* Truncated payload summary, built WITHOUT serializing the whole message.
+     *
+     * This used to be cJSON_PrintUnformatted(json) followed by "keep the first
+     * 500 bytes, free the rest".  cJSON_PrintUnformatted allocates the ENTIRE
+     * tree as one heap string, and a ceremony message carries an O(N) nonce or
+     * partial-sig matrix -- so at scale this allocated megabytes per message
+     * purely to throw ~all of it away, on every message, in both the client and
+     * the LSP.  massif at N=160 named it the largest single allocation site in
+     * the client: 6.16 MB peak, via
+     *     wire_recv -> cJSON_PrintUnformatted -> print_value -> print_string_ptr
+     * and it scaled with N, which is what made a co-located swarm quadratic.
+     *
+     * We now walk only the top-level fields and stop as soon as the 500-byte
+     * budget is spent, so the cost is bounded by the summary size rather than
+     * by the message size.  Nested arrays/objects are rendered as a shape
+     * ("[512 items]"), which is what an audit trail actually wants from a
+     * matrix anyway -- the full payload was never readable in 500 bytes. */
     char summary[501];
     summary[0] = '\0';
     if (json) {
-        char *printed = cJSON_PrintUnformatted((cJSON *)json);
-        if (printed) {
-            size_t len = strlen(printed);
-            if (len > 500) len = 500;
-            memcpy(summary, printed, len);
-            summary[len] = '\0';
-            free(printed);
+        size_t used = 0;
+        const cJSON *child = ((const cJSON *)json)->child;
+        int first = 1;
+        if (used < sizeof(summary) - 1) summary[used++] = '{';
+        for (; child && used < sizeof(summary) - 8; child = child->next) {
+            char field[160];
+            int n;
+            const char *nm = child->string ? child->string : "?";
+            if (cJSON_IsArray(child)) {
+                n = snprintf(field, sizeof(field), "%s\"%s\":[%d items]",
+                             first ? "" : ",", nm, cJSON_GetArraySize((cJSON *)child));
+            } else if (cJSON_IsObject(child)) {
+                n = snprintf(field, sizeof(field), "%s\"%s\":{%d fields}",
+                             first ? "" : ",", nm, cJSON_GetArraySize((cJSON *)child));
+            } else if (cJSON_IsString(child)) {
+                /* Long hex blobs (pubkeys, nonces) get head-truncated. */
+                const char *v = child->valuestring ? child->valuestring : "";
+                n = snprintf(field, sizeof(field), "%s\"%s\":\"%.48s%s\"",
+                             first ? "" : ",", nm, v, strlen(v) > 48 ? "..." : "");
+            } else if (cJSON_IsNumber(child)) {
+                n = snprintf(field, sizeof(field), "%s\"%s\":%.10g",
+                             first ? "" : ",", nm, child->valuedouble);
+            } else if (cJSON_IsBool(child)) {
+                n = snprintf(field, sizeof(field), "%s\"%s\":%s",
+                             first ? "" : ",", nm, cJSON_IsTrue(child) ? "true" : "false");
+            } else {
+                n = snprintf(field, sizeof(field), "%s\"%s\":null", first ? "" : ",", nm);
+            }
+            if (n < 0) break;
+            if (used + (size_t)n >= sizeof(summary) - 8) {
+                /* Budget spent — mark truncation rather than silently stopping. */
+                used += (size_t)snprintf(summary + used, sizeof(summary) - used, ",...");
+                break;
+            }
+            memcpy(summary + used, field, (size_t)n);
+            used += (size_t)n;
+            first = 0;
         }
+        if (used < sizeof(summary) - 1) summary[used++] = '}';
+        summary[used < sizeof(summary) ? used : sizeof(summary) - 1] = '\0';
     }
 
     const char *sql =

--- a/src/readiness.c
+++ b/src/readiness.c
@@ -1,17 +1,47 @@
 #include "superscalar/readiness.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
-void readiness_init(readiness_tracker_t *rt, uint32_t factory_id,
-                    size_t n_clients, persist_t *db) {
-    if (!rt) return;
+int readiness_init(readiness_tracker_t *rt, uint32_t factory_id,
+                   size_t n_clients, persist_t *db) {
+    if (!rt) return 0;
+    /* Must not read any field of *rt before this memset: callers pass
+       uninitialized stack memory (see the header note). */
     memset(rt, 0, sizeof(*rt));
     rt->factory_id = factory_id;
-    rt->n_clients = (n_clients > FACTORY_MAX_SIGNERS) ?
-                    FACTORY_MAX_SIGNERS : n_clients;
     rt->db = db;
+
+    if (n_clients <= READINESS_SMALL) {
+        rt->clients = rt->clients_small;
+        rt->clients_cap = READINESS_SMALL;
+    } else {
+        rt->clients = calloc(n_clients, sizeof(*rt->clients));
+        if (!rt->clients) {
+            /* Stay valid-but-empty rather than half-initialized: every accessor
+               bounds-checks against n_clients, so 0 makes them all safe no-ops
+               and readiness_all_ready() reports NOT ready -- fail closed. */
+            rt->clients = rt->clients_small;
+            rt->clients_cap = READINESS_SMALL;
+            rt->n_clients = 0;
+            return 0;
+        }
+        rt->clients_cap = n_clients;
+    }
+
+    rt->n_clients = n_clients;
     for (size_t i = 0; i < rt->n_clients; i++)
         rt->clients[i].client_idx = (uint32_t)i;
+    return 1;
+}
+
+void readiness_free(readiness_tracker_t *rt) {
+    if (!rt) return;
+    if (rt->clients && rt->clients != rt->clients_small)
+        free(rt->clients);
+    rt->clients = NULL;
+    rt->clients_cap = 0;
+    rt->n_clients = 0;
 }
 
 void readiness_set_connected(readiness_tracker_t *rt, uint32_t client_idx,

--- a/src/regtest.c
+++ b/src/regtest.c
@@ -36,6 +36,15 @@ static inline bool regtest_err_is_expected_poll_miss(int code) {
    a one-shot reload + retry. See task #298. */
 static __thread int g_regtest_last_http_error = 0;
 
+/* Text of that error, so regtest_exec can hand callers the same diagnostic the
+   fork+exec path used to give them.  bitcoin-cli writes its error to stderr and
+   run_command_exec captures it as output, so callers historically received a
+   STRING containing e.g. "bad-txns-inputs-missingorspent" -- and some inspect
+   it (test_close_spendability_full.c asserts the message names the reason a
+   stale broadcast was rejected).  Skipping the fork must not silently downgrade
+   that to a bare NULL. */
+static __thread char g_regtest_last_http_errmsg[512] = {0};
+
 /* Auto-recovery rate limit. bitcoind's "wallet not loaded" state can drive
    long polling loops, so we coalesce concurrent -18 errors into at most one
    loadwallet attempt per second across all callers. */
@@ -624,11 +633,20 @@ static char *regtest_http_rpc(const regtest_t *rt,
            answer (tx not in mempool/chain; wallet path wrong because tx not
            in this wallet). Real errors (-32700 parse, -32601 method missing,
            etc.) still surface. See task #200. */
-        if (!(g_regtest_poll_quiet && regtest_err_is_expected_poll_miss(code))) {
+        {
             char *errstr = cJSON_PrintUnformatted(err);
             if (errstr) {
-                fprintf(stderr, "HTTP RPC %s error: %s\n", method, errstr);
+                /* Record it ALWAYS -- poll-quiet governs whether we PRINT the
+                   error, not whether regtest_exec can hand it back. */
+                snprintf(g_regtest_last_http_errmsg,
+                         sizeof(g_regtest_last_http_errmsg),
+                         "error: %s", errstr);
+                if (!(g_regtest_poll_quiet &&
+                      regtest_err_is_expected_poll_miss(code)))
+                    fprintf(stderr, "HTTP RPC %s error: %s\n", method, errstr);
                 free(errstr);
+            } else {
+                g_regtest_last_http_errmsg[0] = '\0';
             }
         }
         cJSON_Delete(jresp);
@@ -736,8 +754,18 @@ char *regtest_exec(const regtest_t *rt, const char *method, const char *params) 
            persistent wallet-missing failure gets surfaced to the operator
            (task #298). */
         if (g_regtest_last_http_error != 0 &&
-            g_regtest_last_http_error != -18)
+            g_regtest_last_http_error != -18) {
+            /* Return the error AS TEXT, not NULL.  The fork+exec path handed
+               callers bitcoin-cli's stderr, so an RPC error historically
+               arrived as a STRING they could inspect -- and callers do:
+               test_close_spendability_full.c asserts the message names why a
+               stale broadcast was rejected ("missingorspent"/"spent"/...).
+               Skipping the fork is the optimisation; dropping the diagnostic
+               was an accident, and it broke exactly that assertion. */
+            if (g_regtest_last_http_errmsg[0])
+                return strdup(g_regtest_last_http_errmsg);
             return NULL;
+        }
         /* No answer at all (transport failure) — fall through to fork+exec */
     }
 

--- a/src/regtest.c
+++ b/src/regtest.c
@@ -719,7 +719,26 @@ char *regtest_exec(const regtest_t *rt, const char *method, const char *params) 
                 return result;
             }
         }
-        /* HTTP failed — fall through to fork+exec */
+        /* Distinguish "bitcoind answered, and the answer was an error" from
+           "bitcoind did not answer".  regtest_http_rpc returns NULL for both,
+           but only the second is worth a fork+exec retry.
+
+           A JSON-RPC error IS a valid answer: -5 "no such transaction" is the
+           normal negative reply when polling for a tx that was never
+           broadcast.  Re-asking via bitcoin-cli gets the identical -5, having
+           paid a fork+execvp for it.  That is the hot path -- the watchtower
+           polls revoked commitments that by construction are NOT on chain, so
+           EVERY entry cost a process spawn on EVERY check, from every client
+           and the LSP daemon loop.  Entries grow with payments, so the waste
+           grew as O(N^2) over a seed and starved the real work of CPU.
+
+           -18 keeps the old behaviour on purpose: the fork path is how a
+           persistent wallet-missing failure gets surfaced to the operator
+           (task #298). */
+        if (g_regtest_last_http_error != 0 &&
+            g_regtest_last_http_error != -18)
+            return NULL;
+        /* No answer at all (transport failure) — fall through to fork+exec */
     }
 
     /* Fork+exec bitcoin-cli (used when rpcport==0 or HTTP unavailable) */

--- a/src/wire.c
+++ b/src/wire.c
@@ -406,6 +406,87 @@ int wire_send(int fd, uint8_t msg_type, cJSON *json) {
     return ok;
 }
 
+/* Broadcast one message to many peers, serializing the JSON ONCE.
+ *
+ * wire_send() calls cJSON_PrintUnformatted() per call.  Broadcasting a large
+ * ceremony message in a loop therefore re-serializes the whole tree once per
+ * client -- at N=301 that is a 5.6 MB LSP_RESPONSE printed 300 times, ~1.6 GB
+ * of pure serialization the LSP does not need to do.  It was slow enough that
+ * clients waiting on the 120s receive timeout hung up mid-broadcast, the first
+ * EPIPE aborted the attempt, and the whole ceremony failed -- looking like a
+ * wire bug rather than an O(N^2) cost.
+ *
+ * The plaintext is identical for every peer; only the AEAD layer differs
+ * (per-connection key and nonce), so encryption still happens per fd.
+ *
+ * Returns 1 if every peer was written.  On the first failure returns 0 and, if
+ * first_fail is non-NULL, stores that peer's index -- callers report which
+ * client dropped.  Negative fds are skipped, not treated as failures. */
+int wire_send_many(const int *fds, size_t n_fds, uint8_t msg_type, cJSON *json,
+                   size_t *first_fail) {
+    if (!fds || !json) return 0;
+
+    char *payload = cJSON_PrintUnformatted(json);   /* ONCE, not per peer */
+    if (!payload) return 0;
+    uint32_t payload_len = (uint32_t)strlen(payload);
+    uint32_t pt_len = 1 + payload_len;
+
+    unsigned char *plaintext = (unsigned char *)malloc(pt_len);
+    if (!plaintext) { free(payload); return 0; }
+    plaintext[0] = msg_type;
+    memcpy(plaintext + 1, payload, payload_len);
+    free(payload);
+
+    unsigned char *ciphertext = (unsigned char *)malloc(pt_len);
+    if (!ciphertext) { free(plaintext); return 0; }
+
+    int all_ok = 1;
+    for (size_t i = 0; i < n_fds; i++) {
+        int fd = fds[i];
+        if (fd < 0) continue;
+
+        noise_state_t *ns = wire_get_encryption(fd);
+        if (!ns) {
+            /* Unencrypted peer: fall back to the per-peer path so the refusal
+               and framing rules stay in one place. */
+            if (!wire_send(fd, msg_type, json)) {
+                if (first_fail) *first_fail = i;
+                all_ok = 0; break;
+            }
+            continue;
+        }
+
+        unsigned char tag[16], nonce[12];
+        make_nonce(nonce, ns->send_nonce);
+        if (!aead_encrypt(ciphertext, tag, plaintext, pt_len, NULL, 0,
+                          ns->send_key, nonce)) {
+            if (first_fail) *first_fail = i;
+            all_ok = 0; break;
+        }
+
+        uint32_t frame_len = pt_len + 16;
+        unsigned char header[4];
+        header[0] = (unsigned char)(frame_len >> 24);
+        header[1] = (unsigned char)(frame_len >> 16);
+        header[2] = (unsigned char)(frame_len >> 8);
+        header[3] = (unsigned char)(frame_len);
+
+        if (!(write_all(fd, header, 4) &&
+              write_all(fd, ciphertext, pt_len) &&
+              write_all(fd, tag, 16))) {
+            if (first_fail) *first_fail = i;
+            all_ok = 0; break;
+        }
+        ns->send_nonce++;   /* only after a fully successful transmission */
+        if (g_wire_log_cb)
+            g_wire_log_cb(0, msg_type, json, wire_get_peer_label(fd), g_wire_log_ud);
+    }
+
+    free(plaintext);
+    free(ciphertext);
+    return all_ok;
+}
+
 int wire_recv(int fd, wire_msg_t *msg) {
     msg->json = NULL;
     unsigned char header[4];

--- a/src/wire.c
+++ b/src/wire.c
@@ -338,6 +338,22 @@ int wire_send(int fd, uint8_t msg_type, cJSON *json) {
     uint32_t payload_len = (uint32_t)strlen(payload);
     uint32_t pt_len = 1 + payload_len;  /* type byte + JSON */
 
+    /* Refuse oversize frames HERE, where we know the message type and can say
+       so.  Only the receiver checked WIRE_MAX_FRAME_SIZE (see wire_recv), so an
+       over-limit send previously went out and the peer rejected it as an opaque
+       recv failure -- the sender, which has all the context, said nothing.
+       This is not hypothetical: the creation LSP_RESPONSE carries the full
+       n_nodes x n_participants nonce matrix, and the tree gains a level past
+       512 clients, so at N=1024 it is ~158 MB against a 16 MB limit. */
+    if (pt_len > WIRE_MAX_FRAME_SIZE - 16) {
+        fprintf(stderr,
+                "wire_send: msg 0x%02x is %u bytes, over the %d-byte frame limit "
+                "— refusing to send (peer would reject it as a malformed frame)\n",
+                msg_type, pt_len, WIRE_MAX_FRAME_SIZE);
+        free(payload);
+        return 0;
+    }
+
     noise_state_t *ns = wire_get_encryption(fd);
     if (ns) {
         /* Encrypt: plaintext = [type][JSON] */
@@ -430,6 +446,20 @@ int wire_send_many(const int *fds, size_t n_fds, uint8_t msg_type, cJSON *json,
     if (!payload) return 0;
     uint32_t payload_len = (uint32_t)strlen(payload);
     uint32_t pt_len = 1 + payload_len;
+
+    /* Same frame-limit refusal as wire_send -- see the note there.  Broadcast
+       is where this actually bites: the oversize message is the creation
+       LSP_RESPONSE, and failing here reports it once instead of N peers each
+       reporting a malformed frame. */
+    if (pt_len > WIRE_MAX_FRAME_SIZE - 16) {
+        fprintf(stderr,
+                "wire_send_many: msg 0x%02x is %u bytes, over the %d-byte frame "
+                "limit — refusing to broadcast to %zu peers\n",
+                msg_type, pt_len, WIRE_MAX_FRAME_SIZE, n_fds);
+        free(payload);
+        if (first_fail) *first_fail = 0;
+        return 0;
+    }
 
     unsigned char *plaintext = (unsigned char *)malloc(pt_len);
     if (!plaintext) { free(payload); return 0; }

--- a/src/wire.c
+++ b/src/wire.c
@@ -571,9 +571,26 @@ int wire_recv(int fd, wire_msg_t *msg) {
 }
 
 int wire_recv_timeout(int fd, wire_msg_t *msg, int timeout_sec) {
+    /* Restore the socket's PREVIOUS deadline, not the compile-time default.
+       Restoring WIRE_DEFAULT_TIMEOUT_SEC silently discarded any per-connection
+       deadline a caller had set: the client scales its receive timeout with the
+       participant count (the LSP fans ceremony messages out serially, so client
+       k waits behind k-1 sends), and a single wire_recv_timeout() anywhere in
+       the flow reset it to 120s before the message that needed the longer wait
+       ever arrived. The scaled timeout was therefore never in effect -- which is
+       why raising it changed nothing at N=300 and the failure index wandered
+       (113 -> 227 -> 198) with throughput instead of moving with the setting. */
+    struct timeval prev;
+    socklen_t plen = sizeof(prev);
+    int have_prev = (getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &prev, &plen) == 0);
+
     wire_set_timeout(fd, timeout_sec);
     int ok = wire_recv(fd, msg);
-    wire_set_timeout(fd, WIRE_DEFAULT_TIMEOUT_SEC);
+
+    if (have_prev && (prev.tv_sec > 0 || prev.tv_usec > 0))
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &prev, sizeof(prev));
+    else
+        wire_set_timeout(fd, WIRE_DEFAULT_TIMEOUT_SEC);
     return ok;
 }
 

--- a/src/wire.c
+++ b/src/wire.c
@@ -3235,8 +3235,16 @@ size_t wire_parse_bundle(const cJSON *array, wire_bundle_entry_t *entries,
         if (!ni || !cJSON_IsNumber(ni) ||
             !sl || !cJSON_IsNumber(sl) ||
             !d || !cJSON_IsString(d)) continue;
-        if (ni->valuedouble < 0 || ni->valuedouble >= FACTORY_MAX_NODES) continue;
-        if (sl->valuedouble < 0 || sl->valuedouble >= FACTORY_MAX_SIGNERS) continue;
+        /* Sanity ceilings on peer-supplied indices, NOT capacity limits --
+           the real bound is `count < max` against the caller's array.  These
+           were FACTORY_MAX_NODES/FACTORY_MAX_SIGNERS, both of which are now
+           merely defaults, so a large factory had its bundle entries silently
+           DROPPED here (a bare `continue`, no diagnostic): at N=512 the tree
+           carries ~2046 nodes and 513 signers, so most entries vanished and
+           the ceremony failed far downstream with missing nonces.
+           SS_MAX_NODE_INDEX tracks the ~4N node count of the tree shape. */
+        if (ni->valuedouble < 0 || ni->valuedouble >= SS_MAX_NODE_INDEX) continue;
+        if (sl->valuedouble < 0 || sl->valuedouble >= SS_MAX_PARTICIPANTS) continue;
 
         entries[count].node_idx = (uint32_t)ni->valuedouble;
         entries[count].signer_slot = (uint32_t)sl->valuedouble;

--- a/tests/test_adaptor.c
+++ b/tests/test_adaptor.c
@@ -399,7 +399,6 @@ int test_ptlc_factory_coop_close_after_turnover(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -583,7 +582,6 @@ int test_regtest_ptlc_turnover(void) {
 
     /* Init factory */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     for (int i = 0; i < 15; i++)

--- a/tests/test_ceremony.c
+++ b/tests/test_ceremony.c
@@ -1,6 +1,10 @@
 #include "superscalar/ceremony.h"
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/resource.h>
+#include <sys/select.h>
 
 #define TEST_ASSERT(cond, msg) do { \
     if (!(cond)) { \
@@ -172,5 +176,72 @@ int test_funding_reserve_check(void) {
     TEST_ASSERT(ceremony_check_funding_reserve(80000, 80000, 0),
                 "zero fee reserve");
 
+    return 1;
+}
+
+/* ---------------------------------------------------------------------------
+ * ceremony_select_all with HIGH-NUMBERED descriptors.
+ *
+ * This is the N=1024 blocker in miniature.  The old implementation used
+ * select()/FD_SET, where FD_SET(fd, &set) sets bit `fd` in a fixed 1024-bit
+ * fd_set.  The hazard is the descriptor VALUE, not how many are watched: a
+ * single fd >= FD_SETSIZE writes past the end of a stack fd_set.  An LSP with
+ * ~1000 client sockets plus DB handles and logs hands out exactly such
+ * descriptors, so the ceremony would have corrupted its own stack -- the same
+ * failure mode as the fixed [FACTORY_MAX_SIGNERS] arrays at N=256, one order
+ * of magnitude further out.
+ *
+ * Here we deliberately push a socketpair above FD_SETSIZE with dup2 and require
+ * correct results.  Under the old code this was undefined behaviour (and under
+ * ASan, a stack-buffer-overflow); with poll() the value is irrelevant.
+ * ------------------------------------------------------------------------- */
+int test_ceremony_select_high_fds(void) {
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_NOFILE, &rl) != 0) { printf("  SKIP: getrlimit\n"); return 1; }
+    rlim_t want = (rlim_t)FD_SETSIZE + 64;
+    if (rl.rlim_cur < want) {
+        if (rl.rlim_max < want) { printf("  SKIP: fd hard limit too low\n"); return 1; }
+        rl.rlim_cur = want;
+        if (setrlimit(RLIMIT_NOFILE, &rl) != 0) { printf("  SKIP: setrlimit\n"); return 1; }
+    }
+
+    int sp[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp) != 0) { printf("  SKIP: socketpair\n"); return 1; }
+
+    /* Relocate the read end ABOVE FD_SETSIZE — the value select() cannot hold. */
+    int hi = FD_SETSIZE + 7;
+    if (dup2(sp[0], hi) < 0) { close(sp[0]); close(sp[1]); printf("  SKIP: dup2 high\n"); return 1; }
+    close(sp[0]);
+    TEST_ASSERT(hi >= FD_SETSIZE, "test fd is above FD_SETSIZE");
+
+    int fds[3]  = { hi, -1, hi };   /* -1 must still be skipped, as before */
+    int ready[3];
+
+    /* Nothing written yet -> timeout, all clear. */
+    int n = ceremony_select_all(fds, 3, 0, ready);
+    TEST_ASSERT_EQ(n, 0, "timeout with no data");
+    TEST_ASSERT_EQ(ready[0], 0, "slot0 not ready");
+    TEST_ASSERT_EQ(ready[2], 0, "slot2 not ready");
+
+    /* Make it readable -> both slots referencing that fd report ready. */
+    TEST_ASSERT(write(sp[1], "x", 1) == 1, "write to peer");
+    n = ceremony_select_all(fds, 3, 1, ready);
+    TEST_ASSERT_EQ(n, 2, "both slots holding the high fd are ready");
+    TEST_ASSERT_EQ(ready[0], 1, "slot0 ready");
+    TEST_ASSERT_EQ(ready[1], 0, "slot1 (-1) skipped");
+    TEST_ASSERT_EQ(ready[2], 1, "slot2 ready");
+
+    /* Peer hangup counts as ready, matching select(), so callers see EOF. */
+    close(sp[1]);
+    { char b[8]; while (read(hi, b, sizeof(b)) > 0) {} }
+    n = ceremony_select_all(fds, 3, 1, ready);
+    TEST_ASSERT(n >= 1, "hangup reported ready (select parity)");
+
+    /* All-invalid set still returns -1. */
+    int none[2] = { -1, -1 };
+    int nready[2];
+    TEST_ASSERT_EQ(ceremony_select_all(none, 2, 0, nready), -1, "no usable fd -> -1");
+
+    close(hi);
     return 1;
 }

--- a/tests/test_ceremony.c
+++ b/tests/test_ceremony.c
@@ -205,16 +205,34 @@ int test_ceremony_select_high_fds(void) {
         if (setrlimit(RLIMIT_NOFILE, &rl) != 0) { printf("  SKIP: setrlimit\n"); return 1; }
     }
 
-    int sp[2];
-    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp) != 0) { printf("  SKIP: socketpair\n"); return 1; }
+    /* Two SEPARATE pairs, deliberately.  An earlier version of this test put
+       the same fd in two slots and asserted both reported ready.  That passes
+       on Linux and fails on macOS, because POSIX does not actually pin down
+       how poll() treats a repeated fd within one array.  It was also testing
+       something that cannot happen: production client_fds[] are distinct
+       sockets, and a slot with no connection holds -1, not a duplicate.
 
-    /* Relocate the read end ABOVE FD_SETSIZE — the value select() cannot hold. */
-    int hi = FD_SETSIZE + 7;
-    if (dup2(sp[0], hi) < 0) { close(sp[0]); close(sp[1]); printf("  SKIP: dup2 high\n"); return 1; }
-    close(sp[0]);
-    TEST_ASSERT(hi >= FD_SETSIZE, "test fd is above FD_SETSIZE");
+       The property worth protecting is the one that blocks N=1024 -- that
+       these paths work with fd VALUES above FD_SETSIZE, which select() cannot
+       represent and which FD_SET would smash the stack on.  Distinct high fds
+       test that directly and portably. */
+    int sp1[2], sp2[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp1) != 0) { printf("  SKIP: socketpair\n"); return 1; }
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp2) != 0) {
+        close(sp1[0]); close(sp1[1]); printf("  SKIP: socketpair\n"); return 1;
+    }
 
-    int fds[3]  = { hi, -1, hi };   /* -1 must still be skipped, as before */
+    /* Relocate both read ends ABOVE FD_SETSIZE — values select() cannot hold. */
+    int hi1 = FD_SETSIZE + 7;
+    int hi2 = FD_SETSIZE + 8;
+    if (dup2(sp1[0], hi1) < 0 || dup2(sp2[0], hi2) < 0) {
+        close(sp1[0]); close(sp1[1]); close(sp2[0]); close(sp2[1]);
+        printf("  SKIP: dup2 high\n"); return 1;
+    }
+    close(sp1[0]); close(sp2[0]);
+    TEST_ASSERT(hi1 >= FD_SETSIZE && hi2 >= FD_SETSIZE, "test fds are above FD_SETSIZE");
+
+    int fds[3]  = { hi1, -1, hi2 };   /* -1 must still be skipped, as before */
     int ready[3];
 
     /* Nothing written yet -> timeout, all clear. */
@@ -223,17 +241,18 @@ int test_ceremony_select_high_fds(void) {
     TEST_ASSERT_EQ(ready[0], 0, "slot0 not ready");
     TEST_ASSERT_EQ(ready[2], 0, "slot2 not ready");
 
-    /* Make it readable -> both slots referencing that fd report ready. */
-    TEST_ASSERT(write(sp[1], "x", 1) == 1, "write to peer");
+    /* Make both readable -> both high-fd slots report ready. */
+    TEST_ASSERT(write(sp1[1], "x", 1) == 1, "write to peer 1");
+    TEST_ASSERT(write(sp2[1], "x", 1) == 1, "write to peer 2");
     n = ceremony_select_all(fds, 3, 1, ready);
-    TEST_ASSERT_EQ(n, 2, "both slots holding the high fd are ready");
+    TEST_ASSERT_EQ(n, 2, "both high fds are ready");
     TEST_ASSERT_EQ(ready[0], 1, "slot0 ready");
     TEST_ASSERT_EQ(ready[1], 0, "slot1 (-1) skipped");
     TEST_ASSERT_EQ(ready[2], 1, "slot2 ready");
 
     /* Peer hangup counts as ready, matching select(), so callers see EOF. */
-    close(sp[1]);
-    { char b[8]; while (read(hi, b, sizeof(b)) > 0) {} }
+    close(sp1[1]);
+    { char b[8]; while (read(hi1, b, sizeof(b)) > 0) {} }
     n = ceremony_select_all(fds, 3, 1, ready);
     TEST_ASSERT(n >= 1, "hangup reported ready (select parity)");
 
@@ -242,6 +261,6 @@ int test_ceremony_select_high_fds(void) {
     int nready[2];
     TEST_ASSERT_EQ(ceremony_select_all(none, 2, 0, nready), -1, "no usable fd -> -1");
 
-    close(hi);
+    close(hi1); close(hi2); close(sp2[1]);
     return 1;
 }

--- a/tests/test_channel.c
+++ b/tests/test_channel.c
@@ -854,7 +854,6 @@ int test_regtest_channel_unilateral(void) {
     /* Build factory tree, then advance to max state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);  /* step=1, states=4 */
 
@@ -2468,7 +2467,6 @@ int test_regtest_channel_coop_close(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 
@@ -2947,7 +2945,6 @@ int test_factory_advance_past_exhaustion(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, keypairs, 5, 10, 4);
 
@@ -3065,7 +3062,6 @@ int test_regtest_channel_penalty(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 
@@ -3699,7 +3695,6 @@ int test_regtest_penalty_with_htlcs(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -2691,6 +2691,7 @@ int test_regtest_lsp_restart_recovery(void) {
         }
     }
 
+    factory_free(rec_f);   /* heap arrays: free(rec_f) alone orphans them */
     free(rec_f);
     secp256k1_context_destroy(ctx);
     return lsp_ok && all_children_ok;
@@ -2752,6 +2753,7 @@ int test_profit_settlement_calculation(void) {
 
     TEST_ASSERT_EQ(mgr.accumulated_fees_sats, 0, "fees reset after settlement");
     free(mgr.entries);
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     return 1;
 }
@@ -2792,6 +2794,7 @@ int test_settlement_trigger_at_interval(void) {
     TEST_ASSERT_EQ(settled, 0, "no settlement with zero fees");
 
     free(mgr.entries);
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     return 1;
 }
@@ -2827,6 +2830,7 @@ int test_on_close_includes_unsettled(void) {
     TEST_ASSERT_EQ(share1, 900, "client 1 unsettled share (per-channel)");
 
     free(mgr.entries);
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     return 1;
 }
@@ -3302,7 +3306,9 @@ int test_regtest_crash_double_recovery(void) {
         }
     }
 
+    factory_free(rec_f);   /* heap arrays: free(rec_f) alone orphans them */
     free(rec_f);
+    factory_free(rec_f2);   /* heap arrays: free(rec_f2) alone orphans them */
     free(rec_f2);
     secp256k1_context_destroy(ctx);
     return lsp_ok && all_children_ok;
@@ -3816,6 +3822,7 @@ int test_fee_accumulation_and_settlement(void) {
                    "LSP local decreased by per-channel share");
 
     free(mgr.entries);
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     return 1;
 }
@@ -4159,6 +4166,7 @@ int test_close_outputs_wallet_spk(void) {
                 "override beats lsp_close_spk: client 0 uses override");
 
     free(mgr.entries);
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     return 1;
 }

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -2555,7 +2555,6 @@ int test_regtest_lsp_restart_recovery(void) {
     /* Phase 6: Recover from SQLite */
     factory_t *rec_f = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(rec_f);
-    factory_alloc_default_arrays(rec_f);
     if (!rec_f) return 0;
     lsp_channel_mgr_t rec_mgr;
 
@@ -2715,7 +2714,6 @@ int test_profit_settlement_calculation(void) {
     /* Build a minimal factory with profit-shared economics */
     factory_t *f = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     f->economic_mode = ECON_PROFIT_SHARED;
@@ -2771,7 +2769,6 @@ int test_settlement_trigger_at_interval(void) {
 
     factory_t *f = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     f->n_participants = 3;
@@ -2812,7 +2809,6 @@ int test_on_close_includes_unsettled(void) {
     mgr.economic_mode = ECON_PROFIT_SHARED;
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     factory_alloc_default_arrays(f);
     if (!f) { free(mgr.entries); return 0; }
 
@@ -3119,7 +3115,6 @@ int test_regtest_crash_double_recovery(void) {
     /* Recover #1 */
     factory_t *rec_f = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(rec_f);
-    factory_alloc_default_arrays(rec_f);
     if (!rec_f) return 0;
     lsp_channel_mgr_t rec_mgr;
 
@@ -3200,7 +3195,6 @@ int test_regtest_crash_double_recovery(void) {
     /* Recover #2 */
     lsp_channel_mgr_t rec_mgr2;
     factory_t *rec_f2 = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(rec_f2);
     factory_alloc_default_arrays(rec_f2);
     if (!rec_f2) return 0;
 
@@ -3755,7 +3749,6 @@ int test_fee_accumulation_and_settlement(void) {
 
     factory_t *f = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     f->economic_mode = ECON_PROFIT_SHARED;
@@ -3862,7 +3855,6 @@ int test_fee_levels_and_profit_split(void) {
 
             factory_t *f = calloc(1, sizeof(factory_t));
             factory_alloc_default_arrays(f);
-            factory_alloc_default_arrays(f);
             f->economic_mode = (economic_mode_t)configs[ci].econ;
             f->n_participants = 3;
             f->profiles[0].profit_share_bps = configs[ci].lsp_bps;
@@ -3934,6 +3926,10 @@ int test_fee_levels_and_profit_split(void) {
             }
 
             free(mgr.entries);
+            /* factory_free before free: the struct's nine arrays are heap now,
+               so free(f) alone orphans them -- 302,976 bytes per iteration,
+               15 iterations, 4.5 MB. */
+            factory_free(f);
             free(f);
         }
     }
@@ -4050,7 +4046,6 @@ int test_close_outputs_wallet_spk(void) {
     mgr.entries[1].channel.remote_amount = 2000;
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     factory_alloc_default_arrays(f);
     if (!f) return 0;
 

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -206,8 +206,6 @@ int test_lsp_channel_init(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32] = {0};
@@ -1831,8 +1829,6 @@ int test_fee_policy_balance_split(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32] = {0};
@@ -2004,8 +2000,6 @@ int test_fee_estimator_wiring(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 10, 4);
     unsigned char fake_txid[32], fake_spk[34];
@@ -2074,8 +2068,6 @@ int test_fee_estimator_null_fallback(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 10, 4);
     unsigned char fake_txid[32], fake_spk[34];
@@ -4013,8 +4005,6 @@ int test_cltv_delta_from_tree_depth(void) {
 
     /* Factory with step_blocks=6, states_per_layer=2, 5 participants */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     factory_init(f, ctx, kps, 5, 6, 2);
 
     uint32_t delta = lsp_compute_factory_cltv_delta(f);
@@ -4206,8 +4196,6 @@ int test_lsp_close_spk_derived(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32] = {0};
@@ -4478,8 +4466,6 @@ int test_client_ps_double_spend_defense_refuses(void) {
     memset(fake_fund_txid, 0x7A, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, N, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);

--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -5356,7 +5356,6 @@ int test_regtest_mixed_arity_2_4_8_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8}. */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);  /* step_blocks=4, states_per_layer=4 */
     /* Wider N-way state nodes are larger TXs than the binary builder's;
@@ -6672,7 +6671,6 @@ int test_regtest_nway_n64_arity_2_4_8_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8} */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* Wider N-way state nodes need more fee than default 200 sats to
@@ -6979,7 +6977,6 @@ int test_regtest_nway_n64_arity_2_4_8_static_threshold_1_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8} */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* Wider N-way state nodes need more fee than default 200 sats to
@@ -7294,7 +7291,6 @@ int test_regtest_nway_n64_dw_advance_resign_lifecycle(void) {
 
     /* Build factory with mixed level arity {2, 4, 8} */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* Wider N-way state nodes need more fee than default 200 sats to
@@ -7623,7 +7619,6 @@ int test_regtest_static_near_root_lifecycle(void) {
 
     /* Build factory: arity {2,4}, static_threshold=1 (root kickoff-only) */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     /* PR #104 bumped fee_per_tx to 1000 sats for N-way regtest mempool floor. */
@@ -7923,7 +7918,6 @@ int test_regtest_static_near_root_unilateral_exit(void) {
     TEST_ASSERT(fund_vout != UINT32_MAX, "find fund vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f != NULL, "alloc factory");
     factory_init(f, ctx, kps, N, 4, 4);
     f->fee_per_tx = 1000;

--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -1408,7 +1408,6 @@ static int run_k2_ps_subfactory_force_close(regtest_t *rt,
     const size_t N = 5;  /* 1 LSP + 4 clients */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -1665,7 +1664,6 @@ int test_regtest_k2_ps_subfactory_per_client_sweep(void) {
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
     secp256k1_pubkey pks[5];
     for (size_t i = 0; i < N; i++) {

--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -148,7 +148,6 @@ static int run_coop_close_for_arity(regtest_t *rt,
     const size_t N = 5;  /* 1 LSP + 4 clients */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -157,7 +156,7 @@ static int run_coop_close_for_arity(regtest_t *rt,
     uint64_t fund_amount = 0;
     if (!fund_n_party_factory(rt, ctx, N, arity, mine_addr, kps, f,
                                fund_spk, fund_txid, &fund_vout, &fund_amount)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  [arity=%d] factory funded: %s:%u  %llu sats  %zu nodes\n",
            (int)arity, fund_txid, fund_vout, (unsigned long long)fund_amount,
@@ -171,9 +170,9 @@ static int run_coop_close_for_arity(regtest_t *rt,
 
     for (size_t i = 0; i < N; i++) {
         secp256k1_pubkey pk;
-        if (!secp256k1_keypair_pub(ctx, &pk, &kps[i])) { free(f); return 0; }
+        if (!secp256k1_keypair_pub(ctx, &pk, &kps[i])) { factory_free(f); free(f); return 0; }
         secp256k1_xonly_pubkey xo;
-        if (!secp256k1_xonly_pubkey_from_pubkey(ctx, &xo, NULL, &pk)) { free(f); return 0; }
+        if (!secp256k1_xonly_pubkey_from_pubkey(ctx, &xo, NULL, &pk)) { factory_free(f); free(f); return 0; }
         build_p2tr_script_pubkey(outs[i].script_pubkey, &xo);
         outs[i].script_pubkey_len = 34;
         outs[i].amount_sats = (i == 0) ? lsp_amt : per_client;
@@ -185,12 +184,12 @@ static int run_coop_close_for_arity(regtest_t *rt,
     if (!build_unsigned_tx(&unsigned_close, NULL,
                             f->funding_txid, f->funding_vout,
                             0xFFFFFFFEu, outs, N)) {
-        tx_buf_free(&unsigned_close); free(f); return 0;
+        tx_buf_factory_free(f); free(&unsigned_close); free(f); return 0;
     }
     unsigned char sighash[32];
     if (!compute_taproot_sighash(sighash, unsigned_close.data, unsigned_close.len,
                                    0, fund_spk, 34, fund_amount, 0xFFFFFFFEu)) {
-        tx_buf_free(&unsigned_close); free(f); return 0;
+        tx_buf_factory_free(f); free(&unsigned_close); free(f); return 0;
     }
 
     /* Offline N-party MuSig2 ceremony (we have all keypairs locally). */
@@ -198,17 +197,17 @@ static int run_coop_close_for_arity(regtest_t *rt,
     secp256k1_pubkey pks[5];
     for (size_t i = 0; i < N; i++)
         secp256k1_keypair_pub(ctx, &pks[i], &kps[i]);
-    if (!musig_aggregate_keys(ctx, &ka, pks, N)) { free(f); return 0; }
+    if (!musig_aggregate_keys(ctx, &ka, pks, N)) { factory_free(f); free(f); return 0; }
 
     unsigned char sig64[64];
     if (!musig_sign_taproot(ctx, sig64, sighash, kps, N, &ka, NULL)) {
-        tx_buf_free(&unsigned_close); free(f); return 0;
+        tx_buf_factory_free(f); free(&unsigned_close); free(f); return 0;
     }
 
     tx_buf_t signed_close;
     tx_buf_init(&signed_close, 256);
     if (!finalize_signed_tx(&signed_close, unsigned_close.data, unsigned_close.len, sig64)) {
-        tx_buf_free(&unsigned_close); tx_buf_free(&signed_close); free(f); return 0;
+        tx_buf_factory_free(f); free(&unsigned_close); tx_buf_free(&signed_close); free(f); return 0;
     }
     tx_buf_free(&unsigned_close);
 
@@ -219,25 +218,25 @@ static int run_coop_close_for_arity(regtest_t *rt,
     char close_txid[65];
     if (!regtest_send_raw_tx(rt, close_hex, close_txid)) {
         fprintf(stderr, "  coop close broadcast failed\n");
-        tx_buf_free(&signed_close); free(f); return 0;
+        tx_buf_factory_free(f); free(&signed_close); free(f); return 0;
     }
     regtest_mine_blocks(rt, 1, mine_addr);
     tx_buf_free(&signed_close);
     if (regtest_get_confirmations(rt, close_txid) < 1) {
         fprintf(stderr, "  close not confirmed\n");
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  [arity=%d] coop close confirmed: %s\n", (int)arity, close_txid);
 
     /* Spendability gauntlet: each party sweeps its P2TR(xonly(pk_i)). */
     if (!spend_coop_close_gauntlet(ctx, rt, close_txid, N_PARTY_SECKEYS, N - 1)) {
         fprintf(stderr, "  gauntlet failed\n");
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  [arity=%d] all %zu parties swept their outputs  ✓\n",
            (int)arity, N);
 
-    free(f);
+    factory_free(f); free(f);
     return 1;
 }
 
@@ -810,7 +809,6 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
     const size_t N = 3;  /* 1 LSP + 2 clients (minimum for PS MuSig) */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -819,7 +817,7 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
     uint64_t fund_amount = 0;
     if (!fund_n_party_factory(rt, ctx, N, FACTORY_ARITY_PS, mine_addr, kps, f,
                                 fund_spk, fund_txid, &fund_vout, &fund_amount)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  PS chain: factory funded %s:%u (%zu nodes, %d leaves)\n",
            fund_txid, fund_vout, f->n_nodes, f->n_leaf_nodes);
@@ -842,11 +840,11 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
     tx_buf_t uc;
     tx_buf_init(&uc, 256);
     if (!build_unsigned_tx(&uc, NULL, f->funding_txid, f->funding_vout,
-                            0xFFFFFFFEu, outs, N)) { free(f); return 0; }
+                            0xFFFFFFFEu, outs, N)) { factory_free(f); free(f); return 0; }
     unsigned char sh[32];
     if (!compute_taproot_sighash(sh, uc.data, uc.len, 0,
                                   fund_spk, 34, fund_amount, 0xFFFFFFFEu)) {
-        tx_buf_free(&uc); free(f); return 0;
+        tx_buf_factory_free(f); free(&uc); free(f); return 0;
     }
     musig_keyagg_t ka;
     secp256k1_pubkey pks[3];
@@ -854,7 +852,7 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
     musig_aggregate_keys(ctx, &ka, pks, N);
     unsigned char sig[64];
     if (!musig_sign_taproot(ctx, sig, sh, kps, N, &ka, NULL)) {
-        tx_buf_free(&uc); free(f); return 0;
+        tx_buf_factory_free(f); free(&uc); free(f); return 0;
     }
     tx_buf_t sc;
     tx_buf_init(&sc, 256);
@@ -872,11 +870,11 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
 
     /* Gauntlet sweep: 3 parties each spend their P2TR(xonly(pk_i)). */
     if (!spend_coop_close_gauntlet(ctx, rt, close_txid, N_PARTY_SECKEYS, N - 1)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  PS chain: all %zu parties swept final outputs ✓\n", N);
 
-    free(f);
+    factory_free(f); free(f);
     return 1;
 }
 
@@ -1061,10 +1059,8 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     const size_t N = 5;
     secp256k1_keypair kpsA[5], kpsB[5];
     factory_t *fA = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(fA);
     factory_t *fB = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(fB);
-    if (!fA || !fB) { free(fA); free(fB); return 0; }
+    if (!fA || !fB) { factory_free(fA); factory_free(fB); free(fA); free(fB); return 0; }
 
     unsigned char spkA[34], spkB[34];
     char txidA[65], txidB[65];
@@ -1074,7 +1070,7 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     /* Build factory A. */
     if (!fund_n_party_factory(rt, ctx, N, arity, mine_addr, kpsA, fA,
                                 spkA, txidA, &voutA, &amtA)) {
-        free(fA); free(fB); return 0;
+        factory_free(fA); factory_free(fB); free(fA); free(fB); return 0;
     }
     printf("  rotation[arity=%d]: factory A funded %s:%u  %llu sats\n",
            (int)arity, txidA, voutA, (unsigned long long)amtA);
@@ -1084,7 +1080,7 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
         secp256k1_keypair_create(ctx, &kpsB[i], N_PARTY_SECKEYS[i]);
     if (!fund_n_party_factory(rt, ctx, N, arity, mine_addr, kpsB, fB,
                                 spkB, txidB, &voutB, &amtB)) {
-        free(fA); free(fB); return 0;
+        factory_free(fA); factory_free(fB); free(fA); free(fB); return 0;
     }
     printf("  rotation[arity=%d]: factory B funded %s:%u  %llu sats\n",
            (int)arity, txidB, voutB, (unsigned long long)amtB);
@@ -1103,11 +1099,11 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     tx_buf_t ucA;
     tx_buf_init(&ucA, 256);
     if (!build_unsigned_tx(&ucA, NULL, fA->funding_txid, fA->funding_vout,
-                            0xFFFFFFFEu, &rot_out, 1)) { free(fA); free(fB); return 0; }
+                            0xFFFFFFFEu, &rot_out, 1)) { factory_free(fA); factory_free(fB); free(fA); free(fB); return 0; }
     unsigned char shA[32];
     if (!compute_taproot_sighash(shA, ucA.data, ucA.len, 0, spkA, 34,
                                   amtA, 0xFFFFFFFEu)) {
-        tx_buf_free(&ucA); free(fA); free(fB); return 0;
+        tx_buf_factory_free(fA); factory_free(fB); free(&ucA); free(fA); free(fB); return 0;
     }
     musig_keyagg_t kaA;
     secp256k1_pubkey pksA[5];
@@ -1115,7 +1111,7 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     musig_aggregate_keys(ctx, &kaA, pksA, N);
     unsigned char sigA[64];
     if (!musig_sign_taproot(ctx, sigA, shA, kpsA, N, &kaA, NULL)) {
-        tx_buf_free(&ucA); free(fA); free(fB); return 0;
+        tx_buf_factory_free(fA); factory_free(fB); free(&ucA); free(fA); free(fB); return 0;
     }
     tx_buf_t scA;
     tx_buf_init(&scA, 256);
@@ -1150,7 +1146,7 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     tx_buf_t ucB;
     tx_buf_init(&ucB, 256);
     if (!build_unsigned_tx(&ucB, NULL, fB->funding_txid, fB->funding_vout,
-                            0xFFFFFFFEu, outs, N)) { free(fA); free(fB); return 0; }
+                            0xFFFFFFFEu, outs, N)) { factory_free(fA); factory_free(fB); free(fA); free(fB); return 0; }
     unsigned char shB[32];
     compute_taproot_sighash(shB, ucB.data, ucB.len, 0, spkB, 34,
                              amtB, 0xFFFFFFFEu);
@@ -1177,12 +1173,12 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
 
     /* Gauntlet: each party sweeps their B-close output. */
     if (!spend_coop_close_gauntlet(ctx, rt, cB_txid, N_PARTY_SECKEYS, N - 1)) {
-        free(fA); free(fB); return 0;
+        factory_free(fA); factory_free(fB); free(fA); free(fB); return 0;
     }
     printf("  rotation[arity=%d]: balance carried A→B, all 5 parties swept ✓\n",
            (int)arity);
 
-    free(fA); free(fB);
+    factory_free(fA); factory_free(fB); free(fA); free(fB);
     return 1;
 }
 
@@ -1316,7 +1312,6 @@ static int run_full_tree_force_close_for_arity(regtest_t *rt,
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -1325,7 +1320,7 @@ static int run_full_tree_force_close_for_arity(regtest_t *rt,
     uint64_t fund_amount = 0;
     if (!fund_n_party_factory(rt, ctx, N, arity, mine_addr, kps, f,
                                fund_spk, fund_txid, &fund_vout, &fund_amount)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  [arity=%d] factory funded: %s:%u  %llu sats  %zu nodes\n",
            (int)arity, fund_txid, fund_vout,
@@ -1426,37 +1421,37 @@ static int run_k2_ps_subfactory_force_close(regtest_t *rt,
     secp256k1_pubkey pks[5];
     for (size_t i = 0; i < N; i++) {
         if (!secp256k1_keypair_create(ctx, &kps[i], N_PARTY_SECKEYS[i])) {
-            free(f); return 0;
+            factory_free(f); free(f); return 0;
         }
-        if (!secp256k1_keypair_pub(ctx, &pks[i], &kps[i])) { free(f); return 0; }
+        if (!secp256k1_keypair_pub(ctx, &pks[i], &kps[i])) { factory_free(f); free(f); return 0; }
     }
     musig_keyagg_t ka;
-    if (!musig_aggregate_keys(ctx, &ka, pks, N)) { free(f); return 0; }
+    if (!musig_aggregate_keys(ctx, &ka, pks, N)) { factory_free(f); free(f); return 0; }
     unsigned char agg_ser[32];
     if (!secp256k1_xonly_pubkey_serialize(ctx, agg_ser, &ka.agg_pubkey)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     unsigned char tweak[32];
     sha256_tagged("TapTweak", agg_ser, 32, tweak);
     musig_keyagg_t ka_spk = ka;
     secp256k1_pubkey tw_pk;
     if (!secp256k1_musig_pubkey_xonly_tweak_add(ctx, &tw_pk, &ka_spk.cache, tweak)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     secp256k1_xonly_pubkey tw_xonly;
     if (!secp256k1_xonly_pubkey_from_pubkey(ctx, &tw_xonly, NULL, &tw_pk)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     build_p2tr_script_pubkey(fund_spk, &tw_xonly);
     unsigned char tw_ser[32];
     if (!secp256k1_xonly_pubkey_serialize(ctx, tw_ser, &tw_xonly)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     char fund_addr[128];
     if (!regtest_derive_p2tr_address(rt, tw_ser, fund_addr, sizeof(fund_addr))) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
-    if (!regtest_fund_address(rt, fund_addr, 0.005, fund_txid)) { free(f); return 0; }
+    if (!regtest_fund_address(rt, fund_addr, 0.005, fund_txid)) { factory_free(f); free(f); return 0; }
     regtest_mine_blocks(rt, 1, mine_addr);
     fund_vout = UINT32_MAX;
     for (uint32_t v = 0; v < 4; v++) {
@@ -1470,10 +1465,10 @@ static int run_k2_ps_subfactory_force_close(regtest_t *rt,
             break;
         }
     }
-    if (fund_vout == UINT32_MAX) { free(f); return 0; }
+    if (fund_vout == UINT32_MAX) { factory_free(f); free(f); return 0; }
 
     unsigned char txid_bytes[32];
-    if (!hex_decode(fund_txid, txid_bytes, 32)) { free(f); return 0; }
+    if (!hex_decode(fund_txid, txid_bytes, 32)) { factory_free(f); free(f); return 0; }
     reverse_bytes(txid_bytes, 32);
     factory_init(f, ctx, kps, N, 2, 4);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -2419,7 +2414,6 @@ int test_regtest_inversion_of_timeout_default(void) {
     const size_t N = 5;  /* LSP + 4 clients */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -2552,7 +2546,7 @@ int test_regtest_inversion_of_timeout_default(void) {
     printf("  invariant holds: LSP output=0, Σclients=funding-fee ✓\n");
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -2595,7 +2589,6 @@ int test_regtest_old_state_poisoning(void) {
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -2709,7 +2702,7 @@ int test_regtest_old_state_poisoning(void) {
     free(old_signed);
     free(new_signed);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -2760,7 +2753,6 @@ int test_regtest_kickoff_paired_with_latest_state(void) {
     const size_t N = 5;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -2839,7 +2831,7 @@ int test_regtest_kickoff_paired_with_latest_state(void) {
            "                   signed state tx; no orphan kickoff possible ✓\n");
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -2903,7 +2895,6 @@ int test_regtest_full_force_close_and_sweep_arity1(void) {
     const size_t N = 2;  /* LSP + 1 client (smallest arity-1 factory) */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -3122,7 +3113,7 @@ int test_regtest_full_force_close_and_sweep_arity1(void) {
     econ_print_summary(&econ);
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -3162,7 +3153,6 @@ int test_regtest_full_force_close_and_sweep_arity2(void) {
     const size_t N = 5;  /* LSP + 4 clients → 2 arity-2 leaves */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -3381,7 +3371,7 @@ int test_regtest_full_force_close_and_sweep_arity2(void) {
     econ_print_summary(&econ);
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -3423,7 +3413,6 @@ int test_regtest_full_force_close_and_sweep_arityPS(void) {
     const size_t N = 3;  /* LSP + 2 clients → 2 PS leaves */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -3635,7 +3624,7 @@ int test_regtest_full_force_close_and_sweep_arityPS(void) {
     econ_print_summary(&econ);
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -3676,7 +3665,6 @@ static int run_ps_chain_advance_sweep(regtest_t *rt,
     const size_t N = 3;  /* LSP + 2 clients -> 2 PS leaves of 1 client each */
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -4056,7 +4044,7 @@ static int run_ps_chain_advance_sweep(regtest_t *rt,
     econ_print_summary(&econ);
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     return 1;
 }
 
@@ -4136,7 +4124,6 @@ static int run_htlc_force_to_local_for_arity(regtest_t *rt,
     const size_t N = n_participants;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -4145,7 +4132,7 @@ static int run_htlc_force_to_local_for_arity(regtest_t *rt,
     uint64_t fund_amount = 0;
     if (!fund_n_party_factory(rt, ctx, N, arity, mine_addr, kps, f,
                                fund_spk, fund_txid, &fund_vout, &fund_amount)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  [arity=%d N=%zu] factory funded: %llu sats, %zu nodes, %d leaves\n",
            (int)arity, N, (unsigned long long)fund_amount, f->n_nodes,
@@ -4569,7 +4556,7 @@ static int run_htlc_force_to_local_for_arity(regtest_t *rt,
     channel_cleanup(&lsp_ch);
     channel_cleanup(&client_ch);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     return 1;
 }
 
@@ -4605,7 +4592,6 @@ static int run_htlc_breach_for_arity(regtest_t *rt,
     const size_t N = n_participants;
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -4614,7 +4600,7 @@ static int run_htlc_breach_for_arity(regtest_t *rt,
     uint64_t fund_amount = 0;
     if (!fund_n_party_factory(rt, ctx, N, arity, mine_addr, kps, f,
                                fund_spk, fund_txid, &fund_vout, &fund_amount)) {
-        free(f); return 0;
+        factory_free(f); free(f); return 0;
     }
     printf("  [arity=%d N=%zu] factory funded: %llu sats, %zu nodes, %d leaves\n",
            (int)arity, N, (unsigned long long)fund_amount, f->n_nodes,
@@ -5081,7 +5067,7 @@ static int run_htlc_breach_for_arity(regtest_t *rt,
     channel_cleanup(&lsp_ch);
     channel_cleanup(&client_ch);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     return 1;
 }
 
@@ -5637,7 +5623,7 @@ int test_regtest_mixed_arity_2_4_8_lifecycle(void) {
     econ_print_summary(&econ);
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -5999,7 +5985,6 @@ static int run_ps_full_lifecycle(regtest_t *rt,
     secp256k1_keypair kps[32];
     secp256k1_pubkey  pks[32];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     unsigned char fund_spk[34];
@@ -6174,7 +6159,7 @@ static int run_ps_full_lifecycle(regtest_t *rt,
 
     for (int li = 0; li < n_leaves; li++) ps_leaf_chain_free(&leaf_chains[li]);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     return 1;
 }
 
@@ -6445,7 +6430,6 @@ int test_regtest_ps_old_state_broadcast_fails_n8(void) {
     secp256k1_keypair kps[16];
     secp256k1_pubkey  pks[16];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) { secp256k1_context_destroy(ctx); return 0; }
 
     unsigned char fund_spk[34];
@@ -6579,7 +6563,7 @@ int test_regtest_ps_old_state_broadcast_fails_n8(void) {
 
     free(chain0_bytes); free(chain1_bytes); free(chain2_bytes);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -6896,7 +6880,7 @@ int test_regtest_nway_n64_arity_2_4_8_lifecycle(void) {
     free(kps);
     free(pks);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -7210,7 +7194,7 @@ int test_regtest_nway_n64_arity_2_4_8_static_threshold_1_lifecycle(void) {
     free(kps);
     free(pks);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -7535,7 +7519,7 @@ int test_regtest_nway_n64_dw_advance_resign_lifecycle(void) {
     free(kps);
     free(pks);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -7847,7 +7831,7 @@ int test_regtest_static_near_root_lifecycle(void) {
 
     free(txids);
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }
@@ -7954,7 +7938,7 @@ int test_regtest_static_near_root_unilateral_exit(void) {
            "1-block confirm — proves nsequence=0xFFFFFFFE eliminates BIP-68 CSV\n");
 
     factory_free(f);
-    free(f);
+    factory_free(f); free(f);
     secp256k1_context_destroy(ctx);
     return 1;
 }

--- a/tests/test_close_spendability_full.c
+++ b/tests/test_close_spendability_full.c
@@ -184,12 +184,12 @@ static int run_coop_close_for_arity(regtest_t *rt,
     if (!build_unsigned_tx(&unsigned_close, NULL,
                             f->funding_txid, f->funding_vout,
                             0xFFFFFFFEu, outs, N)) {
-        tx_buf_factory_free(f); free(&unsigned_close); free(f); return 0;
+        tx_buf_free(&unsigned_close); factory_free(f); free(f); return 0;
     }
     unsigned char sighash[32];
     if (!compute_taproot_sighash(sighash, unsigned_close.data, unsigned_close.len,
                                    0, fund_spk, 34, fund_amount, 0xFFFFFFFEu)) {
-        tx_buf_factory_free(f); free(&unsigned_close); free(f); return 0;
+        tx_buf_free(&unsigned_close); factory_free(f); free(f); return 0;
     }
 
     /* Offline N-party MuSig2 ceremony (we have all keypairs locally). */
@@ -201,13 +201,13 @@ static int run_coop_close_for_arity(regtest_t *rt,
 
     unsigned char sig64[64];
     if (!musig_sign_taproot(ctx, sig64, sighash, kps, N, &ka, NULL)) {
-        tx_buf_factory_free(f); free(&unsigned_close); free(f); return 0;
+        tx_buf_free(&unsigned_close); factory_free(f); free(f); return 0;
     }
 
     tx_buf_t signed_close;
     tx_buf_init(&signed_close, 256);
     if (!finalize_signed_tx(&signed_close, unsigned_close.data, unsigned_close.len, sig64)) {
-        tx_buf_factory_free(f); free(&unsigned_close); tx_buf_free(&signed_close); free(f); return 0;
+        tx_buf_free(&unsigned_close); tx_buf_free(&signed_close); factory_free(f); free(f); return 0;
     }
     tx_buf_free(&unsigned_close);
 
@@ -218,7 +218,7 @@ static int run_coop_close_for_arity(regtest_t *rt,
     char close_txid[65];
     if (!regtest_send_raw_tx(rt, close_hex, close_txid)) {
         fprintf(stderr, "  coop close broadcast failed\n");
-        tx_buf_factory_free(f); free(&signed_close); free(f); return 0;
+        tx_buf_free(&signed_close); factory_free(f); free(f); return 0;
     }
     regtest_mine_blocks(rt, 1, mine_addr);
     tx_buf_free(&signed_close);
@@ -844,7 +844,7 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
     unsigned char sh[32];
     if (!compute_taproot_sighash(sh, uc.data, uc.len, 0,
                                   fund_spk, 34, fund_amount, 0xFFFFFFFEu)) {
-        tx_buf_factory_free(f); free(&uc); free(f); return 0;
+        tx_buf_free(&uc); factory_free(f); free(f); return 0;
     }
     musig_keyagg_t ka;
     secp256k1_pubkey pks[3];
@@ -852,7 +852,7 @@ static int run_ps_chain_close_spendability(regtest_t *rt, secp256k1_context *ctx
     musig_aggregate_keys(ctx, &ka, pks, N);
     unsigned char sig[64];
     if (!musig_sign_taproot(ctx, sig, sh, kps, N, &ka, NULL)) {
-        tx_buf_factory_free(f); free(&uc); free(f); return 0;
+        tx_buf_free(&uc); factory_free(f); free(f); return 0;
     }
     tx_buf_t sc;
     tx_buf_init(&sc, 256);
@@ -1103,7 +1103,7 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     unsigned char shA[32];
     if (!compute_taproot_sighash(shA, ucA.data, ucA.len, 0, spkA, 34,
                                   amtA, 0xFFFFFFFEu)) {
-        tx_buf_factory_free(fA); factory_free(fB); free(&ucA); free(fA); free(fB); return 0;
+        tx_buf_free(&ucA); factory_free(fA); factory_free(fB); free(fA); free(fB); return 0;
     }
     musig_keyagg_t kaA;
     secp256k1_pubkey pksA[5];
@@ -1111,7 +1111,7 @@ static int run_rotation_for_arity(regtest_t *rt, secp256k1_context *ctx,
     musig_aggregate_keys(ctx, &kaA, pksA, N);
     unsigned char sigA[64];
     if (!musig_sign_taproot(ctx, sigA, shA, kpsA, N, &kaA, NULL)) {
-        tx_buf_factory_free(fA); factory_free(fB); free(&ucA); free(fA); free(fB); return 0;
+        tx_buf_free(&ucA); factory_free(fA); factory_free(fB); free(fA); free(fB); return 0;
     }
     tx_buf_t scA;
     tx_buf_init(&scA, 256);

--- a/tests/test_economic_correctness.c
+++ b/tests/test_economic_correctness.c
@@ -845,6 +845,7 @@ int test_regtest_econ_ps_advance(void) {
     econ_snap_post(&ectx);
     econ_print_summary(&ectx);
 
+    factory_free(f);   /* heap arrays -- free() alone orphans them */
     free(f);
     lsp_channels_cleanup(&mgr);
     secp256k1_context_destroy(ctx);
@@ -1160,6 +1161,7 @@ int test_regtest_econ_buy_liquidity_arity2(void) {
     TEST_ASSERT(expected[1] == c0_expected,
                 "client 0 close output == pre_remote − bought");
 
+    factory_free(f);   /* heap arrays -- free() alone orphans them */
     free(f);
     lsp_channels_cleanup(&mgr);
     secp256k1_context_destroy(ctx);

--- a/tests/test_economic_correctness.c
+++ b/tests/test_economic_correctness.c
@@ -137,7 +137,6 @@ static int run_factory_aware_baseline(secp256k1_context *ctx, regtest_t *rt,
 
     /* Build factory tree (arity-specific). */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, N, 2, 4);
     factory_set_arity(f, arity);
@@ -534,7 +533,6 @@ static int run_rotation_econ_for_arity(secp256k1_context *ctx, regtest_t *rt,
 
     /* Build B's tree, close B cooperatively. */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kpsB, N, 2, 4);
     factory_set_arity(f, arity);
@@ -758,7 +756,6 @@ int test_regtest_econ_ps_advance(void) {
     TEST_ASSERT(fund_vout != UINT32_MAX, "locate vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, N, 2, 4);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -1060,7 +1057,6 @@ int test_regtest_econ_buy_liquidity_arity2(void) {
            (unsigned long long)fund_amount);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, N, 2, 4);
     factory_set_arity(f, FACTORY_ARITY_2);

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -4893,7 +4893,6 @@ int test_factory_variable_arity_backward_compat(void) {
     factory_t *f1 = calloc(1, sizeof(factory_t));
     if (!f1) return 0;
     factory_t *f2 = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f2);
     if (!f2) { free(f1); return 0; }
 
     TEST_ASSERT(setup_n_factory(f1, ctx, kps1, 5, FACTORY_ARITY_2, 2000000), "setup f1");
@@ -8008,7 +8007,6 @@ int test_factory_static_near_root_basic(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[12];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[2] = {2, 4};
@@ -8094,7 +8092,6 @@ int test_factory_static_near_root_n128_arity_2_4_8_static_2(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(128, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n128");
 
     /* {2,4,8}: depth 0 arity-2, depth 1 arity-4, depth 2+ arity-8 */
@@ -8196,7 +8193,6 @@ int test_factory_static_near_root_node_nsequence(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[12];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[2] = {2, 4};

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -1788,6 +1788,7 @@ int test_factory_lifecycle_states(void) {
     TEST_ASSERT(factory_is_expired(f, 4852), "is_expired at 4852");
 
     secp256k1_context_destroy(ctx);
+    factory_free(f);   /* heap arrays -- free() alone orphans them */
     free(f);
     return 1;
 }
@@ -1829,6 +1830,7 @@ int test_factory_lifecycle_queries(void) {
     TEST_ASSERT_EQ(factory_blocks_until_expired(f, 130), 0, "until expired at 130");
 
     secp256k1_context_destroy(ctx);
+    factory_free(f);   /* heap arrays -- free() alone orphans them */
     free(f);
     return 1;
 }

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -106,7 +106,6 @@ int test_factory_build_tree(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);  /* step=2, states=4 */
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -197,7 +196,6 @@ int test_factory_sign_all(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -261,7 +259,6 @@ int test_factory_sign_all_retry(void) {
     unsigned char fake_txid[32]; memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -309,7 +306,6 @@ int test_factory_advance(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);  /* step=2, states_per_layer=4 */
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -510,7 +506,6 @@ int test_regtest_factory_tree(void) {
     /* Init factory, build tree, then advance to newest state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);  /* step=1, states=4 */
 
@@ -598,7 +593,6 @@ int test_factory_sign_split_round_step_by_step(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -714,7 +708,6 @@ int test_factory_split_round_with_pool(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -876,7 +869,6 @@ int test_factory_advance_split_round(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);  /* step=2, states_per_layer=4 */
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -974,7 +966,6 @@ int test_factory_l_stock_with_burn_path(void) {
 
     /* Build factory WITHOUT shachain */
     factory_t *f_plain = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_plain);
     if (!f_plain) return 0;
     factory_init(f_plain, ctx, kps, 5, 2, 4);
     factory_set_funding(f_plain, fake_txid, 0, 100000, fund_spk, 34);
@@ -982,7 +973,6 @@ int test_factory_l_stock_with_burn_path(void) {
 
     /* Build factory WITH shachain */
     factory_t *f_sc = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_sc);
     if (!f_sc) return 0;
     factory_init(f_sc, ctx, kps, 5, 2, 4);
     factory_set_shachain_seed(f_sc, test_shachain_seed);
@@ -1049,7 +1039,6 @@ int test_factory_burn_tx_construction(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_shachain_seed(f, test_shachain_seed);
@@ -1084,7 +1073,6 @@ int test_factory_burn_tx_construction(void) {
        on the L-stock SPK).  Verify the no-shachain case produces a valid
        poison TX too. */
     factory_t *f_no_sc = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_no_sc);
     if (!f_no_sc) return 0;
     factory_init(f_no_sc, ctx, kps, 5, 2, 4);
     factory_set_funding(f_no_sc, fake_txid, 0, 100000, fund_spk, 34);
@@ -1125,7 +1113,6 @@ int test_factory_advance_with_shachain(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_shachain_seed(f, test_shachain_seed);
@@ -1305,7 +1292,6 @@ int test_regtest_burn_tx(void) {
     /* Init factory WITH shachain, build tree, then advance to max state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);  /* step=1, states=4 */
     factory_set_shachain_seed(f, test_shachain_seed);
@@ -1440,7 +1426,6 @@ int test_factory_cooperative_close(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1537,7 +1522,6 @@ int test_factory_cooperative_close_balances(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1695,7 +1679,6 @@ int test_regtest_factory_coop_close(void) {
 
     /* Init factory, build tree (but don't broadcast tree!) */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     factory_set_funding(f, fund_txid_bytes, (uint32_t)found_vout,
@@ -1778,7 +1761,6 @@ int test_factory_lifecycle_states(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1825,7 +1807,6 @@ int test_factory_lifecycle_queries(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1867,7 +1848,6 @@ int test_factory_distribution_tx(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -1970,7 +1950,6 @@ int test_factory_distribution_tx_distributed(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2052,7 +2031,6 @@ int test_factory_distribution_tx_default(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 50000, fund_spk, 34);
@@ -2108,7 +2086,6 @@ int test_factory_advance_leaf_left(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2158,7 +2135,6 @@ int test_factory_advance_leaf_right(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2204,7 +2180,6 @@ int test_factory_advance_leaf_independence(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2250,7 +2225,6 @@ int test_factory_advance_leaf_exhaustion(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -2297,7 +2271,6 @@ int test_factory_advance_leaf_preserves_parent_txids(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3348,7 +3321,6 @@ int test_regtest_tree_ordering(void) {
                 "find factory vout");
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 
@@ -3506,7 +3478,6 @@ int test_regtest_dw_exhaustion_close(void) {
 
     /* Small DW counter for fast exhaustion */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     factory_set_funding(f, fund_txid_bytes, (uint32_t)found_vout,
@@ -3590,7 +3561,6 @@ int test_factory_flat_secrets_round_trip(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 10, 8);
 
@@ -3678,7 +3648,6 @@ int test_factory_path_to_root(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3727,7 +3696,6 @@ int test_factory_subtree_clients(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3783,7 +3751,6 @@ int test_factory_find_leaf_for_client(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3854,7 +3821,6 @@ int test_factory_nav_variable_n(void) {
         memset(fake_txid, 0xAA, 32);
 
         factory_t *f = calloc(1, sizeof(factory_t));
-        factory_alloc_default_arrays(f);
         if (!f) return 0;
         factory_init(f, ctx, kps, (size_t)n, 2, 4);
         factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -3907,7 +3873,6 @@ int test_factory_timeout_spend_tx(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;
@@ -3966,7 +3931,6 @@ int test_factory_timeout_spend_mid_node(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;
@@ -4023,7 +3987,6 @@ int test_placement_sequential(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_SEQUENTIAL;
@@ -4073,7 +4036,6 @@ int test_placement_inward(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_INWARD;
@@ -4136,7 +4098,6 @@ int test_placement_outward(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_OUTWARD;
@@ -4203,7 +4164,6 @@ int test_placement_timezone_cluster(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_TIMEZONE_CLUSTER;
@@ -4322,7 +4282,6 @@ int test_nonce_pool_factory_creation(void) {
 
     /* Build + sign using standard factory_sign_all (on-demand nonces) */
     factory_t *f1 = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f1);
     if (!f1) return 0;
     factory_init(f1, ctx, kps, 5, 2, 4);
     factory_set_funding(f1, fake_txid, 0, 100000, fund_spk, 34);
@@ -4335,7 +4294,6 @@ int test_nonce_pool_factory_creation(void) {
 
     /* Build + sign using pool-drawn nonces via split-round API */
     factory_t *f2 = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f2);
     if (!f2) return 0;
     factory_init(f2, ctx, kps, 5, 2, 4);
     factory_set_funding(f2, fake_txid, 0, 100000, fund_spk, 34);
@@ -4435,7 +4393,6 @@ int test_factory_count_nodes_for_participant(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4480,7 +4437,6 @@ int test_factory_sessions_init_path(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4519,7 +4475,6 @@ int test_factory_rebuild_path_unsigned(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4566,7 +4521,6 @@ int test_factory_sign_path(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4647,7 +4601,6 @@ int test_factory_advance_and_rebuild_path(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -4686,7 +4639,6 @@ int test_arity2_leaf_advance(void) {
     memset(fake_txid, 0xBB, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 4, 4);
     factory_set_arity(f, FACTORY_ARITY_2);
@@ -4774,7 +4726,6 @@ int test_distribution_tx_has_anchor(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_funding(f, fake_txid, 0, 100000, fund_spk, 34);
@@ -5004,7 +4955,6 @@ int test_factory_derive_scid(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 10, 100);
     f->cltv_timeout = 1000;
@@ -5057,7 +5007,6 @@ int test_factory_set_leaf_amounts(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_SEQUENTIAL;
@@ -5131,7 +5080,6 @@ int test_leaf_realloc_signing(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->placement_mode = PLACEMENT_SEQUENTIAL;
@@ -5221,7 +5169,6 @@ int test_leaf_realloc_signing_arity1(void) {
     memset(fake_txid, 0xAA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     factory_set_arity(f, FACTORY_ARITY_1);
@@ -5325,7 +5272,6 @@ int test_factory_config_custom(void) {
     cfg.dust_limit_sats = 1000;
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     int ok = factory_init_with_config(f, ctx, keypairs, 5, 10, 4, &cfg);
     TEST_ASSERT(ok, "factory_init_with_config should succeed");
@@ -5369,7 +5315,6 @@ int test_factory_config_default(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     int ok = factory_init(f, ctx, keypairs, 3, 10, 4);
     TEST_ASSERT(ok, "factory_init should succeed");
@@ -5419,7 +5364,6 @@ int test_factory_ps_leaf_build(void) {
     memset(fake_txid, 0xBB, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 3, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -5515,7 +5459,6 @@ int test_factory_ps_subfactory_k2_n4(void) {
     memset(fake_txid, 0xDD, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -5654,7 +5597,6 @@ int test_factory_ps_subfactory_chain_extension(void) {
     memset(fake_txid, 0xFE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -5904,7 +5846,6 @@ int test_factory_ps_subfactory_chain_tx_validity(void) {
     memset(fake_txid, 0xFA, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -6084,7 +6025,6 @@ int test_factory_ps_subfactory_poison_tx_k2_n4(void) {
     memset(fake_txid, 0xDD, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -6319,7 +6259,6 @@ int test_factory_subfactory_lstock_per_state_hash(void) {
     memset(fake_txid, 0xFE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -6381,7 +6320,6 @@ int test_factory_subfactory_lstock_per_state_hash(void) {
 
     /* (d) CONTROL: a non-hashlock sub keeps a STATIC sales-stock SPK across advances. */
     factory_t *g = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(g);
     TEST_ASSERT(g, "alloc control factory");
     factory_init(g, ctx, kps, 5, 6, 10);
     factory_set_arity(g, FACTORY_ARITY_PS);
@@ -7074,7 +7012,6 @@ int test_factory_ps_leaf_build_n64(void) {
     memset(fake_txid, 0xEE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     /* step=4, states_per_layer=3 — modest values so tree depth with 63
        clients stays within DW_MAX_LAYERS=8. */
@@ -7188,7 +7125,6 @@ int test_factory_ps_build_n128(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "factory alloc");
     /* step=4, states_per_layer=3 keeps DW total states modest; the layer count
        (8) is the binding constraint at N=128, not the per-layer state count. */
@@ -7261,7 +7197,6 @@ int test_factory_ps_leaf_advance(void) {
     memset(fake_txid, 0xDD, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 6, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7348,7 +7283,6 @@ int test_factory_ps_amount_invariant(void) {
     memset(fake_txid, 0xF1, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 1, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7415,7 +7349,6 @@ int test_factory_ps_dust_limit(void) {
     memset(fake_txid, 0xF2, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 1, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7468,7 +7401,6 @@ int test_factory_ps_mixed_arity(void) {
     memset(fake_txid, 0xEE, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 5, 6, 10);
 
@@ -7535,7 +7467,6 @@ int test_factory_ps_split_round_leaf_advance(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
     factory_init(f, ctx, kps, 3, 1, 100);
     factory_set_arity(f, FACTORY_ARITY_PS);
@@ -7702,7 +7633,6 @@ int test_factory_ps_matrix(void) {
         memset(fake_txid, (unsigned char)(0xC0 + c), 32);
 
         factory_t *f = calloc(1, sizeof(factory_t));
-        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc factory");
         factory_init(f, ctx, kps, N, 4, 3);
         factory_set_arity(f, FACTORY_ARITY_PS);
@@ -8504,7 +8434,6 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[5];
         factory_t *f = calloc(1, sizeof(factory_t));
-        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc arity-1 factory");
         ensure_seckeys_n();
         for (int i = 0; i < 5; i++)
@@ -8533,7 +8462,6 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[5];
         factory_t *f = calloc(1, sizeof(factory_t));
-        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc arity-2 factory");
         ensure_seckeys_n();
         for (int i = 0; i < 5; i++)
@@ -8565,7 +8493,6 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[5];
         factory_t *f = calloc(1, sizeof(factory_t));
-        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc PS factory");
         ensure_seckeys_n();
         for (int i = 0; i < 5; i++)

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -2324,7 +2324,6 @@ int test_factory_build_tree_arity1(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree arity-1");
@@ -2386,7 +2385,6 @@ int test_factory_arity1_leaf_outputs(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2419,7 +2417,6 @@ int test_factory_arity1_sign_all(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2441,7 +2438,6 @@ int test_factory_arity1_advance(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2470,7 +2466,6 @@ int test_factory_arity1_advance_leaf(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2499,7 +2494,6 @@ int test_factory_arity1_leaf_independence(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2532,7 +2526,6 @@ int test_factory_arity1_coop_close(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2567,7 +2560,6 @@ int test_factory_arity1_client_to_leaf(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2595,7 +2587,6 @@ int test_factory_arity1_cltv_strict_ordering(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     f->cltv_timeout = 200;  /* Enough room for 5 tiers of TIMEOUT_STEP_BLOCKS=5 */
@@ -2638,7 +2629,6 @@ int test_factory_arity1_min_funding_reject(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
 
@@ -2672,7 +2662,6 @@ int test_factory_arity1_input_amounts_consistent(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2703,7 +2692,6 @@ int test_factory_arity1_split_round_leaf_advance(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -2841,7 +2829,6 @@ int test_factory_tier_b_state_advance_root_rollover(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     TEST_ASSERT(setup_arity1_factory(f, ctx, kps), "setup arity-1 factory");
     TEST_ASSERT(factory_build_tree(f), "build tree");
@@ -3035,7 +3022,6 @@ int test_factory_build_tree_n3(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=3 (LSP + 2 clients), arity-2: 1 leaf with 2 clients, depth=0 */
@@ -3065,7 +3051,6 @@ int test_factory_build_tree_n7(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[7];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=7 (LSP + 6 clients), arity-2: 3 leaves, depth=2 */
@@ -3097,7 +3082,6 @@ int test_factory_build_tree_n9(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[9];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=9 (LSP + 8 clients), arity-2: 4 leaves, depth=2 */
@@ -3128,7 +3112,6 @@ int test_factory_build_tree_n16(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[16];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
 
     /* N=16 (LSP + 15 clients), arity-1 only (arity-2 would need 8 leaves, still ok) */
@@ -3159,7 +3142,6 @@ int test_factory_build_tree_n32(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(32, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n32");
 
     /* N=32, arity-2: 16 leaves, depth=4 */
@@ -3191,7 +3173,6 @@ int test_factory_build_tree_n64(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(64, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n64");
 
     /* N=64, arity-2: 32 leaves, depth=5 */
@@ -3217,7 +3198,6 @@ int test_factory_build_tree_n128(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(128, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n128");
 
     /* N=128, arity-2: 64 leaves, depth=6, 254 factory nodes.
@@ -4859,7 +4839,6 @@ int test_factory_variable_arity_build(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[9];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     uint8_t arities[] = {1, 1, 2};
     TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 9, arities, 3, 5000000),
@@ -4886,7 +4865,6 @@ int test_factory_variable_arity_sign(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[5];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     uint8_t arities[] = {1, 2};
     TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 5, arities, 2, 2000000),
@@ -4913,7 +4891,6 @@ int test_factory_variable_arity_backward_compat(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps1[5], kps2[5];
     factory_t *f1 = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f1);
     if (!f1) return 0;
     factory_t *f2 = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(f2);
@@ -6139,7 +6116,6 @@ int test_factory_lstock_client_mirror(void) {
     /* LSP: hashlock ON — derives per-node H from its seed. */
     secp256k1_keypair kl[3];
     factory_t *lsp = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(lsp);
     TEST_ASSERT(lsp, "alloc lsp");
     TEST_ASSERT(setup_variable_arity_factory(lsp, ctx, kl, 3, arities, 1, 5000000),
                 "setup lsp");
@@ -6153,7 +6129,6 @@ int test_factory_lstock_client_mirror(void) {
     /* CLIENT: NO seed; mirror the LSP's per-node H (simulated FACTORY_PROPOSE). */
     secp256k1_keypair kc[3];
     factory_t *cli = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(cli);
     TEST_ASSERT(cli, "alloc cli");
     TEST_ASSERT(setup_variable_arity_factory(cli, ctx, kc, 3, arities, 1, 5000000),
                 "setup cli");
@@ -6201,7 +6176,6 @@ int test_factory_lstock_client_mirror(void) {
     /* CONTROL: a client WITHOUT the mirror builds a DIFFERENT (single-leaf) SPK. */
     secp256k1_keypair kb[3];
     factory_t *bare = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(bare);
     TEST_ASSERT(bare, "alloc bare");
     TEST_ASSERT(setup_variable_arity_factory(bare, ctx, kb, 3, arities, 1, 5000000),
                 "setup bare");
@@ -6383,7 +6357,6 @@ int test_regtest_lstock_hashlock_poison(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -6579,7 +6552,6 @@ int test_regtest_lstock_poison_ceremony(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -6761,7 +6733,6 @@ int test_factory_anchor_lstock_advance(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -6827,7 +6798,6 @@ int test_regtest_lstock_poison_old_state(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[3];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
 
     uint8_t arities[1] = {2};
@@ -7741,7 +7711,6 @@ int test_factory_nway_n12_arity_2_4(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[12];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[2] = {2, 4};
@@ -7800,7 +7769,6 @@ int test_factory_nway_n64_arity_2_4_8(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair *kps = calloc(64, sizeof(secp256k1_keypair));
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(kps && f, "alloc n64");
 
     uint8_t arities[3] = {2, 4, 8};
@@ -7883,7 +7851,6 @@ int test_factory_nway_arity_8_leaf_outputs(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps[9];
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc");
 
     uint8_t arities[1] = {8};
@@ -7949,7 +7916,6 @@ int test_factory_nway_backward_compat(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps_legacy[8], kps_nway[8];
     factory_t *f_legacy = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_legacy);
     factory_t *f_nway = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(f_nway);
     TEST_ASSERT(f_legacy && f_nway, "alloc");
@@ -8285,7 +8251,6 @@ int test_factory_static_near_root_backward_compat(void) {
     secp256k1_context *ctx = test_ctx();
     secp256k1_keypair kps_a[12], kps_b[12];
     factory_t *f_a = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_a);
     factory_t *f_b = calloc(1, sizeof(factory_t));
     factory_alloc_default_arrays(f_b);
     TEST_ASSERT(f_a && f_b, "alloc");
@@ -8523,7 +8488,6 @@ int test_factory_client_to_leaf_roundtrip(void) {
     {
         secp256k1_keypair kps[12];
         factory_t *f = calloc(1, sizeof(factory_t));
-        factory_alloc_default_arrays(f);
         TEST_ASSERT(f, "alloc mixed {2,4} factory");
         uint8_t arities[2] = { 2, 4 };
         TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, 12, arities, 2,
@@ -8541,7 +8505,6 @@ int test_factory_client_to_leaf_roundtrip(void) {
         const size_t N = 17;  /* 1 LSP + 16 clients */
         secp256k1_keypair *kps = calloc(N, sizeof(secp256k1_keypair));
         factory_t *f = calloc(1, sizeof(factory_t));
-        factory_alloc_default_arrays(f);
         TEST_ASSERT(kps && f, "alloc mixed {2,4,8} factory");
         uint8_t arities[3] = { 2, 4, 8 };
         TEST_ASSERT(setup_variable_arity_factory(f, ctx, kps, N, arities, 3,

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -7919,7 +7919,6 @@ int test_factory_nway_backward_compat(void) {
     secp256k1_keypair kps_legacy[8], kps_nway[8];
     factory_t *f_legacy = calloc(1, sizeof(factory_t));
     factory_t *f_nway = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_nway);
     TEST_ASSERT(f_legacy && f_nway, "alloc");
 
     /* Legacy: factory_set_arity(FACTORY_ARITY_2) — uniform arity-2 */
@@ -8251,7 +8250,6 @@ int test_factory_static_near_root_backward_compat(void) {
     secp256k1_keypair kps_a[12], kps_b[12];
     factory_t *f_a = calloc(1, sizeof(factory_t));
     factory_t *f_b = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_b);
     TEST_ASSERT(f_a && f_b, "alloc");
 
     uint8_t arities[2] = {2, 4};

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -4240,6 +4240,7 @@ int test_economic_mode_validation(void) {
     TEST_ASSERT_EQ((long)f->profiles[1].profit_share_bps, 2000, "client 1 bps");
     TEST_ASSERT_EQ((long)f->profiles[4].profit_share_bps, 1000, "client 4 bps");
 
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     return 1;
 }

--- a/tests/test_factory.c
+++ b/tests/test_factory.c
@@ -5724,7 +5724,7 @@ int test_factory_ps_subfactory_chain_extension(void) {
                         "init per-input session");
             size_t this_n = sub->input_n_signers[i];
             for (size_t s = 0; s < this_n; s++) {
-                uint32_t participant = sub->input_signer_indices[i][s];
+                uint32_t participant = factory_node_input_signers(sub, i)[s];
                 unsigned char seckey[32];
                 secp256k1_pubkey pk;
                 TEST_ASSERT(secp256k1_keypair_sec(ctx, seckey, &kps[participant]),
@@ -5747,7 +5747,7 @@ int test_factory_ps_subfactory_chain_extension(void) {
         for (size_t i = 0; i < n_inp; i++) {
             size_t this_n = sub->input_n_signers[i];
             for (size_t s = 0; s < this_n; s++) {
-                uint32_t participant = sub->input_signer_indices[i][s];
+                uint32_t participant = factory_node_input_signers(sub, i)[s];
                 secp256k1_musig_partial_sig psig;
                 TEST_ASSERT(musig_create_partial_sig(
                                 ctx, &psig, &secnonces[i][s], &kps[participant],
@@ -5799,7 +5799,7 @@ int test_factory_ps_subfactory_chain_extension(void) {
                         "chain[2] init per-input");
             size_t this_n = sub->input_n_signers[i];
             for (size_t s = 0; s < this_n; s++) {
-                uint32_t participant = sub->input_signer_indices[i][s];
+                uint32_t participant = factory_node_input_signers(sub, i)[s];
                 unsigned char seckey[32];
                 secp256k1_pubkey pk;
                 secp256k1_keypair_sec(ctx, seckey, &kps[participant]);
@@ -5820,7 +5820,7 @@ int test_factory_ps_subfactory_chain_extension(void) {
         for (size_t i = 0; i < n_inp2; i++) {
             size_t this_n = sub->input_n_signers[i];
             for (size_t s = 0; s < this_n; s++) {
-                uint32_t participant = sub->input_signer_indices[i][s];
+                uint32_t participant = factory_node_input_signers(sub, i)[s];
                 secp256k1_musig_partial_sig psig;
                 TEST_ASSERT(musig_create_partial_sig(
                                 ctx, &psig, &secnonces2[i][s], &kps[participant],
@@ -5940,7 +5940,7 @@ int test_factory_ps_subfactory_chain_tx_validity(void) {
                         "init input");
             size_t this_n = sub->input_n_signers[i];
             for (size_t s = 0; s < this_n; s++) {
-                uint32_t participant = sub->input_signer_indices[i][s];
+                uint32_t participant = factory_node_input_signers(sub, i)[s];
                 unsigned char seckey[32];
                 secp256k1_pubkey pk;
                 secp256k1_keypair_sec(ctx, seckey, &kps[participant]);
@@ -5961,7 +5961,7 @@ int test_factory_ps_subfactory_chain_tx_validity(void) {
         for (size_t i = 0; i < n_inp; i++) {
             size_t this_n = sub->input_n_signers[i];
             for (size_t s = 0; s < this_n; s++) {
-                uint32_t participant = sub->input_signer_indices[i][s];
+                uint32_t participant = factory_node_input_signers(sub, i)[s];
                 secp256k1_musig_partial_sig psig;
                 TEST_ASSERT(musig_create_partial_sig(
                                 ctx, &psig, &secnonces[i][s], &kps[participant],

--- a/tests/test_factory_multi_input_keyagg.c
+++ b/tests/test_factory_multi_input_keyagg.c
@@ -172,16 +172,16 @@ int test_factory_multi_input_keyagg(void)
                             "channel n_signers = 2-of-2");
             /* Slot 0 = client_i (signer_indices[i+1]); slot 1 = LSP. */
             TEST_ASSERT_EQ(
-                (long)sub->input_signer_indices[i][0],
+                (long)factory_node_input_signers(sub, i)[0],
                 (long)sub->signer_indices[i + 1],
                 "channel slot 0 = client_i");
-            TEST_ASSERT_EQ((long)sub->input_signer_indices[i][1], 0,
+            TEST_ASSERT_EQ((long)factory_node_input_signers(sub, i)[1], 0,
                             "channel slot 1 = LSP");
         }
 
         size_t this_n = sub->input_n_signers[i];
         for (size_t s = 0; s < this_n; s++) {
-            uint32_t participant = sub->input_signer_indices[i][s];
+            uint32_t participant = factory_node_input_signers(sub, i)[s];
             unsigned char seckey[32];
             secp256k1_pubkey pk;
             TEST_ASSERT(secp256k1_keypair_sec(ctx, seckey, &kps[participant]),
@@ -207,7 +207,7 @@ int test_factory_multi_input_keyagg(void)
     for (size_t i = 0; i < n_inp; i++) {
         size_t this_n = sub->input_n_signers[i];
         for (size_t s = 0; s < this_n; s++) {
-            uint32_t participant = sub->input_signer_indices[i][s];
+            uint32_t participant = factory_node_input_signers(sub, i)[s];
             secp256k1_musig_partial_sig psig;
             TEST_ASSERT(musig_create_partial_sig(
                             ctx, &psig, &secnonces[i][s], &kps[participant],

--- a/tests/test_factory_multi_input_keyagg.c
+++ b/tests/test_factory_multi_input_keyagg.c
@@ -125,7 +125,6 @@ int test_factory_multi_input_keyagg(void)
     memset(fake_txid, 0xBE, 32);
 
     factory_t *f = (factory_t *)calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT(f, "alloc factory");
     factory_init(f, ctx, kps, 5, 6, 10);
     factory_set_arity(f, FACTORY_ARITY_PS);

--- a/tests/test_jit.c
+++ b/tests/test_jit.c
@@ -1191,6 +1191,7 @@ int test_regtest_jit_daemon_trigger(void) {
     free(lsp->client_fds);
     free(lsp->client_pubkeys);
     free(lsp);
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     close(sv[0]);
     close(sv[1]);

--- a/tests/test_ladder.c
+++ b/tests/test_ladder.c
@@ -789,7 +789,6 @@ int test_regtest_ladder_distribution_fallback(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid, (uint32_t)found_vout,
@@ -1005,7 +1004,6 @@ int test_rotation_context_save_restore(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
 
@@ -1181,7 +1179,6 @@ int test_regtest_ptlc_no_coop_close(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid, (uint32_t)found_vout,
@@ -1349,7 +1346,6 @@ int test_regtest_all_offline_recovery(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid, (uint32_t)found_vout,
@@ -2024,7 +2020,6 @@ int test_regtest_funding_double_spend_rejected(void) {
 
     /* Init factory, build tree, sign all (creates kickoff tx) */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, all_kps, 5, 1, 4);
     factory_set_funding(f, fund_txid_bytes, (uint32_t)found_vout,

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1683,6 +1683,7 @@ extern int test_arity2_leaf_advance(void);
 /* Production Hardening tests */
 extern int test_distribution_tx_has_anchor(void);
 extern int test_ceremony_retry_excludes_timeout(void);
+extern int test_ceremony_select_high_fds(void);
 extern int test_funding_reserve_check(void);
 
 /* SF-CRASH-INJECT-WIRE #245 Half B: crash injection wire opcodes + runtime target. */
@@ -3580,6 +3581,7 @@ static void run_unit_tests(void) {
     printf("\n=== Production Hardening ===\n");
     RUN_TEST(test_distribution_tx_has_anchor);
     RUN_TEST(test_ceremony_retry_excludes_timeout);
+    RUN_TEST(test_ceremony_select_high_fds);
     RUN_TEST(test_funding_reserve_check);
 
     printf("\n=== Crash Injection (#245 Half B) ===\n");

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -48,6 +48,16 @@ static const char *test_filter = NULL;  /* if non-NULL, only run tests whose
             printf(" OK\n"); \
         } else { \
             tests_failed++; \
+            /* Say WHICH test failed.  This branch used to only bump the
+               counter and print nothing, so the summary reported
+               "1 FAILED" without ever naming it -- a failing test was
+               visible only as the ABSENCE of " OK" after its name, and
+               tests print their own output in between, so in a 6600-line
+               CI log it is effectively unfindable.  Print an unambiguous
+               marker on its own line and flush, so it survives truncation
+               and interleaving. */ \
+            printf("\n  *** FAILED: %s\n", #fn); \
+            fflush(stdout); \
         } \
     } \
 } while(0)

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1986,6 +1986,7 @@ extern int test_readiness_urgency_levels(void);
 extern int test_readiness_get_missing(void);
 extern int test_readiness_reset(void);
 extern int test_readiness_beyond_64(void);
+extern int test_readiness_beyond_max_signers(void);
 
 /* Async Signing: Rotation Readiness (lsp_check_rotation_readiness) */
 extern int test_rotation_readiness_null(void);
@@ -3904,6 +3905,7 @@ static void run_unit_tests(void) {
     RUN_TEST(test_readiness_get_missing);
     RUN_TEST(test_readiness_reset);
     RUN_TEST(test_readiness_beyond_64);
+    RUN_TEST(test_readiness_beyond_max_signers);
 
     printf("\n=== Async Signing: Rotation Readiness ===\n");
     RUN_TEST(test_rotation_readiness_null);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -2634,6 +2634,7 @@ int test_persist_crash_dw_state(void) {
         persist_close(&db);
     }
 
+    factory_free(f);   /* heap arrays -- free() alone orphans them */
     free(f);
     secp256k1_context_destroy(ctx);
     unlink(path);

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -1076,7 +1076,6 @@ int test_persist_factory_round_trip(void) {
     build_p2tr_script_pubkey(fund_spk, &tweaked_xonly);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     f->use_tree_anchor = 1;  /* #56: mirror production — persist_load_factory rebuilds
@@ -1492,7 +1491,6 @@ int test_lsp_recovery_round_trip(void) {
     if (!secp256k1_ec_pubkey_create(ctx, &pks[4], extra_sec4)) return 0;  /* Client 3 */
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     f->cltv_timeout = 200;
@@ -2009,7 +2007,6 @@ int test_persist_crash_stress(void) {
     if (!secp256k1_ec_pubkey_create(ctx, &pks[4], extra_sec4)) return 0;
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     f->cltv_timeout = 200;
@@ -2491,7 +2488,6 @@ int test_persist_crash_dw_state(void) {
     if (!secp256k1_ec_pubkey_create(ctx, &pks[4], s4)) return 0;
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
 

--- a/tests/test_persist.c
+++ b/tests/test_persist.c
@@ -1938,6 +1938,7 @@ int test_persist_validate_factory_load(void) {
     loaded = persist_load_factory(&db, 13, f, ctx);
     TEST_ASSERT(loaded == 0, "step_blocks=0 rejected");
 
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     secp256k1_context_destroy(ctx);
     persist_close(&db);

--- a/tests/test_readiness.c
+++ b/tests/test_readiness.c
@@ -224,5 +224,58 @@ int test_readiness_beyond_64(void) {
     readiness_set_connected(&rt, 126, 1);
     readiness_set_ready(&rt, 126, QUEUE_REQ_ROTATION);
     TEST_ASSERT(readiness_all_ready(&rt) == 1, "all ready again");
+    readiness_free(&rt);   /* 127 > READINESS_SMALL, so this one is heap-backed */
+    return 1;
+}
+
+/* Regression for the SILENT CLAMP.  readiness_init used to do
+ *     rt->n_clients = (n_clients > FACTORY_MAX_SIGNERS) ? FACTORY_MAX_SIGNERS
+ *                                                       : n_clients;
+ * so asking for more than 256 clients quietly tracked only the first 256 and
+ * dropped the rest with no error.  Every accessor bounds-checks against
+ * n_clients, so the surplus clients did not merely go unread -- they became
+ * INVISIBLE: readiness_all_ready() would return TRUE once the tracked prefix
+ * was ready, while the untracked clients were still missing.  That is the same
+ * premature-rotation failure as the uint64_t bitmap bug above, just at a higher
+ * N, and it would have appeared exactly when the daemon cap was lifted.
+ *
+ * The array is now sized to the request, so nothing is dropped. */
+int test_readiness_beyond_max_signers(void) {
+    const size_t N = 300;   /* > FACTORY_MAX_SIGNERS (256) */
+    readiness_tracker_t rt;
+    TEST_ASSERT(readiness_init(&rt, 11, N, NULL) == 1, "init 300 succeeds");
+    TEST_ASSERT(rt.n_clients == N, "all 300 tracked, not clamped to 256");
+
+    /* Ready everyone the OLD code would have tracked (0..255).  If the clamp
+       were still there this would read as "all ready" -- the exact bug. */
+    for (uint32_t i = 0; i < 256; i++) {
+        readiness_set_connected(&rt, i, 1);
+        readiness_set_ready(&rt, i, QUEUE_REQ_ROTATION);
+    }
+    TEST_ASSERT(readiness_count_ready(&rt) == 256, "256 ready");
+    TEST_ASSERT(readiness_all_ready(&rt) == 0,
+                "NOT all ready — 44 clients above the old clamp are still missing");
+
+    /* Clients past the old ceiling must be individually addressable. */
+    readiness_set_connected(&rt, 299, 1);
+    readiness_set_ready(&rt, 299, QUEUE_REQ_ROTATION);
+    TEST_ASSERT(rt.clients[299].is_ready == 1, "entry 299 ready");
+    TEST_ASSERT(rt.clients[299].client_idx == 299, "entry 299 has its own idx");
+    TEST_ASSERT(readiness_count_ready(&rt) == 257, "299 counted once");
+
+    for (uint32_t i = 256; i < (uint32_t)N; i++) {
+        readiness_set_connected(&rt, i, 1);
+        readiness_set_ready(&rt, i, QUEUE_REQ_ROTATION);
+    }
+    TEST_ASSERT(readiness_all_ready(&rt) == 1, "all ready once all 300 are in");
+
+    /* Out-of-range stays a safe no-op, as before. */
+    readiness_set_ready(&rt, (uint32_t)N, QUEUE_REQ_ROTATION);
+    TEST_ASSERT(readiness_count_ready(&rt) == N, "index N ignored");
+
+    readiness_free(&rt);
+    TEST_ASSERT(rt.n_clients == 0, "free empties the tracker");
+    TEST_ASSERT(readiness_all_ready(&rt) == 0, "freed tracker fails closed");
+    readiness_free(&rt);   /* double free must be safe */
     return 1;
 }

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -2584,7 +2584,6 @@ int test_reconnect_commitment_mismatch_rollback(void) {
     unsigned char client_secs[4][32];
     secp256k1_pubkey client_pks[4];
     factory_t *factory = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     lsp_t *lsp = calloc(1, sizeof(lsp_t));
     if (!lsp) { free(factory); return 0; }
@@ -2654,7 +2653,6 @@ int test_reconnect_commitment_mismatch_reject(void) {
     unsigned char client_secs[4][32];
     secp256k1_pubkey client_pks[4];
     factory_t *factory = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     lsp_t *lsp = calloc(1, sizeof(lsp_t));
     if (!lsp) { free(factory); return 0; }
@@ -2729,7 +2727,6 @@ int test_reconnect_htlc_replay(void) {
     unsigned char client_secs[4][32];
     secp256k1_pubkey client_pks[4];
     factory_t *factory = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     lsp_t *lsp = calloc(1, sizeof(lsp_t));
     if (!lsp) { free(factory); return 0; }

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -180,7 +180,6 @@ int test_reconnect_pubkey_match(void) {
         all_pks[i + 1] = client_pks[i];
 
     factory_t *factory = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(factory);
     if (!factory) { free(lsp->client_fds); free(lsp->client_pubkeys); free(lsp); return 0; }
     factory_init_from_pubkeys(factory, ctx, all_pks, 5, 10, 4);
 
@@ -397,7 +396,6 @@ int test_client_persist_reload(void) {
 
     /* Build factory */
     factory_t *factory = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     factory_init_from_pubkeys(factory, ctx, pks, 5, 10, 4);
 
@@ -567,7 +565,6 @@ int test_balance_reporting(void) {
     }
 
     factory_t *factory = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(factory);
     if (!factory) return 0;
     factory_init_from_pubkeys(factory, ctx, pks, 5, 10, 4);
 
@@ -1992,7 +1989,6 @@ int test_distribution_tx_amounts(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
 

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -1789,6 +1789,7 @@ int test_factory_lifecycle_daemon_check(void) {
     s = factory_get_state(f, 200);
     TEST_ASSERT_EQ(s, FACTORY_EXPIRED, "block 200 = EXPIRED");
 
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     return 1;
 }
@@ -1966,6 +1967,7 @@ int test_ladder_daemon_integration(void) {
     TEST_ASSERT_EQ(lf->cached_state, FACTORY_EXPIRED, "EXPIRED at 130");
 
     tx_buf_free(&lf->distribution_tx);
+    factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
     free(lad);
     secp256k1_context_destroy(ctx);

--- a/tests/test_reconnect.c
+++ b/tests/test_reconnect.c
@@ -1969,6 +1969,12 @@ int test_ladder_daemon_integration(void) {
     tx_buf_free(&lf->distribution_tx);
     factory_free(f);   /* heap arrays: free(f) alone orphans them */
     free(f);
+    /* ladder_free, not just free(lad): `lf->factory = *f` is a shallow struct
+       copy, and factory_detach_txbufs then DEEP-COPIES the nine participant
+       arrays so the detached factory owns its own (see factory.c:848).  Those
+       copies belong to lad->factories[0] and only ladder_free releases them --
+       free(lad) drops the struct and orphans 238KB of nodes[]. */
+    ladder_free(lad);
     free(lad);
     secp256k1_context_destroy(ctx);
     return 1;

--- a/tests/test_regtest.c
+++ b/tests/test_regtest.c
@@ -1643,7 +1643,6 @@ int test_regtest_ps_basic_close(void) {
         regtest_mine_blocks(&rt, 101, mine_addr);
 
     f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT_GOTO(f, "alloc factory");
     secp256k1_keypair kps[3];
     char fund_txid[65];
@@ -1705,7 +1704,6 @@ int test_regtest_ps_chain_close(void) {
         regtest_mine_blocks(&rt, 101, mine_addr);
 
     f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT_GOTO(f, "alloc factory");
     secp256k1_keypair kps[3];
     char fund_txid[65];
@@ -1810,7 +1808,6 @@ int test_regtest_ps_old_state_response(void) {
         regtest_mine_blocks(&rt, 101, mine_addr);
 
     f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     TEST_ASSERT_GOTO(f, "alloc factory");
     secp256k1_keypair kps[3];
     char fund_txid[65];

--- a/tests/test_tapscript.c
+++ b/tests/test_tapscript.c
@@ -269,7 +269,6 @@ int test_factory_tree_with_timeout(void) {
 
     /* Build factory WITH cltv_timeout */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;  /* some block height */
@@ -295,7 +294,6 @@ int test_factory_tree_with_timeout(void) {
 
     /* Build factory WITHOUT cltv_timeout for comparison */
     factory_t *f2 = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f2);
     if (!f2) return 0;
     factory_init(f2, ctx, kps, 5, 2, 4);
     f2->cltv_timeout = 0;
@@ -544,7 +542,6 @@ int test_regtest_timeout_spend(void) {
     /* Init factory with timeout, build tree, then advance to max state (all delays = 0).
        factory_build_tree reinitializes the DW counter, so advances must happen after. */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 1, 4);
     f->cltv_timeout = cltv_timeout;
@@ -762,7 +759,6 @@ int test_multi_level_timeout_unit(void) {
     memset(fake_txid, 0xCC, 32);
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     f->cltv_timeout = 1000;

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -71,7 +71,6 @@ int test_wire_pubkey_only_factory(void) {
 
     /* Build factory with keypairs (reference) */
     factory_t *f_ref = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_ref);
     if (!f_ref) return 0;
     factory_init(f_ref, ctx, kps, 5, 10, 4);
 
@@ -88,7 +87,6 @@ int test_wire_pubkey_only_factory(void) {
     }
 
     factory_t *f_pk = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_pk);
     if (!f_pk) return 0;
     factory_init_from_pubkeys(f_pk, ctx, pks, 5, 10, 4);
     factory_set_funding(f_pk, fake_txid, 0, 10000000, fake_spk, 34);
@@ -634,7 +632,6 @@ int test_wire_close_unsigned(void) {
 
     /* Build reference factory */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 10, 4);
 
@@ -702,7 +699,6 @@ int test_wire_distributed_signing(void) {
 
     /* Build reference factory with all keypairs, sign it the old way */
     factory_t *f_ref = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f_ref);
     if (!f_ref) return 0;
     factory_init(f_ref, ctx, kps, 5, 10, 4);
 
@@ -924,7 +920,6 @@ int test_basepoint_independence(void) {
 
     /* Build a factory for testing */
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init_from_pubkeys(f, ctx, pks, 5, 10, 4);
     unsigned char fake_txid[32];
@@ -1751,7 +1746,6 @@ int test_placement_profiles_wire_round_trip(void) {
     }
 
     factory_t *f = calloc(1, sizeof(factory_t));
-    factory_alloc_default_arrays(f);
     if (!f) return 0;
     factory_init(f, ctx, kps, 5, 2, 4);
     unsigned char fake_txid[32];

--- a/tools/superscalar_client.c
+++ b/tools/superscalar_client.c
@@ -1931,8 +1931,14 @@ handle_message:
             /* LSP initiates factory rotation — create new factory */
             printf("Client %u: received FACTORY_PROPOSE (rotation)\n", my_index);
 
-            /* Save pubkeys from current factory */
-            secp256k1_pubkey saved_pubkeys[FACTORY_MAX_SIGNERS];
+            /* Save pubkeys from current factory.
+               Sized to n_participants: this was a fixed [FACTORY_MAX_SIGNERS]
+               written by an UNCLAMPED `pi < n_participants` loop, i.e. a stack
+               buffer overflow for any factory over 256 participants -- not a
+               truncation. It never fired only because this is the rotation
+               path, which the lifecycle harness does not drive; a 300-client
+               factory that rotated would have smashed main's frame. */
+            secp256k1_pubkey saved_pubkeys[n_participants ? n_participants : 1];
             for (size_t pi = 0; pi < n_participants; pi++)
                 saved_pubkeys[pi] = factory->pubkeys[pi];
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -43,6 +43,7 @@
 #include <inttypes.h>
 #include <signal.h>
 #include <unistd.h>
+#include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <poll.h>
@@ -2598,6 +2599,48 @@ int main(int argc, char *argv[]) {
                 "dynamic — see docs/design/distributed-scale-512.md)\n",
                 FACTORY_MAX_SIGNERS - 1);
         return 1;
+    }
+
+    /* File-descriptor budget.  One socket per client, plus the listener, bridge,
+       admin RPC, SQLite handles, logs and stdio.  Raise our own soft limit
+       rather than depending on the operator's shell: a swarm launcher that
+       forgets `ulimit -n` otherwise fails deep inside the ceremony as accept()
+       starts returning EMFILE, which reads like a client-side bug.
+       We only raise the SOFT limit toward the existing hard limit -- no
+       privilege is required for that, and the hard limit still governs. */
+    {
+        struct rlimit rl;
+        rlim_t want = (rlim_t)n_clients + 64;   /* clients + headroom */
+        if (getrlimit(RLIMIT_NOFILE, &rl) == 0) {
+            if (rl.rlim_cur < want) {
+                rlim_t target = (rl.rlim_max == RLIM_INFINITY || rl.rlim_max > want)
+                                ? want : rl.rlim_max;
+                /* Only attempt (and only announce) a real increase: when the
+                   hard limit already caps us, target == rlim_cur and claiming
+                   we "raised 128 -> 128" is just noise in front of the error. */
+                if (target > rl.rlim_cur) {
+                    struct rlimit nrl = rl;
+                    nrl.rlim_cur = target;
+                    if (setrlimit(RLIMIT_NOFILE, &nrl) == 0) {
+                        printf("LSP: raised fd soft limit %llu -> %llu for %d clients\n",
+                               (unsigned long long)rl.rlim_cur,
+                               (unsigned long long)target, n_clients);
+                        rl.rlim_cur = target;
+                    }
+                }
+            }
+            if (rl.rlim_cur < want) {
+                fprintf(stderr,
+                    "Error: fd limit too low — %d clients need ~%llu descriptors "
+                    "but the limit is %llu (hard limit %llu).\n"
+                    "Raise it before launching: ulimit -n %llu\n",
+                    n_clients, (unsigned long long)want,
+                    (unsigned long long)rl.rlim_cur,
+                    (unsigned long long)rl.rlim_max,
+                    (unsigned long long)want);
+                return 1;
+            }
+        }
     }
     /* In uniform mode (no comma list) the leaf semantics are 1, 2, or 3;
        in mixed mode the LAST entry can be any 1..15 since interior arities

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -2592,12 +2592,33 @@ int main(int argc, char *argv[]) {
        array work, the next limits in order are wall-clock (seeding is serialized,
        ~O(N) round-trips), per-client RSS (~21 MB + ~0.085 MB/N), and `ulimit -n`
        on the LSP (~N+20). */
-    if (n_clients < 1 || n_clients + 1 > FACTORY_MAX_SIGNERS) {
-        fprintf(stderr, "Error: --clients must be 1..%d "
-                "(the LSP co-signs every factory, and the daemon still has fixed "
-                "[FACTORY_MAX_SIGNERS] arrays; lifting this needs those made "
-                "dynamic — see docs/design/distributed-scale-512.md)\n",
-                FACTORY_MAX_SIGNERS - 1);
+    /* The ordinary lifecycle is no longer capped at FACTORY_MAX_SIGNERS. The
+       library's participant-indexed state is now sized to the real count, and
+       both daemon-side arrays that used to bound this are dynamic: the keyagg
+       scratch (lsp_ensure_scratch) and the cooperative-close outputs
+       (calloc n_clients+1). SS_MAX_PARTICIPANTS is the hard ceiling on any
+       peer- or operator-supplied count. */
+    if (n_clients < 1 || n_clients + 1 > SS_MAX_PARTICIPANTS) {
+        fprintf(stderr, "Error: --clients must be 1..%d\n",
+                SS_MAX_PARTICIPANTS - 1);
+        return 1;
+    }
+
+    /* The adversarial/demo blocks are a different story. superscalar_lsp_
+       {pre,post}_daemon_tests.inc are #included into main() and still declare
+       31 fixed [FACTORY_MAX_SIGNERS] arrays (keypair sets, dist/close output
+       arrays, rotation snapshots). They are only reachable behind these flags,
+       so gate on the flags rather than capping every operator. Converting them
+       is mechanical but unnecessary for a production-shaped run. */
+    if (n_clients + 1 > FACTORY_MAX_SIGNERS &&
+        (breach_test || cheat_leaf_side >= 0 || cheat_realloc ||
+         cheat_jit || cheat_lstock_buy)) {
+        fprintf(stderr,
+                "Error: --clients %d exceeds %d, and the embedded "
+                "--cheat-*/--test-* blocks still use fixed "
+                "[FACTORY_MAX_SIGNERS] arrays. Run the adversarial modes at "
+                "<= %d clients, or convert those arrays first.\n",
+                n_clients, FACTORY_MAX_SIGNERS - 1, FACTORY_MAX_SIGNERS - 1);
         return 1;
     }
 

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -4183,8 +4183,14 @@ accept_new_factory:
     lsp_p->factory.placement_mode = (placement_mode_t)placement_mode_arg;
     lsp_p->factory.economic_mode = (economic_mode_t)economic_mode_arg;
 
-    /* Populate default profiles from CLI config */
-    for (size_t pi = 0; pi < (size_t)(1 + n_clients) && pi < FACTORY_MAX_SIGNERS; pi++) {
+    /* Populate default profiles from CLI config.
+       Bound by the ALLOCATION (config.max_signers, which factory_config_fit
+       sets to the participant count), not the compile-time FACTORY_MAX_SIGNERS.
+       With the 255-client CLI wall lifted, clamping at 256 here would leave
+       participants 256+ with profit_share_bps = 0 and contribution_sats = 0 --
+       silently offering them nothing. */
+    for (size_t pi = 0; pi < (size_t)(1 + n_clients) &&
+                        pi < lsp_p->factory.config.max_signers; pi++) {
         lsp_p->factory.profiles[pi].participant_idx = (uint32_t)pi;
         if (pi == 0) {
             /* LSP gets remainder of profit share */
@@ -4203,7 +4209,8 @@ accept_new_factory:
        The test PASSES if factory creation fails (client rejection). */
     if (test_bad_terms) {
         lsp_p->factory.economic_mode = ECON_PROFIT_SHARED;
-        for (size_t pi = 1; pi < (size_t)(1 + n_clients) && pi < FACTORY_MAX_SIGNERS; pi++)
+        for (size_t pi = 1; pi < (size_t)(1 + n_clients) &&
+                            pi < lsp_p->factory.config.max_signers; pi++)
             lsp_p->factory.profiles[pi].profit_share_bps = 0;
         lsp_p->factory.profiles[0].profit_share_bps = 10000; /* LSP takes 100% */
         printf("LSP: --test-bad-terms: offering 0 bps profit to all clients\n");

--- a/tools/superscalar_lsp.c
+++ b/tools/superscalar_lsp.c
@@ -3343,11 +3343,23 @@ int main(int argc, char *argv[]) {
             /* Derive funding + mining addresses for rotation */
             {
                 musig_keyagg_t ka;
-                secp256k1_pubkey all_pks[FACTORY_MAX_SIGNERS];
+                /* Heap, sized to the participant count: this block sits inside
+                   main()'s already-huge frame and the array is dead right after
+                   the aggregate, so it is freed immediately -- before any of the
+                   later returns in this scope, which is why no cleanup label is
+                   needed. */
+                secp256k1_pubkey *all_pks = (secp256k1_pubkey *)calloc(
+                    lsp_rp->factory.n_participants, sizeof(secp256k1_pubkey));
+                if (!all_pks) {
+                    fprintf(stderr, "LSP recovery: out of memory for %zu participant keys\n",
+                            lsp_rp->factory.n_participants);
+                    return 1;
+                }
                 for (size_t i = 0; i < lsp_rp->factory.n_participants; i++)
                     all_pks[i] = lsp_rp->factory.pubkeys[i];
                 musig_aggregate_keys(ctx, &ka, all_pks,
                                        lsp_rp->factory.n_participants);
+                free(all_pks);   /* dead from here; no later path uses it */
                 unsigned char is2[32];
                 if (!secp256k1_xonly_pubkey_serialize(ctx, is2, &ka.agg_pubkey)) {
                     fprintf(stderr, "LSP recovery: xonly serialize failed\n");
@@ -3846,7 +3858,21 @@ accept_new_factory:
 
     /* === Phase 2: Compute funding address === */
     size_t n_total = 1 + lsp_p->n_clients;
-    secp256k1_pubkey all_pks[FACTORY_MAX_SIGNERS];
+    /* Reuse the LSP's ceremony scratch rather than a fixed stack array: this is
+       the site ASan named once lsp_accept_clients was converted
+         WRITE of size 64 (= secp256k1_pubkey) at superscalar_lsp.c:3852
+         stack-buffer-overflow, frame main() with 524 objects
+       main()'s frame is already ~287 KB, so a [FACTORY_MAX_SIGNERS] array here
+       is the worst possible place for one.  scratch_pubkeys is sized to
+       expected_clients+1 by lsp_accept_clients (which has already run) and is
+       freed in lsp_cleanup, so there is nothing to free on main's many exits. */
+    if (!lsp_ensure_scratch(lsp_p, n_total)) {
+        fprintf(stderr, "LSP: out of memory sizing keyagg scratch for %zu participants\n",
+                n_total);
+        lsp_cleanup(lsp_p);
+        return 1;
+    }
+    secp256k1_pubkey *all_pks = lsp_p->scratch_pubkeys;
     all_pks[0] = lsp_p->lsp_pubkey;
     for (size_t i = 0; i < lsp_p->n_clients; i++)
         all_pks[i + 1] = lsp_p->client_pubkeys[i];
@@ -4828,7 +4854,19 @@ accept_new_factory:
     }
     printf("LSP: starting cooperative close...\n");
 
-    tx_output_t close_outputs[FACTORY_MAX_SIGNERS];
+    /* Heap: the close builds one output per participant, so a fixed
+       [FACTORY_MAX_SIGNERS] array here caps the cooperative close at 255 parties
+       independently of everything else.  Sized to n_clients+1 (every client plus
+       the LSP).  Lives until process exit -- this is main()'s terminal path and
+       the buffer is in use right through the close ceremony, so freeing it early
+       would be wrong and freeing it late buys nothing. */
+    tx_output_t *close_outputs = (tx_output_t *)calloc(lsp_p->n_clients + 1,
+                                                         sizeof(tx_output_t));
+    if (!close_outputs) {
+        fprintf(stderr, "LSP: out of memory for %zu close outputs\n",
+                lsp_p->n_clients + 1);
+        return 1;
+    }
     size_t n_close_outputs;
 
     /* Get wallet-controlled address for close outputs (UTXO recycling) */

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -220,7 +220,7 @@ nohup "$LSP_BIN" --network regtest --port "$PORT" \
     --amount "$AMOUNT" \
     --active-blocks 500 --dying-blocks 20 --step-blocks 5 --states-per-layer 2 \
     --fee-rate 1000 --lsp-balance-pct 100 --confirm-timeout 600 \
-    --max-conn-rate 100000 --max-handshakes 256 \
+    --max-conn-rate 100000 --max-handshakes "$(( N_CLIENTS + 16 ))" \
     --seckey "$LSP_SECKEY" \
     --rpcuser "$RU" --rpcpassword "$RP" --rpcport "$RPORT" \
     --wallet "$MINERW" --db "$LSP_DB" \

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -318,6 +318,20 @@ eval "$RES"
 [ "${nout:-0}" -eq $((N_CLIENTS+1)) ] && green "  ok: exactly $((N_CLIENTS+1)) outputs (every onboarded-at-zero client got an LN-earned payout)" \
                                        || { red "  CHECK FAIL: nout=${nout:-?} != $((N_CLIENTS+1))"; FAILED=1; }
 
+# ---- DIST-TX: the all-offline safety net must actually have been co-signed ----
+# Checked because this is precisely what degraded silently before.  Each client
+# REBUILDS the distribution TX from the LSP-sent per-client amounts and refuses
+# to co-sign on any mismatch -- and that refusal is a graceful skip: the factory
+# still comes up and every other phase still passes.  At N=300 a truncated
+# amounts list made every client past index 255 skip, so the run reported
+# success while the CLTV fallback (the TX anyone can broadcast to pay everyone
+# if all parties vanish) covered nobody.  Nothing here was looking.
+# Counted after the close so every client log is flushed.
+DIST_OK=$(grep -al "stored signed distribution TX" /tmp/ss_${TAG}_c*.log 2>/dev/null | wc -l)
+DIST_OK=${DIST_OK:-0}
+[ "$DIST_OK" -ge "$N_CLIENTS" ] && green "  ok: dist-TX co-signed by $DIST_OK/$N_CLIENTS clients (all-offline CLTV fallback covers everyone)" \
+                                || { red "  CHECK FAIL: dist-TX co-signed by only $DIST_OK/$N_CLIENTS — CLTV fallback does not cover every client"; FAILED=1; }
+
 info "=== EXACT accounting: output_i == received_i - sent_i (baseline 0) ==="
 python3 - "$LSP_LOG" "$N_CLIENTS" <<'PYEOF'
 import sys, re

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -76,6 +76,35 @@ red(){   printf '\033[31m%s\033[0m\n' "$*"; }
 green(){ printf '\033[32m%s\033[0m\n' "$*"; }
 info(){  printf '\033[36m[pct100]\033[0m %s\n' "$*"; }
 ts(){ date -u +%H:%M:%S; }
+
+# ---- phase timing ------------------------------------------------------------
+# Every run self-reports where its wall-clock went, so an ETA at a new N is a
+# regression on measured phases rather than a guess, and a slow phase is visible
+# without re-deriving it from scattered log timestamps.
+# Measured N=300 (release, regtest): creation 166s, seed 449s -- i.e. the seed,
+# which is N strictly-serial independent payments, dominates creation 2.7:1.
+# That is the sort of thing this table is meant to make obvious.
+PHASE_NAMES=(); PHASE_SECS=(); _PH_T0=$(date +%s); _PH_CUR=""
+phase_begin(){ phase_end; _PH_CUR="$1"; _PH_T0=$(date +%s); }
+phase_end(){
+    [ -z "$_PH_CUR" ] && return 0
+    local d=$(( $(date +%s) - _PH_T0 ))
+    PHASE_NAMES+=("$_PH_CUR"); PHASE_SECS+=("$d"); _PH_CUR=""
+}
+phase_report(){
+    phase_end
+    local total=0 i
+    for i in "${!PHASE_NAMES[@]}"; do total=$(( total + PHASE_SECS[i] )); done
+    [ "$total" -eq 0 ] && total=1
+    printf '\n\033[36m[pct100]\033[0m PHASE TIMING  (N=%s, total %ds)\n' "$N_CLIENTS" "$total"
+    for i in "${!PHASE_NAMES[@]}"; do
+        printf '   %-26s %6ds  %5.1f%%  %s\n' \
+            "${PHASE_NAMES[i]}" "${PHASE_SECS[i]}" \
+            "$(awk -v a="${PHASE_SECS[i]}" -v b="$total" 'BEGIN{printf "%.1f", 100*a/b}')" \
+            "$(awk -v a="${PHASE_SECS[i]}" -v n="$N_CLIENTS" 'BEGIN{if(n>0)printf "%.2fs/client", a/n}')"
+    done
+    printf '   %-26s %6ds\n' "TOTAL" "$total"
+}
 die(){ red "FAIL: $*"; exit 1; }
 
 declare -A CPID CDB CSK
@@ -89,7 +118,7 @@ cleanup(){
     rm -f "$FIFO" 2>/dev/null || true
     cp "$LSP_LOG" /tmp/pct100_last_lsp.log 2>/dev/null || true
 }
-trap cleanup EXIT
+trap 'phase_report; cleanup' EXIT
 cli(){ printf '%s\n' "$1" >&3 2>/dev/null || true; }
 seed_amt(){ echo $(( SEED_MIN + RANDOM % (SEED_MAX - SEED_MIN + 1) )); }
 econ_amt(){ echo $(( ECON_MIN + RANDOM % (ECON_MAX - ECON_MIN + 1) )); }
@@ -199,6 +228,7 @@ nohup "$LSP_BIN" --network regtest --port "$PORT" \
 LSP_PID=$!
 for i in $(seq 1 60); do sleep 1; grep -q "listening on port $PORT" "$LSP_LOG" 2>/dev/null && break; kill -0 "$LSP_PID" 2>/dev/null || { tail -25 "$LSP_LOG"; die "LSP died before listening"; }; done
 grep -q "listening on port $PORT" "$LSP_LOG" || { tail -25 "$LSP_LOG"; die "LSP never listened"; }
+phase_begin "launch+connect"
 info "$(ts) LSP listening; launching $N_CLIENTS zero-balance clients + block miner..."
 for i in $(seq 1 "$N_CLIENTS"); do
     nohup "$CLIENT_BIN" --network regtest --host 127.0.0.1 --port "$PORT" \
@@ -229,6 +259,7 @@ done
 green "$(ts) FACTORY LIVE — $N_CLIENTS clients onboarded with ZERO balance (pct-100)"
 
 # ---- SEED: every client's first sats arrive over LN ----
+phase_begin "seed"
 info "$(ts) SEED: LSP pays each of the $N_CLIENTS clients over LN (lsppay, random $SEED_MIN..$SEED_MAX sats)..."
 for i in $(seq 0 $((N_CLIENTS-1))); do
     lsppay_cli "$i" "$(seed_amt)" || red "$(ts)   seed of client $i did not settle (retry pass follows)"
@@ -242,6 +273,7 @@ SEEDED=$(grep -aoE "Payment complete: LSP -> client [0-9]+ \(" "$LSP_LOG" 2>/dev
                                 || red   "$(ts) SEED INCOMPLETE: $SEEDED/$N_CLIENTS (close will have $((SEEDED+1)) outputs)"
 
 # ---- ECONOMY: bounded random c2c circulation (auto-stop on conservation violation) ----
+phase_begin "economy"
 info "$(ts) ECONOMY: up to $MAX_PAYS random client->client payments..."
 ECON_OK=0; ECON_FAIL=0
 for _k in $(seq 1 "$MAX_PAYS"); do
@@ -257,6 +289,7 @@ info "$(ts) economy done: $ECON_OK settled, $ECON_FAIL not settled (insufficient
 
 # ---- CLOSE ----
 sleep 10
+phase_begin "close"
 info "$(ts) issuing CLI close -> $((N_CLIENTS+1))-output cooperative payout..."
 cli "close"
 CLOSE_TXID=""; CDEAD=$(( $(date +%s) + CLOSE_WAIT_SEC ))

--- a/tools/test_regtest_pct100_lifecycle.sh
+++ b/tools/test_regtest_pct100_lifecycle.sh
@@ -212,14 +212,20 @@ for i in $(seq 1 "$N_CLIENTS"); do
 done
 ( while kill -0 "$LSP_PID" 2>/dev/null; do mine 1; sleep 2; done ) & MINER_PID=$!
 
-CDEAD=$(( $(date +%s) + 420 )); CREATED=0
+# Creation is an O(N)-round ceremony, so the budget must scale with N.  A fixed
+# 420s silently became a spurious "factory not created" at large N: measured
+# ~150s at N=224, so 512 lands near the old ceiling and 1024 sails past it --
+# a harness artifact that reads exactly like a code bug.  ~1.2s/client + 120s
+# floor, overridable.
+CREATE_WAIT_SEC="${CREATE_WAIT_SEC:-$(( 120 + (N_CLIENTS * 12 + 9) / 10 ))}"
+CDEAD=$(( $(date +%s) + CREATE_WAIT_SEC )); CREATED=0
 while [ "$(date +%s)" -lt "$CDEAD" ]; do
     grep -q "entering daemon mode" "$LSP_LOG" 2>/dev/null && { CREATED=1; break; }
     grep -qE "event loop failed|channel init failed|ceremony failed|FATAL" "$LSP_LOG" 2>/dev/null && { tail -30 "$LSP_LOG"; die "LSP creation failure"; }
     kill -0 "$LSP_PID" 2>/dev/null || { tail -30 "$LSP_LOG"; die "LSP died during creation"; }
     sleep 3
 done
-[ "$CREATED" = 1 ] || { tail -30 "$LSP_LOG"; die "factory not created in 420s"; }
+[ "$CREATED" = 1 ] || { tail -30 "$LSP_LOG"; die "factory not created in ${CREATE_WAIT_SEC}s"; }
 green "$(ts) FACTORY LIVE — $N_CLIENTS clients onboarded with ZERO balance (pct-100)"
 
 # ---- SEED: every client's first sats arrive over LN ----


### PR DESCRIPTION
Groundwork toward running **512–1024 real client daemons** (real sockets, real processes, real payments) on a small box. Three gates were identified by measurement; this PR closes one of them and starts two.

Everything here is measured, and where a measurement contradicted an earlier claim of mine the commit message says so.

## What's in it

**1. `readiness`: size the tracker to the client count** — fixes a *correctness* bug, not just a ceiling. `readiness_init` clamped to `FACTORY_MAX_SIGNERS`, so above 256 clients the surplus was silently dropped. Every accessor bounds-checks `n_clients`, so those clients became **invisible**: `readiness_all_ready()` would report TRUE with clients still missing → **premature rotation**. Same class as the `uint64_t` bitmap bug fixed earlier, one order of N further out, and it would have surfaced the moment the daemon cap moved. New test drives N=300.

**2. `factory`: `input_signer_indices` made dynamic** — `[FACTORY_MAX_OUTPUTS][FACTORY_MAX_SIGNERS]` = 16 KB carried by *every* node (69% of `factory_node_t`), though only multi-input PS sub-factory nodes use it. Its three siblings in the same struct were already heap-allocated; this one was never converted with them.

  - `sizeof(factory_node_t)`: 23,816 → **7,448 B**
  - `nodes[]` allocated at N=512: 48.0 → **15.6 MB**
  - measured per-client resident: 15.9 → **13.0 MB** (18%)

  Smaller than the allocation math implied — `calloc` zero pages aren't resident until written, and PSS counts residency. Commit message records the mis-attribution rather than the flattering number.

**3. `poll()` everywhere + self-raised fd limit** — `FD_SETSIZE` is about the descriptor **value**, not the count: `FD_SET(fd,&set)` sets bit `fd` in a fixed 1024-bit bitmap. So `bridge.c` and `jit_channel.c`, watching 2–3 descriptors, were *exactly* as unsafe as the ceremony path at ~1000 clients. All four sites converted. The LSP now raises its own soft `RLIMIT_NOFILE` to `n_clients + 64` and refuses with an actionable message instead of dying mid-ceremony on `EMFILE`.

## Falsified, not assumed

The new high-fd test was verified to **fail against the old code** — old `select()` restored in a scratch tree, built under ASan:

```
[64, 192) 'rfds' <== Memory access at offset 192 overflows this variable
SUMMARY: AddressSanitizer: stack-buffer-overflow ceremony.c:46 in ceremony_select_all
```

## Measured state

| N | per-client PSS | swarm |
|---|---|---|
| 64 | 4.0 MB | 0.3 GB |
| 224 | 13.0 MB | 2.9 GB |

Per-client ≈ `0.4 + 0.056·N` — **still linear per client, so still O(N²) in aggregate.** The remaining dominant term is not yet identified; massif shows it is diffuse rather than one allocation. No extrapolation to 512 is claimed here.

## Not done yet

- **Gate 1**: the 255-client `--clients` cap. ~51 fixed `[FACTORY_MAX_SIGNERS]` sites (46 stack locals + 5 struct members); 1 converted. The cap stays load-bearing until they're all done — lifting it early produced a stack smash at N=256, not a clean refusal.
- **Gate 2**: the quadratic. Next target is `nodes[]` at `4N+64`, which is my own over-allocation and worth roughly half the slope.

## Gate

`test_superscalar` **1524/1524**, N=224 regtest lifecycle passes (224/224 seeded, full cooperative close, sat-for-sat reconciliation).